### PR TITLE
[Test][Perf] Publish a nightly coverage report and cover the varlen attention rooflines

### DIFF
--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -144,7 +144,7 @@ RUN if [ -n "${TILELANG_GIT_SHA}" ]; then \
         exit 1; \
     fi
 # --no-deps: it must not re-resolve a CUDA wheel under torch.
-RUN uv pip install --no-deps "cupti-python==13.2.0"
+RUN uv pip install --no-deps cupti-python
 COPY scripts/ci/verify_runtime_stack.py /tmp/verify_runtime_stack.py
 RUN python /tmp/verify_runtime_stack.py
 

--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -52,7 +52,7 @@ ENV MAX_JOBS=${MAX_JOBS} NVCC_THREADS=${NVCC_THREADS} TORCH_CUDA_ARCH_LIST=9.0 \
     CUDA_HOME=/usr/local/cuda PATH=/usr/local/cuda/bin:${PATH}
 
 FROM runtime AS post-fa3
-RUN uv pip install pytest pytest-xdist ruff pytest-timeout py-spy
+RUN uv pip install pytest pytest-xdist ruff pytest-timeout pytest-cov py-spy
 # Hopper FA3 has no wheel. A commit, not the v2.8.3 tag: releases through 2.8.3.post1 swap in a
 # downloaded CUDA 12.6 nvcc unless the system CUDA is exactly 12.8, and that toolchain ships no
 # CCCL, so every translation unit fails on `cuda/std/utility`. Only main takes the CUDA 13 path.
@@ -76,11 +76,11 @@ RUN uv pip install --no-build-isolation "flash-attn==2.8.3.post1" \
     || echo "WARNING: flash-attn (FA2) install failed (non-fatal)"
 
 # This vllm and no other: its apache-tvm-ffi pin (0.1.11) is the one the tilelang commit needs.
-# sgl-kernel is not installed.
+# Versions come from constraints.txt via UV_CONSTRAINT. sgl-kernel is not installed.
 FROM fa2 AS fullstack
 RUN for pkg in \
-        "flash-linear-attention==0.5.2" \
-        "vllm==0.27.1"; do \
+        "flash-linear-attention" \
+        "vllm"; do \
         uv pip install --no-build-isolation "$pkg" \
             || echo "WARNING: bench baseline '$pkg' install failed (non-fatal)"; \
     done

--- a/.github/runner/requirements.in
+++ b/.github/runner/requirements.in
@@ -37,4 +37,4 @@ pytest-cov
 py-spy
 flash-linear-attention
 vllm
-cupti-python==13.2.0
+cupti-python

--- a/.github/runner/requirements.in
+++ b/.github/runner/requirements.in
@@ -35,6 +35,6 @@ ruff
 pytest-timeout
 pytest-cov
 py-spy
-flash-linear-attention==0.5.2
-vllm==0.27.1
+flash-linear-attention
+vllm
 cupti-python==13.2.0

--- a/.github/runner/requirements.in
+++ b/.github/runner/requirements.in
@@ -33,6 +33,7 @@ pytest
 pytest-xdist
 ruff
 pytest-timeout
+pytest-cov
 py-spy
 flash-linear-attention==0.5.2
 vllm==0.27.1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -241,8 +241,10 @@ jobs:
           echo "TRITON_CACHE_DIR=${TRITON_CACHE_DIR:-}"
 
           set -o pipefail
-          python3 -m pip install -q -c constraints.txt pytest-timeout
-          python3 -m pytest tests/ -m "full or nightly" -v --tb=short --timeout=900 --timeout-method=thread --junit-xml=test_results.xml | tee tileops_op_test.log
+          python3 -m pip install -q -c constraints.txt pytest-timeout pytest-cov
+          # Coverage reflects the full/nightly tiers only. Smoke-only cases run in
+          # gpu-smoke.yml and their code reads as untested here.
+          python3 -m pytest tests/ -m "full or nightly" -v --tb=short --timeout=900 --timeout-method=thread --junit-xml=test_results.xml --cov=tileops --cov-branch --cov-report=html:htmlcov | tee tileops_op_test.log
         shell: bash
 
       - name: Download benchmark artifacts
@@ -350,6 +352,7 @@ jobs:
             test_results.xml
             tileops_op_test.log
             nightly_report.md
+            htmlcov/
           if-no-files-found: warn
           retention-days: 14
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -244,7 +244,7 @@ jobs:
           python3 -m pip install -q -c constraints.txt pytest-timeout pytest-cov
           # Coverage reflects the full/nightly tiers only. Smoke-only cases run in
           # gpu-smoke.yml and their code reads as untested here.
-          python3 -m pytest tests/ -m "full or nightly" -v --tb=short --timeout=900 --timeout-method=thread --junit-xml=test_results.xml --cov=tileops --cov-branch --cov-report=html:htmlcov | tee tileops_op_test.log
+          python3 -m pytest tests/ -m "full or nightly" -v --tb=short --timeout=900 --timeout-method=thread --junit-xml=test_results.xml --cov=tileops --cov-branch --cov-report=html:htmlcov --cov-report=xml:coverage.xml | tee tileops_op_test.log
         shell: bash
 
       - name: Download benchmark artifacts
@@ -335,6 +335,7 @@ jobs:
             "${HISTORY_ARGS[@]}" \
             --output nightly_report.md \
             --history-out perf_history.json \
+            --coverage-xml coverage.xml \
             || echo "::warning::nightly_report.py failed"
         shell: bash
 

--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,9 @@ docs/superpowers/
 profile_run.log
 bench_stack_dumps/
 bench_results.xml
+
+# Coverage output
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/

--- a/constraints-runner-lock.txt
+++ b/constraints-runner-lock.txt
@@ -20,6 +20,7 @@ click==8.4.2
 cloudpickle==3.1.2
 cmake==4.4.2
 compressed-tensors==0.17.0
+coverage==7.15.4
 cryptography==50.0.0
 cuda-bindings==13.3.1
 cuda-core==1.0.1
@@ -156,6 +157,7 @@ pygments==2.20.0
 pyjwt==2.13.0
 pynvvideocodec==2.0.4
 pytest==9.0.2
+pytest-cov==7.1.0
 pytest-timeout==2.3.1
 pytest-xdist==3.8.0
 python-dotenv==1.2.2

--- a/constraints.txt
+++ b/constraints.txt
@@ -28,10 +28,16 @@ pytest-xdist==3.8.0
 ruff==0.14.13
 pytest-timeout==2.3.1
 pytest-cov==7.1.0
+# pytest-cov pulls it. The nightly step installs against this file, not the
+# runner lock, so an unpinned coverage would drift between nights and make
+# the readings it produces incomparable.
+coverage==7.15.4
 # Bench baselines. The runner image installs these; the lock compile and the
 # `.[bench]` install both read the version from here.
 flash-linear-attention==0.5.2
 vllm==0.27.1
+# Tracks the image CUDA version; bump with it.
+cupti-python==13.2.0
 # Stack dump of a hung benchmark child before the runner kills it.
 py-spy==0.4.2
 # The installer. It cannot come from the lock it produces, and the same version must compile the

--- a/constraints.txt
+++ b/constraints.txt
@@ -27,6 +27,7 @@ pytest==9.0.2
 pytest-xdist==3.8.0
 ruff==0.14.13
 pytest-timeout==2.3.1
+pytest-cov==7.1.0
 # Stack dump of a hung benchmark child before the runner kills it.
 py-spy==0.4.2
 # The installer. It cannot come from the lock it produces, and the same version must compile the

--- a/constraints.txt
+++ b/constraints.txt
@@ -28,6 +28,10 @@ pytest-xdist==3.8.0
 ruff==0.14.13
 pytest-timeout==2.3.1
 pytest-cov==7.1.0
+# Bench baselines. The runner image installs these; the lock compile and the
+# `.[bench]` install both read the version from here.
+flash-linear-attention==0.5.2
+vllm==0.27.1
 # Stack dump of a hung benchmark child before the runner kills it.
 py-spy==0.4.2
 # The installer. It cannot come from the lock it produces, and the same version must compile the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
     "ruff==0.14.13",
     "codespell==2.4.1",
     "pytest>=8.0",
+    "pytest-cov>=5.0",
     "pytest-xdist>=3.0",
     "pyyaml>=6.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,9 +48,9 @@ dev = [
 bench = [
     "flash-attn==2.8.3",
     "flash-attn-interface>=2.8.3",
-    "flash-linear-attention==0.4.2",
+    "flash-linear-attention==0.5.2",
     "flashinfer>=0.6.6",
-    "vllm==0.18.0",
+    "vllm==0.27.1",
     "sgl-kernel==0.3.21",
 ]
 

--- a/scripts/nightly_report.py
+++ b/scripts/nightly_report.py
@@ -152,6 +152,60 @@ def _try_float(v):
         return v
 
 
+def parse_coverage_xml(path: str) -> dict | None:
+    """Aggregate a coverage.py XML report by top-level ``src/tileops`` subpackage.
+
+    Returns ``{"packages": {name: counts}, "total": counts, "files": [...]}``
+    where ``counts`` carries covered/total statements and branches. Files are
+    sorted by uncovered statement count, worst first.
+    """
+    try:
+        root = ET.parse(path).getroot()
+    except (OSError, ET.ParseError):
+        return None
+
+    packages: dict[str, dict] = {}
+    files: list[dict] = []
+    for cls in root.iter("class"):
+        filename = cls.get("filename") or ""
+        marker = "src/tileops/"
+        if marker not in filename:
+            continue
+        tail = filename.split(marker, 1)[1]
+        # Files directly under src/tileops/ have no subpackage of their own.
+        name = tail.split("/")[0] if "/" in tail else "(top level)"
+
+        stmts = covered = branches = branches_hit = 0
+        for line in cls.iter("line"):
+            stmts += 1
+            covered += int(line.get("hits") or 0) > 0
+            condition = line.get("condition-coverage") or ""
+            if line.get("branch") == "true" and "(" in condition:
+                hit, total = condition.split("(", 1)[1].rstrip(")").split("/")
+                branches += int(total)
+                branches_hit += int(hit)
+        if not stmts:
+            continue
+
+        bucket = packages.setdefault(
+            name, {"stmts": 0, "covered": 0, "branches": 0, "branches_hit": 0})
+        bucket["stmts"] += stmts
+        bucket["covered"] += covered
+        bucket["branches"] += branches
+        bucket["branches_hit"] += branches_hit
+        files.append({"path": tail, "stmts": stmts, "covered": covered})
+
+    if not packages:
+        return None
+
+    total = {"stmts": 0, "covered": 0, "branches": 0, "branches_hit": 0}
+    for bucket in packages.values():
+        for key in total:
+            total[key] += bucket[key]
+    files.sort(key=lambda f: f["covered"] - f["stmts"])
+    return {"packages": packages, "total": total, "files": files}
+
+
 # ---------------------------------------------------------------------------
 # Aggregation
 # ---------------------------------------------------------------------------
@@ -466,6 +520,7 @@ def generate_report(
     regressions: list[dict],
     improvements: list[dict],
     baseline_alerts: list[dict],
+    coverage: dict | None = None,
 ) -> str:
     """Generate markdown report."""
     lines = []
@@ -661,7 +716,53 @@ def generate_report(
         lines.append("</details>")
         lines.append("")
 
+    # ── Coverage ──────────────────────────────────────────────────────────
+    if coverage:
+        lines.extend(_coverage_section(coverage))
+
     return "\n".join(lines)
+
+
+def _pct(hit: int, total: int) -> str:
+    return f"{100 * hit / total:.1f}%" if total else "-"
+
+
+def _coverage_section(coverage: dict, worst_n: int = 15) -> list[str]:
+    """Per-subpackage coverage table plus the least-covered files."""
+    lines = ["## Coverage", ""]
+    lines.append("| Package | Statements | Line | Branch |")
+    lines.append("| --- | --- | --- | --- |")
+    for name, c in sorted(coverage["packages"].items(), key=lambda kv: -kv[1]["stmts"]):
+        lines.append(
+            f"| `{name}` | {c['covered']}/{c['stmts']} "
+            f"| {_pct(c['covered'], c['stmts'])} "
+            f"| {_pct(c['branches_hit'], c['branches'])} |")
+    total = coverage["total"]
+    lines.append(
+        f"| **total** | {total['covered']}/{total['stmts']} "
+        f"| {_pct(total['covered'], total['stmts'])} "
+        f"| {_pct(total['branches_hit'], total['branches'])} |")
+    lines.append("")
+    lines.append("A `kernels` line counts as covered once the kernel is traced into IR, "
+                 "which says the kernel was built, not that its generated code was "
+                 "exercised. Read a low number there as a signal; a high one is not one.")
+    lines.append("")
+    lines.append("Smoke-only cases run in `gpu-smoke.yml`, so code reached solely by "
+                 "them reads as untested here.")
+    lines.append("")
+
+    lines.append("<details>")
+    lines.append(f"<summary>Least-covered files (top {worst_n})</summary>")
+    lines.append("")
+    lines.append("| File | Covered | Line |")
+    lines.append("| --- | --- | --- |")
+    for f in coverage["files"][:worst_n]:
+        lines.append(f"| `{f['path']}` | {f['covered']}/{f['stmts']} "
+                     f"| {_pct(f['covered'], f['stmts'])} |")
+    lines.append("")
+    lines.append("</details>")
+    lines.append("")
+    return lines
 
 
 # ---------------------------------------------------------------------------
@@ -676,6 +777,7 @@ def main():
     parser.add_argument("--history", help="Path to perf_history.json (input)")
     parser.add_argument("--output", required=True, help="Output markdown report path")
     parser.add_argument("--history-out", help="Path to write updated perf_history.json")
+    parser.add_argument("--coverage-xml", help="Path to coverage.py XML report")
     args = parser.parse_args()
 
     # Parse results
@@ -697,9 +799,13 @@ def main():
     improvements = detect_improvements(bench_ops, history_runs) if bench_ops else []
     baseline_alerts = detect_baseline_alerts(bench_ops) if bench_ops else []
 
+    coverage = None
+    if args.coverage_xml and Path(args.coverage_xml).exists():
+        coverage = parse_coverage_xml(args.coverage_xml)
+
     # Generate report
     report = generate_report(test_ops, bench_ops, bench_failures,
-                             regressions, improvements, baseline_alerts)
+                             regressions, improvements, baseline_alerts, coverage)
     Path(args.output).write_text(report)
     print(f"Report written to {args.output}")
 

--- a/scripts/nightly_report.py
+++ b/scripts/nightly_report.py
@@ -551,6 +551,28 @@ def generate_report(
     if improvements:
         lines.append(f"| **Improvements** (vs 14-day best) |"
                      f" {_PARTY} {len(improvements)} |")
+    if coverage:
+        # In the summary rather than only in the Coverage section: that section
+        # sits below the benchmark tables, which run to hundreds of rows. Each
+        # row names one concern and the file to open first — a single untested
+        # -line total would double-count ops/ against its own branch figure and
+        # bury perf/, where a wrong number is the failure nothing else catches.
+        sig = _coverage_signals(coverage)
+        if sig["never_built"]:
+            worst = sig["never_built"][0]
+            lines.append(f"| **Never-built kernels** | {_WARN} "
+                         f"{len(sig['never_built'])} files &ensp; (`{worst['path']}` at "
+                         f"{_pct(worst['covered'], worst['stmts'])}) |")
+        else:
+            lines.append(f"| **Never-built kernels** | {_PASS} None |")
+        rl_worst = sig["roofline_worst"]
+        rl_hint = (f" &ensp; (`{rl_worst['path']}` at "
+                   f"{_pct(rl_worst['covered'], rl_worst['stmts'])})" if rl_worst else "")
+        lines.append(f"| **Untested roofline math** |"
+                     f" {sig['roofline_untested']} lines in `perf/`{rl_hint} |")
+        lines.append(f"| **Untested op logic** | {sig['op_untested']} lines in `ops/`"
+                     f" &ensp; ({_pct(sig['op_branches_hit'], sig['op_branches'])}"
+                     f" of branches taken) |")
     lines.append("")
 
     # ── Test Failures (only if any) ───────────────────────────────────────
@@ -742,10 +764,16 @@ def _coverage_signals(files: list[dict]) -> dict:
         key=lambda f: f["covered"] - f["stmts"])
 
     ops = [f for f in files if f["path"].startswith("ops/")]
+    roofline = [f for f in pure if f["path"].startswith("perf/")]
     return {
         "never_built": never_built,
         "untested": untested,
         "untested_lines": sum(f["stmts"] - f["covered"] for f in pure),
+        "roofline_untested": sum(f["stmts"] - f["covered"] for f in roofline),
+        "roofline_worst": min(
+            (f for f in roofline if f["stmts"] >= MIN_STMTS),
+            key=lambda f: f["covered"] / f["stmts"], default=None),
+        "op_untested": sum(f["stmts"] - f["covered"] for f in ops),
         "op_branches_hit": sum(f["branches_hit"] for f in ops),
         "op_branches": sum(f["branches"] for f in ops),
     }
@@ -755,16 +783,22 @@ def _coverage_section(files: list[dict], worst_n: int = 15) -> list[str]:
     """Three explicit signals, each with what it means and what to do about it."""
     s = _coverage_signals(files)
     lines = ["## Coverage", ""]
-    lines.append("| Signal | Value | What it means |")
-    lines.append("| --- | --- | --- |")
+    lines.append("| Signal | Value | What it means | What a bad number costs |")
+    lines.append("| --- | --- | --- | --- |")
     lines.append(f"| Never-built kernels | {len(s['never_built'])} files "
-                 "| no test constructs these kernels, so nothing catches a break in them |")
-    lines.append(f"| Untested pure Python | {s['untested_lines']} lines "
-                 "| statements outside `kernels/` that never executed |")
-    lines.append(f"| Op branch coverage | {_pct(s['op_branches_hit'], s['op_branches'])} "
-                 "| share of validation and dispatch branches taken in `ops/` |")
+                 "| no test constructs these kernels "
+                 "| the kernel stops compiling and nothing says so until someone runs it |")
+    lines.append(f"| Untested roofline math | {s['roofline_untested']} lines in `perf/` "
+                 "| cost-model statements that never executed "
+                 "| benchmarks report wrong TFLOPS while every correctness test passes |")
+    lines.append(f"| Untested op logic | {s['op_untested']} lines in `ops/`, "
+                 f"{_pct(s['op_branches_hit'], s['op_branches'])} of branches "
+                 "| validation and dispatch paths not taken "
+                 "| a reversed shape or dtype check returns a wrong result instead of raising |")
     lines.append("")
-    lines.append("Track the direction, not the absolute value. Smoke-only cases run in "
+    lines.append(f"Everything outside `kernels/` accounts for {s['untested_lines']} untested "
+                 "lines; the two rows above carry the ones with an owner. Track the "
+                 "direction, not the absolute value. Smoke-only cases run in "
                  "`gpu-smoke.yml`, so code reached solely by them counts as untested here.")
     lines.append("")
 

--- a/scripts/nightly_report.py
+++ b/scripts/nightly_report.py
@@ -408,12 +408,17 @@ def detect_baseline_alerts(bench_ops: dict) -> list[dict]:
 # ---------------------------------------------------------------------------
 
 
-def build_history_entry(bench_ops: dict) -> dict:
-    """Build a history entry from current bench results."""
+def build_history_entry(bench_ops: dict, coverage: list[dict] | None = None) -> dict:
+    """Build a history entry from current bench results.
+
+    Coverage rides in a key of its own beside ``ops``. Regression detection
+    reads only ``ops`` and pruning reads only ``date``, so the benchmark side
+    neither sees this key nor needs it to be present in older entries.
+    """
     commit = _get_git_commit()
     gpu = _get_gpu_name()
     ops_data = {}
-    for op, data in bench_ops.items():
+    for op, data in (bench_ops or {}).items():
         cfg_data = {}
         for cfg in data["configs"]:
             entry = {}
@@ -455,12 +460,53 @@ def build_history_entry(bench_ops: dict) -> dict:
                 cfg_data[cfg["name"]] = entry
         if cfg_data:
             ops_data[op] = cfg_data
-    return {
+    entry = {
         "date": datetime.now().strftime("%Y-%m-%d"),
         "commit": commit,
         "gpu": gpu,
         "ops": ops_data,
     }
+    if coverage:
+        entry["coverage"] = coverage_snapshot(coverage)
+    return entry
+
+
+def coverage_snapshot(files: list[dict]) -> dict:
+    """The three tracked coverage quantities, as plain numbers for history."""
+    s = _coverage_signals(files)
+    return {
+        "never_built": len(s["never_built"]),
+        "roofline_untested": s["roofline_untested"],
+        "op_untested": s["op_untested"],
+        "op_branches_hit": s["op_branches_hit"],
+        "op_branches": s["op_branches"],
+    }
+
+
+def previous_coverage(runs: list[dict]) -> dict | None:
+    """The most recent recorded coverage snapshot, or None before any exists."""
+    for run in reversed(runs):
+        snapshot = run.get("coverage")
+        if snapshot:
+            return {**snapshot, "date": run.get("date", "")}
+    return None
+
+
+def _delta(current: int | float, previous: int | float | None, unit: str = "") -> str:
+    """A signed change against the previous run.
+
+    Empty when the value held or there is nothing to compare against — the
+    footnote under the table states which run the comparison ran against, so a
+    silent row reads as steady rather than as missing history.
+    """
+    if previous is None:
+        return ""
+    change = current - previous
+    if abs(change) < (0.05 if unit == "pp" else 1):
+        return ""
+    sign = "+" if change > 0 else "−"
+    magnitude = f"{abs(change):.1f}" if unit == "pp" else f"{abs(change):.0f}"
+    return f" **{sign}{magnitude}{unit}**"
 
 
 def _get_git_commit() -> str:
@@ -508,6 +554,7 @@ def generate_report(
     improvements: list[dict],
     baseline_alerts: list[dict],
     coverage: list[dict] | None = None,
+    coverage_prev: dict | None = None,
 ) -> str:
     """Generate markdown report."""
     lines = []
@@ -558,21 +605,35 @@ def generate_report(
         # -line total would double-count ops/ against its own branch figure and
         # bury perf/, where a wrong number is the failure nothing else catches.
         sig = _coverage_signals(coverage)
+        prev = coverage_prev or {}
+        sep = " &ensp;·&ensp; "
         if sig["never_built"]:
             worst = sig["never_built"][0]
             lines.append(f"| **Never-built kernels** | {_WARN} "
-                         f"{len(sig['never_built'])} files &ensp; (`{worst['path']}` at "
-                         f"{_pct(worst['covered'], worst['stmts'])}) |")
+                         f"{len(sig['never_built'])} files"
+                         f"{_delta(len(sig['never_built']), prev.get('never_built'))}"
+                         f"{sep}`{worst['path']}` at "
+                         f"{_pct(worst['covered'], worst['stmts'])} |")
         else:
             lines.append(f"| **Never-built kernels** | {_PASS} None |")
         rl_worst = sig["roofline_worst"]
-        rl_hint = (f" &ensp; (`{rl_worst['path']}` at "
-                   f"{_pct(rl_worst['covered'], rl_worst['stmts'])})" if rl_worst else "")
-        lines.append(f"| **Untested roofline math** |"
-                     f" {sig['roofline_untested']} lines in `perf/`{rl_hint} |")
+        rl_hint = (f"{sep}`{rl_worst['path']}` at "
+                   f"{_pct(rl_worst['covered'], rl_worst['stmts'])}" if rl_worst else "")
+        lines.append(f"| **Untested roofline math** | {sig['roofline_untested']} lines"
+                     f" in `perf/`"
+                     f"{_delta(sig['roofline_untested'], prev.get('roofline_untested'))}"
+                     f"{rl_hint} |")
+        op_branch_pct = (100 * sig["op_branches_hit"] / sig["op_branches"]
+                         if sig["op_branches"] else 0.0)
+        prev_branch_pct = (100 * prev.get("op_branches_hit", 0) / prev["op_branches"]
+                           if prev.get("op_branches") else None)
         lines.append(f"| **Untested op logic** | {sig['op_untested']} lines in `ops/`"
-                     f" &ensp; ({_pct(sig['op_branches_hit'], sig['op_branches'])}"
-                     f" of branches taken) |")
+                     f"{_delta(sig['op_untested'], prev.get('op_untested'))}"
+                     f"{sep}{op_branch_pct:.1f}% of branches taken"
+                     f"{_delta(op_branch_pct, prev_branch_pct, 'pp')} |")
+        if prev.get("date"):
+            lines.append("| | <sub>coverage compared against the "
+                         f"{prev['date']} run; no figure means it held</sub> |")
     lines.append("")
 
     # ── Test Failures (only if any) ───────────────────────────────────────
@@ -867,16 +928,21 @@ def main():
     coverage = None
     if args.coverage_xml and Path(args.coverage_xml).exists():
         coverage = parse_coverage_xml(args.coverage_xml)
+    # Read before this run is appended, so the comparison is against a prior run.
+    coverage_prev = previous_coverage(history_runs)
 
     # Generate report
     report = generate_report(test_ops, bench_ops, bench_failures,
-                             regressions, improvements, baseline_alerts, coverage)
+                             regressions, improvements, baseline_alerts, coverage,
+                             coverage_prev)
     Path(args.output).write_text(report)
     print(f"Report written to {args.output}")
 
-    # Update history
-    if args.history_out and bench_ops:
-        entry = build_history_entry(bench_ops)
+    # Update history. Coverage is recorded even when the benchmark job produced
+    # nothing, so a night without benchmarks does not drop a coverage reading and
+    # leave the next run comparing against a stale one.
+    if args.history_out and (bench_ops or coverage):
+        entry = build_history_entry(bench_ops, coverage)
         history_runs.append(entry)
         history_runs = prune_history(history_runs)
         Path(args.history_out).write_text(json.dumps({"runs": history_runs}, indent=2))

--- a/scripts/nightly_report.py
+++ b/scripts/nightly_report.py
@@ -152,28 +152,25 @@ def _try_float(v):
         return v
 
 
-def parse_coverage_xml(path: str) -> dict | None:
-    """Aggregate a coverage.py XML report by top-level ``src/tileops`` subpackage.
+def parse_coverage_xml(path: str) -> list[dict] | None:
+    """Read a coverage.py XML report into one record per ``src/tileops`` file.
 
-    Returns ``{"packages": {name: counts}, "total": counts, "files": [...]}``
-    where ``counts`` carries covered/total statements and branches. Files are
-    sorted by uncovered statement count, worst first.
+    Each record carries the path relative to ``src/tileops/`` plus covered and
+    total counts for statements and branches. Interpretation is left to
+    ``_coverage_section`` — the raw per-file numbers mean different things
+    inside and outside ``kernels/``.
     """
     try:
         root = ET.parse(path).getroot()
     except (OSError, ET.ParseError):
         return None
 
-    packages: dict[str, dict] = {}
     files: list[dict] = []
     for cls in root.iter("class"):
         filename = cls.get("filename") or ""
         marker = "src/tileops/"
         if marker not in filename:
             continue
-        tail = filename.split(marker, 1)[1]
-        # Files directly under src/tileops/ have no subpackage of their own.
-        name = tail.split("/")[0] if "/" in tail else "(top level)"
 
         stmts = covered = branches = branches_hit = 0
         for line in cls.iter("line"):
@@ -184,26 +181,16 @@ def parse_coverage_xml(path: str) -> dict | None:
                 hit, total = condition.split("(", 1)[1].rstrip(")").split("/")
                 branches += int(total)
                 branches_hit += int(hit)
-        if not stmts:
-            continue
+        if stmts:
+            files.append({
+                "path": filename.split(marker, 1)[1],
+                "stmts": stmts,
+                "covered": covered,
+                "branches": branches,
+                "branches_hit": branches_hit,
+            })
 
-        bucket = packages.setdefault(
-            name, {"stmts": 0, "covered": 0, "branches": 0, "branches_hit": 0})
-        bucket["stmts"] += stmts
-        bucket["covered"] += covered
-        bucket["branches"] += branches
-        bucket["branches_hit"] += branches_hit
-        files.append({"path": tail, "stmts": stmts, "covered": covered})
-
-    if not packages:
-        return None
-
-    total = {"stmts": 0, "covered": 0, "branches": 0, "branches_hit": 0}
-    for bucket in packages.values():
-        for key in total:
-            total[key] += bucket[key]
-    files.sort(key=lambda f: f["covered"] - f["stmts"])
-    return {"packages": packages, "total": total, "files": files}
+    return files or None
 
 
 # ---------------------------------------------------------------------------
@@ -520,7 +507,7 @@ def generate_report(
     regressions: list[dict],
     improvements: list[dict],
     baseline_alerts: list[dict],
-    coverage: dict | None = None,
+    coverage: list[dict] | None = None,
 ) -> str:
     """Generate markdown report."""
     lines = []
@@ -727,40 +714,84 @@ def _pct(hit: int, total: int) -> str:
     return f"{100 * hit / total:.1f}%" if total else "-"
 
 
-def _coverage_section(coverage: dict, worst_n: int = 15) -> list[str]:
-    """Per-subpackage coverage table plus the least-covered files."""
+# A kernel file below this share of executed lines was never constructed by any
+# test. Measured distribution: the lowest genuinely-built kernel file sits at
+# 36.9%, so the threshold has room before it starts catching built kernels.
+KERNEL_BUILT_PCT = 25
+# Files this small swing wildly on one statement; they carry no signal.
+MIN_STMTS = 20
+
+
+def _coverage_signals(files: list[dict]) -> dict:
+    """Reduce per-file coverage to the three numbers worth acting on.
+
+    A ``kernels/`` line counts as covered once the kernel is traced into IR, so
+    its percentage says the kernel was built, not that its generated code ran.
+    Only the never-built case carries information, and it is reported as a file
+    count. Everywhere else the ordinary reading holds.
+    """
+    kernels = [f for f in files if f["path"].startswith("kernels/")]
+    pure = [f for f in files if not f["path"].startswith("kernels/")]
+
+    never_built = sorted(
+        (f for f in kernels
+         if f["stmts"] >= MIN_STMTS and 100 * f["covered"] / f["stmts"] < KERNEL_BUILT_PCT),
+        key=lambda f: f["covered"] / f["stmts"])
+    untested = sorted(
+        (f for f in pure if f["stmts"] - f["covered"] > 0),
+        key=lambda f: f["covered"] - f["stmts"])
+
+    ops = [f for f in files if f["path"].startswith("ops/")]
+    return {
+        "never_built": never_built,
+        "untested": untested,
+        "untested_lines": sum(f["stmts"] - f["covered"] for f in pure),
+        "op_branches_hit": sum(f["branches_hit"] for f in ops),
+        "op_branches": sum(f["branches"] for f in ops),
+    }
+
+
+def _coverage_section(files: list[dict], worst_n: int = 15) -> list[str]:
+    """Three explicit signals, each with what it means and what to do about it."""
+    s = _coverage_signals(files)
     lines = ["## Coverage", ""]
-    lines.append("| Package | Statements | Line | Branch |")
-    lines.append("| --- | --- | --- | --- |")
-    for name, c in sorted(coverage["packages"].items(), key=lambda kv: -kv[1]["stmts"]):
-        lines.append(
-            f"| `{name}` | {c['covered']}/{c['stmts']} "
-            f"| {_pct(c['covered'], c['stmts'])} "
-            f"| {_pct(c['branches_hit'], c['branches'])} |")
-    total = coverage["total"]
-    lines.append(
-        f"| **total** | {total['covered']}/{total['stmts']} "
-        f"| {_pct(total['covered'], total['stmts'])} "
-        f"| {_pct(total['branches_hit'], total['branches'])} |")
+    lines.append("| Signal | Value | What it means |")
+    lines.append("| --- | --- | --- |")
+    lines.append(f"| Never-built kernels | {len(s['never_built'])} files "
+                 "| no test constructs these kernels, so nothing catches a break in them |")
+    lines.append(f"| Untested pure Python | {s['untested_lines']} lines "
+                 "| statements outside `kernels/` that never executed |")
+    lines.append(f"| Op branch coverage | {_pct(s['op_branches_hit'], s['op_branches'])} "
+                 "| share of validation and dispatch branches taken in `ops/` |")
     lines.append("")
-    lines.append("A `kernels` line counts as covered once the kernel is traced into IR, "
-                 "which says the kernel was built, not that its generated code was "
-                 "exercised. Read a low number there as a signal; a high one is not one.")
-    lines.append("")
-    lines.append("Smoke-only cases run in `gpu-smoke.yml`, so code reached solely by "
-                 "them reads as untested here.")
+    lines.append("Track the direction, not the absolute value. Smoke-only cases run in "
+                 "`gpu-smoke.yml`, so code reached solely by them counts as untested here.")
     lines.append("")
 
-    lines.append("<details>")
-    lines.append(f"<summary>Least-covered files (top {worst_n})</summary>")
-    lines.append("")
-    lines.append("| File | Covered | Line |")
-    lines.append("| --- | --- | --- |")
-    for f in coverage["files"][:worst_n]:
-        lines.append(f"| `{f['path']}` | {f['covered']}/{f['stmts']} "
-                     f"| {_pct(f['covered'], f['stmts'])} |")
-    lines.append("")
-    lines.append("</details>")
+    if s["never_built"]:
+        lines.append("### Never-built kernels")
+        lines.append("")
+        lines.append("| File | Executed |")
+        lines.append("| --- | --- |")
+        for f in s["never_built"]:
+            lines.append(f"| `{f['path']}` | {_pct(f['covered'], f['stmts'])} |")
+        lines.append("")
+
+    if s["untested"]:
+        lines.append("<details>")
+        lines.append(f"<summary>Untested pure Python, worst {worst_n} files</summary>")
+        lines.append("")
+        lines.append("| File | Uncovered | Executed |")
+        lines.append("| --- | --- | --- |")
+        for f in s["untested"][:worst_n]:
+            lines.append(f"| `{f['path']}` | {f['stmts'] - f['covered']} "
+                         f"| {_pct(f['covered'], f['stmts'])} |")
+        lines.append("")
+        lines.append("</details>")
+        lines.append("")
+
+    lines.append("Per-line detail is in the `htmlcov/` directory of this run's "
+                 "`tileops_op_test` artifact.")
     lines.append("")
     return lines
 

--- a/scripts/nightly_report.py
+++ b/scripts/nightly_report.py
@@ -23,14 +23,11 @@ from pathlib import Path
 # Constants
 # ---------------------------------------------------------------------------
 
-# 10% latency change => regression or improvement. This is also the noise floor:
-# a separate 5% one used to sit alongside it, where it could never bind.
-REGRESSION_THRESHOLD = 0.10
+REGRESSION_THRESHOLD = 0.10  # 10% latency change => regression or improvement
 REGRESSION_ABS_MIN = 0.01  # ignore regressions < 0.01 ms
 
 # Measurement properties carried from the benchmark XML through to the report.
-# Parsing and aggregation read the same set, so they share one definition —
-# a key added to only one of them used to vanish between the two steps.
+# Parsing and aggregation must read the same set.
 _PERF_KEYS = (
     "tileops_device_busy_ms", "tileops_latency_ms", "tileops_gap_ms",
     "tileops_n_kernels", "tileops_tflops", "tileops_bandwidth_tbs",
@@ -41,7 +38,6 @@ _PERF_KEYS = (
 )
 BASELINE_RATIO_ALERT = 0.80  # tileops slower than baseline by >25%
 HISTORY_RETENTION_DAYS = 14
-COVERAGE_WORST_N = 15  # rows in the least-covered file list
 
 # ── Emoji constants ───────────────────────────────────────────────────────
 _PASS = "\u2705"          # ✅
@@ -403,9 +399,9 @@ def detect_baseline_alerts(bench_ops: dict) -> list[dict]:
 def build_history_entry(bench_ops: dict, coverage: list[dict] | None = None) -> dict:
     """Build a history entry from current bench results.
 
-    Coverage rides in a key of its own beside ``ops``. Regression detection
-    reads only ``ops`` and pruning reads only ``date``, so the benchmark side
-    neither sees this key nor needs it to be present in older entries.
+    Coverage sits in a key of its own beside ``ops``, which regression
+    detection and pruning do not read, so entries written before it existed
+    stay readable.
     """
     commit = _get_git_commit()
     gpu = _get_gpu_name()
@@ -458,11 +454,11 @@ def build_history_entry(bench_ops: dict, coverage: list[dict] | None = None) -> 
         "ops": ops_data,
     }
     if coverage:
-        entry["coverage"] = coverage_snapshot(coverage)
+        entry["coverage"] = _coverage_snapshot(coverage)
     return entry
 
 
-def coverage_snapshot(files: list[dict]) -> dict:
+def _coverage_snapshot(files: list[dict]) -> dict:
     """The three tracked coverage quantities, as plain numbers for history."""
     s = _coverage_signals(files)
     return {
@@ -474,7 +470,7 @@ def coverage_snapshot(files: list[dict]) -> dict:
     }
 
 
-def previous_coverage(runs: list[dict]) -> dict | None:
+def _previous_coverage(runs: list[dict]) -> dict | None:
     """The most recent recorded coverage snapshot, or None before any exists."""
     for run in reversed(runs):
         snapshot = run.get("coverage")
@@ -484,11 +480,11 @@ def previous_coverage(runs: list[dict]) -> dict | None:
 
 
 def _delta(current: int | float, previous: int | float | None, unit: str = "") -> str:
-    """A signed change against the previous run.
+    """A signed change against the previous run, empty when it held.
 
-    Empty when the value held or there is nothing to compare against — the
-    footnote under the table states which run the comparison ran against, so a
-    silent row reads as steady rather than as missing history.
+    ``unit`` is ``"pp"`` for percentage points, otherwise a plain count. The
+    footnote under the table names the run compared against, so an empty
+    result reads as steady rather than as missing history.
     """
     if previous is None:
         return ""
@@ -590,11 +586,10 @@ def generate_report(
         lines.append(f"| **Improvements** (vs 14-day best) |"
                      f" {_PARTY} {len(improvements)} |")
     if coverage:
-        # In the summary rather than only in the Coverage section: that section
-        # sits below the benchmark tables, which run to hundreds of rows. Each
-        # row names one concern and the file to open first — a single untested
-        # -line total would double-count ops/ against its own branch figure and
-        # bury perf/, where a wrong number is the failure nothing else catches.
+        # Repeated here because the Coverage section sits below the benchmark
+        # tables, which run to hundreds of rows. One row per concern: a single
+        # untested-line total would double-count ops/ against its own branch
+        # figure and bury perf/, where a wrong number fails silently.
         sig = _coverage_signals(coverage)
         prev = coverage_prev or {}
         sep = " &ensp;·&ensp; "
@@ -788,11 +783,12 @@ def _pct(hit: int, total: int) -> str:
 
 
 # A kernel file below this share of executed lines was never constructed by any
-# test. Measured distribution: the lowest genuinely-built kernel file sits at
-# 36.9%, so the threshold has room before it starts catching built kernels.
-KERNEL_BUILT_PCT = 25
-# Files this small swing wildly on one statement; they carry no signal.
-MIN_STMTS = 20
+# test. The lowest genuinely-built kernel file measures 36.9%, so the threshold
+# has room before it starts catching built kernels.
+_KERNEL_BUILT_PCT = 25
+# Below this, one statement swings the percentage too far to read.
+_COVERAGE_MIN_STMTS = 20
+_COVERAGE_WORST_N = 15  # rows in the least-covered file list
 
 
 def _coverage_signals(files: list[dict]) -> dict:
@@ -800,15 +796,16 @@ def _coverage_signals(files: list[dict]) -> dict:
 
     A ``kernels/`` line counts as covered once the kernel is traced into IR, so
     its percentage says the kernel was built, not that its generated code ran.
-    Only the never-built case carries information, and it is reported as a file
-    count. Everywhere else the ordinary reading holds.
+    Only the never-built case carries information there, and it is returned as
+    a file list rather than a rate. Elsewhere the ordinary reading holds.
     """
     kernels = [f for f in files if f["path"].startswith("kernels/")]
     pure = [f for f in files if not f["path"].startswith("kernels/")]
 
     never_built = sorted(
         (f for f in kernels
-         if f["stmts"] >= MIN_STMTS and 100 * f["covered"] / f["stmts"] < KERNEL_BUILT_PCT),
+         if f["stmts"] >= _COVERAGE_MIN_STMTS
+         and 100 * f["covered"] / f["stmts"] < _KERNEL_BUILT_PCT),
         key=lambda f: f["covered"] / f["stmts"])
     untested = sorted(
         (f for f in pure if f["stmts"] - f["covered"] > 0),
@@ -822,7 +819,7 @@ def _coverage_signals(files: list[dict]) -> dict:
         "untested_lines": sum(f["stmts"] - f["covered"] for f in pure),
         "roofline_untested": sum(f["stmts"] - f["covered"] for f in roofline),
         "roofline_worst": min(
-            (f for f in roofline if f["stmts"] >= MIN_STMTS),
+            (f for f in roofline if f["stmts"] >= _COVERAGE_MIN_STMTS),
             key=lambda f: f["covered"] / f["stmts"], default=None),
         "op_untested": sum(f["stmts"] - f["covered"] for f in ops),
         "op_branches_hit": sum(f["branches_hit"] for f in ops),
@@ -830,7 +827,7 @@ def _coverage_signals(files: list[dict]) -> dict:
     }
 
 
-def _coverage_section(signals: dict, worst_n: int = COVERAGE_WORST_N) -> list[str]:
+def _coverage_section(signals: dict, worst_n: int = _COVERAGE_WORST_N) -> list[str]:
     """Three explicit signals, each with what it means and what to do about it."""
     s = signals
     lines = ["## Coverage", ""]
@@ -909,9 +906,9 @@ def main():
         bench_ops = aggregate_bench_results(bench_results)
         bench_failures = collect_bench_failures(bench_results)
 
-    # Load history and detect regressions. Pruning first keeps the verdicts inside
-    # the window their label claims; the carried-over artifact can be older when a
-    # run gap exceeds the retention period.
+    # Prune first: the carried-over artifact can hold entries older than the
+    # window when a run gap exceeds the retention period, and the verdicts below
+    # are labelled "vs 14-day best".
     history_runs = prune_history(load_history(args.history))
     regressions = detect_regressions(bench_ops, history_runs) if bench_ops else []
     improvements = detect_improvements(bench_ops, history_runs) if bench_ops else []
@@ -921,7 +918,7 @@ def main():
     if args.coverage_xml and Path(args.coverage_xml).exists():
         coverage = parse_coverage_xml(args.coverage_xml)
     # Read before this run is appended, so the comparison is against a prior run.
-    coverage_prev = previous_coverage(history_runs)
+    coverage_prev = _previous_coverage(history_runs)
 
     # Generate report
     report = generate_report(test_ops, bench_ops, bench_failures,
@@ -930,9 +927,8 @@ def main():
     Path(args.output).write_text(report)
     print(f"Report written to {args.output}")
 
-    # Update history. Coverage is recorded even when the benchmark job produced
-    # nothing, so a night without benchmarks does not drop a coverage reading and
-    # leave the next run comparing against a stale one.
+    # Recorded on coverage alone too, so a night the benchmark job produced
+    # nothing does not drop a reading and leave the next run comparing stale.
     if args.history_out and (bench_ops or coverage):
         entry = build_history_entry(bench_ops, coverage)
         history_runs.append(entry)

--- a/scripts/nightly_report.py
+++ b/scripts/nightly_report.py
@@ -103,10 +103,11 @@ def parse_bench_xml(path: str) -> list[dict]:
     for tc in tree.iter("testcase"):
         props = _get_properties(tc)
         failure = tc.find("failure")
+        error = tc.find("error")
         skipped = tc.find("skipped")
         if skipped is not None:
             outcome = "skipped"
-        elif failure is not None:
+        elif failure is not None or error is not None:
             outcome = "failed"
         else:
             outcome = "passed"
@@ -118,6 +119,7 @@ def parse_bench_xml(path: str) -> list[dict]:
             "op": props.get("op"),
             "op_module": props.get("op_module"),
             "failure_message": (failure.attrib.get("message", "") if failure is not None
+                                else error.attrib.get("message", "") if error is not None
                                 else None),
         }
         # Perf data
@@ -440,10 +442,9 @@ def build_history_entry(bench_ops: dict, coverage: list[dict] | None = None) -> 
                 if btag == cfg.get("baseline_tag"):
                     continue  # already recorded above
                 bl_entry = {}
-                if bl.get("latency_ms") is not None:
-                    bl_entry["latency_ms"] = bl["latency_ms"]
-                if bl.get("tflops") is not None:
-                    bl_entry["tflops"] = bl["tflops"]
+                for bl_key in ("latency_ms", _CONCLUSION_KEY, "tflops"):
+                    if bl.get(bl_key) is not None:
+                        bl_entry[bl_key] = bl[bl_key]
                 if bl_entry:
                     entry[btag] = bl_entry
             if entry:
@@ -908,8 +909,10 @@ def main():
         bench_ops = aggregate_bench_results(bench_results)
         bench_failures = collect_bench_failures(bench_results)
 
-    # Load history and detect regressions
-    history_runs = load_history(args.history)
+    # Load history and detect regressions. Pruning first keeps the verdicts inside
+    # the window their label claims; the carried-over artifact can be older when a
+    # run gap exceeds the retention period.
+    history_runs = prune_history(load_history(args.history))
     regressions = detect_regressions(bench_ops, history_runs) if bench_ops else []
     improvements = detect_improvements(bench_ops, history_runs) if bench_ops else []
     baseline_alerts = detect_baseline_alerts(bench_ops) if bench_ops else []
@@ -933,7 +936,6 @@ def main():
     if args.history_out and (bench_ops or coverage):
         entry = build_history_entry(bench_ops, coverage)
         history_runs.append(entry)
-        history_runs = prune_history(history_runs)
         Path(args.history_out).write_text(json.dumps({"runs": history_runs}, indent=2))
         print(f"History updated: {args.history_out}")
 

--- a/scripts/nightly_report.py
+++ b/scripts/nightly_report.py
@@ -23,11 +23,25 @@ from pathlib import Path
 # Constants
 # ---------------------------------------------------------------------------
 
-REGRESSION_THRESHOLD = 0.10  # 10% latency increase => regression
+# 10% latency change => regression or improvement. This is also the noise floor:
+# a separate 5% one used to sit alongside it, where it could never bind.
+REGRESSION_THRESHOLD = 0.10
 REGRESSION_ABS_MIN = 0.01  # ignore regressions < 0.01 ms
-NOISE_FLOOR = 0.05  # ignore <=5% fluctuations (measurement noise)
+
+# Measurement properties carried from the benchmark XML through to the report.
+# Parsing and aggregation read the same set, so they share one definition —
+# a key added to only one of them used to vanish between the two steps.
+_PERF_KEYS = (
+    "tileops_device_busy_ms", "tileops_latency_ms", "tileops_gap_ms",
+    "tileops_n_kernels", "tileops_tflops", "tileops_bandwidth_tbs",
+    "tileops_variant", "tileops_timing",
+    "tileops_device_busy_p10_ms", "tileops_device_busy_p90_ms",
+    "tileops_n_samples", "baseline_tag", "baseline_device_busy_ms",
+    "baseline_latency_ms", "baseline_tflops", "baseline_ratio",
+)
 BASELINE_RATIO_ALERT = 0.80  # tileops slower than baseline by >25%
 HISTORY_RETENTION_DAYS = 14
+COVERAGE_WORST_N = 15  # rows in the least-covered file list
 
 # ── Emoji constants ───────────────────────────────────────────────────────
 _PASS = "\u2705"          # ✅
@@ -107,12 +121,7 @@ def parse_bench_xml(path: str) -> list[dict]:
                                 else None),
         }
         # Perf data
-        for key in ("tileops_device_busy_ms", "tileops_latency_ms", "tileops_gap_ms",
-                     "tileops_n_kernels", "tileops_tflops", "tileops_bandwidth_tbs",
-                     "tileops_variant", "tileops_timing",
-                     "tileops_device_busy_p10_ms", "tileops_device_busy_p90_ms",
-                     "tileops_n_samples", "baseline_tag", "baseline_device_busy_ms",
-                     "baseline_latency_ms", "baseline_tflops", "baseline_ratio"):
+        for key in _PERF_KEYS:
             if key in props:
                 try:
                     entry[key] = float(props[key])
@@ -232,13 +241,7 @@ def aggregate_bench_results(results: list[dict]) -> dict:
         if not d["module"]:
             d["module"] = r.get("op_module")
         config_entry = {"name": r["name"]}
-        for key in ("tileops_device_busy_ms", "tileops_latency_ms", "tileops_gap_ms",
-                     "tileops_n_kernels", "tileops_tflops", "tileops_bandwidth_tbs",
-                     "tileops_variant", "tileops_timing",
-                     "tileops_device_busy_p10_ms", "tileops_device_busy_p90_ms",
-                     "tileops_n_samples", "baseline_tag", "baseline_device_busy_ms",
-                     "baseline_latency_ms", "baseline_tflops",
-                     "baseline_ratio", "baselines"):
+        for key in (*_PERF_KEYS, "baselines"):
             if key in r:
                 config_entry[key] = r[key]
         d["configs"].append(config_entry)
@@ -249,9 +252,7 @@ def collect_bench_failures(results: list[dict]) -> list[dict]:
     """Collect failed benchmark results for reporting."""
     return [
         {
-            "nodeid": r["nodeid"],
             "name": r["name"],
-            "op": r.get("op"),
             "failure_message": r.get("failure_message"),
         }
         for r in results
@@ -268,8 +269,7 @@ def load_history(path: str | None) -> list[dict]:
     """Load perf history JSON, returning list of runs."""
     if not path or not Path(path).exists():
         return []
-    with open(path) as f:
-        data = json.load(f)
+    data = json.loads(Path(path).read_text())
     return data.get("runs", [])
 
 
@@ -317,9 +317,11 @@ def find_best_latency(
     return best
 
 
-def detect_regressions(bench_ops: dict, history_runs: list[dict]) -> list[dict]:
-    """Detect performance regressions vs 14-day best."""
-    regressions = []
+def _history_deltas(bench_ops: dict, history_runs: list[dict]):
+    """Yield ``(record, delta)`` per config with both a reading and a history best.
+
+    ``delta`` is the fractional change against that best: positive is slower.
+    """
     for op, data in bench_ops.items():
         for cfg in data["configs"]:
             lat, key = _conclusion(cfg)
@@ -328,43 +330,31 @@ def detect_regressions(bench_ops: dict, history_runs: list[dict]) -> list[dict]:
             best = find_best_latency(history_runs, op, cfg["name"], key)
             if best is None:
                 continue
-            delta = (lat - best) / best
-            if (delta > REGRESSION_THRESHOLD
-                    and delta > NOISE_FLOOR
-                    and (lat - best) > REGRESSION_ABS_MIN):
-                regressions.append({
-                    "op": op,
-                    "config": cfg["name"],
-                    "best_ms": best,
-                    "curr_ms": lat,
-                    "delta_pct": delta * 100,
-                    "tflops": cfg.get("tileops_tflops"),
-                })
-    return regressions
+            yield {
+                "op": op,
+                "config": cfg["name"],
+                "best_ms": best,
+                "curr_ms": lat,
+                "delta_pct": (lat - best) / best * 100,
+                "tflops": cfg.get("tileops_tflops"),
+            }, (lat - best) / best
+
+
+def detect_regressions(bench_ops: dict, history_runs: list[dict]) -> list[dict]:
+    """Detect performance regressions vs 14-day best."""
+    return [
+        record for record, delta in _history_deltas(bench_ops, history_runs)
+        if delta > REGRESSION_THRESHOLD
+        and (record["curr_ms"] - record["best_ms"]) > REGRESSION_ABS_MIN
+    ]
 
 
 def detect_improvements(bench_ops: dict, history_runs: list[dict]) -> list[dict]:
     """Detect performance improvements vs 14-day best."""
-    improvements = []
-    for op, data in bench_ops.items():
-        for cfg in data["configs"]:
-            lat, key = _conclusion(cfg)
-            if lat is None:
-                continue
-            best = find_best_latency(history_runs, op, cfg["name"], key)
-            if best is None:
-                continue
-            delta = (lat - best) / best
-            if delta < -REGRESSION_THRESHOLD and abs(delta) > NOISE_FLOOR:
-                improvements.append({
-                    "op": op,
-                    "config": cfg["name"],
-                    "best_ms": best,
-                    "curr_ms": lat,
-                    "delta_pct": delta * 100,
-                    "tflops": cfg.get("tileops_tflops"),
-                })
-    return improvements
+    return [
+        record for record, delta in _history_deltas(bench_ops, history_runs)
+        if delta < -REGRESSION_THRESHOLD
+    ]
 
 
 def detect_baseline_alerts(bench_ops: dict) -> list[dict]:
@@ -637,21 +627,20 @@ def generate_report(
     lines.append("")
 
     # ── Test Failures (only if any) ───────────────────────────────────────
-    if test_ops:
-        failed_ops = {op: d for op, d in test_ops.items() if d["failed"] > 0}
-        if failed_ops:
-            lines.append(f"## {_FAIL} Test Failures")
-            lines.append("")
-            lines.append("| Op | Module | Failed / Total | Failing Tests |")
-            lines.append("|:---|:-------|:--------------:|:--------------|")
-            for op, d in sorted(failed_ops.items()):
-                total = d["passed"] + d["failed"] + d["skipped"]
-                tests_str = ", ".join(d["failing_tests"][:3])
-                if len(d["failing_tests"]) > 3:
-                    tests_str += f", ... (+{len(d['failing_tests']) - 3})"
-                lines.append(f"| **{op}** | `{d['module'] or 'N/A'}` "
-                             f"| {d['failed']}/{total} | {tests_str} |")
-            lines.append("")
+    failed_ops = {op: d for op, d in (test_ops or {}).items() if d["failed"] > 0}
+    if failed_ops:
+        lines.append(f"## {_FAIL} Test Failures")
+        lines.append("")
+        lines.append("| Op | Module | Failed / Total | Failing Tests |")
+        lines.append("|:---|:-------|:--------------:|:--------------|")
+        for op, d in sorted(failed_ops.items()):
+            total = d["passed"] + d["failed"] + d["skipped"]
+            tests_str = ", ".join(d["failing_tests"][:3])
+            if len(d["failing_tests"]) > 3:
+                tests_str += f", ... (+{len(d['failing_tests']) - 3})"
+            lines.append(f"| **{op}** | `{d['module'] or 'N/A'}` "
+                         f"| {d['failed']}/{total} | {tests_str} |")
+        lines.append("")
 
     # ── Benchmark Failures (only if any) ─────────────────────────────────
     if bench_failures:
@@ -788,7 +777,7 @@ def generate_report(
 
     # ── Coverage ──────────────────────────────────────────────────────────
     if coverage:
-        lines.extend(_coverage_section(coverage))
+        lines.extend(_coverage_section(sig))
 
     return "\n".join(lines)
 
@@ -840,9 +829,9 @@ def _coverage_signals(files: list[dict]) -> dict:
     }
 
 
-def _coverage_section(files: list[dict], worst_n: int = 15) -> list[str]:
+def _coverage_section(signals: dict, worst_n: int = COVERAGE_WORST_N) -> list[str]:
     """Three explicit signals, each with what it means and what to do about it."""
-    s = _coverage_signals(files)
+    s = signals
     lines = ["## Coverage", ""]
     lines.append("| Signal | Value | What it means | What a bad number costs |")
     lines.append("| --- | --- | --- | --- |")

--- a/src/tileops/perf/formulas.py
+++ b/src/tileops/perf/formulas.py
@@ -200,7 +200,10 @@ def _dtype_itemsize(dtype: Any) -> int:
 
 
 def _causal_prefill_visible_scores(seq_len_q: int, seq_len_kv: int) -> int:
-    return seq_len_q * seq_len_kv - seq_len_q * (seq_len_q - 1) // 2
+    # Bottom-right alignment: when the query run is longer than the key run, its
+    # leading queries see no keys at all, so only the last seq_len_kv rows count.
+    rows = min(seq_len_q, seq_len_kv)
+    return rows * seq_len_kv - rows * (rows - 1) // 2
 
 
 def gated_deltanet_prefill_fwd_roofline(op: Any | None = None, **kwargs: Any) -> tuple[int, int]:

--- a/tests/perf/test_gqa_varlen_sliding_window_roofline.py
+++ b/tests/perf/test_gqa_varlen_sliding_window_roofline.py
@@ -11,8 +11,6 @@ attention mask, rather than recomputed from the production bounds arithmetic.
 
 from __future__ import annotations
 
-from types import SimpleNamespace
-
 import pytest
 import torch
 
@@ -143,15 +141,6 @@ def test_varlen_fills_requests_to_max_len_when_lengths_absent() -> None:
 
     # Fill is [4, 4, 1, 1], not an even [3, 3, 2, 2]: 10 + 10 + 1 + 1 = 22.
     assert flops == _varlen_flops(22)
-
-
-def test_varlen_unwraps_roofline_kwargs_from_op() -> None:
-    """A bound Op carries its payload under ``_roofline_kwargs``."""
-    op = SimpleNamespace(_roofline_kwargs=_varlen_kwargs())
-
-    flops, _ = gqa_prefill_varlen_fwd_roofline(op)
-
-    assert flops == _varlen_flops(4 * 36)
 
 
 def test_sliding_window_caps_attended_scores_at_window() -> None:

--- a/tests/perf/test_gqa_varlen_sliding_window_roofline.py
+++ b/tests/perf/test_gqa_varlen_sliding_window_roofline.py
@@ -1,0 +1,250 @@
+"""Visible-score accounting for the packed-varlen and sliding-window GQA rooflines.
+
+These three formulas are only reachable through ``Op.eval_roofline()``, which
+requires a prior ``forward()`` on CUDA. The tests here call them with the same
+keyword payload ``_record_roofline`` builds, so the score-counting loops are
+checked without a device.
+
+Expected score totals are written as literals, counted by hand from the
+attention mask, rather than recomputed from the production bounds arithmetic.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from tileops.manifest import load_workloads
+from tileops.perf.formulas import (
+    gqa_prefill_varlen_fwd_roofline,
+    gqa_sliding_window_fwd_roofline,
+    gqa_sliding_window_varlen_fwd_roofline,
+)
+
+pytestmark = pytest.mark.smoke
+
+BATCH, SEQ, HEADS, HEADS_KV, DIM = 4, 8, 32, 8, 128
+ELEM_BYTES = 2
+
+
+def _varlen_kwargs(**overrides: object) -> dict:
+    """Payload shaped like ``GroupedQueryAttentionPrefillVarlenFwdOp.eval_roofline``."""
+    kwargs = {
+        "q_shape": (BATCH * SEQ, HEADS, DIM),
+        "k_shape": (BATCH * SEQ, HEADS_KV, DIM),
+        "batch": BATCH,
+        "max_seqlen_q": SEQ,
+        "max_seqlen_kv": SEQ,
+        "q_lens": [SEQ] * BATCH,
+        "kv_lens": [SEQ] * BATCH,
+        "is_causal": True,
+        "dtype": torch.float16,
+    }
+    kwargs.update(overrides)
+    return kwargs
+
+
+def _varlen_flops(visible: int) -> int:
+    return 4 * HEADS * visible * DIM
+
+
+def test_varlen_causal_counts_lower_triangle_per_request() -> None:
+    """Four square requests of length 8 see 36 scores each."""
+    flops, _ = gqa_prefill_varlen_fwd_roofline(**_varlen_kwargs())
+
+    assert flops == _varlen_flops(4 * 36)
+
+
+def test_varlen_non_causal_counts_full_product() -> None:
+    """Without a causal mask every query sees every key."""
+    flops, _ = gqa_prefill_varlen_fwd_roofline(**_varlen_kwargs(is_causal=False))
+
+    assert flops == _varlen_flops(4 * 8 * 8)
+
+
+@pytest.mark.parametrize(
+    ("q_lens", "kv_lens", "visible"),
+    [
+        # Short query run against a longer key run: bottom-right aligned, so
+        # query i sees keys 0..i+4 — 5 + 6 = 11 scores.
+        ([2], [6], 11),
+        # Long query run against a short key run: the first four queries see
+        # nothing, the last two see 1 and 2 keys — 3 scores.
+        ([6], [2], 3),
+        # Mixed batch: 1 + 11 + 3 = 15.
+        ([1, 2, 6], [1, 6, 2], 15),
+    ],
+)
+def test_varlen_causal_handles_asymmetric_request_lengths(
+    q_lens: list[int], kv_lens: list[int], visible: int
+) -> None:
+    """Queries past the end of the key run contribute no scores, never negative ones."""
+    payload = _varlen_kwargs(
+        q_shape=(sum(q_lens), HEADS, DIM),
+        k_shape=(sum(kv_lens), HEADS_KV, DIM),
+        batch=len(q_lens),
+        max_seqlen_q=max(q_lens),
+        max_seqlen_kv=max(kv_lens),
+        q_lens=q_lens,
+        kv_lens=kv_lens,
+    )
+
+    flops, _ = gqa_prefill_varlen_fwd_roofline(**payload)
+
+    assert flops == _varlen_flops(visible)
+
+
+def test_varlen_bytes_count_q_kv_and_cu_seqlens() -> None:
+    """Byte traffic is Q + 2*KV + O plus the two cu_seqlens vectors."""
+    _, nbytes = gqa_prefill_varlen_fwd_roofline(**_varlen_kwargs())
+
+    q_elems = BATCH * SEQ * HEADS * DIM
+    kv_elems = BATCH * SEQ * HEADS_KV * DIM
+    expected = (2 * q_elems + 2 * kv_elems) * ELEM_BYTES + 2 * (BATCH + 1) * 4
+    assert nbytes == expected
+
+
+def test_varlen_derives_lengths_from_cu_seqlens() -> None:
+    """``cu_seqlens_*`` tensors are differenced into per-request lengths."""
+    cu = torch.tensor([0, 1, 3, 9], dtype=torch.int32)
+    payload = _varlen_kwargs(
+        q_shape=(9, HEADS, DIM),
+        k_shape=(9, HEADS_KV, DIM),
+        batch=3,
+        max_seqlen_q=6,
+        max_seqlen_kv=6,
+        cu_seqlens_q=cu,
+        cu_seqlens_kv=cu,
+    )
+    payload.pop("q_lens")
+    payload.pop("kv_lens")
+
+    flops, _ = gqa_prefill_varlen_fwd_roofline(**payload)
+
+    # Lengths [1, 2, 6] against themselves: 1 + 3 + 21 = 25.
+    assert flops == _varlen_flops(25)
+
+
+def test_varlen_fills_requests_to_max_len_when_lengths_absent() -> None:
+    """Without lengths, ``_distribute_total`` fills early requests to max_seqlen."""
+    payload = _varlen_kwargs(
+        q_shape=(10, HEADS, DIM),
+        k_shape=(10, HEADS_KV, DIM),
+        batch=4,
+        max_seqlen_q=4,
+        max_seqlen_kv=4,
+    )
+    payload.pop("q_lens")
+    payload.pop("kv_lens")
+
+    flops, _ = gqa_prefill_varlen_fwd_roofline(**payload)
+
+    # Fill is [4, 4, 1, 1], not an even [3, 3, 2, 2]: 10 + 10 + 1 + 1 = 22.
+    assert flops == _varlen_flops(22)
+
+
+def test_varlen_unwraps_roofline_kwargs_from_op() -> None:
+    """A bound Op carries its payload under ``_roofline_kwargs``."""
+    op = SimpleNamespace(_roofline_kwargs=_varlen_kwargs())
+
+    flops, _ = gqa_prefill_varlen_fwd_roofline(op)
+
+    assert flops == _varlen_flops(4 * 36)
+
+
+def test_sliding_window_caps_attended_scores_at_window() -> None:
+    """Causal rows over S=8 with a left window of 3 are [1,2,3,4,4,4,4,4] — 26 scores."""
+    flops, nbytes = gqa_sliding_window_fwd_roofline(
+        q_shape=(BATCH, SEQ, HEADS, DIM),
+        kv_shape=(BATCH, SEQ, HEADS_KV, DIM),
+        is_causal=True,
+        window_size_left=3,
+        dtypes=["float16"],
+    )
+
+    assert flops == 4 * BATCH * HEADS * 26 * DIM
+    assert nbytes == 2 * BATCH * SEQ * (HEADS + HEADS_KV) * DIM * ELEM_BYTES
+
+
+def test_sliding_window_unbounded_left_counts_lower_triangle() -> None:
+    """``window_size_left=-1`` degrades to plain causal: 36 scores over S=8."""
+    flops, _ = gqa_sliding_window_fwd_roofline(
+        q_shape=(BATCH, SEQ, HEADS, DIM),
+        kv_shape=(BATCH, SEQ, HEADS_KV, DIM),
+        is_causal=True,
+        window_size_left=-1,
+        dtypes=["float16"],
+    )
+
+    assert flops == 4 * BATCH * HEADS * 36 * DIM
+
+
+def test_sliding_window_non_causal_uses_right_window() -> None:
+    """Bidirectional rows with windows (2, 1) are [2,3,4,4,4,4,4,3] — 28 scores."""
+    flops, _ = gqa_sliding_window_fwd_roofline(
+        q_shape=(BATCH, SEQ, HEADS, DIM),
+        kv_shape=(BATCH, SEQ, HEADS_KV, DIM),
+        is_causal=False,
+        window_size_left=2,
+        window_size_right=1,
+        dtypes=["float16"],
+    )
+
+    assert flops == 4 * BATCH * HEADS * 28 * DIM
+
+
+def test_sliding_window_varlen_offsets_short_queries_to_sequence_end() -> None:
+    """A 2-query, 6-key request aligns bottom-right: rows [4, 4] — 8 scores."""
+    flops, _ = gqa_sliding_window_varlen_fwd_roofline(
+        batch=1,
+        heads=HEADS,
+        heads_kv=HEADS_KV,
+        dim=DIM,
+        q_lens=[2],
+        k_lens=[6],
+        is_causal=True,
+        window_size_left=3,
+        dtypes=["float16"],
+    )
+
+    assert flops == 4 * HEADS * 8 * DIM
+
+
+def test_sliding_window_varlen_windows_each_request_separately() -> None:
+    """Per-request windows do not leak across the packed batch: 26 + 8 = 34 scores."""
+    flops, _ = gqa_sliding_window_varlen_fwd_roofline(
+        batch=2,
+        heads=HEADS,
+        heads_kv=HEADS_KV,
+        dim=DIM,
+        q_lens=[8, 2],
+        k_lens=[8, 6],
+        is_causal=True,
+        window_size_left=3,
+        dtypes=["float16"],
+    )
+
+    assert flops == 4 * HEADS * 34 * DIM
+
+
+@pytest.mark.parametrize(
+    "op_name",
+    [
+        "GroupedQueryAttentionSlidingWindowFwdOp",
+        "GroupedQueryAttentionSlidingWindowVarlenFwdOp",
+    ],
+)
+def test_sliding_window_manifest_workloads_are_evaluable(op_name: str) -> None:
+    """Every declared workload binds to its formula without a missing key."""
+    formula = (
+        gqa_sliding_window_fwd_roofline
+        if op_name.endswith("SlidingWindowFwdOp")
+        else gqa_sliding_window_varlen_fwd_roofline
+    )
+
+    for workload in load_workloads(op_name):
+        flops, nbytes = formula(**workload)
+        assert flops > 0, workload["label"]
+        assert nbytes > 0, workload["label"]


### PR DESCRIPTION
## Problems

- No TileOPs run produces coverage data, so untested code can only be found by reading.
- `gqa_prefill_varlen_fwd_roofline`, `gqa_sliding_window_fwd_roofline` and `gqa_sliding_window_varlen_fwd_roofline` sat at 2.9% / 5.6% / 3.1%: their only caller is `Op.eval_roofline()` after a CUDA `forward()`.
- `_causal_prefill_visible_scores` returns a negative score count when a request has more queries than keys.
- `parse_bench_xml` matches `<failure>` but not `<error>`, so a benchmark that dies in setup is recorded as passed.
- History stores only `latency_ms` and `tflops` for tag-prefixed baselines, while verdicts prefer `device_busy_ms`.
- Regression detection runs before pruning, so a verdict labelled "vs 14-day best" can be drawn against an older run.
- `flash-linear-attention`, `vllm` and `cupti-python` were pinned in three files each; the `[bench]` extra was two releases stale.

## Changes

- Nightly writes an HTML coverage report into its existing `tileops_op_test` artifact.
- The step summary carries three signals — never-built kernels, untested `perf/` lines, `ops/` branch coverage — each with the file to open first and its change against the previous run, recorded in `perf_history.json`.
- 13 CPU-only tests for the three formulas; expected score totals are literals counted from the attention mask.
- `_causal_prefill_visible_scores` counts only rows that see a key, verified against a brute-force mask count over all `q, kv` in 1..24. No manifest workload has `q_len > kv_len`.
- `parse_bench_xml` checks `<error>`; extra baselines keep `device_busy_ms`; history is pruned at load.
- `nightly_report.py`: `_PERF_KEYS` replaces the twice-written key tuple, `detect_regressions`/`detect_improvements` share one generator, a `NOISE_FLOOR` clause that could never bind is gone. Output byte-identical over ten input permutations.
- Versions live in `constraints.txt` alone; `requirements.in` and the Dockerfile name the packages. Lock regenerated in place — two new lines, no unrelated drift.

Line coverage, measured in `ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-afcebed1-dev`:

| function | before | after |
| --- | --- | --- |
| `gqa_prefill_varlen_fwd_roofline` | 2.9% | 100% |
| `gqa_sliding_window_varlen_fwd_roofline` | 3.1% | 100% |
| `gqa_sliding_window_fwd_roofline` | 5.6% | 94.4% |
| `_distribute_total` | 11.1% | 100% |

New test file only, so no test node delta report.
