### PR TITLE
[Refactor][MoE] Collapse the expert-parallel op pairs onto an optional expert_map

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -30,6 +30,8 @@
 
 - Filenames: all-lowercase with underscores. Multi-letter abbreviations stay lowercase (`rms_norm.py`, `ssd_decode.py`); never capitalize a single letter. Never contract norm names (`rms_norm`, not `rmsnorm`).
 
+- An `optional: true` input defaults to `None` in `forward`, and presence is read from the call, not settled at construction. Where the presence changes what the kernel build produces, it goes in that kernel's cache key.
+
 - Docstrings: Google style. One-line summary, blank line, then optional `Args:` / `Returns:` / `Raises:` / `Example:`. Internal helpers may use a single-line summary. Never mix Sphinx (`:param:`) or NumPy headers in one file.
 
 - Expand domain abbreviations on first use in a docstring: `State Space Model (SSM)`, `State-Space Dual (SSD)`. Later uses may abbreviate.

--- a/.claude/skills/add-manifest/SKILL.md
+++ b/.claude/skills/add-manifest/SKILL.md
@@ -95,7 +95,7 @@ Lookup is **class-based**, not filename-based — many TileOPs ops share a file 
 
 Names match the reference verbatim. Include every reference param even if the kernel ignores it. Exclude `float64` and `complex32/64/128` (TileOPs is GPU-only).
 
-For references with `Optional[Tensor]` inputs, the caller has decided which slice corresponds to `op_name` (primary = required only; variant = primary + chosen optional). The skill emits inputs accordingly.
+A reference input the op may be called without is emitted with `optional: true` (R18) on the single entry, after the required inputs.
 
 ### 5. DRAFT_ENTRY
 

--- a/benchmarks/ops/bench_fused_moe_experts.py
+++ b/benchmarks/ops/bench_fused_moe_experts.py
@@ -56,11 +56,13 @@ except ImportError:
 from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark
 from tileops.manifest import load_workloads
 from tileops.ops.moe import (
+    FusedMoEExpertsNopadPersistent3WGEpFwdOp,
     FusedMoEExpertsNopadPersistent3WGFwdOp,
 )
 from workloads.moe import MoeExpertsWorkload
 
 _OP_NAME = "FusedMoEExpertsNopadPersistent3WGFwdOp"  # manifest entry name
+_OP_NAME_EP = "FusedMoEExpertsNopadPersistent3WGEpFwdOp"
 
 
 # Workload
@@ -173,3 +175,71 @@ def test_moe_experts_nopad_bench(
         functors["torch-ref"] = _torch_fn
 
     bm.compare(functors, hidden, w1, w2, topk_weights, topk_ids, record_as=nopad, params=locals())
+
+
+def _manifest_params_ep():
+    params = []
+    for w in load_workloads(_OP_NAME_EP):
+        label = w.get("label", "unlabeled")
+        for dtype_str in w["dtypes"]:
+            dtype = getattr(torch, dtype_str)
+            params.append(pytest.param(
+                w["num_tokens"], w["num_experts"], w["num_experts_local"],
+                w["top_k"], w["hidden_size"], w["ffn_size"], dtype,
+                id=f"{label}-{dtype_str}",
+            ))
+    return params
+
+
+@pytest.mark.parametrize(
+    "num_tokens, num_experts, num_experts_local, top_k, hidden_size, ffn_size, dtype",
+    _manifest_params_ep(),
+)
+def test_moe_experts_nopad_ep_bench(
+    num_tokens: int, num_experts: int, num_experts_local: int, top_k: int,
+    hidden_size: int, ffn_size: int, dtype: torch.dtype,
+) -> None:
+    """The same pipeline over the expert slice one rank owns.
+
+    Routing still draws from all ``num_experts`` global ids; the weights and the
+    grouped GEMMs are sized by ``num_experts_local``. No vLLM column: its
+    ``fused_experts`` takes the full weight table, so the two would not measure
+    the same work.
+    """
+    # The workload draws routing ids over the global expert table; the weights it
+    # generates are the global set, so the local slice is taken below.
+    test = MoeExpertsWorkload(
+        num_tokens, num_experts, top_k, hidden_size, ffn_size, dtype)
+    hidden, w1, w2, topk_weights, topk_ids = test.gen_inputs()
+    w1, w2 = w1[:num_experts_local].contiguous(), w2[:num_experts_local].contiguous()
+
+    expert_map = torch.full((num_experts,), -1, dtype=torch.int32, device=hidden.device)
+    expert_map[:num_experts_local] = torch.arange(
+        num_experts_local, dtype=torch.int32, device=hidden.device)
+
+    output = torch.empty(num_tokens, hidden_size, dtype=dtype, device="cuda")
+    ws1 = torch.empty(0, dtype=dtype, device="cuda")
+    ws2 = torch.empty(0, dtype=dtype, device="cuda")
+
+    ep = FusedMoEExpertsNopadPersistent3WGEpFwdOp(
+        num_tokens=num_tokens, num_experts=num_experts,
+        num_experts_local=num_experts_local, top_k=top_k,
+        hidden_size=hidden_size, ffn_size=ffn_size,
+    )
+    bm = ManifestBenchmark(_OP_NAME_EP, ep, test)
+
+    def _ep_fn(hidden, w1, w2, topk_weights, topk_ids):
+        ep.forward(
+            output, hidden, w1, w2, topk_weights, topk_ids,
+            expert_map=expert_map, workspace1=ws1, workspace2=ws2,
+            num_experts=num_experts,
+        )
+        return output
+
+    _ep_fn(hidden, w1, w2, topk_weights, topk_ids)  # warmup / JIT compile
+    torch.cuda.synchronize()
+
+    bm.compare(
+        {"tileops-nopad-3wg-ep": _ep_fn}, hidden, w1, w2, topk_weights, topk_ids,
+        record_as=ep, params=locals(),
+    )

--- a/benchmarks/ops/bench_fused_moe_experts.py
+++ b/benchmarks/ops/bench_fused_moe_experts.py
@@ -55,14 +55,10 @@ except ImportError:
 
 from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark
 from tileops.manifest import load_workloads
-from tileops.ops.moe import (
-    FusedMoEExpertsNopadPersistent3WGEpFwdOp,
-    FusedMoEExpertsNopadPersistent3WGFwdOp,
-)
+from tileops.ops.moe import FusedMoEExpertsNopadPersistent3WGFwdOp
 from workloads.moe import MoeExpertsWorkload
 
 _OP_NAME = "FusedMoEExpertsNopadPersistent3WGFwdOp"  # manifest entry name
-_OP_NAME_EP = "FusedMoEExpertsNopadPersistent3WGEpFwdOp"
 
 
 # Workload
@@ -81,8 +77,8 @@ def _manifest_params():
         for dtype_str in w["dtypes"]:
             dtype = getattr(torch, dtype_str)
             params.append(pytest.param(
-                w["num_tokens"], w["num_experts"], w["top_k"],
-                w["hidden_size"], w["ffn_size"], dtype,
+                w["num_tokens"], w["num_experts"], w["num_experts_local"],
+                w["top_k"], w["hidden_size"], w["ffn_size"], dtype,
                 id=f"{label}-{dtype_str}",
             ))
     return params
@@ -92,32 +88,43 @@ def _manifest_params():
 
 
 @pytest.mark.parametrize(
-    "num_tokens, num_experts, top_k, hidden_size, ffn_size, dtype",
+    "num_tokens, num_experts, num_experts_local, top_k, hidden_size, ffn_size, dtype",
     _manifest_params(),
 )
 def test_moe_experts_nopad_bench(
-    num_tokens: int, num_experts: int, top_k: int, hidden_size: int,
-    ffn_size: int, dtype: torch.dtype,
+    num_tokens: int, num_experts: int, num_experts_local: int, top_k: int,
+    hidden_size: int, ffn_size: int, dtype: torch.dtype,
 ) -> None:
+    # Routing always draws from the global expert table. Under expert parallelism
+    # the weights are this rank's slice of it and expert_map names that slice.
     test = MoeExpertsWorkload(num_tokens, num_experts, top_k, hidden_size, ffn_size, dtype)
     hidden, w1, w2, topk_weights, topk_ids = test.gen_inputs()
 
-    kwargs = dict(
-        num_tokens=num_tokens, num_experts=num_experts, top_k=top_k,
-        hidden_size=hidden_size, ffn_size=ffn_size,
-    )
+    expert_map = None
+    if num_experts_local < num_experts:
+        w1, w2 = w1[:num_experts_local].contiguous(), w2[:num_experts_local].contiguous()
+        expert_map = torch.full(
+            (num_experts,), -1, dtype=torch.int32, device=hidden.device)
+        expert_map[:num_experts_local] = torch.arange(
+            num_experts_local, dtype=torch.int32, device=hidden.device)
+
     output = torch.empty(num_tokens, hidden_size, dtype=dtype, device="cuda")
     ws1 = torch.empty(0, dtype=dtype, device="cuda")
     ws2 = torch.empty(0, dtype=dtype, device="cuda")
 
     # -- TileOPs nopad (3WG persistent) --------------------------------------
-    nopad = FusedMoEExpertsNopadPersistent3WGFwdOp(**kwargs)
+    nopad = FusedMoEExpertsNopadPersistent3WGFwdOp(
+        num_tokens=num_tokens, num_experts=num_experts,
+        num_experts_local=num_experts_local, top_k=top_k,
+        hidden_size=hidden_size, ffn_size=ffn_size,
+    )
     bm = ManifestBenchmark(_OP_NAME, nopad, test)
 
     def _nopad_fn(hidden, w1, w2, topk_weights, topk_ids):
         nopad.forward(
             output, hidden, w1, w2, topk_weights, topk_ids,
-            expert_map=None, workspace1=ws1, workspace2=ws2, num_experts=num_experts,
+            expert_map=expert_map, workspace1=ws1, workspace2=ws2,
+            num_experts=num_experts,
         )
         return output
 
@@ -125,6 +132,15 @@ def test_moe_experts_nopad_bench(
     torch.cuda.synchronize()
 
     functors = {"tileops-nopad-3wg": _nopad_fn}
+
+    if expert_map is not None:
+        # No vLLM column: its fused_experts takes the full weight table, so the
+        # two would not measure the same work.
+        bm.compare(
+            functors, hidden, w1, w2, topk_weights, topk_ids,
+            record_as=nopad, params=locals(),
+        )
+        return
 
     # -- vLLM Triton baseline -------------------------------------------------
     if _VLLM_TRITON_AVAILABLE:
@@ -175,71 +191,3 @@ def test_moe_experts_nopad_bench(
         functors["torch-ref"] = _torch_fn
 
     bm.compare(functors, hidden, w1, w2, topk_weights, topk_ids, record_as=nopad, params=locals())
-
-
-def _manifest_params_ep():
-    params = []
-    for w in load_workloads(_OP_NAME_EP):
-        label = w.get("label", "unlabeled")
-        for dtype_str in w["dtypes"]:
-            dtype = getattr(torch, dtype_str)
-            params.append(pytest.param(
-                w["num_tokens"], w["num_experts"], w["num_experts_local"],
-                w["top_k"], w["hidden_size"], w["ffn_size"], dtype,
-                id=f"{label}-{dtype_str}",
-            ))
-    return params
-
-
-@pytest.mark.parametrize(
-    "num_tokens, num_experts, num_experts_local, top_k, hidden_size, ffn_size, dtype",
-    _manifest_params_ep(),
-)
-def test_moe_experts_nopad_ep_bench(
-    num_tokens: int, num_experts: int, num_experts_local: int, top_k: int,
-    hidden_size: int, ffn_size: int, dtype: torch.dtype,
-) -> None:
-    """The same pipeline over the expert slice one rank owns.
-
-    Routing still draws from all ``num_experts`` global ids; the weights and the
-    grouped GEMMs are sized by ``num_experts_local``. No vLLM column: its
-    ``fused_experts`` takes the full weight table, so the two would not measure
-    the same work.
-    """
-    # The workload draws routing ids over the global expert table; the weights it
-    # generates are the global set, so the local slice is taken below.
-    test = MoeExpertsWorkload(
-        num_tokens, num_experts, top_k, hidden_size, ffn_size, dtype)
-    hidden, w1, w2, topk_weights, topk_ids = test.gen_inputs()
-    w1, w2 = w1[:num_experts_local].contiguous(), w2[:num_experts_local].contiguous()
-
-    expert_map = torch.full((num_experts,), -1, dtype=torch.int32, device=hidden.device)
-    expert_map[:num_experts_local] = torch.arange(
-        num_experts_local, dtype=torch.int32, device=hidden.device)
-
-    output = torch.empty(num_tokens, hidden_size, dtype=dtype, device="cuda")
-    ws1 = torch.empty(0, dtype=dtype, device="cuda")
-    ws2 = torch.empty(0, dtype=dtype, device="cuda")
-
-    ep = FusedMoEExpertsNopadPersistent3WGEpFwdOp(
-        num_tokens=num_tokens, num_experts=num_experts,
-        num_experts_local=num_experts_local, top_k=top_k,
-        hidden_size=hidden_size, ffn_size=ffn_size,
-    )
-    bm = ManifestBenchmark(_OP_NAME_EP, ep, test)
-
-    def _ep_fn(hidden, w1, w2, topk_weights, topk_ids):
-        ep.forward(
-            output, hidden, w1, w2, topk_weights, topk_ids,
-            expert_map=expert_map, workspace1=ws1, workspace2=ws2,
-            num_experts=num_experts,
-        )
-        return output
-
-    _ep_fn(hidden, w1, w2, topk_weights, topk_ids)  # warmup / JIT compile
-    torch.cuda.synchronize()
-
-    bm.compare(
-        {"tileops-nopad-3wg-ep": _ep_fn}, hidden, w1, w2, topk_weights, topk_ids,
-        record_as=ep, params=locals(),
-    )

--- a/benchmarks/ops/bench_moe_permute_nopad.py
+++ b/benchmarks/ops/bench_moe_permute_nopad.py
@@ -23,11 +23,10 @@ except ImportError:
 
 from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark
 from tileops.manifest import load_workloads
-from tileops.ops.moe import MoePermuteNopadEpFwdOp, MoePermuteNopadFwdOp
+from tileops.ops.moe import MoePermuteNopadFwdOp
 from workloads.moe import MoePermuteWorkload
 
 _OP_NAME = "MoePermuteNopadFwdOp"
-_OP_NAME_EP = "MoePermuteNopadEpFwdOp"
 
 # Benchmark class
 
@@ -45,7 +44,8 @@ def _manifest_params():
         assert topk_tokens == total_tokens
         for dtype_str in w["dtypes"]:
             params.append(pytest.param(
-                total_tokens, top_k, w["num_experts"], hidden_size,
+                total_tokens, top_k, w["num_experts"], w["num_experts_local"],
+                hidden_size,
                 id=f"{label}-{dtype_str}",
             ))
     return params
@@ -55,24 +55,44 @@ def _manifest_params():
 
 
 @pytest.mark.parametrize(
-    "total_tokens, top_k, num_experts, hidden_size",
+    "total_tokens, top_k, num_experts, num_experts_local, hidden_size",
     _manifest_params(),
 )
 def test_moe_permute_nopad_bench(
-    total_tokens: int, top_k: int, num_experts: int, hidden_size: int
+    total_tokens: int, top_k: int, num_experts: int, num_experts_local: int,
+    hidden_size: int,
 ) -> None:
     dtype = torch.bfloat16
     workload = MoePermuteWorkload(total_tokens, top_k, num_experts, hidden_size, dtype)
     torch.manual_seed(42)
     hidden_states, topk_ids = workload.gen_inputs()
 
+    # Under expert parallelism this rank owns the first num_experts_local ids;
+    # the rest belong elsewhere.
+    expert_map = None
+    if num_experts_local < num_experts:
+        expert_map = torch.full(
+            (num_experts,), -1, dtype=torch.int32, device=hidden_states.device)
+        expert_map[:num_experts_local] = torch.arange(
+            num_experts_local, dtype=torch.int32, device=hidden_states.device)
+
     # TileOPs
-    op = MoePermuteNopadFwdOp(num_experts=num_experts)
+    op = MoePermuteNopadFwdOp(
+        num_experts=num_experts, num_experts_local=num_experts_local)
     bm = ManifestBenchmark(_OP_NAME, op, workload)
-    op(hidden_states, topk_ids)  # warmup / JIT compile
+    op(hidden_states, topk_ids, expert_map)  # warmup / JIT compile
     torch.cuda.synchronize()
 
     functors = {"tileops": op}
+
+    if expert_map is not None:
+        # No vLLM or torch column: their permute takes the whole expert table, so
+        # the two would not measure the same work.
+        bm.compare(
+            functors, hidden_states, topk_ids, expert_map,
+            record_as=op, params=locals(),
+        )
+        return
 
     # vLLM baseline (optional)
     if _VLLM_AVAILABLE:
@@ -117,50 +137,3 @@ def test_moe_permute_nopad_bench(
         functors["torch-ref"] = _torch_fn
 
     bm.compare(functors, hidden_states, topk_ids, record_as=op, params=locals())
-
-
-def _manifest_params_ep():
-    """Convert the expert-parallel manifest workloads to pytest params."""
-    params = []
-    for w in load_workloads(_OP_NAME_EP):
-        label = w.get("label", "unlabeled")
-        total_tokens, hidden_size = w["hidden_states_shape"]
-        topk_tokens, top_k = w["topk_ids_shape"]
-        assert topk_tokens == total_tokens
-        for dtype_str in w["dtypes"]:
-            params.append(pytest.param(
-                total_tokens, top_k, w["num_experts"], w["num_experts_local"],
-                hidden_size,
-                id=f"{label}-{dtype_str}",
-            ))
-    return params
-
-
-@pytest.mark.parametrize(
-    "total_tokens, top_k, num_experts, num_experts_local, hidden_size",
-    _manifest_params_ep(),
-)
-def test_moe_permute_nopad_ep_bench(
-    total_tokens: int, top_k: int, num_experts: int, num_experts_local: int,
-    hidden_size: int,
-) -> None:
-    dtype = torch.bfloat16
-    workload = MoePermuteWorkload(total_tokens, top_k, num_experts, hidden_size, dtype)
-    torch.manual_seed(42)
-    hidden_states, topk_ids = workload.gen_inputs()
-
-    # This rank owns the first num_experts_local ids; the rest belong elsewhere.
-    expert_map = torch.full((num_experts,), -1, dtype=torch.int32, device=hidden_states.device)
-    expert_map[:num_experts_local] = torch.arange(
-        num_experts_local, dtype=torch.int32, device=hidden_states.device)
-
-    op = MoePermuteNopadEpFwdOp(
-        num_experts=num_experts, num_experts_local=num_experts_local)
-    bm = ManifestBenchmark(_OP_NAME_EP, op, workload)
-    op(hidden_states, topk_ids, expert_map)  # warmup / JIT compile
-    torch.cuda.synchronize()
-
-    bm.compare(
-        {"tileops": op}, hidden_states, topk_ids, expert_map,
-        record_as=op, params=locals(),
-    )

--- a/benchmarks/ops/bench_moe_permute_nopad.py
+++ b/benchmarks/ops/bench_moe_permute_nopad.py
@@ -23,10 +23,11 @@ except ImportError:
 
 from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark
 from tileops.manifest import load_workloads
-from tileops.ops.moe import MoePermuteNopadFwdOp
+from tileops.ops.moe import MoePermuteNopadEpFwdOp, MoePermuteNopadFwdOp
 from workloads.moe import MoePermuteWorkload
 
 _OP_NAME = "MoePermuteNopadFwdOp"
+_OP_NAME_EP = "MoePermuteNopadEpFwdOp"
 
 # Benchmark class
 
@@ -116,3 +117,50 @@ def test_moe_permute_nopad_bench(
         functors["torch-ref"] = _torch_fn
 
     bm.compare(functors, hidden_states, topk_ids, record_as=op, params=locals())
+
+
+def _manifest_params_ep():
+    """Convert the expert-parallel manifest workloads to pytest params."""
+    params = []
+    for w in load_workloads(_OP_NAME_EP):
+        label = w.get("label", "unlabeled")
+        total_tokens, hidden_size = w["hidden_states_shape"]
+        topk_tokens, top_k = w["topk_ids_shape"]
+        assert topk_tokens == total_tokens
+        for dtype_str in w["dtypes"]:
+            params.append(pytest.param(
+                total_tokens, top_k, w["num_experts"], w["num_experts_local"],
+                hidden_size,
+                id=f"{label}-{dtype_str}",
+            ))
+    return params
+
+
+@pytest.mark.parametrize(
+    "total_tokens, top_k, num_experts, num_experts_local, hidden_size",
+    _manifest_params_ep(),
+)
+def test_moe_permute_nopad_ep_bench(
+    total_tokens: int, top_k: int, num_experts: int, num_experts_local: int,
+    hidden_size: int,
+) -> None:
+    dtype = torch.bfloat16
+    workload = MoePermuteWorkload(total_tokens, top_k, num_experts, hidden_size, dtype)
+    torch.manual_seed(42)
+    hidden_states, topk_ids = workload.gen_inputs()
+
+    # This rank owns the first num_experts_local ids; the rest belong elsewhere.
+    expert_map = torch.full((num_experts,), -1, dtype=torch.int32, device=hidden_states.device)
+    expert_map[:num_experts_local] = torch.arange(
+        num_experts_local, dtype=torch.int32, device=hidden_states.device)
+
+    op = MoePermuteNopadEpFwdOp(
+        num_experts=num_experts, num_experts_local=num_experts_local)
+    bm = ManifestBenchmark(_OP_NAME_EP, op, workload)
+    op(hidden_states, topk_ids, expert_map)  # warmup / JIT compile
+    torch.cuda.synchronize()
+
+    bm.compare(
+        {"tileops": op}, hidden_states, topk_ids, expert_map,
+        record_as=op, params=locals(),
+    )

--- a/docs/design/manifest.md
+++ b/docs/design/manifest.md
@@ -293,6 +293,7 @@ signature:
 | `shape`       | no       | Dimension names (e.g., `"[M, K]"`). Present = fixed rank.                                                                                |
 | `constraints` | no       | Dimension restrictions (requires `shape`).                                                                                               |
 | `layout`      | no       | Memory format when non-default (R19).                                                                                                    |
+| `optional`    | no       | `true` when the op may be called without this input (R18). Inputs only.                                                                  |
 
 **Param fields:** `type` (string: `int`, `float`, `bool`, `"list[int]"`) + optional `default`.
 A param that omits `default` MUST have no `__init__` default either: a
@@ -315,7 +316,8 @@ Fixed rank, expressible with dimension names?
 #### Optional Inputs
 
 A tensor input the op reads may be optional (R18). One entry then covers passing it and
-omitting it.
+omitting it. Optional inputs are the trailing inputs: `forward` takes each with a `None`
+default in the declared order, and a defaulted parameter cannot precede a required one.
 
 ```yaml
 signature:
@@ -335,6 +337,11 @@ workloads:
 
 Optional inputs that share one switch state that relation in `shape_rules`, as the first
 rule above does. The rules are ordinary conjuncts — no new field, no separate list.
+
+The op branches on whether an argument was supplied — which kernel it builds, which
+buffers it allocates. It does not branch on what the argument contains: that would be a
+device read at dispatch time, and the fact read is not in the signature. A fact that
+selects a kernel is a `params` entry.
 
 **Where the name may appear.** In three places: `X`'s own `dtype` / `shape` declaration; a
 bare presence test `X is None` / `X is not None`; and a use already guarded by `X is None`
@@ -369,10 +376,10 @@ completeness, tracked on its own; which shape range picks which kernel is a bran
 kernel knows, and [testing.md](testing.md) already makes the op author cover it with the
 smallest shape that triggers each branch.
 
-**Roofline counts the call that ran.** Its cost includes the optional inputs the call
-passed and excludes the ones it did not; "everything passed" is not an upper bound to fall
-back on. Inline expressions branch on a presence test taken from `vars`, `func` mode reads
-the call.
+**Roofline describes the call that ran.** A formula whose cost varies with an optional
+input reads that input's presence — inline through a `vars` presence test, or `func` mode,
+which sees the call. "Everything passed" is not an upper bound to fall back on. How much of
+a call's traffic a formula models at all is [roofline.md](roofline.md)'s matter.
 
 **What the validator does not check.** Five things, deliberately:
 

--- a/docs/design/ops-design.md
+++ b/docs/design/ops-design.md
@@ -157,6 +157,8 @@ class ExampleCumsumFwdOp(Op):
 
 **Input.** Manifest `source.kernel_map`; `signature.inputs`; `static_dims` (for the forward-time commitment check); `shape_rules` (for `dim` range validation).
 
+**Optional inputs.** An `optional: true` input takes a `None` default in `forward`, and presence is read from the call rather than settled at construction, so one instance serves both ways of calling the op. A `shape_rules` entry naming it applies to the calls that supply it, and `forward` is what enforces that. Where the presence changes what gets built, it belongs in the kernel cache key alongside the shapes.
+
 **Output.**
 
 ```python

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -1844,8 +1844,73 @@ def _input_bound_symbols(sig: dict) -> set[str]:
     return bound
 
 
+def _optional_inputs(sig: dict) -> set[str]:
+    """Input names declared ``optional: true`` (R18)."""
+    inputs = sig.get("inputs")
+    if not isinstance(inputs, dict):
+        return set()
+    return {
+        name for name, attrs in inputs.items()
+        if isinstance(name, str)
+        and isinstance(attrs, dict)
+        and attrs.get("optional") is True
+    }
+
+
+# Witness values for a required param the workloads do not pin. Positive and
+# type-valid, so a shape sized by the param stays a legal extent.
+_REQUIRED_PARAM_WITNESS: dict[str, object] = {
+    "int": _MOCK_DIM_SIZE,
+    "float": 1.0,
+    "bool": True,
+}
+
+
+def _param_env(sig: dict, workloads: object, absent: Collection[str] = ()) -> dict:
+    """Parameter values every probe of a generated method runs under.
+
+    A param carrying a ``default`` contributes it. A param that omits one is
+    required — the op cannot be constructed without it — so it contributes a
+    deterministic witness instead: the value the first workload pins, else a
+    type-valid positive scalar. Probing without it would leave
+    ``self.<param>`` unset and turn a parameter-sized output into an
+    AttributeError, which says nothing about the manifest.
+
+    *absent* names the optional inputs this probe withholds. Only rows whose
+    presence pattern matches are pinned from, so a probe that supplies an
+    optional input runs under the params of a call that actually supplies it —
+    otherwise every probe would use the first row, and a param that only
+    differs on those rows would never reach the generated method.
+    """
+    params = sig.get("params")
+    if not isinstance(params, dict):
+        return {}
+    env = _param_defaults(params)
+    rows = [w for w in workloads if isinstance(w, dict)] if isinstance(workloads, list) else []
+    optional = _optional_inputs(sig)
+    if optional:
+        matching = [
+            w for w in rows
+            if all((f"{name}_shape" in w) == (name not in absent) for name in optional)
+        ]
+        rows = matching or rows
+    for pname, pattrs in params.items():
+        if not isinstance(pname, str) or not isinstance(pattrs, dict):
+            continue
+        if pname in env:
+            continue
+        pinned = next((w[pname] for w in rows if pname in w), None)
+        if pinned is not None:
+            env[pname] = pinned
+            continue
+        witness = _REQUIRED_PARAM_WITNESS.get(pattrs.get("type"))
+        if witness is not None:
+            env[pname] = witness
+    return env
+
+
 def _mock_input_shapes(
-    sig: dict,
+    sig: dict, param_env: dict | None = None,
 ) -> tuple[dict[str, _MockShape], dict[str, int]] | None:
     """Derive concrete mock input shapes for every declared input.
 
@@ -1856,6 +1921,10 @@ def _mock_input_shapes(
     name to the integer size used in the mock shapes, so callers can bind
     those names into a shape_rules evaluation context. Returns None only
     if ``signature.inputs`` is malformed.
+
+    A dim name that is also a param in *param_env* takes that param's
+    integer value rather than a synthetic size, so the mock inputs and the
+    parameters the probe runs under describe one consistent op.
     """
     inputs = sig.get("inputs")
     if not isinstance(inputs, dict) or not inputs:
@@ -1879,18 +1948,33 @@ def _mock_input_shapes(
     # get distinct sizes (first-seen order) so cross-tensor equality
     # rules do not spuriously pass on colliding mock sizes.
     dim_sizes: dict[str, int] = {}
+    pinned = {
+        name: int(val) for name, val in (param_env or {}).items()
+        if isinstance(val, int) and not isinstance(val, bool) and val > 0
+    }
+    next_synthetic = _MOCK_DIM_SIZE
+
+    def _bind_dim(p: str) -> None:
+        nonlocal next_synthetic
+        if p in dim_sizes:
+            return
+        if p in pinned:
+            dim_sizes[p] = pinned[p]
+            return
+        dim_sizes[p] = next_synthetic
+        next_synthetic += 1
+
     for _tname, parts in rule_literals:
         for p in parts:
-            if _IDENT_RE.fullmatch(p) and p not in dim_sizes:
-                dim_sizes[p] = _MOCK_DIM_SIZE + len(dim_sizes)
+            if _IDENT_RE.fullmatch(p):
+                _bind_dim(p)
 
     # Also bind symbolic dims from input shape declarations, then from
     # declared output shapes, so downstream rule / shape-decl checks
     # resolve them against the same mock sizes.
     for parts in shape_decls.values():
         for p in parts:
-            if p not in dim_sizes:
-                dim_sizes[p] = _MOCK_DIM_SIZE + len(dim_sizes)
+            _bind_dim(p)
     outputs_map = sig.get("outputs") or {}
     if isinstance(outputs_map, dict):
         for attrs in outputs_map.values():
@@ -1900,8 +1984,7 @@ def _mock_input_shapes(
             if out_parts is None:
                 continue
             for p in out_parts:
-                if p not in dim_sizes:
-                    dim_sizes[p] = _MOCK_DIM_SIZE + len(dim_sizes)
+                _bind_dim(p)
 
     for name in inputs:
         if name in ranks:
@@ -2208,7 +2291,6 @@ def check_l2_infer_parity(
     errors: list[str] = []
     if cls is None:
         return errors
-    err = _emit_to(errors, "shape", op_name)
     warn = _emit_to(warnings, "shape", op_name)
 
     sig = entry.get("signature", {})
@@ -2241,20 +2323,72 @@ def check_l2_infer_parity(
     if infer_fn is None:
         return errors
 
-    mock = _mock_input_shapes(sig)
-    if mock is None:
-        return errors
-    mock_shapes, dim_sizes = mock
+    # Presence of an optional input is the declared dispatch fact (R18), so the
+    # probe runs once with every optional input supplied and once with none.
+    optional = _optional_inputs(sig)
+    variants: list[frozenset[str]] = [frozenset()]
+    if optional:
+        variants.append(frozenset(optional))
+    for absent in variants:
+        param_env = _param_env(sig, entry.get("workloads"), absent)
+        mock = _mock_input_shapes(sig, param_env)
+        if mock is None:
+            return errors
+        errors.extend(_probe_infer_parity(
+            op_name, sig, cls, infer_fn, mock, param_env, absent,
+            declared_output_shapes, rules, warnings=warnings,
+        ))
+    return errors
 
-    params = sig.get("params") or {}
-    param_defaults = _param_defaults(params)
+
+def _probe_infer_parity(
+    op_name: str,
+    sig: dict,
+    cls: type,
+    infer_fn,
+    mock: tuple[dict[str, _MockShape], dict[str, int]],
+    param_env: dict,
+    absent: frozenset[str],
+    declared_output_shapes: dict[str, list[str]],
+    rules: list,
+    *,
+    warnings: list[str] | None,
+) -> list[str]:
+    """One parity probe of ``_infer_output_shapes`` over the mock inputs.
+
+    *absent* names the optional inputs this probe withholds; their
+    ``<name>_shape`` argument is passed as ``None`` and every shape rule
+    mentioning one of them is skipped, since such a rule constrains the
+    argument only when it is supplied.
+    """
+    errors: list[str] = []
+    suffix = (
+        f" (probed with {', '.join(sorted(absent))} absent)" if absent else ""
+    )
+
+    def err(msg: str) -> None:
+        errors.append(f"[shape] {op_name}: {msg}{suffix}")
+
+    def warn(msg: str) -> None:
+        if warnings is not None:
+            warnings.append(f"[shape] {op_name}: {msg}{suffix}")
+
+    all_mock_shapes, dim_sizes = mock
+    mock_shapes = {
+        name: shape for name, shape in all_mock_shapes.items()
+        if name not in absent
+    }
 
     # Resolve static_dims against the mock inputs so implementations reading
     # ``self.<dim>`` do not AttributeError and silently skip the check.
-    extra_attrs = _static_dim_values(sig, mock_shapes, param_defaults)
-    mock_self = _build_mock_self(cls, param_defaults, extra_attrs)
+    extra_attrs = _static_dim_values(sig, mock_shapes, param_env)
+    mock_self = _build_mock_self(cls, param_env, extra_attrs)
 
-    shape_kwargs = {f"{name}_shape": tuple(shape) for name, shape in mock_shapes.items()}
+    shape_kwargs: dict[str, object] = {
+        f"{name}_shape": tuple(shape) for name, shape in mock_shapes.items()
+    }
+    for name in absent:
+        shape_kwargs[f"{name}_shape"] = None
     # Bind before calling: only a TypeError from ``bind`` is a signature
     # mismatch. TypeErrors from the body must not be reported as one.
     try:
@@ -2307,7 +2441,7 @@ def check_l2_infer_parity(
     # later in the dict take precedence on any accidental collision.
     ctx: dict = {}
     ctx.update(dim_sizes)
-    ctx.update(param_defaults)
+    ctx.update(param_env)
     for name, shape in mock_shapes.items():
         ctx[name] = _MockShape(shape)
     # Rebind output-only symbols from the inferred ``result`` so their rules
@@ -2357,6 +2491,10 @@ def check_l2_infer_parity(
     for i, rule in enumerate(rules):
         if not isinstance(rule, str):
             continue
+        if any(
+            re.search(rf"\b{re.escape(name)}\b", rule) for name in absent
+        ):
+            continue
         ok, reason = _eval_shape_rule(rule, ctx)
         if reason is not None:
             # Could not evaluate this rule under the mock context; do not
@@ -2398,15 +2536,15 @@ def check_l2_infer_parity(
         name: int(val) for name, val in extra_attrs.items()
         if isinstance(val, int) and not isinstance(val, bool)
     }
-    # An int ``default`` is compile-time known, so it pins a dim with the same
-    # authority as ``static_dims``. No default or non-int → cannot pin.
-    for pname, pdefault in param_defaults.items():
+    # An int param value is compile-time known, so it pins a dim with the same
+    # authority as ``static_dims``. Non-int → cannot pin.
+    for pname, pvalue in param_env.items():
         if pname in static_expected:
             continue  # static_dims wins — it is the declared source of truth.
-        if isinstance(pdefault, bool):
+        if isinstance(pvalue, bool):
             continue
-        if isinstance(pdefault, int):
-            static_expected[pname] = int(pdefault)
+        if isinstance(pvalue, int):
+            static_expected[pname] = int(pvalue)
     output_only_seen: dict[str, int] = {}
     for out_name, decl_parts in declared_output_shapes.items():
         if out_name not in result:
@@ -2614,7 +2752,7 @@ def _make_mock_tensor(dtype_name: str):
 
 def _combo_accepted(
     cls: type, forward_inputs: list[str], combo: dict[str, str],
-    param_defaults: dict, sig: dict | None = None,
+    param_env: dict, sig: dict | None = None,
     self_dtype_name: str | None = None,
 ) -> tuple[bool, str | None]:
     """Invoke ``cls._validate_dtypes`` on a mock-self with *combo*.
@@ -2653,11 +2791,11 @@ def _combo_accepted(
     # (beyond manifest params) do not falsely raise AttributeError.
     extra_attrs: dict = {}
     if sig is not None:
-        mock = _mock_input_shapes(sig)
+        mock = _mock_input_shapes(sig, param_env)
         if mock is not None:
             mock_shapes, _ = mock
             extra_attrs.update(
-                _static_dim_values(sig, mock_shapes, param_defaults)
+                _static_dim_values(sig, mock_shapes, param_env)
             )
         # self.dtype tracks the candidate's primary dtype (first non-same_as
         # input, or ``self_dtype_name``) so a derived _validate_dtypes comparing
@@ -2671,7 +2809,7 @@ def _combo_accepted(
             primary = _primary_dtype_input(sig, forward_inputs)
             if primary is not None and primary in tensors:
                 extra_attrs["dtype"] = tensors[primary].dtype
-    mock_self = _build_mock_self(cls, param_defaults, extra_attrs)
+    mock_self = _build_mock_self(cls, param_env, extra_attrs)
     # Pre-bind the callable signature so only genuine signature mismatches
     # surface as ``TypeError: ...``. TypeError raised from inside the body
     # (e.g. comparing incompatible torch dtypes) is a legitimate rejection
@@ -2746,7 +2884,7 @@ def _probe_out_of_union(
     forward_inputs: list[str],
     baseline: dict[str, str],
     dtype_options: dict[str, list[str]],
-    param_defaults: dict,
+    param_env: dict,
     errors: list[str],
     warnings: list[str] | None,
 ) -> None:
@@ -2794,7 +2932,7 @@ def _probe_out_of_union(
                 if ref == target and tname in candidate:
                     candidate[tname] = bad_dtype
             accepted, reason = _combo_accepted(
-                cls, forward_inputs, candidate, param_defaults,
+                cls, forward_inputs, candidate, param_env,
                 sig=sig, self_dtype_name=baseline_self_dtype,
             )
             if _probe_reason_kind(reason) == "unexpected":
@@ -2858,8 +2996,7 @@ def check_l3_validate_dtypes_parity(
     # demanded one for it could never be satisfied.
     optional_inputs = set(_optional_input_names(sig))
     forward_inputs = [n for n in inputs if n not in optional_inputs]
-    params = sig.get("params") or {}
-    param_defaults = _param_defaults(params)
+    param_env = _param_env(sig, entry.get("workloads"))
 
     dtype_options = _resolve_tensor_dtype_options(sig)
     if dtype_options is None:
@@ -2902,7 +3039,7 @@ def check_l3_validate_dtypes_parity(
             if not isinstance(combo, dict):
                 continue
             accepted, reason = _combo_accepted(
-                cls, forward_inputs, combo, param_defaults, sig=sig,
+                cls, forward_inputs, combo, param_env, sig=sig,
             )
             kind = _probe_reason_kind(reason)
             if kind == "signature":
@@ -2950,7 +3087,7 @@ def check_l3_validate_dtypes_parity(
                         continue
                     accepted, reason = _combo_accepted(
                         cls, forward_inputs + [name],
-                        {**combo, name: dtype_name}, param_defaults, sig=sig,
+                        {**combo, name: dtype_name}, param_env, sig=sig,
                     )
                     if reason is None and not accepted:
                         err(
@@ -2990,7 +3127,7 @@ def check_l3_validate_dtypes_parity(
             candidate = dict(zip(forward_inputs, tup, strict=True))
             checked_any = True
             accepted, reason = _combo_accepted(
-                cls, forward_inputs, candidate, param_defaults, sig=sig,
+                cls, forward_inputs, candidate, param_env, sig=sig,
             )
             kind = _probe_reason_kind(reason)
             if kind in ("introspect", "signature"):
@@ -3023,7 +3160,7 @@ def check_l3_validate_dtypes_parity(
         if baseline_combo is not None:
             _probe_out_of_union(
                 op_name, cls, sig, forward_inputs, baseline_combo,
-                dtype_options, param_defaults, errors, warnings,
+                dtype_options, param_env, errors, warnings,
             )
 
         if not errors:
@@ -3067,7 +3204,7 @@ def check_l3_validate_dtypes_parity(
             if not _honours_same_as(sig, candidate):
                 continue
             accepted, reason = _combo_accepted(
-                cls, forward_inputs, candidate, param_defaults, sig=sig,
+                cls, forward_inputs, candidate, param_env, sig=sig,
             )
             kind = _probe_reason_kind(reason)
             if kind == "signature":
@@ -3111,7 +3248,7 @@ def check_l3_validate_dtypes_parity(
         if baseline is not None:
             _probe_out_of_union(
                 op_name, cls, sig, forward_inputs, baseline,
-                dtype_options, param_defaults, errors, warnings,
+                dtype_options, param_env, errors, warnings,
             )
 
         # same_as identity negative probe (R3 rejection side): each
@@ -3140,7 +3277,7 @@ def check_l3_validate_dtypes_parity(
                     candidate = dict(baseline)
                     candidate[tname] = alt
                     accepted, reason = _combo_accepted(
-                        cls, forward_inputs, candidate, param_defaults, sig=sig,
+                        cls, forward_inputs, candidate, param_env, sig=sig,
                     )
                     kind = _probe_reason_kind(reason)
                     if kind in ("introspect", "signature"):

--- a/src/tileops/kernels/moe/permute_nopad.py
+++ b/src/tileops/kernels/moe/permute_nopad.py
@@ -252,8 +252,14 @@ class MoePermuteNopadKernel(Kernel):
 
     Sorts tokens into tight expert-contiguous order (no inter-expert gaps).
     Output perm_h has exactly M_local rows, where M_local = T*K when
-    expert_map is None (all experts local), or M_local ≤ T*K when expert_map
-    filters out non-local experts.  Non-local positions get fwd_idx = -1.
+    ``num_experts_local`` is None (all experts local), or M_local ≤ T*K when an
+    expert map filters out non-local experts.  Non-local positions get
+    fwd_idx = -1.
+
+    Expert Parallel (EP) splits across the two lifetimes: the number of local
+    experts is compile-time — it sizes the scan kernel and its output buffers —
+    while the global→local map itself is read at launch and is a ``forward``
+    argument.
 
     Args:
         num_tokens: Number of input tokens T.
@@ -261,9 +267,8 @@ class MoePermuteNopadKernel(Kernel):
         num_experts: Total number of experts E (global count).
         hidden_size: Hidden dimension H.
         dtype: Data type of hidden_states.
-        expert_map: Optional [E_global] int32 tensor mapping global expert ids
-            to local ids (-1 = not on this rank).  When provided, only local
-            token-expert pairs are included in the permuted output.
+        num_experts_local: Number of experts owned by this rank under EP.
+            None selects the non-EP scan, which takes no expert map.
         config: Optional config dict with "threads".
         tune: Whether to autotune. The scan thread count is fixed by the
             single-block prefix-sum algorithm, so ``autotune_configs`` is
@@ -284,7 +289,7 @@ class MoePermuteNopadKernel(Kernel):
         num_experts: int,
         hidden_size: int,
         dtype: torch.dtype = torch.bfloat16,
-        expert_map: Optional[torch.Tensor] = None,
+        num_experts_local: Optional[int] = None,
         config: Optional[dict] = None,
         tune: bool = False,
     ):
@@ -295,13 +300,17 @@ class MoePermuteNopadKernel(Kernel):
         self.hidden_size = hidden_size
         self.dtype = dtype
         self.numel = num_tokens * top_k
-        self.expert_map = expert_map
+        self.expert_parallel = num_experts_local is not None
 
-        if expert_map is not None:
-            assert expert_map.dtype == torch.int32
-            self.num_experts_local = int((expert_map >= 0).sum().item())
+        if num_experts_local is not None:
+            if not 0 < num_experts_local <= num_experts:
+                raise ValueError(
+                    f"num_experts_local must be in (0, {num_experts}], "
+                    f"got {num_experts_local}"
+                )
+            self.num_experts_local = num_experts_local
             self._scan_fn = _make_scan_kernel_nopad_ep(
-                self.numel, num_experts, self.num_experts_local, top_k
+                self.numel, num_experts, num_experts_local, top_k
             )
         else:
             self.num_experts_local = num_experts
@@ -321,26 +330,51 @@ class MoePermuteNopadKernel(Kernel):
         self,
         hidden_states: torch.Tensor,
         topk_ids: torch.Tensor,
+        expert_map: Optional[torch.Tensor] = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         """Run moe_permute without padding.
 
         Args:
             hidden_states: [T, H] input activations.
             topk_ids: [T, K] int32 expert assignments (global ids).
+            expert_map: [E_global] int32 global→local expert ids (-1 = not on
+                this rank). Required when the kernel was built with
+                ``num_experts_local``, rejected otherwise.
 
         Returns:
-            perm_h:                    [T*K, H] tight hidden states.  When expert_map
-                                       is set, only rows 0..M_local-1 contain valid
-                                       data; rows M_local..T*K-1 are safe but unused.
+            perm_h:                    [T*K, H] tight hidden states.  Under EP, only
+                                       rows 0..M_local-1 contain valid data; rows
+                                       M_local..T*K-1 are safe but unused.
             true_offsets:              [E_local] int32 tight start per local expert
             true_sizes:                [E_local] int32 true token count per local expert
             expert_first_token_offset: [E_local+1] int64 non-padded exclusive prefix-sum
             fwd_idx:                   [T*K] int32 forward mapping: flat_idx → tight slot
-                                       (-1 for non-local token-expert pairs when expert_map set)
+                                       (-1 for non-local token-expert pairs under EP)
         """
         assert topk_ids.dtype == torch.int32
         assert hidden_states.is_cuda and topk_ids.is_cuda
         assert topk_ids.numel() == self.numel
+        if self.expert_parallel:
+            if expert_map is None:
+                raise ValueError(
+                    "this kernel was built for expert parallelism "
+                    f"(num_experts_local={self.num_experts_local}) and needs an "
+                    "expert_map at every call"
+                )
+            if expert_map.dtype != torch.int32:
+                raise ValueError(
+                    f"Expected expert_map.dtype torch.int32, got {expert_map.dtype}"
+                )
+            if expert_map.shape != (self.num_experts,):
+                raise ValueError(
+                    f"Expected expert_map.shape ({self.num_experts},), "
+                    f"got {tuple(expert_map.shape)}"
+                )
+        elif expert_map is not None:
+            raise ValueError(
+                "this kernel was built without expert parallelism, so it takes "
+                "no expert_map; rebuild it with num_experts_local"
+            )
 
         dev = hidden_states.device
         flat_ids = topk_ids.flatten().contiguous()
@@ -356,9 +390,9 @@ class MoePermuteNopadKernel(Kernel):
 
         threads = self.config["threads"]
         scan_fn = self._scan_fn(threads)
-        if self.expert_map is not None:
+        if self.expert_parallel:
             scan_fn(
-                flat_ids, self.expert_map,
+                flat_ids, expert_map,
                 expert_first_token_offset, true_offsets, true_sizes,
                 permuted_idx, fwd_idx, write_offsets,
             )

--- a/src/tileops/kernels/moe/permute_nopad.py
+++ b/src/tileops/kernels/moe/permute_nopad.py
@@ -159,7 +159,11 @@ def _make_scan_kernel_nopad_ep(
                     if idx < numel:
                         global_eid = flat_ids[idx]
                         local_eid = expert_map[global_eid]
-                        if local_eid >= T.int32(0):
+                        # ``s_counts`` holds num_experts_local entries. The map is a
+                        # device tensor the kernel does not own, so the upper bound is
+                        # checked here too: an id past the end would otherwise write
+                        # past the shared buffer into ``s_offset``.
+                        if local_eid >= T.int32(0) and local_eid < T.int32(num_experts_local):
                             T.atomic_add(s_counts[local_eid], 1)
                 T.sync_threads()
 
@@ -189,15 +193,17 @@ def _make_scan_kernel_nopad_ep(
                     if idx < numel:
                         global_eid = flat_ids[idx]
                         local_eid = expert_map[global_eid]
-                        if local_eid < T.int32(0):
-                            fwd_idx[idx] = T.int32(-1)
-                        else:
+                        # Same bound as step 2, so a pair counted there is the pair
+                        # scattered here.
+                        if local_eid >= T.int32(0) and local_eid < T.int32(num_experts_local):
                             # Keep the returned slot in a local buffer: TileLang may otherwise
                             # duplicate the atomic while lowering bounds checks for the stores.
                             slot_buf[0] = T.atomic_add(write_offsets[local_eid], T.int32(1), return_prev=True)
                             slot = slot_buf[0]
                             permuted_idx[slot] = idx // T.int32(top_k)
                             fwd_idx[idx] = slot
+                        else:
+                            fwd_idx[idx] = T.int32(-1)
 
         return _scan_ep_main
 

--- a/src/tileops/manifest/elementwise_binary.yaml
+++ b/src/tileops/manifest/elementwise_binary.yaml
@@ -55,8 +55,8 @@ MaskedFillFwdOp:
   # mask=torch.zeros((2,3), dtype=torch.bool), value=1.0)`` returns shape
   # ``(2, 3)``). The in-place ``masked_fill_`` is unidirectional, but
   # the manifest models only the out-of-place form. The scalar (Number)
-  # value form lands as MaskedFillScalarFwdOp below per the
-  # "No Optional[Tensor]" manifest rule for variant splits.
+  # value form is its own entry, MaskedFillScalarFwdOp below: a Number is
+  # not a tensor, so it cannot be one entry's optional tensor input.
   family: elementwise
   status: implemented
   torch_compile_fullgraph: true

--- a/src/tileops/manifest/moe.yaml
+++ b/src/tileops/manifest/moe.yaml
@@ -61,6 +61,10 @@ MoePermuteNopadFwdOp:
     inputs:
       hidden_states: {dtype: "float16 | bfloat16"}
       topk_ids: {dtype: "int32"}
+      # Expert parallelism: supplied when this rank owns num_experts_local of the
+      # num_experts global experts, absent when it owns them all. Presence picks
+      # the scan kernel; the ids inside are read only at launch.
+      expert_map: {dtype: "int32", optional: true}
     outputs:
       perm_h: {dtype: "same_as(hidden_states)"}
       true_offsets: {dtype: "int32"}
@@ -69,87 +73,14 @@ MoePermuteNopadFwdOp:
       fwd_idx: {dtype: "int32"}
     params:
       num_experts: {type: int}
-    shape_rules:
-    - "hidden_states.ndim == 2"
-    - "topk_ids.ndim == 2"
-    - "topk_ids.shape[0] == hidden_states.shape[0]"
-    - "perm_h.shape == (hidden_states.shape[0] * topk_ids.shape[1], hidden_states.shape[1])"
-    - "true_offsets.shape == (num_experts,)"
-    - "true_sizes.shape == (num_experts,)"
-    - "expert_first_token_offset.shape == (num_experts + 1,)"
-    - "fwd_idx.shape == (hidden_states.shape[0] * topk_ids.shape[1],)"
-
-  workloads:
-    # Kimi K2: H=7168, E=384, K=8
-  - {hidden_states_shape: [1, 7168], topk_ids_shape: [1, 8], num_experts: 384, dtypes: [bfloat16], label: "kimi-k2-decode"}
-  - {hidden_states_shape: [32, 7168], topk_ids_shape: [32, 8], num_experts: 384, dtypes: [bfloat16], label: "kimi-k2-small"}
-  - {hidden_states_shape: [512, 7168], topk_ids_shape: [512, 8], num_experts: 384, dtypes: [bfloat16], label: "kimi-k2-medium"}
-  - {hidden_states_shape: [4096, 7168], topk_ids_shape: [4096, 8], num_experts: 384, dtypes: [bfloat16], label: "kimi-k2-prefill"}
-    # DeepSeek-V3: H=7168, E=256, K=8
-  - {hidden_states_shape: [1, 7168], topk_ids_shape: [1, 8], num_experts: 256, dtypes: [bfloat16], label: "deepseek-v3-decode"}
-  - {hidden_states_shape: [32, 7168], topk_ids_shape: [32, 8], num_experts: 256, dtypes: [bfloat16], label: "deepseek-v3-small"}
-  - {hidden_states_shape: [512, 7168], topk_ids_shape: [512, 8], num_experts: 256, dtypes: [bfloat16], label: "deepseek-v3-medium"}
-  - {hidden_states_shape: [4096, 7168], topk_ids_shape: [4096, 8], num_experts: 256, dtypes: [bfloat16], label: "deepseek-v3-prefill"}
-    # Qwen3-235B-A22B: H=7168, E=128, K=8
-  - {hidden_states_shape: [1, 7168], topk_ids_shape: [1, 8], num_experts: 128, dtypes: [bfloat16], label: "qwen3-235b-decode"}
-  - {hidden_states_shape: [32, 7168], topk_ids_shape: [32, 8], num_experts: 128, dtypes: [bfloat16], label: "qwen3-235b-small"}
-  - {hidden_states_shape: [512, 7168], topk_ids_shape: [512, 8], num_experts: 128, dtypes: [bfloat16], label: "qwen3-235b-medium"}
-  - {hidden_states_shape: [4096, 7168], topk_ids_shape: [4096, 8], num_experts: 128, dtypes: [bfloat16], label: "qwen3-235b-prefill"}
-    # Qwen3-30B-A3B: H=3072, E=128, K=8
-  - {hidden_states_shape: [1, 3072], topk_ids_shape: [1, 8], num_experts: 128, dtypes: [bfloat16], label: "qwen3-30b-decode"}
-  - {hidden_states_shape: [32, 3072], topk_ids_shape: [32, 8], num_experts: 128, dtypes: [bfloat16], label: "qwen3-30b-small"}
-  - {hidden_states_shape: [512, 3072], topk_ids_shape: [512, 8], num_experts: 128, dtypes: [bfloat16], label: "qwen3-30b-medium"}
-  - {hidden_states_shape: [4096, 3072], topk_ids_shape: [4096, 8], num_experts: 128, dtypes: [bfloat16], label: "qwen3-30b-prefill"}
-
-  roofline:
-    vars:
-      T: "hidden_states_shape[0]"
-      K: "topk_ids_shape[1]"
-      H: "hidden_states_shape[1]"
-    # Permute is memory-bound; flops = 0
-    flops: "0"
-    # hidden_states read [T, H] + perm_h write [T*K, H] + metadata
-    bytes: "(T * H + T * K * H) * elem_bytes + (num_experts + 1) * 8 + 2 * T * K * 4 + num_experts * 8"
-
-  source:
-    kernel: tileops/kernels/moe/permute_nopad.py
-    op: tileops/ops/moe/routed_expert/permute_nopad.py
-    test: tests/ops/test_moe_permute_nopad.py
-    bench: benchmarks/ops/bench_moe_permute_nopad.py
-    bench_manifest_driven: true
-    kernel_map:
-      permute_nopad_kernel: MoePermuteNopadKernel
-
-# Expert-parallel shape of MoePermuteNopadFwdOp: the rank owns num_experts_local
-# of the num_experts global experts. The count is a param because it sizes the
-# four per-expert outputs; the map is an input because its values are read at
-# launch.
-MoePermuteNopadEpFwdOp:
-  ref_api: "none"
-  family: moe
-  status: implemented
-  torch_compile_fullgraph: true
-  variant_of: MoePermuteNopadFwdOp
-
-  signature:
-    inputs:
-      hidden_states: {dtype: "float16 | bfloat16"}
-      topk_ids: {dtype: "int32"}
-      expert_map: {dtype: "int32"}
-    outputs:
-      perm_h: {dtype: "same_as(hidden_states)"}
-      true_offsets: {dtype: "int32"}
-      true_sizes: {dtype: "int32"}
-      expert_first_token_offset: {dtype: "int64"}
-      fwd_idx: {dtype: "int32"}
-    params:
-      num_experts: {type: int}
+      # Sizes the scan kernel's shared counters and its four per-expert outputs,
+      # so it is fixed at construction. Equals num_experts without EP.
       num_experts_local: {type: int}
     shape_rules:
     - "hidden_states.ndim == 2"
     - "topk_ids.ndim == 2"
     - "topk_ids.shape[0] == hidden_states.shape[0]"
-    - "expert_map.shape == (num_experts,)"
+    - "expert_map is None or expert_map.shape == (num_experts,)"
     - "perm_h.shape == (hidden_states.shape[0] * topk_ids.shape[1], hidden_states.shape[1])"
     - "true_offsets.shape == (num_experts_local,)"
     - "true_sizes.shape == (num_experts_local,)"
@@ -157,20 +88,36 @@ MoePermuteNopadEpFwdOp:
     - "fwd_idx.shape == (hidden_states.shape[0] * topk_ids.shape[1],)"
 
   workloads:
+    # Kimi K2: H=7168, E=384, K=8
+  - {hidden_states_shape: [1, 7168], topk_ids_shape: [1, 8], num_experts: 384, num_experts_local: 384, dtypes: [bfloat16], label: "kimi-k2-decode"}
+  - {hidden_states_shape: [32, 7168], topk_ids_shape: [32, 8], num_experts: 384, num_experts_local: 384, dtypes: [bfloat16], label: "kimi-k2-small"}
+  - {hidden_states_shape: [512, 7168], topk_ids_shape: [512, 8], num_experts: 384, num_experts_local: 384, dtypes: [bfloat16], label: "kimi-k2-medium"}
+  - {hidden_states_shape: [4096, 7168], topk_ids_shape: [4096, 8], num_experts: 384, num_experts_local: 384, dtypes: [bfloat16], label: "kimi-k2-prefill"}
+    # DeepSeek-V3: H=7168, E=256, K=8
+  - {hidden_states_shape: [1, 7168], topk_ids_shape: [1, 8], num_experts: 256, num_experts_local: 256, dtypes: [bfloat16], label: "deepseek-v3-decode"}
+  - {hidden_states_shape: [32, 7168], topk_ids_shape: [32, 8], num_experts: 256, num_experts_local: 256, dtypes: [bfloat16], label: "deepseek-v3-small"}
+  - {hidden_states_shape: [512, 7168], topk_ids_shape: [512, 8], num_experts: 256, num_experts_local: 256, dtypes: [bfloat16], label: "deepseek-v3-medium"}
+  - {hidden_states_shape: [4096, 7168], topk_ids_shape: [4096, 8], num_experts: 256, num_experts_local: 256, dtypes: [bfloat16], label: "deepseek-v3-prefill"}
+    # Qwen3-235B-A22B: H=7168, E=128, K=8
+  - {hidden_states_shape: [1, 7168], topk_ids_shape: [1, 8], num_experts: 128, num_experts_local: 128, dtypes: [bfloat16], label: "qwen3-235b-decode"}
+  - {hidden_states_shape: [32, 7168], topk_ids_shape: [32, 8], num_experts: 128, num_experts_local: 128, dtypes: [bfloat16], label: "qwen3-235b-small"}
+  - {hidden_states_shape: [512, 7168], topk_ids_shape: [512, 8], num_experts: 128, num_experts_local: 128, dtypes: [bfloat16], label: "qwen3-235b-medium"}
+  - {hidden_states_shape: [4096, 7168], topk_ids_shape: [4096, 8], num_experts: 128, num_experts_local: 128, dtypes: [bfloat16], label: "qwen3-235b-prefill"}
+    # Qwen3-30B-A3B: H=3072, E=128, K=8
+  - {hidden_states_shape: [1, 3072], topk_ids_shape: [1, 8], num_experts: 128, num_experts_local: 128, dtypes: [bfloat16], label: "qwen3-30b-decode"}
+  - {hidden_states_shape: [32, 3072], topk_ids_shape: [32, 8], num_experts: 128, num_experts_local: 128, dtypes: [bfloat16], label: "qwen3-30b-small"}
+  - {hidden_states_shape: [512, 3072], topk_ids_shape: [512, 8], num_experts: 128, num_experts_local: 128, dtypes: [bfloat16], label: "qwen3-30b-medium"}
+  - {hidden_states_shape: [4096, 3072], topk_ids_shape: [4096, 8], num_experts: 128, num_experts_local: 128, dtypes: [bfloat16], label: "qwen3-30b-prefill"}
     # Two-way expert parallelism over the DeepSeek-V3 and Qwen3-235B expert tables.
-  - {hidden_states_shape: [1, 7168], topk_ids_shape: [1, 8], expert_map_shape: [256], num_experts: 256, num_experts_local: 128, dtypes: [bfloat16], label: "deepseek-v3-ep2-decode"}
-  - {hidden_states_shape: [512, 7168], topk_ids_shape: [512, 8], expert_map_shape: [256], num_experts: 256, num_experts_local: 128, dtypes: [bfloat16], label: "deepseek-v3-ep2-medium"}
-  - {hidden_states_shape: [4096, 7168], topk_ids_shape: [4096, 8], expert_map_shape: [256], num_experts: 256, num_experts_local: 128, dtypes: [bfloat16], label: "deepseek-v3-ep2-prefill"}
-  - {hidden_states_shape: [512, 7168], topk_ids_shape: [512, 8], expert_map_shape: [128], num_experts: 128, num_experts_local: 64, dtypes: [bfloat16], label: "qwen3-235b-ep2-medium"}
+  - {hidden_states_shape: [1, 7168], topk_ids_shape: [1, 8], num_experts: 256, num_experts_local: 128, expert_map_shape: [256], dtypes: [bfloat16], label: "deepseek-v3-ep2-decode"}
+  - {hidden_states_shape: [512, 7168], topk_ids_shape: [512, 8], num_experts: 256, num_experts_local: 128, expert_map_shape: [256], dtypes: [bfloat16], label: "deepseek-v3-ep2-medium"}
+  - {hidden_states_shape: [4096, 7168], topk_ids_shape: [4096, 8], num_experts: 256, num_experts_local: 128, expert_map_shape: [256], dtypes: [bfloat16], label: "deepseek-v3-ep2-prefill"}
+  - {hidden_states_shape: [512, 7168], topk_ids_shape: [512, 8], num_experts: 128, num_experts_local: 64, expert_map_shape: [128], dtypes: [bfloat16], label: "qwen3-235b-ep2-medium"}
 
+  # Func mode: the map plane is read only when the map is supplied, so the byte
+  # count turns on a presence fact no inline expression can carry.
   roofline:
-    vars:
-      T: "hidden_states_shape[0]"
-      K: "topk_ids_shape[1]"
-      H: "hidden_states_shape[1]"
-    flops: "0"
-    # hidden_states read [T, H] + perm_h write [T*K, H] + the map + per-local-expert metadata
-    bytes: "(T * H + T * K * H) * elem_bytes + num_experts * 4 + (num_experts_local + 1) * 8 + 2 * T * K * 4 + num_experts_local * 8"
+    func: "tileops.perf.formulas.moe_permute_nopad_fwd_roofline"
 
   source:
     kernel: tileops/kernels/moe/permute_nopad.py
@@ -351,90 +298,19 @@ FusedMoEExpertsNopadPersistent3WGFwdOp:
       workspace2:
         dtype: float16 | bfloat16
         note: scratch buffer, may be empty
-    outputs:
-      output: {dtype: "same_as(hidden_states)"}
-    params:
-      num_tokens: {type: int}
-      num_experts:
-        type: int
-      top_k: {type: int}
-      hidden_size: {type: int}
-      ffn_size: {type: int}
-      routed_scaling_factor: {type: float, default: 1.0}
-      activation: {type: str, default: silu_and_mul, kw_only: true}
-    shape_rules:
-    - "hidden_states.shape == (num_tokens, hidden_size)"
-    - "w_gate_up.shape     == (num_experts, 2 * ffn_size, hidden_size)"
-    - "w_down.shape        == (num_experts, hidden_size, ffn_size)"
-    - "topk_weights.shape  == (num_tokens, top_k)"
-    - "topk_ids.shape      == (num_tokens, top_k)"
-    - "output.shape        == (num_tokens, hidden_size)"
-
-  workloads:
-    # Qwen3-235B-A22B: H=7168, F=2048, E=128, K=8
-  - {num_tokens: 512, num_experts: 128, top_k: 8, hidden_size: 7168, ffn_size: 2048, dtypes: [bfloat16], label: "qwen3-235b-decode"}
-  - {num_tokens: 4096, num_experts: 128, top_k: 8, hidden_size: 7168, ffn_size: 2048, dtypes: [bfloat16], label: "qwen3-235b-prefill"}
-    # DeepSeek-V3: H=7168, F=2048, E=256, K=8
-  - {num_tokens: 512, num_experts: 256, top_k: 8, hidden_size: 7168, ffn_size: 2048, dtypes: [bfloat16], label: "deepseek-v3-decode"}
-  - {num_tokens: 4096, num_experts: 256, top_k: 8, hidden_size: 7168, ffn_size: 2048, dtypes: [bfloat16], label: "deepseek-v3-prefill"}
-
-  roofline:
-    flops: "num_tokens * top_k * 6 * ffn_size * hidden_size"
-    bytes: "(num_experts * 3 * ffn_size * hidden_size + 2 * num_tokens * hidden_size) * elem_bytes"
-
-  source:
-    kernel: tileops/kernels/moe/moe_grouped_gemm_nopad.py
-    op: tileops/ops/moe/routed_expert/fused_routed_expert.py
-    test: tests/ops/test_fused_moe_experts.py
-    bench: benchmarks/ops/bench_fused_moe_experts.py
-    bench_manifest_driven: true
-    kernel_map:
-      permute_nopad_kernel: MoePermuteNopadKernel
-      moe_grouped_gemm_kernel: MoeGroupedGemmNopadKernel
-      moe_grouped_gemm_persistent_kernel: GroupedGemmPersistent3WGKernel
-      moe_grouped_gemm_fused_act_kernel: MoeGroupedGemmPersistent3WGFusedActKernel
-      silu_and_mul: SiluAndMulFwdKernel
-      gelu_and_mul: GeluAndMulFwdKernel
-      unpermute_kernel: MoeUnpermuteKernel
-
-# Expert-parallel shape of FusedMoEExpertsNopadPersistent3WGFwdOp. The weights are
-# the rank's own slice, so they are sized by num_experts_local; expert_map maps the
-# global routing ids onto that slice.
-FusedMoEExpertsNopadPersistent3WGEpFwdOp:
-  ref_api: "none"
-  family: moe
-  status: implemented
-  variant_of: FusedMoEExpertsNopadPersistent3WGFwdOp
-
-  signature:
-    inputs:
-      output:
-        dtype: same_as(hidden_states)
-        note: pre-allocated output buffer
-      hidden_states:
-        dtype: float16 | bfloat16
-      w_gate_up:
-        dtype: same_as(hidden_states)
-      w_down:
-        dtype: same_as(hidden_states)
-      topk_weights:
-        dtype: float32
-      topk_ids:
-        dtype: int32
+      # Expert parallelism: supplied when the weights are this rank's slice of
+      # the global expert table, absent when they are the whole table.
       expert_map:
         dtype: int32
-      workspace1:
-        dtype: float16 | bfloat16
-        note: scratch buffer, may be empty
-      workspace2:
-        dtype: float16 | bfloat16
-        note: scratch buffer, may be empty
+        optional: true
     outputs:
       output: {dtype: "same_as(hidden_states)"}
     params:
       num_tokens: {type: int}
       num_experts:
         type: int
+      # Sizes the weights, both grouped GEMMs and the permute stage. Equals
+      # num_experts without EP.
       num_experts_local: {type: int}
       top_k: {type: int}
       hidden_size: {type: int}
@@ -447,13 +323,19 @@ FusedMoEExpertsNopadPersistent3WGEpFwdOp:
     - "w_down.shape        == (num_experts_local, hidden_size, ffn_size)"
     - "topk_weights.shape  == (num_tokens, top_k)"
     - "topk_ids.shape      == (num_tokens, top_k)"
-    - "expert_map.shape    == (num_experts,)"
+    - "expert_map is None or expert_map.shape == (num_experts,)"
     - "output.shape        == (num_tokens, hidden_size)"
 
   workloads:
+    # Qwen3-235B-A22B: H=7168, F=2048, E=128, K=8
+  - {num_tokens: 512, num_experts: 128, num_experts_local: 128, top_k: 8, hidden_size: 7168, ffn_size: 2048, dtypes: [bfloat16], label: "qwen3-235b-decode"}
+  - {num_tokens: 4096, num_experts: 128, num_experts_local: 128, top_k: 8, hidden_size: 7168, ffn_size: 2048, dtypes: [bfloat16], label: "qwen3-235b-prefill"}
+    # DeepSeek-V3: H=7168, F=2048, E=256, K=8
+  - {num_tokens: 512, num_experts: 256, num_experts_local: 256, top_k: 8, hidden_size: 7168, ffn_size: 2048, dtypes: [bfloat16], label: "deepseek-v3-decode"}
+  - {num_tokens: 4096, num_experts: 256, num_experts_local: 256, top_k: 8, hidden_size: 7168, ffn_size: 2048, dtypes: [bfloat16], label: "deepseek-v3-prefill"}
     # Two-way expert parallelism over the DeepSeek-V3 expert table.
-  - {num_tokens: 512, num_experts: 256, num_experts_local: 128, top_k: 8, hidden_size: 7168, ffn_size: 2048, dtypes: [bfloat16], label: "deepseek-v3-ep2-decode"}
-  - {num_tokens: 4096, num_experts: 256, num_experts_local: 128, top_k: 8, hidden_size: 7168, ffn_size: 2048, dtypes: [bfloat16], label: "deepseek-v3-ep2-prefill"}
+  - {num_tokens: 512, num_experts: 256, num_experts_local: 128, top_k: 8, hidden_size: 7168, ffn_size: 2048, expert_map_shape: [256], dtypes: [bfloat16], label: "deepseek-v3-ep2-decode"}
+  - {num_tokens: 4096, num_experts: 256, num_experts_local: 128, top_k: 8, hidden_size: 7168, ffn_size: 2048, expert_map_shape: [256], dtypes: [bfloat16], label: "deepseek-v3-ep2-prefill"}
 
   roofline:
     flops: "num_tokens * top_k * 6 * ffn_size * hidden_size"

--- a/src/tileops/manifest/moe.yaml
+++ b/src/tileops/manifest/moe.yaml
@@ -120,6 +120,67 @@ MoePermuteNopadFwdOp:
     kernel_map:
       permute_nopad_kernel: MoePermuteNopadKernel
 
+# Expert-parallel shape of MoePermuteNopadFwdOp: the rank owns num_experts_local
+# of the num_experts global experts. The count is a param because it sizes the
+# four per-expert outputs; the map is an input because its values are read at
+# launch.
+MoePermuteNopadEpFwdOp:
+  ref_api: "none"
+  family: moe
+  status: implemented
+  torch_compile_fullgraph: true
+  variant_of: MoePermuteNopadFwdOp
+
+  signature:
+    inputs:
+      hidden_states: {dtype: "float16 | bfloat16"}
+      topk_ids: {dtype: "int32"}
+      expert_map: {dtype: "int32"}
+    outputs:
+      perm_h: {dtype: "same_as(hidden_states)"}
+      true_offsets: {dtype: "int32"}
+      true_sizes: {dtype: "int32"}
+      expert_first_token_offset: {dtype: "int64"}
+      fwd_idx: {dtype: "int32"}
+    params:
+      num_experts: {type: int}
+      num_experts_local: {type: int}
+    shape_rules:
+    - "hidden_states.ndim == 2"
+    - "topk_ids.ndim == 2"
+    - "topk_ids.shape[0] == hidden_states.shape[0]"
+    - "expert_map.shape == (num_experts,)"
+    - "perm_h.shape == (hidden_states.shape[0] * topk_ids.shape[1], hidden_states.shape[1])"
+    - "true_offsets.shape == (num_experts_local,)"
+    - "true_sizes.shape == (num_experts_local,)"
+    - "expert_first_token_offset.shape == (num_experts_local + 1,)"
+    - "fwd_idx.shape == (hidden_states.shape[0] * topk_ids.shape[1],)"
+
+  workloads:
+    # Two-way expert parallelism over the DeepSeek-V3 and Qwen3-235B expert tables.
+  - {hidden_states_shape: [1, 7168], topk_ids_shape: [1, 8], expert_map_shape: [256], num_experts: 256, num_experts_local: 128, dtypes: [bfloat16], label: "deepseek-v3-ep2-decode"}
+  - {hidden_states_shape: [512, 7168], topk_ids_shape: [512, 8], expert_map_shape: [256], num_experts: 256, num_experts_local: 128, dtypes: [bfloat16], label: "deepseek-v3-ep2-medium"}
+  - {hidden_states_shape: [4096, 7168], topk_ids_shape: [4096, 8], expert_map_shape: [256], num_experts: 256, num_experts_local: 128, dtypes: [bfloat16], label: "deepseek-v3-ep2-prefill"}
+  - {hidden_states_shape: [512, 7168], topk_ids_shape: [512, 8], expert_map_shape: [128], num_experts: 128, num_experts_local: 64, dtypes: [bfloat16], label: "qwen3-235b-ep2-medium"}
+
+  roofline:
+    vars:
+      T: "hidden_states_shape[0]"
+      K: "topk_ids_shape[1]"
+      H: "hidden_states_shape[1]"
+    flops: "0"
+    # hidden_states read [T, H] + perm_h write [T*K, H] + the map + per-local-expert metadata
+    bytes: "(T * H + T * K * H) * elem_bytes + num_experts * 4 + (num_experts_local + 1) * 8 + 2 * T * K * 4 + num_experts_local * 8"
+
+  source:
+    kernel: tileops/kernels/moe/permute_nopad.py
+    op: tileops/ops/moe/routed_expert/permute_nopad.py
+    test: tests/ops/test_moe_permute_nopad.py
+    bench: benchmarks/ops/bench_moe_permute_nopad.py
+    bench_manifest_driven: true
+    kernel_map:
+      permute_nopad_kernel: MoePermuteNopadKernel
+
 MoeUnpermuteFwdOp:
   ref_api: "none"
   family: moe
@@ -284,9 +345,6 @@ FusedMoEExpertsNopadPersistent3WGFwdOp:
         dtype: float32
       topk_ids:
         dtype: int32
-      expert_map:
-        dtype: int32
-        note: EP mapping, None for single-GPU
       workspace1:
         dtype: float16 | bfloat16
         note: scratch buffer, may be empty
@@ -323,6 +381,83 @@ FusedMoEExpertsNopadPersistent3WGFwdOp:
   roofline:
     flops: "num_tokens * top_k * 6 * ffn_size * hidden_size"
     bytes: "(num_experts * 3 * ffn_size * hidden_size + 2 * num_tokens * hidden_size) * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/moe/moe_grouped_gemm_nopad.py
+    op: tileops/ops/moe/routed_expert/fused_routed_expert.py
+    test: tests/ops/test_fused_moe_experts.py
+    bench: benchmarks/ops/bench_fused_moe_experts.py
+    bench_manifest_driven: true
+    kernel_map:
+      permute_nopad_kernel: MoePermuteNopadKernel
+      moe_grouped_gemm_kernel: MoeGroupedGemmNopadKernel
+      moe_grouped_gemm_persistent_kernel: GroupedGemmPersistent3WGKernel
+      moe_grouped_gemm_fused_act_kernel: MoeGroupedGemmPersistent3WGFusedActKernel
+      silu_and_mul: SiluAndMulFwdKernel
+      gelu_and_mul: GeluAndMulFwdKernel
+      unpermute_kernel: MoeUnpermuteKernel
+
+# Expert-parallel shape of FusedMoEExpertsNopadPersistent3WGFwdOp. The weights are
+# the rank's own slice, so they are sized by num_experts_local; expert_map maps the
+# global routing ids onto that slice.
+FusedMoEExpertsNopadPersistent3WGEpFwdOp:
+  ref_api: "none"
+  family: moe
+  status: implemented
+  variant_of: FusedMoEExpertsNopadPersistent3WGFwdOp
+
+  signature:
+    inputs:
+      output:
+        dtype: same_as(hidden_states)
+        note: pre-allocated output buffer
+      hidden_states:
+        dtype: float16 | bfloat16
+      w_gate_up:
+        dtype: same_as(hidden_states)
+      w_down:
+        dtype: same_as(hidden_states)
+      topk_weights:
+        dtype: float32
+      topk_ids:
+        dtype: int32
+      expert_map:
+        dtype: int32
+      workspace1:
+        dtype: float16 | bfloat16
+        note: scratch buffer, may be empty
+      workspace2:
+        dtype: float16 | bfloat16
+        note: scratch buffer, may be empty
+    outputs:
+      output: {dtype: "same_as(hidden_states)"}
+    params:
+      num_tokens: {type: int}
+      num_experts:
+        type: int
+      num_experts_local: {type: int}
+      top_k: {type: int}
+      hidden_size: {type: int}
+      ffn_size: {type: int}
+      routed_scaling_factor: {type: float, default: 1.0}
+      activation: {type: str, default: silu_and_mul, kw_only: true}
+    shape_rules:
+    - "hidden_states.shape == (num_tokens, hidden_size)"
+    - "w_gate_up.shape     == (num_experts_local, 2 * ffn_size, hidden_size)"
+    - "w_down.shape        == (num_experts_local, hidden_size, ffn_size)"
+    - "topk_weights.shape  == (num_tokens, top_k)"
+    - "topk_ids.shape      == (num_tokens, top_k)"
+    - "expert_map.shape    == (num_experts,)"
+    - "output.shape        == (num_tokens, hidden_size)"
+
+  workloads:
+    # Two-way expert parallelism over the DeepSeek-V3 expert table.
+  - {num_tokens: 512, num_experts: 256, num_experts_local: 128, top_k: 8, hidden_size: 7168, ffn_size: 2048, dtypes: [bfloat16], label: "deepseek-v3-ep2-decode"}
+  - {num_tokens: 4096, num_experts: 256, num_experts_local: 128, top_k: 8, hidden_size: 7168, ffn_size: 2048, dtypes: [bfloat16], label: "deepseek-v3-ep2-prefill"}
+
+  roofline:
+    flops: "num_tokens * top_k * 6 * ffn_size * hidden_size"
+    bytes: "(num_experts_local * 3 * ffn_size * hidden_size + 2 * num_tokens * hidden_size) * elem_bytes"
 
   source:
     kernel: tileops/kernels/moe/moe_grouped_gemm_nopad.py

--- a/src/tileops/manifest/moe.yaml
+++ b/src/tileops/manifest/moe.yaml
@@ -2,6 +2,7 @@ MoePermuteAlignFwdOp:
   ref_api: "none"
   family: moe
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -54,6 +55,7 @@ MoePermuteNopadFwdOp:
   ref_api: "none"
   family: moe
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -122,6 +124,7 @@ MoeUnpermuteFwdOp:
   ref_api: "none"
   family: moe
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -172,6 +175,7 @@ MoeGroupedGemmNopadFwdOp:
   ref_api: "none"
   family: moe
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -213,6 +217,7 @@ MoeGateUpFwdOp:
   ref_api: "none"
   family: moe
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:

--- a/src/tileops/ops/moe/__init__.py
+++ b/src/tileops/ops/moe/__init__.py
@@ -13,9 +13,11 @@ from .fused_topk import FusedTopKOp
 from .permute_align import MoePermuteAlignFwdOp
 from .prepare_finalize.no_dp_ep import MoEPrepareAndFinalizeNoDPEP
 from .routed_expert import (
+    FusedMoEExpertsNopadPersistent3WGEpFwdOp,
     FusedMoEExpertsNopadPersistent3WGFwdOp,
     MoeGateUpFwdOp,
     MoeGroupedGemmNopadFwdOp,
+    MoePermuteNopadEpFwdOp,
     MoePermuteNopadFwdOp,
     MoeUnpermuteFwdOp,
 )
@@ -24,6 +26,7 @@ from .shared_fused_moe import SharedFusedMoE
 __all__ = [
     "FusedMoEExperts",
     "FusedMoEExpertsModular",
+    "FusedMoEExpertsNopadPersistent3WGEpFwdOp",
     "FusedMoEExpertsNopadPersistent3WGFwdOp",
     "FusedMoEPrepareAndFinalize",
     "FusedMoe",
@@ -33,6 +36,7 @@ __all__ = [
     "MoeGateUpFwdOp",
     "MoeGroupedGemmNopadFwdOp",
     "MoePermuteAlignFwdOp",
+    "MoePermuteNopadEpFwdOp",
     "MoePermuteNopadFwdOp",
     "MoeUnpermuteFwdOp",
     "PrepareResult",

--- a/src/tileops/ops/moe/__init__.py
+++ b/src/tileops/ops/moe/__init__.py
@@ -13,11 +13,9 @@ from .fused_topk import FusedTopKOp
 from .permute_align import MoePermuteAlignFwdOp
 from .prepare_finalize.no_dp_ep import MoEPrepareAndFinalizeNoDPEP
 from .routed_expert import (
-    FusedMoEExpertsNopadPersistent3WGEpFwdOp,
     FusedMoEExpertsNopadPersistent3WGFwdOp,
     MoeGateUpFwdOp,
     MoeGroupedGemmNopadFwdOp,
-    MoePermuteNopadEpFwdOp,
     MoePermuteNopadFwdOp,
     MoeUnpermuteFwdOp,
 )
@@ -26,7 +24,6 @@ from .shared_fused_moe import SharedFusedMoE
 __all__ = [
     "FusedMoEExperts",
     "FusedMoEExpertsModular",
-    "FusedMoEExpertsNopadPersistent3WGEpFwdOp",
     "FusedMoEExpertsNopadPersistent3WGFwdOp",
     "FusedMoEPrepareAndFinalize",
     "FusedMoe",
@@ -36,7 +33,6 @@ __all__ = [
     "MoeGateUpFwdOp",
     "MoeGroupedGemmNopadFwdOp",
     "MoePermuteAlignFwdOp",
-    "MoePermuteNopadEpFwdOp",
     "MoePermuteNopadFwdOp",
     "MoeUnpermuteFwdOp",
     "PrepareResult",

--- a/src/tileops/ops/moe/abc.py
+++ b/src/tileops/ops/moe/abc.py
@@ -48,9 +48,9 @@ def _validate_fused_moe_experts_dtypes(
 ) -> None:
     """Shared dtype validator for FusedMoEExperts subclasses.
 
-    Covers the inputs every implementation takes. An expert-parallel identity
-    adds its own check for ``expert_map`` on top; keeping the common body here
-    avoids drift between implementations.
+    Covers the inputs every implementation takes; an implementation checks its
+    optional inputs on top. Keeping the common body here avoids drift between
+    implementations.
     """
     allowed = (torch.float16, torch.bfloat16)
     if op_dtype not in allowed:
@@ -198,21 +198,23 @@ class FusedMoEExperts(Op, ABC):
     @abstractmethod
     def forward(
         self,
-        output: Tensor,           # pre-allocated, shape == output_shape()
-        hidden_states: Tensor,    # [T', H] from PrepareResult.hidden_q
-        w_gate_up: Tensor,        # [E, 2F, H]
-        w_down: Tensor,           # [E, H, F]
-        topk_weights: Tensor,     # [T', K] float32
-        topk_ids: Tensor,         # [T', K] int32
+        output: Tensor,             # pre-allocated, shape == output_shape()
+        hidden_states: Tensor,      # [T', H] from PrepareResult.hidden_q
+        w_gate_up: Tensor,          # [E_local, 2F, H]
+        w_down: Tensor,             # [E_local, H, F]
+        topk_weights: Tensor,       # [T', K] float32
+        topk_ids: Tensor,           # [T', K] int32
+        expert_map: Tensor | None,  # [E] int32 global-to-local ids; None if all local
         workspace1: Tensor,
         workspace2: Tensor,
         num_experts: int,
     ) -> None:
         """Write expert computation result to output in-place.
 
-        An expert-parallel implementation takes the number of experts this rank
-        owns at construction — it sizes the kernels — and adds ``expert_map``
-        to this signature as the tensor carrying the global-to-local ids.
+        The number of experts this rank owns is fixed at construction — it sizes
+        the kernels. ``expert_map`` carries the global-to-local ids the kernels
+        read at launch, and its presence is what selects the expert-parallel
+        path.
         """
 
 

--- a/src/tileops/ops/moe/abc.py
+++ b/src/tileops/ops/moe/abc.py
@@ -213,7 +213,13 @@ class FusedMoEExperts(Op, ABC):
         workspace2: Tensor,
         num_experts: int,
     ) -> None:
-        """Write expert computation result to output in-place."""
+        """Write expert computation result to output in-place.
+
+        An implementation that compiles kernels against the EP layout takes
+        ``expert_map`` at construction as well. It must then reject a
+        ``forward`` call handed a different map rather than ignore the
+        argument.
+        """
 
 
 class FusedMoEExpertsModular(FusedMoEExperts, ABC):

--- a/src/tileops/ops/moe/abc.py
+++ b/src/tileops/ops/moe/abc.py
@@ -43,16 +43,14 @@ def _validate_fused_moe_experts_dtypes(
     w_down: Tensor,
     topk_weights: Tensor,
     topk_ids: Tensor,
-    expert_map: Tensor | None,
     workspace1: Tensor,
     workspace2: Tensor,
 ) -> None:
     """Shared dtype validator for FusedMoEExperts subclasses.
 
-    Concrete subclasses route through this helper because the manifest-driven
-    ``_validate_dtypes`` codegen path does not handle ``Optional[Tensor]``
-    inputs (``expert_map`` is None for single-GPU); having one shared body
-    avoids drift between the nopad and padded implementations.
+    Covers the inputs every implementation takes. An expert-parallel identity
+    adds its own check for ``expert_map`` on top; keeping the common body here
+    avoids drift between implementations.
     """
     allowed = (torch.float16, torch.bfloat16)
     if op_dtype not in allowed:
@@ -73,8 +71,6 @@ def _validate_fused_moe_experts_dtypes(
         raise ValueError(f"Expected topk_weights.dtype == float32, got {topk_weights.dtype}")
     if topk_ids.dtype != torch.int32:
         raise ValueError(f"Expected topk_ids.dtype == int32, got {topk_ids.dtype}")
-    if expert_map is not None and expert_map.dtype != torch.int32:
-        raise ValueError(f"Expected expert_map.dtype == int32, got {expert_map.dtype}")
     for name, t in (("workspace1", workspace1), ("workspace2", workspace2)):
         if t.dtype not in allowed:
             raise ValueError(f"Expected {name}.dtype in {allowed}, got {t.dtype}")
@@ -208,17 +204,15 @@ class FusedMoEExperts(Op, ABC):
         w_down: Tensor,           # [E, H, F]
         topk_weights: Tensor,     # [T', K] float32
         topk_ids: Tensor,         # [T', K] int32
-        expert_map: Tensor | None,
         workspace1: Tensor,
         workspace2: Tensor,
         num_experts: int,
     ) -> None:
         """Write expert computation result to output in-place.
 
-        An implementation that compiles kernels against the EP layout takes
-        ``expert_map`` at construction as well. It must then reject a
-        ``forward`` call handed a different map rather than ignore the
-        argument.
+        An expert-parallel implementation takes the number of experts this rank
+        owns at construction — it sizes the kernels — and adds ``expert_map``
+        to this signature as the tensor carrying the global-to-local ids.
         """
 
 

--- a/src/tileops/ops/moe/fused_moe.py
+++ b/src/tileops/ops/moe/fused_moe.py
@@ -21,10 +21,7 @@ from tileops.ops.moe.abc import (
 )
 from tileops.ops.moe.fused_topk import FusedTopKOp
 from tileops.ops.moe.prepare_finalize.no_dp_ep import MoEPrepareAndFinalizeNoDPEP
-from tileops.ops.moe.routed_expert import (
-    FusedMoEExpertsNopadPersistent3WGEpFwdOp,
-    FusedMoEExpertsNopadPersistent3WGFwdOp,
-)
+from tileops.ops.moe.routed_expert import FusedMoEExpertsNopadPersistent3WGFwdOp
 
 from ..op_base import Op
 
@@ -147,21 +144,16 @@ class FusedMoe(Op):
             self._experts: FusedMoEExpertsModular = experts
         else:
             self.activation = activation
-            common = dict(
+            self._experts = FusedMoEExpertsNopadPersistent3WGFwdOp(
                 num_tokens=num_tokens,
                 num_experts=num_experts,
+                num_experts_local=self.num_experts_local,
                 top_k=top_k,
                 hidden_size=hidden_size,
                 ffn_size=ffn_size,
                 routed_scaling_factor=routed_scaling_factor,
                 kernel_map=kernel_map,
                 activation=activation,
-            )
-            self._experts = (
-                FusedMoEExpertsNopadPersistent3WGFwdOp(**common)
-                if expert_map is None
-                else FusedMoEExpertsNopadPersistent3WGEpFwdOp(
-                    num_experts_local=num_experts_local, **common)
             )
 
     @property
@@ -200,23 +192,13 @@ class FusedMoe(Op):
         output = hidden_states.new_empty(hidden_states.shape)
         expert_out_shape = self._experts.output_shape(T_prime, self.hidden_size)
         expert_out = output if expert_out_shape == tuple(hidden_states.shape) else hidden_states.new_empty(expert_out_shape)
-        # Which experts identity was built is fixed at construction, so which arm
-        # runs is a constant.
-        if self.expert_map is None:
-            self._experts.forward(
-                expert_out, r.hidden_q, w_gate_up, w_down,
-                r.topk_weights, r.topk_ids,
-                workspace1=ws1, workspace2=ws2,
-                num_experts=self.num_experts,
-            )
-        else:
-            self._experts.forward(
-                expert_out, r.hidden_q, w_gate_up, w_down,
-                r.topk_weights, r.topk_ids,
-                expert_map=self.expert_map,
-                workspace1=ws1, workspace2=ws2,
-                num_experts=self.num_experts,
-            )
+        self._experts.forward(
+            expert_out, r.hidden_q, w_gate_up, w_down,
+            r.topk_weights, r.topk_ids,
+            expert_map=self.expert_map,
+            workspace1=ws1, workspace2=ws2,
+            num_experts=self.num_experts,
+        )
 
         self._prepare.finalize(
             output, expert_out,

--- a/src/tileops/ops/moe/fused_moe.py
+++ b/src/tileops/ops/moe/fused_moe.py
@@ -22,6 +22,7 @@ from tileops.ops.moe.abc import (
 from tileops.ops.moe.fused_topk import FusedTopKOp
 from tileops.ops.moe.prepare_finalize.no_dp_ep import MoEPrepareAndFinalizeNoDPEP
 from tileops.ops.moe.routed_expert import (
+    FusedMoEExpertsNopadPersistent3WGEpFwdOp,
     FusedMoEExpertsNopadPersistent3WGFwdOp,
 )
 
@@ -46,6 +47,10 @@ class FusedMoe(Op):
         renormalize: Renormalize top-k weights to sum to 1.
         routed_scaling_factor: Multiplier on expert output (Kimi K2: 2.827).
         expert_map: [E_global] int32 for Expert Parallel local filtering.
+        num_experts_local: Number of experts this rank owns. Required with
+            `expert_map` and rejected without it: it sizes the expert
+            pipeline's kernels, which are built here, and reading it off the
+            map would mean a device read at construction.
         prepare_finalize: Override the PrepareAndFinalize implementation.
         experts: Override the Experts implementation.
         kernel_map: Override the dispatched kernel map.
@@ -62,12 +67,22 @@ class FusedMoe(Op):
         renormalize: bool = False,
         routed_scaling_factor: float = 1.0,
         expert_map: Optional[torch.Tensor] = None,
+        num_experts_local: Optional[int] = None,
         prepare_finalize: Optional[FusedMoEPrepareAndFinalize] = None,
         experts: Optional[FusedMoEExpertsModular] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         *,
         activation: str = "silu_and_mul",
     ):
+        if (expert_map is None) != (num_experts_local is None):
+            raise ValueError(
+                "expert_map and num_experts_local go together: the map carries the "
+                "global-to-local ids read at launch, the count sizes the kernels "
+                "built here. Got "
+                f"expert_map={'a map' if expert_map is not None else None}, "
+                f"num_experts_local={num_experts_local}."
+            )
+
         self.num_tokens = num_tokens
         self.num_experts = num_experts
         self.top_k = top_k
@@ -77,6 +92,9 @@ class FusedMoe(Op):
         self.renormalize = renormalize
         self.routed_scaling_factor = routed_scaling_factor
         self.expert_map = expert_map
+        self.num_experts_local = (
+            num_experts if num_experts_local is None else num_experts_local
+        )
 
         self.dispatch_kernel(kernel_map)
 
@@ -129,16 +147,21 @@ class FusedMoe(Op):
             self._experts: FusedMoEExpertsModular = experts
         else:
             self.activation = activation
-            self._experts = FusedMoEExpertsNopadPersistent3WGFwdOp(
+            common = dict(
                 num_tokens=num_tokens,
                 num_experts=num_experts,
                 top_k=top_k,
                 hidden_size=hidden_size,
                 ffn_size=ffn_size,
-                activation=activation,
                 routed_scaling_factor=routed_scaling_factor,
-                expert_map=expert_map,
                 kernel_map=kernel_map,
+                activation=activation,
+            )
+            self._experts = (
+                FusedMoEExpertsNopadPersistent3WGFwdOp(**common)
+                if expert_map is None
+                else FusedMoEExpertsNopadPersistent3WGEpFwdOp(
+                    num_experts_local=num_experts_local, **common)
             )
 
     @property
@@ -177,13 +200,23 @@ class FusedMoe(Op):
         output = hidden_states.new_empty(hidden_states.shape)
         expert_out_shape = self._experts.output_shape(T_prime, self.hidden_size)
         expert_out = output if expert_out_shape == tuple(hidden_states.shape) else hidden_states.new_empty(expert_out_shape)
-        self._experts.forward(
-            expert_out, r.hidden_q, w_gate_up, w_down,
-            r.topk_weights, r.topk_ids,
-            expert_map=self.expert_map,
-            workspace1=ws1, workspace2=ws2,
-            num_experts=self.num_experts,
-        )
+        # Which experts identity was built is fixed at construction, so which arm
+        # runs is a constant.
+        if self.expert_map is None:
+            self._experts.forward(
+                expert_out, r.hidden_q, w_gate_up, w_down,
+                r.topk_weights, r.topk_ids,
+                workspace1=ws1, workspace2=ws2,
+                num_experts=self.num_experts,
+            )
+        else:
+            self._experts.forward(
+                expert_out, r.hidden_q, w_gate_up, w_down,
+                r.topk_weights, r.topk_ids,
+                expert_map=self.expert_map,
+                workspace1=ws1, workspace2=ws2,
+                num_experts=self.num_experts,
+            )
 
         self._prepare.finalize(
             output, expert_out,
@@ -214,6 +247,7 @@ class FusedMoeFwdOp(FusedMoe):
         renormalize: bool = False,
         routed_scaling_factor: float = 1.0,
         expert_map: Optional[torch.Tensor] = None,
+        num_experts_local: Optional[int] = None,
         prepare_finalize: Optional[FusedMoEPrepareAndFinalize] = None,
         experts: Optional[FusedMoEExpertsModular] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
@@ -230,6 +264,7 @@ class FusedMoeFwdOp(FusedMoe):
             renormalize=renormalize,
             routed_scaling_factor=routed_scaling_factor,
             expert_map=expert_map,
+            num_experts_local=num_experts_local,
             prepare_finalize=prepare_finalize,
             experts=experts,
             kernel_map=kernel_map,

--- a/src/tileops/ops/moe/permute_align.py
+++ b/src/tileops/ops/moe/permute_align.py
@@ -1,12 +1,13 @@
 """MoE permute-align op: routes tokens to experts and pads to tile boundary."""
 
-from typing import Dict, Optional, Tuple
+from typing import ClassVar, Dict, Optional, Tuple
 
 import torch
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.moe import MoePermuteAlignKernel
 
+from ..compile_boundary import get_instance
 from ..op_base import Op
 
 __all__ = ["MoePermuteAlignFwdOp"]
@@ -32,6 +33,9 @@ class MoePermuteAlignFwdOp(Op):
         >>> sorted_ids, expert_ids, num_post_pad = op(topk_ids)
     """
 
+    #: The operator this op registers; a test asserts the graph holds nothing else.
+    compile_op_names: ClassVar[Tuple[str, ...]] = ("top::moe_permute_align_fwd",)
+
     def __init__(
         self,
         total_tokens: int,
@@ -56,9 +60,33 @@ class MoePermuteAlignFwdOp(Op):
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"permute_align_kernel": MoePermuteAlignKernel}
 
+    def _padded_extents(self, numel: int) -> Tuple[int, int]:
+        """``(max_padded, num_blocks)`` — the two padded extents the manifest states.
+
+        Both appear verbatim in the manifest ``roofline.bytes`` expression, which is
+        where the output extents of this op are written down.
+        """
+        max_padded = numel + (self.num_experts + 1) * (self.block_size - 1)
+        return max_padded, (max_padded + self.block_size - 1) // self.block_size
+
+    def _infer_output_shapes(
+        self, topk_ids_shape: Tuple[int, ...],
+    ) -> Dict[str, Tuple[int, ...]]:
+        """Manifest ``signature.outputs`` at the extents ``roofline.bytes`` declares.
+
+        ``numel`` comes off ``topk_ids``: the manifest states
+        ``topk_ids.shape == (total_tokens, top_k)``.
+        """
+        max_padded, num_blocks = self._padded_extents(
+            topk_ids_shape[0] * topk_ids_shape[1])
+        return {
+            "sorted_token_ids": (max_padded,),
+            "expert_ids": (num_blocks,),
+            "num_tokens_post_pad": (1,),
+        }
+
     def eval_roofline(self) -> tuple[int, int]:
-        max_padded = self.numel + (self.num_experts + 1) * (self.block_size - 1)
-        num_blocks = (max_padded + self.block_size - 1) // self.block_size
+        max_padded, num_blocks = self._padded_extents(self.numel)
         return (
             0,
             self.numel * 4 + max_padded * 4 + num_blocks * 4 + 4,
@@ -77,4 +105,30 @@ class MoePermuteAlignFwdOp(Op):
             expert_ids:       [num_blocks] int32
             num_tokens_post_pad: [1] int32
         """
+        return _moe_permute_align_fwd(topk_ids, self._instance_key)
+
+    def _eager_forward(
+        self, topk_ids: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Launch inside the operator, where dynamo does not follow the kernel call."""
         return self.kernel(topk_ids)
+
+
+@torch.library.custom_op("top::moe_permute_align_fwd", mutates_args=())
+def _moe_permute_align_fwd(
+    topk_ids: torch.Tensor, instance_key: str,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    return get_instance(instance_key)._eager_forward(topk_ids)
+
+
+@_moe_permute_align_fwd.register_fake
+def _moe_permute_align_fwd_fake(
+    topk_ids: torch.Tensor, instance_key: str,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    op = get_instance(instance_key)
+    shapes = op._infer_output_shapes(tuple(topk_ids.shape))
+    # All three outputs are ``int32`` by the manifest, independent of the input dtype.
+    return tuple(
+        torch.empty(shapes[name], dtype=torch.int32, device=topk_ids.device)
+        for name in ("sorted_token_ids", "expert_ids", "num_tokens_post_pad")
+    )

--- a/src/tileops/ops/moe/routed_expert/__init__.py
+++ b/src/tileops/ops/moe/routed_expert/__init__.py
@@ -1,17 +1,20 @@
 """Routed expert implementations and supporting operations."""
 
 from .fused_routed_expert import (
+    FusedMoEExpertsNopadPersistent3WGEpFwdOp,
     FusedMoEExpertsNopadPersistent3WGFwdOp,
 )
 from .gate_up import MoeGateUpFwdOp
 from .moe_grouped_gemm_nopad import MoeGroupedGemmNopadFwdOp
-from .permute_nopad import MoePermuteNopadFwdOp
+from .permute_nopad import MoePermuteNopadEpFwdOp, MoePermuteNopadFwdOp
 from .unpermute import MoeUnpermuteFwdOp
 
 __all__ = [
+    "FusedMoEExpertsNopadPersistent3WGEpFwdOp",
     "FusedMoEExpertsNopadPersistent3WGFwdOp",
     "MoeGateUpFwdOp",
     "MoeGroupedGemmNopadFwdOp",
+    "MoePermuteNopadEpFwdOp",
     "MoePermuteNopadFwdOp",
     "MoeUnpermuteFwdOp",
 ]

--- a/src/tileops/ops/moe/routed_expert/__init__.py
+++ b/src/tileops/ops/moe/routed_expert/__init__.py
@@ -1,20 +1,17 @@
 """Routed expert implementations and supporting operations."""
 
 from .fused_routed_expert import (
-    FusedMoEExpertsNopadPersistent3WGEpFwdOp,
     FusedMoEExpertsNopadPersistent3WGFwdOp,
 )
 from .gate_up import MoeGateUpFwdOp
 from .moe_grouped_gemm_nopad import MoeGroupedGemmNopadFwdOp
-from .permute_nopad import MoePermuteNopadEpFwdOp, MoePermuteNopadFwdOp
+from .permute_nopad import MoePermuteNopadFwdOp
 from .unpermute import MoeUnpermuteFwdOp
 
 __all__ = [
-    "FusedMoEExpertsNopadPersistent3WGEpFwdOp",
     "FusedMoEExpertsNopadPersistent3WGFwdOp",
     "MoeGateUpFwdOp",
     "MoeGroupedGemmNopadFwdOp",
-    "MoePermuteNopadEpFwdOp",
     "MoePermuteNopadFwdOp",
     "MoeUnpermuteFwdOp",
 ]

--- a/src/tileops/ops/moe/routed_expert/fused_routed_expert.py
+++ b/src/tileops/ops/moe/routed_expert/fused_routed_expert.py
@@ -1,9 +1,21 @@
-"""FusedMoEExperts implementation: nopad + 3WG persistent variant."""
+"""FusedMoEExperts implementation: nopad + 3WG persistent variant.
+
+Two manifest identities share the pipeline, one per expert-parallel (EP) shape:
+
+- ``FusedMoEExpertsNopadPersistent3WGFwdOp`` — every expert is local.
+- ``FusedMoEExpertsNopadPersistent3WGEpFwdOp`` — this rank owns
+  ``num_experts_local`` experts, a constructor parameter, and takes the
+  global-to-local map as a ``forward`` input.
+
+Neither registers an operator of its own: a composite is not the unit of
+replacement, so its graph is its leaves' operators.
+"""
 
 from __future__ import annotations
 
 from typing import Dict, Optional
 
+import torch
 from torch import Tensor
 
 from tileops.kernels.kernel_base import Kernel
@@ -17,10 +29,11 @@ from ..abc import (
 )
 from .gate_up import MoeGateUpFwdOp
 from .moe_grouped_gemm_nopad import MoeGroupedGemmNopadFwdOp
-from .permute_nopad import MoePermuteNopadFwdOp
+from .permute_nopad import MoePermuteNopadEpFwdOp, MoePermuteNopadFwdOp
 from .unpermute import MoeUnpermuteFwdOp
 
 __all__ = [
+    "FusedMoEExpertsNopadPersistent3WGEpFwdOp",
     "FusedMoEExpertsNopadPersistent3WGFwdOp",
 ]
 
@@ -28,10 +41,9 @@ __all__ = [
 class FusedMoEExpertsNopadPersistent3WGFwdOp(FusedMoEExpertsModular):
     """Expert GEMM using tight (T*K rows, no-pad) layout with 3WG persistent kernel.
 
-    Internal pipeline: MoePermuteNopadFwdOp → MoeGateUpFwdOp → down GEMM →
-    MoeUnpermuteFwdOp (weighted reduction included). Each stage picks its own
-    implementation when it is called, from the shapes it was built for and the
-    dtype and device of the call.
+    Internal pipeline: MoePermuteNopadFwdOp -> MoeGateUpFwdOp -> down GEMM ->
+    MoeUnpermuteFwdOp (weighted reduction included). Every stage is built at
+    construction, so ``forward`` resolves nothing and stays traceable.
 
     forward() output shape is (T, H): reduction is done internally by
     MoeUnpermuteFwdOp, so make_weighted_reduce() returns WeightedReduceNoOp.
@@ -45,9 +57,6 @@ class FusedMoEExpertsNopadPersistent3WGFwdOp(FusedMoEExpertsModular):
         ffn_size: Per-expert FFN intermediate dimension F.
         routed_scaling_factor: Scalar applied to the final reduced output.
             Defaults to 1.0 (no scaling).
-        expert_map: Optional global→local expert id map for expert parallelism
-            (EP). Entries < 0 mark experts not owned by this rank. This is the
-            map the op is built for; ``forward`` must be handed the same tensor.
         kernel_map: Optional kernel overrides forwarded to the inner Ops.
         activation: Gated activation applied to gate_up: 'silu_and_mul' or
             'gelu_and_mul'.
@@ -67,70 +76,87 @@ class FusedMoEExpertsNopadPersistent3WGFwdOp(FusedMoEExpertsModular):
         hidden_size: int,
         ffn_size: int,
         routed_scaling_factor: float = 1.0,
-        expert_map: Optional[Tensor] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         *,
         activation: str = "silu_and_mul",
     ):
         self.dispatch_kernel(kernel_map)
+        self._init_pipeline(
+            num_tokens=num_tokens,
+            num_experts=num_experts,
+            num_experts_local=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            ffn_size=ffn_size,
+            routed_scaling_factor=routed_scaling_factor,
+            kernel_map=kernel_map,
+            activation=activation,
+        )
+        self._permute = MoePermuteNopadFwdOp(
+            num_experts=num_experts, kernel_map=kernel_map,
+        )
+
+    def _init_pipeline(
+        self,
+        *,
+        num_tokens: int,
+        num_experts: int,
+        num_experts_local: int,
+        top_k: int,
+        hidden_size: int,
+        ffn_size: int,
+        routed_scaling_factor: float,
+        kernel_map: Optional[Dict[str, Kernel]],
+        activation: str,
+    ) -> None:
+        """Build the stages sized by the expert count this rank owns.
+
+        The two grouped GEMMs and the unpermute are the same for both identities;
+        only the permute stage differs, and each identity builds its own.
+        """
         self.num_tokens = num_tokens
         self.num_experts = num_experts
+        self.num_experts_local = num_experts_local
         self.top_k = top_k
         self.hidden_size = hidden_size
         self.ffn_size = ffn_size
-        self.expert_map = expert_map
-        numel = num_tokens * top_k
-        self._numel = numel
-        self._kernel_map = kernel_map
-
         self.activation = activation
-        self._permute = MoePermuteNopadFwdOp(
-            num_experts=num_experts, expert_map=expert_map,
+        self._routed_scaling_factor = routed_scaling_factor
+        numel = num_tokens * top_k
+
+        self._gate_up = MoeGateUpFwdOp(
+            numel=numel, num_experts=num_experts_local,
+            ffn=ffn_size, k=hidden_size, activation=activation,
             kernel_map=kernel_map,
         )
-        # The two grouped GEMMs are compiled for the number of experts this rank
-        # owns. That count is read from the permute output at forward time, so
-        # construction reads nothing off the device.
-        self._gemm_stages: Dict[int, tuple[MoeGateUpFwdOp, MoeGroupedGemmNopadFwdOp]] = {}
+        self._gemm_down = MoeGroupedGemmNopadFwdOp(
+            numel=numel, num_experts=num_experts_local,
+            n=hidden_size, k=ffn_size,
+            kernel_map=kernel_map,
+        )
         self._unpermute = MoeUnpermuteFwdOp(
             total_tokens=num_tokens, top_k=top_k,
             hidden_size=hidden_size, padded_batch_sum=numel,
             kernel_map=kernel_map,
             routed_scaling_factor=routed_scaling_factor,
         )
-        self._routed_scaling_factor = routed_scaling_factor
-
-    def _gemm_stage_ops(
-        self, num_experts_local: int,
-    ) -> tuple[MoeGateUpFwdOp, MoeGroupedGemmNopadFwdOp]:
-        """Return the gate/up and down GEMM ops for a local expert count.
-
-        ``self.tune`` is read here rather than at construction so a stage first
-        built after ``autotune()`` is tuned like the rest of the pipeline.
-        """
-        stages = self._gemm_stages.get(num_experts_local)
-        if stages is None:
-            stages = (
-                MoeGateUpFwdOp(
-                    numel=self._numel, num_experts=num_experts_local,
-                    ffn=self.ffn_size, k=self.hidden_size, activation=self.activation,
-                    kernel_map=self._kernel_map, tune=self.tune,
-                ),
-                MoeGroupedGemmNopadFwdOp(
-                    numel=self._numel, num_experts=num_experts_local,
-                    n=self.hidden_size, k=self.ffn_size,
-                    kernel_map=self._kernel_map, tune=self.tune,
-                ),
-            )
-            self._gemm_stages[num_experts_local] = stages
-        return stages
 
     def kernel_delegates(self) -> tuple[Op, ...]:
-        return (
-            self._permute,
-            self._unpermute,
-            *(op for stages in self._gemm_stages.values() for op in stages),
-        )
+        return (self._permute, self._gate_up, self._gemm_down, self._unpermute)
+
+    def eval_roofline(self) -> tuple[int, int]:
+        """Manifest ``roofline``: three F x H weight planes per local expert."""
+        if self.dtype is None:
+            raise ValueError(
+                f"{type(self).__name__}.eval_roofline() requires a prior forward() "
+                "to bind dtype"
+            )
+        flops = self.num_tokens * self.top_k * 6 * self.ffn_size * self.hidden_size
+        nbytes = (
+            self.num_experts_local * 3 * self.ffn_size * self.hidden_size
+            + 2 * self.num_tokens * self.hidden_size
+        ) * self.dtype.itemsize
+        return int(flops), int(nbytes)
 
     def _validate_dtypes(
         self,
@@ -140,7 +166,6 @@ class FusedMoEExpertsNopadPersistent3WGFwdOp(FusedMoEExpertsModular):
         w_down: Tensor,
         topk_weights: Tensor,
         topk_ids: Tensor,
-        expert_map: Tensor | None,
         workspace1: Tensor,
         workspace2: Tensor,
     ) -> None:
@@ -150,14 +175,18 @@ class FusedMoEExpertsNopadPersistent3WGFwdOp(FusedMoEExpertsModular):
         _validate_fused_moe_experts_dtypes(
             hidden_states.dtype,
             output, hidden_states, w_gate_up, w_down,
-            topk_weights, topk_ids, expert_map, workspace1, workspace2,
+            topk_weights, topk_ids, workspace1, workspace2,
         )
-        # workspace_shapes() returns ((0,), (0,)) for this implementation; flag
-        # callers that pass non-empty workspaces (likely a pipeline mismatch).
+        self._reject_non_empty_workspaces(workspace1, workspace2)
+
+    def _reject_non_empty_workspaces(
+        self, workspace1: Tensor, workspace2: Tensor,
+    ) -> None:
+        """workspace_shapes() returns ((0,), (0,)); anything else is a mismatch."""
         if workspace1.numel() != 0 or workspace2.numel() != 0:
             raise ValueError(
                 "workspace1 and workspace2 must be empty (numel == 0) for "
-                "FusedMoEExpertsNopadPersistent3WGFwdOp; got "
+                f"{type(self).__name__}; got "
                 f"workspace1.numel()={workspace1.numel()}, "
                 f"workspace2.numel()={workspace2.numel()}."
             )
@@ -178,6 +207,22 @@ class FusedMoEExpertsNopadPersistent3WGFwdOp(FusedMoEExpertsModular):
         # All sub-kernels are owned by the inner Ops (permute / GEMM / activation / unpermute).
         return {}
 
+    def _run_stages(
+        self,
+        output: Tensor,
+        w_gate_up: Tensor,
+        w_down: Tensor,
+        topk_weights: Tensor,
+        permuted: tuple,
+    ) -> None:
+        """The three stages after the permute, shared by both identities."""
+        perm_h, true_offsets, true_sizes, _, fwd_idx = permuted
+        act = self._gate_up(perm_h, w_gate_up, true_sizes, true_offsets)
+        mm2 = self._gemm_down(act, w_down, true_sizes, true_offsets)
+        # Unpermute reduces into ``output`` directly and folds
+        # ``routed_scaling_factor`` into its prim_func — no separate copy/scale.
+        self._unpermute(mm2, fwd_idx, topk_weights, out=output)
+
     def forward(
         self,
         output: Tensor,
@@ -186,27 +231,117 @@ class FusedMoEExpertsNopadPersistent3WGFwdOp(FusedMoEExpertsModular):
         w_down: Tensor,
         topk_weights: Tensor,
         topk_ids: Tensor,
-        expert_map: Tensor | None,
         workspace1: Tensor,
         workspace2: Tensor,
         num_experts: int,
     ) -> None:
-        if expert_map is not self.expert_map:
+        self._validate_dtypes(
+            output, hidden_states, w_gate_up, w_down,
+            topk_weights, topk_ids, workspace1, workspace2,
+        )
+        self._run_stages(
+            output, w_gate_up, w_down, topk_weights,
+            self._permute(hidden_states, topk_ids),
+        )
+
+
+class FusedMoEExpertsNopadPersistent3WGEpFwdOp(FusedMoEExpertsNopadPersistent3WGFwdOp):
+    """The same pipeline sized for the experts one rank owns under expert parallelism.
+
+    ``num_experts_local`` sizes the permute kernel's output buffers and both
+    grouped GEMMs, so it is a constructor parameter. ``expert_map`` holds the
+    global-to-local ids, read at launch, so it is a ``forward`` input; the permute
+    stage rejects a map that does not cover exactly the local ids.
+
+    Args:
+        num_tokens: Number of input tokens T (rows of hidden_states).
+        num_experts: Total number of experts E in the routing table.
+        num_experts_local: Number of those experts this rank owns.
+        top_k: Number of experts each token is routed to (K).
+        hidden_size: Model hidden dimension H.
+        ffn_size: Per-expert FFN intermediate dimension F.
+        routed_scaling_factor: Scalar applied to the final reduced output.
+        kernel_map: Optional kernel overrides forwarded to the inner Ops.
+        activation: Gated activation applied to gate_up.
+
+    Example:
+        >>> experts = FusedMoEExpertsNopadPersistent3WGEpFwdOp(
+        ...     num_tokens=512, num_experts=256, num_experts_local=128, top_k=8,
+        ...     hidden_size=7168, ffn_size=2048,
+        ... )
+    """
+
+    def __init__(
+        self,
+        num_tokens: int,
+        num_experts: int,
+        num_experts_local: int,
+        top_k: int,
+        hidden_size: int,
+        ffn_size: int,
+        routed_scaling_factor: float = 1.0,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        *,
+        activation: str = "silu_and_mul",
+    ):
+        self.dispatch_kernel(kernel_map)
+        self._init_pipeline(
+            num_tokens=num_tokens,
+            num_experts=num_experts,
+            num_experts_local=num_experts_local,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            ffn_size=ffn_size,
+            routed_scaling_factor=routed_scaling_factor,
+            kernel_map=kernel_map,
+            activation=activation,
+        )
+        self._permute = MoePermuteNopadEpFwdOp(
+            num_experts=num_experts, num_experts_local=num_experts_local,
+            kernel_map=kernel_map,
+        )
+
+    def _validate_dtypes(
+        self,
+        output: Tensor,
+        hidden_states: Tensor,
+        w_gate_up: Tensor,
+        w_down: Tensor,
+        topk_weights: Tensor,
+        topk_ids: Tensor,
+        expert_map: Tensor,
+        workspace1: Tensor,
+        workspace2: Tensor,
+    ) -> None:
+        self.dtype = hidden_states.dtype
+        _validate_fused_moe_experts_dtypes(
+            hidden_states.dtype,
+            output, hidden_states, w_gate_up, w_down,
+            topk_weights, topk_ids, workspace1, workspace2,
+        )
+        if expert_map.dtype != torch.int32:
             raise ValueError(
-                "expert_map must be the tensor this op was constructed with: the "
-                "number of experts it marks local is compiled into the permute "
-                "kernel and both grouped GEMMs. Construct a second op for a "
-                f"second map (built for {'no map' if self.expert_map is None else 'a map'}, "
-                f"called with {'no map' if expert_map is None else 'a different map'})."
-            )
+                f"Expected expert_map.dtype == int32, got {expert_map.dtype}")
+        self._reject_non_empty_workspaces(workspace1, workspace2)
+
+    def forward(
+        self,
+        output: Tensor,
+        hidden_states: Tensor,
+        w_gate_up: Tensor,
+        w_down: Tensor,
+        topk_weights: Tensor,
+        topk_ids: Tensor,
+        expert_map: Tensor,
+        workspace1: Tensor,
+        workspace2: Tensor,
+        num_experts: int,
+    ) -> None:
         self._validate_dtypes(
             output, hidden_states, w_gate_up, w_down,
             topk_weights, topk_ids, expert_map, workspace1, workspace2,
         )
-        perm_h, true_offsets, true_sizes, _, fwd_idx = self._permute(hidden_states, topk_ids)
-        gate_up, gemm_down = self._gemm_stage_ops(true_sizes.shape[0])
-        act = gate_up(perm_h, w_gate_up, true_sizes, true_offsets)
-        mm2 = gemm_down(act, w_down, true_sizes, true_offsets)
-        # Unpermute reduces into ``output`` directly and folds
-        # ``routed_scaling_factor`` into its prim_func — no separate copy/scale.
-        self._unpermute(mm2, fwd_idx, topk_weights, out=output)
+        self._run_stages(
+            output, w_gate_up, w_down, topk_weights,
+            self._permute(hidden_states, topk_ids, expert_map),
+        )

--- a/src/tileops/ops/moe/routed_expert/fused_routed_expert.py
+++ b/src/tileops/ops/moe/routed_expert/fused_routed_expert.py
@@ -8,6 +8,7 @@ from torch import Tensor
 
 from tileops.kernels.kernel_base import Kernel
 
+from ...op_base import Op
 from ..abc import (
     FusedMoEExpertsModular,
     WeightedReduce,
@@ -45,7 +46,8 @@ class FusedMoEExpertsNopadPersistent3WGFwdOp(FusedMoEExpertsModular):
         routed_scaling_factor: Scalar applied to the final reduced output.
             Defaults to 1.0 (no scaling).
         expert_map: Optional global→local expert id map for expert parallelism
-            (EP). Entries < 0 mark experts not owned by this rank.
+            (EP). Entries < 0 mark experts not owned by this rank. This is the
+            map the op is built for; ``forward`` must be handed the same tensor.
         kernel_map: Optional kernel overrides forwarded to the inner Ops.
         activation: Gated activation applied to gate_up: 'silu_and_mul' or
             'gelu_and_mul'.
@@ -76,26 +78,20 @@ class FusedMoEExpertsNopadPersistent3WGFwdOp(FusedMoEExpertsModular):
         self.top_k = top_k
         self.hidden_size = hidden_size
         self.ffn_size = ffn_size
+        self.expert_map = expert_map
         numel = num_tokens * top_k
-        num_experts_local = (
-            int((expert_map >= 0).sum().item()) if expert_map is not None else num_experts
-        )
+        self._numel = numel
+        self._kernel_map = kernel_map
 
         self.activation = activation
         self._permute = MoePermuteNopadFwdOp(
             num_experts=num_experts, expert_map=expert_map,
             kernel_map=kernel_map,
         )
-        self._gate_up = MoeGateUpFwdOp(
-            numel=numel, num_experts=num_experts_local,
-            ffn=ffn_size, k=hidden_size, activation=activation,
-            kernel_map=kernel_map,
-        )
-        self._gemm_down = MoeGroupedGemmNopadFwdOp(
-            numel=numel, num_experts=num_experts_local,
-            n=hidden_size, k=ffn_size,
-            kernel_map=kernel_map,
-        )
+        # The two grouped GEMMs are compiled for the number of experts this rank
+        # owns. That count is read from the permute output at forward time, so
+        # construction reads nothing off the device.
+        self._gemm_stages: Dict[int, tuple[MoeGateUpFwdOp, MoeGroupedGemmNopadFwdOp]] = {}
         self._unpermute = MoeUnpermuteFwdOp(
             total_tokens=num_tokens, top_k=top_k,
             hidden_size=hidden_size, padded_batch_sum=numel,
@@ -103,6 +99,38 @@ class FusedMoEExpertsNopadPersistent3WGFwdOp(FusedMoEExpertsModular):
             routed_scaling_factor=routed_scaling_factor,
         )
         self._routed_scaling_factor = routed_scaling_factor
+
+    def _gemm_stage_ops(
+        self, num_experts_local: int,
+    ) -> tuple[MoeGateUpFwdOp, MoeGroupedGemmNopadFwdOp]:
+        """Return the gate/up and down GEMM ops for a local expert count.
+
+        ``self.tune`` is read here rather than at construction so a stage first
+        built after ``autotune()`` is tuned like the rest of the pipeline.
+        """
+        stages = self._gemm_stages.get(num_experts_local)
+        if stages is None:
+            stages = (
+                MoeGateUpFwdOp(
+                    numel=self._numel, num_experts=num_experts_local,
+                    ffn=self.ffn_size, k=self.hidden_size, activation=self.activation,
+                    kernel_map=self._kernel_map, tune=self.tune,
+                ),
+                MoeGroupedGemmNopadFwdOp(
+                    numel=self._numel, num_experts=num_experts_local,
+                    n=self.hidden_size, k=self.ffn_size,
+                    kernel_map=self._kernel_map, tune=self.tune,
+                ),
+            )
+            self._gemm_stages[num_experts_local] = stages
+        return stages
+
+    def kernel_delegates(self) -> tuple[Op, ...]:
+        return (
+            self._permute,
+            self._unpermute,
+            *(op for stages in self._gemm_stages.values() for op in stages),
+        )
 
     def _validate_dtypes(
         self,
@@ -163,13 +191,22 @@ class FusedMoEExpertsNopadPersistent3WGFwdOp(FusedMoEExpertsModular):
         workspace2: Tensor,
         num_experts: int,
     ) -> None:
+        if expert_map is not self.expert_map:
+            raise ValueError(
+                "expert_map must be the tensor this op was constructed with: the "
+                "number of experts it marks local is compiled into the permute "
+                "kernel and both grouped GEMMs. Construct a second op for a "
+                f"second map (built for {'no map' if self.expert_map is None else 'a map'}, "
+                f"called with {'no map' if expert_map is None else 'a different map'})."
+            )
         self._validate_dtypes(
             output, hidden_states, w_gate_up, w_down,
             topk_weights, topk_ids, expert_map, workspace1, workspace2,
         )
         perm_h, true_offsets, true_sizes, _, fwd_idx = self._permute(hidden_states, topk_ids)
-        act = self._gate_up(perm_h, w_gate_up, true_sizes, true_offsets)
-        mm2 = self._gemm_down(act, w_down, true_sizes, true_offsets)
+        gate_up, gemm_down = self._gemm_stage_ops(true_sizes.shape[0])
+        act = gate_up(perm_h, w_gate_up, true_sizes, true_offsets)
+        mm2 = gemm_down(act, w_down, true_sizes, true_offsets)
         # Unpermute reduces into ``output`` directly and folds
         # ``routed_scaling_factor`` into its prim_func — no separate copy/scale.
         self._unpermute(mm2, fwd_idx, topk_weights, out=output)

--- a/src/tileops/ops/moe/routed_expert/fused_routed_expert.py
+++ b/src/tileops/ops/moe/routed_expert/fused_routed_expert.py
@@ -1,14 +1,7 @@
 """FusedMoEExperts implementation: nopad + 3WG persistent variant.
 
-Two manifest identities share the pipeline, one per expert-parallel (EP) shape:
-
-- ``FusedMoEExpertsNopadPersistent3WGFwdOp`` — every expert is local.
-- ``FusedMoEExpertsNopadPersistent3WGEpFwdOp`` — this rank owns
-  ``num_experts_local`` experts, a constructor parameter, and takes the
-  global-to-local map as a ``forward`` input.
-
-Neither registers an operator of its own: a composite is not the unit of
-replacement, so its graph is its leaves' operators.
+Registers no operator of its own: a composite is not the unit of replacement,
+so its graph is its leaves' operators.
 """
 
 from __future__ import annotations
@@ -29,13 +22,10 @@ from ..abc import (
 )
 from .gate_up import MoeGateUpFwdOp
 from .moe_grouped_gemm_nopad import MoeGroupedGemmNopadFwdOp
-from .permute_nopad import MoePermuteNopadEpFwdOp, MoePermuteNopadFwdOp
+from .permute_nopad import MoePermuteNopadFwdOp
 from .unpermute import MoeUnpermuteFwdOp
 
-__all__ = [
-    "FusedMoEExpertsNopadPersistent3WGEpFwdOp",
-    "FusedMoEExpertsNopadPersistent3WGFwdOp",
-]
+__all__ = ["FusedMoEExpertsNopadPersistent3WGFwdOp"]
 
 
 class FusedMoEExpertsNopadPersistent3WGFwdOp(FusedMoEExpertsModular):
@@ -51,6 +41,9 @@ class FusedMoEExpertsNopadPersistent3WGFwdOp(FusedMoEExpertsModular):
     Args:
         num_tokens: Number of input tokens T (rows of hidden_states).
         num_experts: Total number of experts E in the routing table.
+        num_experts_local: Number of those experts this rank owns; the weights
+            and both grouped GEMMs are sized by it. Equal to ``num_experts``
+            outside expert parallelism.
         top_k: Number of experts each token is routed to (K).
         hidden_size: Model hidden dimension H (GEMM contraction dim for
             gate_up, output dim for down).
@@ -63,7 +56,7 @@ class FusedMoEExpertsNopadPersistent3WGFwdOp(FusedMoEExpertsModular):
 
     Example:
         >>> experts = FusedMoEExpertsNopadPersistent3WGFwdOp(
-        ...     num_tokens=512, num_experts=128, top_k=8,
+        ...     num_tokens=512, num_experts=128, num_experts_local=128, top_k=8,
         ...     hidden_size=7168, ffn_size=2048,
         ... )
     """
@@ -72,6 +65,7 @@ class FusedMoEExpertsNopadPersistent3WGFwdOp(FusedMoEExpertsModular):
         self,
         num_tokens: int,
         num_experts: int,
+        num_experts_local: int,
         top_k: int,
         hidden_size: int,
         ffn_size: int,
@@ -81,39 +75,6 @@ class FusedMoEExpertsNopadPersistent3WGFwdOp(FusedMoEExpertsModular):
         activation: str = "silu_and_mul",
     ):
         self.dispatch_kernel(kernel_map)
-        self._init_pipeline(
-            num_tokens=num_tokens,
-            num_experts=num_experts,
-            num_experts_local=num_experts,
-            top_k=top_k,
-            hidden_size=hidden_size,
-            ffn_size=ffn_size,
-            routed_scaling_factor=routed_scaling_factor,
-            kernel_map=kernel_map,
-            activation=activation,
-        )
-        self._permute = MoePermuteNopadFwdOp(
-            num_experts=num_experts, kernel_map=kernel_map,
-        )
-
-    def _init_pipeline(
-        self,
-        *,
-        num_tokens: int,
-        num_experts: int,
-        num_experts_local: int,
-        top_k: int,
-        hidden_size: int,
-        ffn_size: int,
-        routed_scaling_factor: float,
-        kernel_map: Optional[Dict[str, Kernel]],
-        activation: str,
-    ) -> None:
-        """Build the stages sized by the expert count this rank owns.
-
-        The two grouped GEMMs and the unpermute are the same for both identities;
-        only the permute stage differs, and each identity builds its own.
-        """
         self.num_tokens = num_tokens
         self.num_experts = num_experts
         self.num_experts_local = num_experts_local
@@ -139,6 +100,10 @@ class FusedMoEExpertsNopadPersistent3WGFwdOp(FusedMoEExpertsModular):
             hidden_size=hidden_size, padded_batch_sum=numel,
             kernel_map=kernel_map,
             routed_scaling_factor=routed_scaling_factor,
+        )
+        self._permute = MoePermuteNopadFwdOp(
+            num_experts=num_experts, num_experts_local=num_experts_local,
+            kernel_map=kernel_map,
         )
 
     def kernel_delegates(self) -> tuple[Op, ...]:
@@ -168,6 +133,8 @@ class FusedMoEExpertsNopadPersistent3WGFwdOp(FusedMoEExpertsModular):
         topk_ids: Tensor,
         workspace1: Tensor,
         workspace2: Tensor,
+        *,
+        expert_map: Optional[Tensor] = None,
     ) -> None:
         # hidden_states is the dtype anchor: the helper requires output,
         # w_gate_up and w_down to agree with it.
@@ -177,6 +144,9 @@ class FusedMoEExpertsNopadPersistent3WGFwdOp(FusedMoEExpertsModular):
             output, hidden_states, w_gate_up, w_down,
             topk_weights, topk_ids, workspace1, workspace2,
         )
+        if expert_map is not None and expert_map.dtype != torch.int32:
+            raise ValueError(
+                f"Expected expert_map.dtype == int32, got {expert_map.dtype}")
         self._reject_non_empty_workspaces(workspace1, workspace2)
 
     def _reject_non_empty_workspaces(
@@ -207,141 +177,37 @@ class FusedMoEExpertsNopadPersistent3WGFwdOp(FusedMoEExpertsModular):
         # All sub-kernels are owned by the inner Ops (permute / GEMM / activation / unpermute).
         return {}
 
-    def _run_stages(
+    def forward(
         self,
         output: Tensor,
+        hidden_states: Tensor,
         w_gate_up: Tensor,
         w_down: Tensor,
         topk_weights: Tensor,
-        permuted: tuple,
+        topk_ids: Tensor,
+        workspace1: Tensor,
+        workspace2: Tensor,
+        expert_map: Optional[Tensor] = None,
+        *,
+        num_experts: int,
     ) -> None:
-        """The three stages after the permute, shared by both identities."""
-        perm_h, true_offsets, true_sizes, _, fwd_idx = permuted
+        """Run the expert pipeline, writing the reduced result into ``output``.
+
+        Args:
+            expert_map: [E] int32 global-to-local expert ids under expert
+                parallelism; ``None`` when this rank owns every expert. The
+                permute stage rejects a map that does not cover exactly the
+                local ids.
+        """
+        self._validate_dtypes(
+            output, hidden_states, w_gate_up, w_down,
+            topk_weights, topk_ids, workspace1, workspace2,
+            expert_map=expert_map,
+        )
+        perm_h, true_offsets, true_sizes, _, fwd_idx = self._permute(
+            hidden_states, topk_ids, expert_map)
         act = self._gate_up(perm_h, w_gate_up, true_sizes, true_offsets)
         mm2 = self._gemm_down(act, w_down, true_sizes, true_offsets)
         # Unpermute reduces into ``output`` directly and folds
         # ``routed_scaling_factor`` into its prim_func — no separate copy/scale.
         self._unpermute(mm2, fwd_idx, topk_weights, out=output)
-
-    def forward(
-        self,
-        output: Tensor,
-        hidden_states: Tensor,
-        w_gate_up: Tensor,
-        w_down: Tensor,
-        topk_weights: Tensor,
-        topk_ids: Tensor,
-        workspace1: Tensor,
-        workspace2: Tensor,
-        num_experts: int,
-    ) -> None:
-        self._validate_dtypes(
-            output, hidden_states, w_gate_up, w_down,
-            topk_weights, topk_ids, workspace1, workspace2,
-        )
-        self._run_stages(
-            output, w_gate_up, w_down, topk_weights,
-            self._permute(hidden_states, topk_ids),
-        )
-
-
-class FusedMoEExpertsNopadPersistent3WGEpFwdOp(FusedMoEExpertsNopadPersistent3WGFwdOp):
-    """The same pipeline sized for the experts one rank owns under expert parallelism.
-
-    ``num_experts_local`` sizes the permute kernel's output buffers and both
-    grouped GEMMs, so it is a constructor parameter. ``expert_map`` holds the
-    global-to-local ids, read at launch, so it is a ``forward`` input; the permute
-    stage rejects a map that does not cover exactly the local ids.
-
-    Args:
-        num_tokens: Number of input tokens T (rows of hidden_states).
-        num_experts: Total number of experts E in the routing table.
-        num_experts_local: Number of those experts this rank owns.
-        top_k: Number of experts each token is routed to (K).
-        hidden_size: Model hidden dimension H.
-        ffn_size: Per-expert FFN intermediate dimension F.
-        routed_scaling_factor: Scalar applied to the final reduced output.
-        kernel_map: Optional kernel overrides forwarded to the inner Ops.
-        activation: Gated activation applied to gate_up.
-
-    Example:
-        >>> experts = FusedMoEExpertsNopadPersistent3WGEpFwdOp(
-        ...     num_tokens=512, num_experts=256, num_experts_local=128, top_k=8,
-        ...     hidden_size=7168, ffn_size=2048,
-        ... )
-    """
-
-    def __init__(
-        self,
-        num_tokens: int,
-        num_experts: int,
-        num_experts_local: int,
-        top_k: int,
-        hidden_size: int,
-        ffn_size: int,
-        routed_scaling_factor: float = 1.0,
-        kernel_map: Optional[Dict[str, Kernel]] = None,
-        *,
-        activation: str = "silu_and_mul",
-    ):
-        self.dispatch_kernel(kernel_map)
-        self._init_pipeline(
-            num_tokens=num_tokens,
-            num_experts=num_experts,
-            num_experts_local=num_experts_local,
-            top_k=top_k,
-            hidden_size=hidden_size,
-            ffn_size=ffn_size,
-            routed_scaling_factor=routed_scaling_factor,
-            kernel_map=kernel_map,
-            activation=activation,
-        )
-        self._permute = MoePermuteNopadEpFwdOp(
-            num_experts=num_experts, num_experts_local=num_experts_local,
-            kernel_map=kernel_map,
-        )
-
-    def _validate_dtypes(
-        self,
-        output: Tensor,
-        hidden_states: Tensor,
-        w_gate_up: Tensor,
-        w_down: Tensor,
-        topk_weights: Tensor,
-        topk_ids: Tensor,
-        expert_map: Tensor,
-        workspace1: Tensor,
-        workspace2: Tensor,
-    ) -> None:
-        self.dtype = hidden_states.dtype
-        _validate_fused_moe_experts_dtypes(
-            hidden_states.dtype,
-            output, hidden_states, w_gate_up, w_down,
-            topk_weights, topk_ids, workspace1, workspace2,
-        )
-        if expert_map.dtype != torch.int32:
-            raise ValueError(
-                f"Expected expert_map.dtype == int32, got {expert_map.dtype}")
-        self._reject_non_empty_workspaces(workspace1, workspace2)
-
-    def forward(
-        self,
-        output: Tensor,
-        hidden_states: Tensor,
-        w_gate_up: Tensor,
-        w_down: Tensor,
-        topk_weights: Tensor,
-        topk_ids: Tensor,
-        expert_map: Tensor,
-        workspace1: Tensor,
-        workspace2: Tensor,
-        num_experts: int,
-    ) -> None:
-        self._validate_dtypes(
-            output, hidden_states, w_gate_up, w_down,
-            topk_weights, topk_ids, expert_map, workspace1, workspace2,
-        )
-        self._run_stages(
-            output, w_gate_up, w_down, topk_weights,
-            self._permute(hidden_states, topk_ids, expert_map),
-        )

--- a/src/tileops/ops/moe/routed_expert/gate_up.py
+++ b/src/tileops/ops/moe/routed_expert/gate_up.py
@@ -1,6 +1,6 @@
 """The gate/up stage of the MoE expert pipeline, activation included."""
 
-from typing import Dict, Optional
+from typing import ClassVar, Dict, Optional, Tuple
 
 import torch
 
@@ -12,6 +12,7 @@ from tileops.kernels.moe import (
     MoeGroupedGemmSeparateActKernel,
 )
 
+from ...compile_boundary import get_instance
 from ...op_base import Op
 
 __all__ = ["MoeGateUpFwdOp"]
@@ -42,6 +43,9 @@ class MoeGateUpFwdOp(Op):
         >>> op = MoeGateUpFwdOp(numel=4096, num_experts=128, ffn=2048, k=7168)
         >>> act = op(a, b, true_sizes, true_offsets)  # [4096, 2048]
     """
+
+    #: The operator this op registers; a test asserts the graph holds nothing else.
+    compile_op_names: ClassVar[Tuple[str, ...]] = ("top::moe_gate_up_fwd",)
 
     def __init__(
         self,
@@ -125,6 +129,20 @@ class MoeGateUpFwdOp(Op):
         Returns:
             [numel, ffn] activated output.
         """
+        return _moe_gate_up_fwd(a, b, true_sizes, true_offsets, self._instance_key)
+
+    def _eager_forward(
+        self,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        true_sizes: torch.Tensor,
+        true_offsets: torch.Tensor,
+    ) -> torch.Tensor:
+        """Validate, normalize, resolve the kernel and launch, inside the operator.
+
+        Never traced: kernel construction enters a TileLang builder, which dynamo
+        cannot follow.
+        """
         self._validate_dtypes(a, b, true_sizes, true_offsets)
         for name, t in (("b", b), ("true_sizes", true_sizes), ("true_offsets", true_offsets)):
             if t.device != a.device:
@@ -135,3 +153,32 @@ class MoeGateUpFwdOp(Op):
         # out is its own business.
         inputs = tuple(t.contiguous() for t in (a, b, true_sizes, true_offsets))
         return self._get_kernel(inputs, a.dtype)(*inputs)
+
+
+@torch.library.custom_op("top::moe_gate_up_fwd", mutates_args=())
+def _moe_gate_up_fwd(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    true_sizes: torch.Tensor,
+    true_offsets: torch.Tensor,
+    instance_key: str,
+) -> torch.Tensor:
+    return get_instance(instance_key)._eager_forward(a, b, true_sizes, true_offsets)
+
+
+@_moe_gate_up_fwd.register_fake
+def _moe_gate_up_fwd_fake(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    true_sizes: torch.Tensor,
+    true_offsets: torch.Tensor,
+    instance_key: str,
+) -> torch.Tensor:
+    op = get_instance(instance_key)
+    shapes = op._infer_output_shapes(
+        tuple(a.shape), tuple(b.shape), tuple(true_sizes.shape),
+        tuple(true_offsets.shape))
+    # ``new_empty``, not ``empty_like``: ``_eager_forward`` normalizes contiguity, so a
+    # non-contiguous public input's strides must not survive into the fake. Dtype is the
+    # manifest's ``same_as(a)``.
+    return a.new_empty(shapes["c"])

--- a/src/tileops/ops/moe/routed_expert/moe_grouped_gemm_nopad.py
+++ b/src/tileops/ops/moe/routed_expert/moe_grouped_gemm_nopad.py
@@ -1,6 +1,6 @@
 """MoE grouped GEMM op (no-pad variant): NT GEMM with precomputed tile scheduling."""
 
-from typing import Dict, Optional
+from typing import ClassVar, Dict, Optional, Tuple
 
 import torch
 
@@ -8,6 +8,7 @@ from tileops.kernels.grouped_gemm import GroupedGemmCall, GroupedGemmPersistent3
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.moe.moe_grouped_gemm_nopad import MoeGroupedGemmNopadKernel
 
+from ...compile_boundary import get_instance
 from ...op_base import Op
 
 __all__ = ["MoeGroupedGemmNopadFwdOp"]
@@ -38,6 +39,9 @@ class MoeGroupedGemmNopadFwdOp(Op):
         ...)
         >>> C = op(A, B, true_sizes, true_offsets)  # [numel, N]
     """
+
+    #: The operator this op registers; a test asserts the graph holds nothing else.
+    compile_op_names: ClassVar[Tuple[str, ...]] = ("top::moe_grouped_gemm_nopad_fwd",)
 
     def __init__(
         self,
@@ -106,6 +110,21 @@ class MoeGroupedGemmNopadFwdOp(Op):
         Returns:
             C: [numel, N] GEMM output.
         """
+        return _moe_grouped_gemm_nopad_fwd(
+            a, b, true_sizes, true_offsets, self._instance_key)
+
+    def _eager_forward(
+        self,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        true_sizes: torch.Tensor,
+        true_offsets: torch.Tensor,
+    ) -> torch.Tensor:
+        """Validate, normalize, resolve the kernel and launch, inside the operator.
+
+        Never traced: kernel construction enters a TileLang builder, which dynamo
+        cannot follow.
+        """
         self._validate_dtypes(a, b, true_sizes, true_offsets)
         for name, t in (("b", b), ("true_sizes", true_sizes), ("true_offsets", true_offsets)):
             if t.device != a.device:
@@ -116,3 +135,32 @@ class MoeGroupedGemmNopadFwdOp(Op):
         # out is its own business.
         inputs = tuple(t.contiguous() for t in (a, b, true_sizes, true_offsets))
         return self._get_kernel(inputs, a.dtype)(*inputs)
+
+
+@torch.library.custom_op("top::moe_grouped_gemm_nopad_fwd", mutates_args=())
+def _moe_grouped_gemm_nopad_fwd(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    true_sizes: torch.Tensor,
+    true_offsets: torch.Tensor,
+    instance_key: str,
+) -> torch.Tensor:
+    return get_instance(instance_key)._eager_forward(a, b, true_sizes, true_offsets)
+
+
+@_moe_grouped_gemm_nopad_fwd.register_fake
+def _moe_grouped_gemm_nopad_fwd_fake(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    true_sizes: torch.Tensor,
+    true_offsets: torch.Tensor,
+    instance_key: str,
+) -> torch.Tensor:
+    op = get_instance(instance_key)
+    shapes = op._infer_output_shapes(
+        tuple(a.shape), tuple(b.shape), tuple(true_sizes.shape),
+        tuple(true_offsets.shape))
+    # ``new_empty``, not ``empty_like``: ``_eager_forward`` normalizes contiguity, so a
+    # non-contiguous public input's strides must not survive into the fake. Dtype is the
+    # manifest's ``same_as(a)``.
+    return a.new_empty(shapes["c"])

--- a/src/tileops/ops/moe/routed_expert/permute_nopad.py
+++ b/src/tileops/ops/moe/routed_expert/permute_nopad.py
@@ -30,6 +30,9 @@ class MoePermuteNopadFwdOp(Op):
         expert_map: Optional [E_global] int32 tensor mapping global expert ids
             to local ids (-1 = not on this rank).  When provided, only local
             token-expert pairs are counted; non-local positions get fwd_idx = -1.
+            The map is handed to the kernel at every call, so editing its values
+            in place takes effect on the next call; editing how many entries are
+            local rebuilds the kernel, because that count sizes its buffers.
         kernel_map: Optional kernel override dict.
 
     Example:
@@ -56,6 +59,27 @@ class MoePermuteNopadFwdOp(Op):
 
         self.dispatch_kernel(kernel_map)
         self.expert_map = expert_map
+        # (storage, in-place version) of the map the cached count was read from.
+        self._expert_map_stamp: Optional[tuple[int, int]] = None
+        self._num_experts_local = num_experts
+
+    def _local_expert_count(self) -> Optional[int]:
+        """Number of experts this rank owns, or None when EP is off.
+
+        The count is baked into the kernel — it sizes the scan and its output
+        buffers — so it belongs in the kernel cache key. Reading it costs a
+        device sync, so it is cached against the map's storage address and
+        in-place version counter and re-read only when the map is replaced or
+        edited in place.
+        """
+        expert_map = self.expert_map
+        if expert_map is None:
+            return None
+        stamp = (expert_map.data_ptr(), expert_map._version)
+        if stamp != self._expert_map_stamp:
+            self._num_experts_local = int((expert_map >= 0).sum().item())
+            self._expert_map_stamp = stamp
+        return self._num_experts_local
 
     def eval_roofline(self) -> tuple[int, int]:
         if (
@@ -86,19 +110,25 @@ class MoePermuteNopadFwdOp(Op):
 
     def _get_kernel(
         self,
+        inputs: Tuple[torch.Tensor, ...],
         total_tokens: int,
         top_k: int,
         num_experts: int,
         hidden_size: int,
         dtype: torch.dtype,
         device_index: int | None,
+        num_experts_local: Optional[int],
     ) -> Kernel:
-        key = (total_tokens, top_k, num_experts, hidden_size, dtype, device_index)
+        key = (
+            total_tokens, top_k, num_experts, hidden_size, dtype, device_index,
+            num_experts_local,
+        )
         return self.get_or_build_kernel(
-            "permute_nopad_kernel",
+            "permute_nopad_kernel", inputs,
             key=key,
             build=lambda: self.kernel_map["permute_nopad_kernel"](
-                total_tokens, top_k, num_experts, hidden_size, dtype, self.expert_map
+                total_tokens, top_k, num_experts, hidden_size, dtype,
+                num_experts_local=num_experts_local,
             ),
         )
 
@@ -177,7 +207,8 @@ class MoePermuteNopadFwdOp(Op):
         self.hidden_states_shape = tuple(hidden_states.shape)
         self.topk_ids_shape = tuple(topk_ids.shape)
         kernel = self._get_kernel(
+            (hidden_states, topk_ids),
             total_tokens, top_k, self.num_experts, hidden_size, dtype,
-            hidden_states.device.index,
+            hidden_states.device.index, self._local_expert_count(),
         )
-        return kernel(hidden_states, topk_ids)
+        return kernel(hidden_states, topk_ids, self.expert_map)

--- a/src/tileops/ops/moe/routed_expert/permute_nopad.py
+++ b/src/tileops/ops/moe/routed_expert/permute_nopad.py
@@ -1,12 +1,13 @@
 """MoE permute op (no-pad variant): counting sort + tight gather without block_m padding."""
 
-from typing import Dict, Optional, Tuple
+from typing import ClassVar, Dict, Optional, Tuple
 
 import torch
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.moe.permute_nopad import MoePermuteNopadKernel
 
+from ...compile_boundary import get_instance
 from ...op_base import Op
 
 __all__ = ["MoePermuteNopadFwdOp"]
@@ -40,6 +41,9 @@ class MoePermuteNopadFwdOp(Op):
         >>> perm_h, offsets, sizes, expert_offset, fwd_idx = op(hidden_states, topk_ids)
     """
 
+    #: The operator this op registers; a test asserts the graph holds nothing else.
+    compile_op_names: ClassVar[Tuple[str, ...]] = ("top::moe_permute_nopad_fwd",)
+
     def __init__(
         self,
         num_experts: int,
@@ -67,10 +71,10 @@ class MoePermuteNopadFwdOp(Op):
         """Number of experts this rank owns, or None when EP is off.
 
         The count is baked into the kernel — it sizes the scan and its output
-        buffers — so it belongs in the kernel cache key. Reading it costs a
-        device sync, so it is cached against the map's storage address and
-        in-place version counter and re-read only when the map is replaced or
-        edited in place.
+        buffers — so it belongs in the kernel cache key, and the fake needs it to
+        size the same outputs. Reading it costs a device sync, so it is cached
+        against the map's storage address and in-place version counter and
+        re-read only when the map is replaced or edited in place.
         """
         expert_map = self.expert_map
         if expert_map is None:
@@ -80,6 +84,28 @@ class MoePermuteNopadFwdOp(Op):
             self._num_experts_local = int((expert_map >= 0).sum().item())
             self._expert_map_stamp = stamp
         return self._num_experts_local
+
+    def _infer_output_shapes(
+        self,
+        hidden_states_shape: Tuple[int, ...],
+        topk_ids_shape: Tuple[int, ...],
+    ) -> Dict[str, Tuple[int, ...]]:
+        """Manifest ``shape_rules`` for the five outputs.
+
+        The per-expert outputs are sized by the experts this rank owns. The manifest
+        writes that count as ``num_experts`` because it does not model ``expert_map``;
+        with a map installed the owned count is what the manifest name stands for.
+        """
+        numel = hidden_states_shape[0] * topk_ids_shape[1]
+        owned = self._local_expert_count()
+        e = self.num_experts if owned is None else owned
+        return {
+            "perm_h": (numel, hidden_states_shape[1]),
+            "true_offsets": (e,),
+            "true_sizes": (e,),
+            "expert_first_token_offset": (e + 1,),
+            "fwd_idx": (numel,),
+        }
 
     def eval_roofline(self) -> tuple[int, int]:
         if (
@@ -151,6 +177,18 @@ class MoePermuteNopadFwdOp(Op):
             fwd_idx:                   [T*K] int32 forward mapping: flat_idx → tight slot
                                        (-1 for non-local pairs when expert_map is set)
         """
+        return _moe_permute_nopad_fwd(hidden_states, topk_ids, self._instance_key)
+
+    def _eager_forward(
+        self,
+        hidden_states: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Validate, resolve the kernel and launch, inside the operator.
+
+        Never traced: kernel construction enters a TileLang builder, which dynamo
+        cannot follow.
+        """
         if not hidden_states.is_cuda:
             raise ValueError("hidden_states must be a CUDA tensor")
         if not topk_ids.is_cuda:
@@ -212,3 +250,28 @@ class MoePermuteNopadFwdOp(Op):
             hidden_states.device.index, self._local_expert_count(),
         )
         return kernel(hidden_states, topk_ids, self.expert_map)
+
+
+@torch.library.custom_op("top::moe_permute_nopad_fwd", mutates_args=())
+def _moe_permute_nopad_fwd(
+    hidden_states: torch.Tensor, topk_ids: torch.Tensor, instance_key: str,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    return get_instance(instance_key)._eager_forward(hidden_states, topk_ids)
+
+
+@_moe_permute_nopad_fwd.register_fake
+def _moe_permute_nopad_fwd_fake(
+    hidden_states: torch.Tensor, topk_ids: torch.Tensor, instance_key: str,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    op = get_instance(instance_key)
+    shapes = op._infer_output_shapes(tuple(hidden_states.shape), tuple(topk_ids.shape))
+    device = hidden_states.device
+    # Dtypes are the manifest's: ``same_as(hidden_states)`` for the gathered rows,
+    # int32 for the index arrays, int64 for the prefix sum.
+    return (
+        hidden_states.new_empty(shapes["perm_h"]),
+        torch.empty(shapes["true_offsets"], dtype=torch.int32, device=device),
+        torch.empty(shapes["true_sizes"], dtype=torch.int32, device=device),
+        torch.empty(shapes["expert_first_token_offset"], dtype=torch.int64, device=device),
+        torch.empty(shapes["fwd_idx"], dtype=torch.int32, device=device),
+    )

--- a/src/tileops/ops/moe/routed_expert/permute_nopad.py
+++ b/src/tileops/ops/moe/routed_expert/permute_nopad.py
@@ -1,5 +1,15 @@
-"""MoE permute op (no-pad variant): counting sort + tight gather without block_m padding."""
+"""MoE permute op (no-pad variant): counting sort + tight gather without block_m padding.
 
+Two manifest identities, one per expert-parallel (EP) shape:
+
+- ``MoePermuteNopadFwdOp`` — every expert is local; the op takes no map.
+- ``MoePermuteNopadEpFwdOp`` — this rank owns ``num_experts_local`` of the
+  ``num_experts`` global experts. That count is a constructor parameter because it
+  sizes the scan kernel's output buffers; the global-to-local map is a ``forward``
+  input because its values are read at launch.
+"""
+
+import weakref
 from typing import ClassVar, Dict, Optional, Tuple
 
 import torch
@@ -10,7 +20,51 @@ from tileops.kernels.moe.permute_nopad import MoePermuteNopadKernel
 from ...compile_boundary import get_instance
 from ...op_base import Op
 
-__all__ = ["MoePermuteNopadFwdOp"]
+__all__ = ["MoePermuteNopadEpFwdOp", "MoePermuteNopadFwdOp"]
+
+_HIDDEN_DTYPES = (torch.float16, torch.bfloat16)
+
+
+def _check_routing_dtypes(hidden_states: torch.Tensor, topk_ids: torch.Tensor) -> None:
+    """Dtypes both identities share, per manifest ``signature.inputs``."""
+    if hidden_states.dtype not in _HIDDEN_DTYPES:
+        raise ValueError(
+            "Expected hidden_states.dtype to be torch.float16 or "
+            f"torch.bfloat16, got {hidden_states.dtype}"
+        )
+    if topk_ids.dtype != torch.int32:
+        raise ValueError(f"Expected topk_ids.dtype torch.int32, got {topk_ids.dtype}")
+
+
+def _output_shapes(
+    numel: int, hidden_size: int, num_experts_local: int,
+) -> Dict[str, Tuple[int, ...]]:
+    """The five output shapes both identities declare, in manifest order."""
+    return {
+        "perm_h": (numel, hidden_size),
+        "true_offsets": (num_experts_local,),
+        "true_sizes": (num_experts_local,),
+        "expert_first_token_offset": (num_experts_local + 1,),
+        "fwd_idx": (numel,),
+    }
+
+
+def _fake_outputs(
+    hidden_states: torch.Tensor, shapes: Dict[str, Tuple[int, ...]],
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Empty tensors in the manifest's dtypes.
+
+    ``same_as(hidden_states)`` for the gathered rows, int32 for the index arrays,
+    int64 for the prefix sum.
+    """
+    device = hidden_states.device
+    return (
+        hidden_states.new_empty(shapes["perm_h"]),
+        torch.empty(shapes["true_offsets"], dtype=torch.int32, device=device),
+        torch.empty(shapes["true_sizes"], dtype=torch.int32, device=device),
+        torch.empty(shapes["expert_first_token_offset"], dtype=torch.int64, device=device),
+        torch.empty(shapes["fwd_idx"], dtype=torch.int32, device=device),
+    )
 
 
 class MoePermuteNopadFwdOp(Op):
@@ -21,19 +75,13 @@ class MoePermuteNopadFwdOp(Op):
     the MoE pipeline.
 
     Args:
+        num_experts: Total number of experts E.
         total_tokens: Optional committed number of input tokens T. Preferred
             API infers it from ``hidden_states.shape[0]``.
         top_k: Optional committed number of experts selected per token K.
             Preferred API infers it from ``topk_ids.shape[1]``.
-        num_experts: Total number of experts E (global count).
         hidden_size: Optional committed hidden dimension H. Preferred API
             infers it from ``hidden_states.shape[1]``.
-        expert_map: Optional [E_global] int32 tensor mapping global expert ids
-            to local ids (-1 = not on this rank).  When provided, only local
-            token-expert pairs are counted; non-local positions get fwd_idx = -1.
-            The map is handed to the kernel at every call, so editing its values
-            in place takes effect on the next call; editing how many entries are
-            local rebuilds the kernel, because that count sizes its buffers.
         kernel_map: Optional kernel override dict.
 
     Example:
@@ -50,62 +98,34 @@ class MoePermuteNopadFwdOp(Op):
         total_tokens: Optional[int] = None,
         top_k: Optional[int] = None,
         hidden_size: Optional[int] = None,
-        expert_map: Optional[torch.Tensor] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
     ) -> None:
         self.total_tokens = total_tokens
         self.top_k = top_k
         self.num_experts = num_experts
         self.hidden_size = hidden_size
+        # Experts whose rows this op lays out. Without EP that is all of them; the
+        # EP identity overwrites it with the count this rank owns.
+        self.num_experts_local = num_experts
         self._committed_total_tokens = total_tokens
         self._committed_top_k = top_k
         self._committed_hidden_size = hidden_size
 
         self.dispatch_kernel(kernel_map)
-        self.expert_map = expert_map
-        # (storage, in-place version) of the map the cached count was read from.
-        self._expert_map_stamp: Optional[tuple[int, int]] = None
-        self._num_experts_local = num_experts
 
-    def _local_expert_count(self) -> Optional[int]:
-        """Number of experts this rank owns, or None when EP is off.
-
-        The count is baked into the kernel — it sizes the scan and its output
-        buffers — so it belongs in the kernel cache key, and the fake needs it to
-        size the same outputs. Reading it costs a device sync, so it is cached
-        against the map's storage address and in-place version counter and
-        re-read only when the map is replaced or edited in place.
-        """
-        expert_map = self.expert_map
-        if expert_map is None:
-            return None
-        stamp = (expert_map.data_ptr(), expert_map._version)
-        if stamp != self._expert_map_stamp:
-            self._num_experts_local = int((expert_map >= 0).sum().item())
-            self._expert_map_stamp = stamp
-        return self._num_experts_local
+    def _validate_dtypes(
+        self, hidden_states: torch.Tensor, topk_ids: torch.Tensor,
+    ) -> None:
+        _check_routing_dtypes(hidden_states, topk_ids)
 
     def _infer_output_shapes(
         self,
         hidden_states_shape: Tuple[int, ...],
         topk_ids_shape: Tuple[int, ...],
     ) -> Dict[str, Tuple[int, ...]]:
-        """Manifest ``shape_rules`` for the five outputs.
-
-        The per-expert outputs are sized by the experts this rank owns. The manifest
-        writes that count as ``num_experts`` because it does not model ``expert_map``;
-        with a map installed the owned count is what the manifest name stands for.
-        """
+        """Manifest ``shape_rules`` for the five outputs."""
         numel = hidden_states_shape[0] * topk_ids_shape[1]
-        owned = self._local_expert_count()
-        e = self.num_experts if owned is None else owned
-        return {
-            "perm_h": (numel, hidden_states_shape[1]),
-            "true_offsets": (e,),
-            "true_sizes": (e,),
-            "expert_first_token_offset": (e + 1,),
-            "fwd_idx": (numel,),
-        }
+        return _output_shapes(numel, hidden_states_shape[1], self.num_experts)
 
     def eval_roofline(self) -> tuple[int, int]:
         if (
@@ -115,18 +135,19 @@ class MoePermuteNopadFwdOp(Op):
             or self.num_experts is None
         ):
             raise ValueError(
-                "MoePermuteNopadFwdOp.eval_roofline() requires a prior forward() "
+                f"{type(self).__name__}.eval_roofline() requires a prior forward() "
                 "to bind hidden_states_shape, topk_ids_shape, dtype, and num_experts"
             )
         total_tokens, hidden_size = self.hidden_states_shape
         top_k = self.topk_ids_shape[1]
         elem_bytes = self.dtype.itemsize
+        e_local = self.num_experts_local
         nbytes = (
             (total_tokens * hidden_size + total_tokens * top_k * hidden_size)
             * elem_bytes
-            + (self.num_experts + 1) * 8
+            + (e_local + 1) * 8
             + 2 * total_tokens * top_k * 4
-            + self.num_experts * 8
+            + e_local * 8
         )
         return 0, int(nbytes)
 
@@ -139,56 +160,28 @@ class MoePermuteNopadFwdOp(Op):
         inputs: Tuple[torch.Tensor, ...],
         total_tokens: int,
         top_k: int,
-        num_experts: int,
         hidden_size: int,
         dtype: torch.dtype,
         device_index: int | None,
         num_experts_local: Optional[int],
     ) -> Kernel:
         key = (
-            total_tokens, top_k, num_experts, hidden_size, dtype, device_index,
+            total_tokens, top_k, self.num_experts, hidden_size, dtype, device_index,
             num_experts_local,
         )
         return self.get_or_build_kernel(
             "permute_nopad_kernel", inputs,
             key=key,
             build=lambda: self.kernel_map["permute_nopad_kernel"](
-                total_tokens, top_k, num_experts, hidden_size, dtype,
+                total_tokens, top_k, self.num_experts, hidden_size, dtype,
                 num_experts_local=num_experts_local,
             ),
         )
 
-    def forward(
-        self,
-        hidden_states: torch.Tensor,
-        topk_ids: torch.Tensor,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-        """Run moe_permute without padding.
-
-        Args:
-            hidden_states: [T, H] input activations (bf16/fp16).
-            topk_ids: [T, K] int32 expert assignments (global ids).
-
-        Returns:
-            perm_h:                    [T*K, H] tight hidden states
-            true_offsets:              [E_local] int32 tight start per local expert
-            true_sizes:                [E_local] int32 true token count per local expert
-            expert_first_token_offset: [E_local+1] int64 non-padded prefix-sum
-            fwd_idx:                   [T*K] int32 forward mapping: flat_idx → tight slot
-                                       (-1 for non-local pairs when expert_map is set)
-        """
-        return _moe_permute_nopad_fwd(hidden_states, topk_ids, self._instance_key)
-
-    def _eager_forward(
-        self,
-        hidden_states: torch.Tensor,
-        topk_ids: torch.Tensor,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-        """Validate, resolve the kernel and launch, inside the operator.
-
-        Never traced: kernel construction enters a TileLang builder, which dynamo
-        cannot follow.
-        """
+    def _validate_routing_shapes(
+        self, hidden_states: torch.Tensor, topk_ids: torch.Tensor,
+    ) -> Tuple[int, int, int]:
+        """Check devices and shapes of the two routing tensors; return ``(T, K, H)``."""
         if not hidden_states.is_cuda:
             raise ValueError("hidden_states must be a CUDA tensor")
         if not topk_ids.is_cuda:
@@ -229,27 +222,226 @@ class MoePermuteNopadFwdOp(Op):
             raise ValueError(
                 f"Expected hidden_size={self._committed_hidden_size}, got {hidden_size}"
             )
-        if hidden_states.dtype not in (torch.float16, torch.bfloat16):
-            raise ValueError(
-                "Expected hidden_states.dtype to be torch.float16 or "
-                f"torch.bfloat16, got {hidden_states.dtype}"
-            )
-        if topk_ids.dtype != torch.int32:
-            raise ValueError(f"Expected topk_ids.dtype torch.int32, got {topk_ids.dtype}")
+        return total_tokens, top_k, hidden_size
 
-        dtype = hidden_states.dtype
-        self.dtype = dtype
+    def _bind_call_state(
+        self, hidden_states: torch.Tensor, topk_ids: torch.Tensor,
+        total_tokens: int, top_k: int, hidden_size: int,
+    ) -> None:
+        """Record what ``eval_roofline`` reads off the call."""
+        self.dtype = hidden_states.dtype
         self.total_tokens = total_tokens
         self.top_k = top_k
         self.hidden_size = hidden_size
         self.hidden_states_shape = tuple(hidden_states.shape)
         self.topk_ids_shape = tuple(topk_ids.shape)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Run moe_permute without padding.
+
+        Args:
+            hidden_states: [T, H] input activations (bf16/fp16).
+            topk_ids: [T, K] int32 expert assignments.
+
+        Returns:
+            perm_h:                    [T*K, H] tight hidden states
+            true_offsets:              [E] int32 tight start per expert
+            true_sizes:                [E] int32 true token count per expert
+            expert_first_token_offset: [E+1] int64 non-padded prefix-sum
+            fwd_idx:                   [T*K] int32 forward mapping: flat_idx -> tight slot
+        """
+        return _moe_permute_nopad_fwd(hidden_states, topk_ids, self._instance_key)
+
+    def _eager_forward(
+        self,
+        hidden_states: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Validate, resolve the kernel and launch, inside the operator.
+
+        Never traced: kernel construction enters a TileLang builder, which dynamo
+        cannot follow.
+        """
+        total_tokens, top_k, hidden_size = self._validate_routing_shapes(
+            hidden_states, topk_ids)
+        self._validate_dtypes(hidden_states, topk_ids)
+        self._bind_call_state(
+            hidden_states, topk_ids, total_tokens, top_k, hidden_size)
         kernel = self._get_kernel(
             (hidden_states, topk_ids),
-            total_tokens, top_k, self.num_experts, hidden_size, dtype,
-            hidden_states.device.index, self._local_expert_count(),
+            total_tokens, top_k, hidden_size, hidden_states.dtype,
+            hidden_states.device.index, None,
         )
-        return kernel(hidden_states, topk_ids, self.expert_map)
+        return kernel(hidden_states, topk_ids)
+
+
+class MoePermuteNopadEpFwdOp(MoePermuteNopadFwdOp):
+    """Expert-parallel permute: lay out only the rows this rank owns.
+
+    ``num_experts_local`` sizes the scan kernel's shared counters and its four
+    per-expert outputs, so it is a constructor parameter. ``expert_map`` carries
+    the global-to-local ids the kernel reads at launch, so it is a ``forward``
+    input; a map that is not a bijection onto ``0 .. num_experts_local - 1`` is
+    rejected rather than silently dropping the tokens routed past the end.
+
+    Args:
+        num_experts: Total number of experts E.
+        num_experts_local: Number of those experts this rank owns.
+        total_tokens: Optional committed number of input tokens T.
+        top_k: Optional committed number of experts selected per token K.
+        hidden_size: Optional committed hidden dimension H.
+        kernel_map: Optional kernel override dict.
+
+    Example:
+        >>> op = MoePermuteNopadEpFwdOp(num_experts=8, num_experts_local=4)
+        >>> perm_h, offsets, sizes, expert_offset, fwd_idx = op(
+        ...     hidden_states, topk_ids, expert_map)
+    """
+
+    #: The operator this op registers; a test asserts the graph holds nothing else.
+    compile_op_names: ClassVar[Tuple[str, ...]] = ("top::moe_permute_nopad_ep_fwd",)
+
+    def __init__(
+        self,
+        num_experts: int,
+        num_experts_local: int,
+        total_tokens: Optional[int] = None,
+        top_k: Optional[int] = None,
+        hidden_size: Optional[int] = None,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+    ) -> None:
+        if not 0 < num_experts_local <= num_experts:
+            raise ValueError(
+                f"num_experts_local must be in (0, {num_experts}], "
+                f"got {num_experts_local}"
+            )
+        # Identity and in-place version of the map the density check last passed on.
+        # A weak reference, so a freed tensor cannot pass as this one through a
+        # reused address.
+        self._checked_map: Optional[tuple["weakref.ref", int]] = None
+        super().__init__(
+            num_experts=num_experts,
+            total_tokens=total_tokens,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            kernel_map=kernel_map,
+        )
+        self.num_experts_local = num_experts_local
+
+    def _validate_dtypes(
+        self,
+        hidden_states: torch.Tensor,
+        topk_ids: torch.Tensor,
+        expert_map: torch.Tensor,
+    ) -> None:
+        _check_routing_dtypes(hidden_states, topk_ids)
+        if expert_map.dtype != torch.int32:
+            raise ValueError(
+                f"Expected expert_map.dtype torch.int32, got {expert_map.dtype}")
+
+    def _infer_output_shapes(
+        self,
+        hidden_states_shape: Tuple[int, ...],
+        topk_ids_shape: Tuple[int, ...],
+        expert_map_shape: Tuple[int, ...],
+    ) -> Dict[str, Tuple[int, ...]]:
+        """Manifest ``shape_rules`` for the five outputs.
+
+        Every size follows from the two routing shapes and ``num_experts_local``;
+        the map's contents are never read here.
+        """
+        numel = hidden_states_shape[0] * topk_ids_shape[1]
+        return _output_shapes(numel, hidden_states_shape[1], self.num_experts_local)
+
+    def _validate_expert_map(self, expert_map: torch.Tensor) -> None:
+        """Reject a map that is not a bijection onto the local expert ids.
+
+        The kernel indexes ``num_experts_local`` counters with the map's values, so
+        the non-negative entries must be exactly ``0 .. num_experts_local - 1``, each
+        once. Reading them costs a host sync, so the verdict is remembered against
+        the map's identity and in-place version and re-taken only when either
+        changes — a warm-up call pays it, a captured replay does not.
+        """
+        if tuple(expert_map.shape) != (self.num_experts,):
+            raise ValueError(
+                f"Expected expert_map.shape ({self.num_experts},), "
+                f"got {tuple(expert_map.shape)}")
+        if not expert_map.is_cuda:
+            raise ValueError("expert_map must be a CUDA tensor")
+
+        checked = self._checked_map
+        if (
+            checked is not None
+            and checked[0]() is expert_map
+            and checked[1] == expert_map._version
+        ):
+            return
+
+        local = sorted(expert_map[expert_map >= 0].tolist())
+        if local != list(range(self.num_experts_local)):
+            raise ValueError(
+                "expert_map must assign the local expert ids "
+                f"0 .. {self.num_experts_local - 1} exactly once each; this op was "
+                f"built for num_experts_local={self.num_experts_local} and the map's "
+                f"non-negative entries are {local}. A gap or a repeat sizes the "
+                "kernel's counters for one set of experts while the kernel is handed "
+                "another, and the tokens routed past the end are dropped."
+            )
+        self._checked_map = (weakref.ref(expert_map), expert_map._version)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        topk_ids: torch.Tensor,
+        expert_map: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Run moe_permute without padding, keeping only this rank's experts.
+
+        Args:
+            hidden_states: [T, H] input activations (bf16/fp16).
+            topk_ids: [T, K] int32 expert assignments (global ids).
+            expert_map: [E] int32 global-to-local expert ids; -1 marks an expert
+                another rank owns.
+
+        Returns:
+            perm_h:                    [T*K, H] tight hidden states; only the first
+                                       M_local rows carry data
+            true_offsets:              [E_local] int32 tight start per local expert
+            true_sizes:                [E_local] int32 true token count per local expert
+            expert_first_token_offset: [E_local+1] int64 non-padded prefix-sum
+            fwd_idx:                   [T*K] int32 forward mapping: flat_idx -> tight
+                                       slot, -1 for a non-local pair
+        """
+        return _moe_permute_nopad_ep_fwd(
+            hidden_states, topk_ids, expert_map, self._instance_key)
+
+    def _eager_forward(
+        self,
+        hidden_states: torch.Tensor,
+        topk_ids: torch.Tensor,
+        expert_map: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Validate, resolve the kernel and launch, inside the operator."""
+        total_tokens, top_k, hidden_size = self._validate_routing_shapes(
+            hidden_states, topk_ids)
+        self._validate_dtypes(hidden_states, topk_ids, expert_map)
+        if expert_map.device != hidden_states.device:
+            raise ValueError(
+                f"Expected expert_map on {hidden_states.device}, "
+                f"got {expert_map.device}")
+        self._validate_expert_map(expert_map)
+        self._bind_call_state(
+            hidden_states, topk_ids, total_tokens, top_k, hidden_size)
+        kernel = self._get_kernel(
+            (hidden_states, topk_ids, expert_map),
+            total_tokens, top_k, hidden_size, hidden_states.dtype,
+            hidden_states.device.index, self.num_experts_local,
+        )
+        return kernel(hidden_states, topk_ids, expert_map)
 
 
 @torch.library.custom_op("top::moe_permute_nopad_fwd", mutates_args=())
@@ -265,13 +457,28 @@ def _moe_permute_nopad_fwd_fake(
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     op = get_instance(instance_key)
     shapes = op._infer_output_shapes(tuple(hidden_states.shape), tuple(topk_ids.shape))
-    device = hidden_states.device
-    # Dtypes are the manifest's: ``same_as(hidden_states)`` for the gathered rows,
-    # int32 for the index arrays, int64 for the prefix sum.
-    return (
-        hidden_states.new_empty(shapes["perm_h"]),
-        torch.empty(shapes["true_offsets"], dtype=torch.int32, device=device),
-        torch.empty(shapes["true_sizes"], dtype=torch.int32, device=device),
-        torch.empty(shapes["expert_first_token_offset"], dtype=torch.int64, device=device),
-        torch.empty(shapes["fwd_idx"], dtype=torch.int32, device=device),
-    )
+    return _fake_outputs(hidden_states, shapes)
+
+
+@torch.library.custom_op("top::moe_permute_nopad_ep_fwd", mutates_args=())
+def _moe_permute_nopad_ep_fwd(
+    hidden_states: torch.Tensor,
+    topk_ids: torch.Tensor,
+    expert_map: torch.Tensor,
+    instance_key: str,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    return get_instance(instance_key)._eager_forward(
+        hidden_states, topk_ids, expert_map)
+
+
+@_moe_permute_nopad_ep_fwd.register_fake
+def _moe_permute_nopad_ep_fwd_fake(
+    hidden_states: torch.Tensor,
+    topk_ids: torch.Tensor,
+    expert_map: torch.Tensor,
+    instance_key: str,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    op = get_instance(instance_key)
+    shapes = op._infer_output_shapes(
+        tuple(hidden_states.shape), tuple(topk_ids.shape), tuple(expert_map.shape))
+    return _fake_outputs(hidden_states, shapes)

--- a/src/tileops/ops/moe/routed_expert/permute_nopad.py
+++ b/src/tileops/ops/moe/routed_expert/permute_nopad.py
@@ -1,12 +1,10 @@
 """MoE permute op (no-pad variant): counting sort + tight gather without block_m padding.
 
-Two manifest identities, one per expert-parallel (EP) shape:
-
-- ``MoePermuteNopadFwdOp`` — every expert is local; the op takes no map.
-- ``MoePermuteNopadEpFwdOp`` — this rank owns ``num_experts_local`` of the
-  ``num_experts`` global experts. That count is a constructor parameter because it
-  sizes the scan kernel's output buffers; the global-to-local map is a ``forward``
-  input because its values are read at launch.
+``expert_map`` is optional. Supplied, this rank owns ``num_experts_local`` of the
+``num_experts`` global experts and the scan kernel reads the map to keep only its
+own rows; absent, every expert is local and the scan kernel takes no map at all.
+The count is a constructor parameter because it sizes the scan kernel's shared
+counters and its four per-expert outputs.
 """
 
 import weakref
@@ -20,62 +18,21 @@ from tileops.kernels.moe.permute_nopad import MoePermuteNopadKernel
 from ...compile_boundary import get_instance
 from ...op_base import Op
 
-__all__ = ["MoePermuteNopadEpFwdOp", "MoePermuteNopadFwdOp"]
+__all__ = ["MoePermuteNopadFwdOp"]
 
 _HIDDEN_DTYPES = (torch.float16, torch.bfloat16)
-
-
-def _check_routing_dtypes(hidden_states: torch.Tensor, topk_ids: torch.Tensor) -> None:
-    """Dtypes both identities share, per manifest ``signature.inputs``."""
-    if hidden_states.dtype not in _HIDDEN_DTYPES:
-        raise ValueError(
-            "Expected hidden_states.dtype to be torch.float16 or "
-            f"torch.bfloat16, got {hidden_states.dtype}"
-        )
-    if topk_ids.dtype != torch.int32:
-        raise ValueError(f"Expected topk_ids.dtype torch.int32, got {topk_ids.dtype}")
-
-
-def _output_shapes(
-    numel: int, hidden_size: int, num_experts_local: int,
-) -> Dict[str, Tuple[int, ...]]:
-    """The five output shapes both identities declare, in manifest order."""
-    return {
-        "perm_h": (numel, hidden_size),
-        "true_offsets": (num_experts_local,),
-        "true_sizes": (num_experts_local,),
-        "expert_first_token_offset": (num_experts_local + 1,),
-        "fwd_idx": (numel,),
-    }
-
-
-def _fake_outputs(
-    hidden_states: torch.Tensor, shapes: Dict[str, Tuple[int, ...]],
-) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Empty tensors in the manifest's dtypes.
-
-    ``same_as(hidden_states)`` for the gathered rows, int32 for the index arrays,
-    int64 for the prefix sum.
-    """
-    device = hidden_states.device
-    return (
-        hidden_states.new_empty(shapes["perm_h"]),
-        torch.empty(shapes["true_offsets"], dtype=torch.int32, device=device),
-        torch.empty(shapes["true_sizes"], dtype=torch.int32, device=device),
-        torch.empty(shapes["expert_first_token_offset"], dtype=torch.int64, device=device),
-        torch.empty(shapes["fwd_idx"], dtype=torch.int32, device=device),
-    )
 
 
 class MoePermuteNopadFwdOp(Op):
     """Route tokens to tight (non-padded) expert-contiguous layout.
 
-    The output perm_h has exactly T*K rows with no
-    inter-expert padding, enabling smaller intermediate tensors throughout
-    the MoE pipeline.
+    The output perm_h has exactly T*K rows with no inter-expert padding,
+    enabling smaller intermediate tensors throughout the MoE pipeline.
 
     Args:
-        num_experts: Total number of experts E.
+        num_experts: Total number of experts E in the routing table.
+        num_experts_local: Number of those experts this rank lays out. Equal to
+            ``num_experts`` outside expert parallelism.
         total_tokens: Optional committed number of input tokens T. Preferred
             API infers it from ``hidden_states.shape[0]``.
         top_k: Optional committed number of experts selected per token K.
@@ -85,7 +42,7 @@ class MoePermuteNopadFwdOp(Op):
         kernel_map: Optional kernel override dict.
 
     Example:
-        >>> op = MoePermuteNopadFwdOp(num_experts=8)
+        >>> op = MoePermuteNopadFwdOp(num_experts=8, num_experts_local=8)
         >>> perm_h, offsets, sizes, expert_offset, fwd_idx = op(hidden_states, topk_ids)
     """
 
@@ -95,61 +52,76 @@ class MoePermuteNopadFwdOp(Op):
     def __init__(
         self,
         num_experts: int,
+        num_experts_local: int,
         total_tokens: Optional[int] = None,
         top_k: Optional[int] = None,
         hidden_size: Optional[int] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
     ) -> None:
+        if not 0 < num_experts_local <= num_experts:
+            raise ValueError(
+                f"num_experts_local must be in (0, {num_experts}], "
+                f"got {num_experts_local}"
+            )
         self.total_tokens = total_tokens
         self.top_k = top_k
         self.num_experts = num_experts
+        self.num_experts_local = num_experts_local
         self.hidden_size = hidden_size
-        # Experts whose rows this op lays out. Without EP that is all of them; the
-        # EP identity overwrites it with the count this rank owns.
-        self.num_experts_local = num_experts
         self._committed_total_tokens = total_tokens
         self._committed_top_k = top_k
         self._committed_hidden_size = hidden_size
+        # Identity and in-place version of the map the density check last passed
+        # on. A weak reference, so a freed tensor cannot pass as this one through
+        # a reused address.
+        self._checked_map: Optional[tuple["weakref.ref", int]] = None
+        # Whether the last call supplied a map, for eval_roofline().
+        self.used_expert_map = False
 
         self.dispatch_kernel(kernel_map)
 
     def _validate_dtypes(
-        self, hidden_states: torch.Tensor, topk_ids: torch.Tensor,
+        self,
+        hidden_states: torch.Tensor,
+        topk_ids: torch.Tensor,
+        expert_map: Optional[torch.Tensor] = None,
     ) -> None:
-        _check_routing_dtypes(hidden_states, topk_ids)
+        if hidden_states.dtype not in _HIDDEN_DTYPES:
+            raise ValueError(
+                "Expected hidden_states.dtype to be torch.float16 or "
+                f"torch.bfloat16, got {hidden_states.dtype}"
+            )
+        if topk_ids.dtype != torch.int32:
+            raise ValueError(
+                f"Expected topk_ids.dtype torch.int32, got {topk_ids.dtype}")
+        if expert_map is not None and expert_map.dtype != torch.int32:
+            raise ValueError(
+                f"Expected expert_map.dtype torch.int32, got {expert_map.dtype}")
 
     def _infer_output_shapes(
         self,
         hidden_states_shape: Tuple[int, ...],
         topk_ids_shape: Tuple[int, ...],
+        expert_map_shape: Optional[Tuple[int, ...]] = None,
     ) -> Dict[str, Tuple[int, ...]]:
-        """Manifest ``shape_rules`` for the five outputs."""
+        """Manifest ``shape_rules`` for the five outputs.
+
+        Every size follows from the two routing shapes and
+        ``num_experts_local``; the map's contents are never read here.
+        """
         numel = hidden_states_shape[0] * topk_ids_shape[1]
-        return _output_shapes(numel, hidden_states_shape[1], self.num_experts)
+        e_local = self.num_experts_local
+        return {
+            "perm_h": (numel, hidden_states_shape[1]),
+            "true_offsets": (e_local,),
+            "true_sizes": (e_local,),
+            "expert_first_token_offset": (e_local + 1,),
+            "fwd_idx": (numel,),
+        }
 
     def eval_roofline(self) -> tuple[int, int]:
-        if (
-            not hasattr(self, "hidden_states_shape")
-            or not hasattr(self, "topk_ids_shape")
-            or self.dtype is None
-            or self.num_experts is None
-        ):
-            raise ValueError(
-                f"{type(self).__name__}.eval_roofline() requires a prior forward() "
-                "to bind hidden_states_shape, topk_ids_shape, dtype, and num_experts"
-            )
-        total_tokens, hidden_size = self.hidden_states_shape
-        top_k = self.topk_ids_shape[1]
-        elem_bytes = self.dtype.itemsize
-        e_local = self.num_experts_local
-        nbytes = (
-            (total_tokens * hidden_size + total_tokens * top_k * hidden_size)
-            * elem_bytes
-            + (e_local + 1) * 8
-            + 2 * total_tokens * top_k * 4
-            + e_local * 8
-        )
-        return 0, int(nbytes)
+        from tileops.perf.formulas import moe_permute_nopad_fwd_roofline
+        return moe_permute_nopad_fwd_roofline(self)
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
@@ -224,139 +196,6 @@ class MoePermuteNopadFwdOp(Op):
             )
         return total_tokens, top_k, hidden_size
 
-    def _bind_call_state(
-        self, hidden_states: torch.Tensor, topk_ids: torch.Tensor,
-        total_tokens: int, top_k: int, hidden_size: int,
-    ) -> None:
-        """Record what ``eval_roofline`` reads off the call."""
-        self.dtype = hidden_states.dtype
-        self.total_tokens = total_tokens
-        self.top_k = top_k
-        self.hidden_size = hidden_size
-        self.hidden_states_shape = tuple(hidden_states.shape)
-        self.topk_ids_shape = tuple(topk_ids.shape)
-
-    def forward(
-        self,
-        hidden_states: torch.Tensor,
-        topk_ids: torch.Tensor,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-        """Run moe_permute without padding.
-
-        Args:
-            hidden_states: [T, H] input activations (bf16/fp16).
-            topk_ids: [T, K] int32 expert assignments.
-
-        Returns:
-            perm_h:                    [T*K, H] tight hidden states
-            true_offsets:              [E] int32 tight start per expert
-            true_sizes:                [E] int32 true token count per expert
-            expert_first_token_offset: [E+1] int64 non-padded prefix-sum
-            fwd_idx:                   [T*K] int32 forward mapping: flat_idx -> tight slot
-        """
-        return _moe_permute_nopad_fwd(hidden_states, topk_ids, self._instance_key)
-
-    def _eager_forward(
-        self,
-        hidden_states: torch.Tensor,
-        topk_ids: torch.Tensor,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-        """Validate, resolve the kernel and launch, inside the operator.
-
-        Never traced: kernel construction enters a TileLang builder, which dynamo
-        cannot follow.
-        """
-        total_tokens, top_k, hidden_size = self._validate_routing_shapes(
-            hidden_states, topk_ids)
-        self._validate_dtypes(hidden_states, topk_ids)
-        self._bind_call_state(
-            hidden_states, topk_ids, total_tokens, top_k, hidden_size)
-        kernel = self._get_kernel(
-            (hidden_states, topk_ids),
-            total_tokens, top_k, hidden_size, hidden_states.dtype,
-            hidden_states.device.index, None,
-        )
-        return kernel(hidden_states, topk_ids)
-
-
-class MoePermuteNopadEpFwdOp(MoePermuteNopadFwdOp):
-    """Expert-parallel permute: lay out only the rows this rank owns.
-
-    ``num_experts_local`` sizes the scan kernel's shared counters and its four
-    per-expert outputs, so it is a constructor parameter. ``expert_map`` carries
-    the global-to-local ids the kernel reads at launch, so it is a ``forward``
-    input; a map that is not a bijection onto ``0 .. num_experts_local - 1`` is
-    rejected rather than silently dropping the tokens routed past the end.
-
-    Args:
-        num_experts: Total number of experts E.
-        num_experts_local: Number of those experts this rank owns.
-        total_tokens: Optional committed number of input tokens T.
-        top_k: Optional committed number of experts selected per token K.
-        hidden_size: Optional committed hidden dimension H.
-        kernel_map: Optional kernel override dict.
-
-    Example:
-        >>> op = MoePermuteNopadEpFwdOp(num_experts=8, num_experts_local=4)
-        >>> perm_h, offsets, sizes, expert_offset, fwd_idx = op(
-        ...     hidden_states, topk_ids, expert_map)
-    """
-
-    #: The operator this op registers; a test asserts the graph holds nothing else.
-    compile_op_names: ClassVar[Tuple[str, ...]] = ("top::moe_permute_nopad_ep_fwd",)
-
-    def __init__(
-        self,
-        num_experts: int,
-        num_experts_local: int,
-        total_tokens: Optional[int] = None,
-        top_k: Optional[int] = None,
-        hidden_size: Optional[int] = None,
-        kernel_map: Optional[Dict[str, Kernel]] = None,
-    ) -> None:
-        if not 0 < num_experts_local <= num_experts:
-            raise ValueError(
-                f"num_experts_local must be in (0, {num_experts}], "
-                f"got {num_experts_local}"
-            )
-        # Identity and in-place version of the map the density check last passed on.
-        # A weak reference, so a freed tensor cannot pass as this one through a
-        # reused address.
-        self._checked_map: Optional[tuple["weakref.ref", int]] = None
-        super().__init__(
-            num_experts=num_experts,
-            total_tokens=total_tokens,
-            top_k=top_k,
-            hidden_size=hidden_size,
-            kernel_map=kernel_map,
-        )
-        self.num_experts_local = num_experts_local
-
-    def _validate_dtypes(
-        self,
-        hidden_states: torch.Tensor,
-        topk_ids: torch.Tensor,
-        expert_map: torch.Tensor,
-    ) -> None:
-        _check_routing_dtypes(hidden_states, topk_ids)
-        if expert_map.dtype != torch.int32:
-            raise ValueError(
-                f"Expected expert_map.dtype torch.int32, got {expert_map.dtype}")
-
-    def _infer_output_shapes(
-        self,
-        hidden_states_shape: Tuple[int, ...],
-        topk_ids_shape: Tuple[int, ...],
-        expert_map_shape: Tuple[int, ...],
-    ) -> Dict[str, Tuple[int, ...]]:
-        """Manifest ``shape_rules`` for the five outputs.
-
-        Every size follows from the two routing shapes and ``num_experts_local``;
-        the map's contents are never read here.
-        """
-        numel = hidden_states_shape[0] * topk_ids_shape[1]
-        return _output_shapes(numel, hidden_states_shape[1], self.num_experts_local)
-
     def _validate_expert_map(self, expert_map: torch.Tensor) -> None:
         """Reject a map that is not a bijection onto the local expert ids.
 
@@ -397,88 +236,111 @@ class MoePermuteNopadEpFwdOp(MoePermuteNopadFwdOp):
         self,
         hidden_states: torch.Tensor,
         topk_ids: torch.Tensor,
-        expert_map: torch.Tensor,
+        expert_map: Optional[torch.Tensor] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-        """Run moe_permute without padding, keeping only this rank's experts.
+        """Run moe_permute without padding.
 
         Args:
             hidden_states: [T, H] input activations (bf16/fp16).
             topk_ids: [T, K] int32 expert assignments (global ids).
-            expert_map: [E] int32 global-to-local expert ids; -1 marks an expert
-                another rank owns.
+            expert_map: [E] int32 global-to-local expert ids under expert
+                parallelism; -1 marks an expert another rank owns. Omit it when
+                this rank owns every expert.
 
         Returns:
-            perm_h:                    [T*K, H] tight hidden states; only the first
-                                       M_local rows carry data
+            perm_h:                    [T*K, H] tight hidden states; with a map,
+                                       only the first M_local rows carry data
             true_offsets:              [E_local] int32 tight start per local expert
             true_sizes:                [E_local] int32 true token count per local expert
             expert_first_token_offset: [E_local+1] int64 non-padded prefix-sum
             fwd_idx:                   [T*K] int32 forward mapping: flat_idx -> tight
                                        slot, -1 for a non-local pair
         """
-        return _moe_permute_nopad_ep_fwd(
+        return _moe_permute_nopad_fwd(
             hidden_states, topk_ids, expert_map, self._instance_key)
 
     def _eager_forward(
         self,
         hidden_states: torch.Tensor,
         topk_ids: torch.Tensor,
-        expert_map: torch.Tensor,
+        expert_map: Optional[torch.Tensor] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-        """Validate, resolve the kernel and launch, inside the operator."""
+        """Validate, resolve the kernel and launch, inside the operator.
+
+        Never traced: kernel construction enters a TileLang builder, which dynamo
+        cannot follow.
+        """
         total_tokens, top_k, hidden_size = self._validate_routing_shapes(
             hidden_states, topk_ids)
         self._validate_dtypes(hidden_states, topk_ids, expert_map)
-        if expert_map.device != hidden_states.device:
-            raise ValueError(
-                f"Expected expert_map on {hidden_states.device}, "
-                f"got {expert_map.device}")
-        self._validate_expert_map(expert_map)
-        self._bind_call_state(
-            hidden_states, topk_ids, total_tokens, top_k, hidden_size)
+        if expert_map is None:
+            # A map is the only thing that can name which experts are local, so
+            # without one the op must own the whole table.
+            if self.num_experts_local != self.num_experts:
+                raise ValueError(
+                    f"this op was built for num_experts_local="
+                    f"{self.num_experts_local} of {self.num_experts} experts and "
+                    "needs an expert_map to say which ones they are"
+                )
+        else:
+            if expert_map.device != hidden_states.device:
+                raise ValueError(
+                    f"Expected expert_map on {hidden_states.device}, "
+                    f"got {expert_map.device}")
+            self._validate_expert_map(expert_map)
+
+        self.dtype = hidden_states.dtype
+        self.total_tokens = total_tokens
+        self.top_k = top_k
+        self.hidden_size = hidden_size
+        self.hidden_states_shape = tuple(hidden_states.shape)
+        self.topk_ids_shape = tuple(topk_ids.shape)
+        self.used_expert_map = expert_map is not None
+
+        # A map-free kernel and a map-reading one are two different scans, so the
+        # argument's presence — not the local expert count — picks between them.
         kernel = self._get_kernel(
-            (hidden_states, topk_ids, expert_map),
+            (hidden_states, topk_ids) if expert_map is None
+            else (hidden_states, topk_ids, expert_map),
             total_tokens, top_k, hidden_size, hidden_states.dtype,
-            hidden_states.device.index, self.num_experts_local,
+            hidden_states.device.index,
+            self.num_experts_local if expert_map is not None else None,
         )
+        if expert_map is None:
+            return kernel(hidden_states, topk_ids)
         return kernel(hidden_states, topk_ids, expert_map)
 
 
 @torch.library.custom_op("top::moe_permute_nopad_fwd", mutates_args=())
 def _moe_permute_nopad_fwd(
-    hidden_states: torch.Tensor, topk_ids: torch.Tensor, instance_key: str,
-) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    return get_instance(instance_key)._eager_forward(hidden_states, topk_ids)
-
-
-@_moe_permute_nopad_fwd.register_fake
-def _moe_permute_nopad_fwd_fake(
-    hidden_states: torch.Tensor, topk_ids: torch.Tensor, instance_key: str,
-) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    op = get_instance(instance_key)
-    shapes = op._infer_output_shapes(tuple(hidden_states.shape), tuple(topk_ids.shape))
-    return _fake_outputs(hidden_states, shapes)
-
-
-@torch.library.custom_op("top::moe_permute_nopad_ep_fwd", mutates_args=())
-def _moe_permute_nopad_ep_fwd(
     hidden_states: torch.Tensor,
     topk_ids: torch.Tensor,
-    expert_map: torch.Tensor,
+    expert_map: Optional[torch.Tensor],
     instance_key: str,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     return get_instance(instance_key)._eager_forward(
         hidden_states, topk_ids, expert_map)
 
 
-@_moe_permute_nopad_ep_fwd.register_fake
-def _moe_permute_nopad_ep_fwd_fake(
+@_moe_permute_nopad_fwd.register_fake
+def _moe_permute_nopad_fwd_fake(
     hidden_states: torch.Tensor,
     topk_ids: torch.Tensor,
-    expert_map: torch.Tensor,
+    expert_map: Optional[torch.Tensor],
     instance_key: str,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     op = get_instance(instance_key)
     shapes = op._infer_output_shapes(
-        tuple(hidden_states.shape), tuple(topk_ids.shape), tuple(expert_map.shape))
-    return _fake_outputs(hidden_states, shapes)
+        tuple(hidden_states.shape), tuple(topk_ids.shape),
+        None if expert_map is None else tuple(expert_map.shape),
+    )
+    device = hidden_states.device
+    # Manifest dtypes: ``same_as(hidden_states)`` for the gathered rows, int32 for
+    # the index arrays, int64 for the prefix sum.
+    return (
+        hidden_states.new_empty(shapes["perm_h"]),
+        torch.empty(shapes["true_offsets"], dtype=torch.int32, device=device),
+        torch.empty(shapes["true_sizes"], dtype=torch.int32, device=device),
+        torch.empty(shapes["expert_first_token_offset"], dtype=torch.int64, device=device),
+        torch.empty(shapes["fwd_idx"], dtype=torch.int32, device=device),
+    )

--- a/src/tileops/ops/moe/routed_expert/unpermute.py
+++ b/src/tileops/ops/moe/routed_expert/unpermute.py
@@ -1,12 +1,13 @@
 """MoE unpermute op (cutlass path): scatter-add padded expert outputs back to token order."""
 
-from typing import Dict, Optional
+from typing import ClassVar, Dict, Optional, Tuple
 
 import torch
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.moe import MoeUnpermuteKernel
 
+from ...compile_boundary import get_instance
 from ...op_base import Op
 
 __all__ = ["MoeUnpermuteFwdOp"]
@@ -33,6 +34,15 @@ class MoeUnpermuteFwdOp(Op):
         >>> op = MoeUnpermuteFwdOp(total_tokens=4, top_k=2, hidden_size=128, padded_batch_sum=512)
         >>> output = op(mm2_pad, fwd_idx, topk_weights)
     """
+
+    #: Two operators, because ``mutates_args`` is fixed at registration while ``out``
+    #: decides per call whether this op writes a caller buffer. Same split as aten's
+    #: ``relu`` / ``relu_``: ``forward`` picks one, and a test asserts the graph holds
+    #: nothing else.
+    compile_op_names: ClassVar[Tuple[str, ...]] = (
+        "top::moe_unpermute_fwd",
+        "top::moe_unpermute_fwd_inplace",
+    )
 
     def __init__(
         self,
@@ -66,6 +76,15 @@ class MoeUnpermuteFwdOp(Op):
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"unpermute_kernel": MoeUnpermuteKernel}
 
+    def _infer_output_shapes(
+        self,
+        mm2_pad_shape: Tuple[int, ...],
+        fwd_idx_shape: Tuple[int, ...],
+        topk_weights_shape: Tuple[int, ...],
+    ) -> Dict[str, Tuple[int, ...]]:
+        """Manifest ``shape_rules``: ``output.shape == (total_tokens, hidden_size)``."""
+        return {"output": (self.total_tokens, self.hidden_size)}
+
     def forward(
         self,
         mm2_pad: torch.Tensor,
@@ -85,6 +104,66 @@ class MoeUnpermuteFwdOp(Op):
         Returns:
             output: [T, H] bf16/fp16 (``out`` if provided).
         """
+        if out is None:
+            return _moe_unpermute_fwd(
+                mm2_pad, fwd_idx, topk_weights, self._instance_key)
+        _moe_unpermute_fwd_inplace(
+            mm2_pad, fwd_idx, topk_weights, out, self._instance_key)
+        # The in-place operator returns None so its result cannot alias an input; the
+        # buffer the caller handed over is what this op returns.
+        return out
+
+    def _eager_forward(
+        self,
+        mm2_pad: torch.Tensor,
+        fwd_idx: torch.Tensor,
+        topk_weights: torch.Tensor,
+        out: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Validate, resolve the kernel and launch, inside the operator.
+
+        Never traced: kernel construction enters a TileLang builder, which dynamo
+        cannot follow.
+        """
         self._validate_dtypes(mm2_pad, fwd_idx, topk_weights)
         self.dtype = mm2_pad.dtype
         return self._get_kernel(mm2_pad.dtype)(mm2_pad, fwd_idx, topk_weights, out=out)
+
+
+@torch.library.custom_op("top::moe_unpermute_fwd", mutates_args=())
+def _moe_unpermute_fwd(
+    mm2_pad: torch.Tensor,
+    fwd_idx: torch.Tensor,
+    topk_weights: torch.Tensor,
+    instance_key: str,
+) -> torch.Tensor:
+    return get_instance(instance_key)._eager_forward(mm2_pad, fwd_idx, topk_weights)
+
+
+@_moe_unpermute_fwd.register_fake
+def _moe_unpermute_fwd_fake(
+    mm2_pad: torch.Tensor,
+    fwd_idx: torch.Tensor,
+    topk_weights: torch.Tensor,
+    instance_key: str,
+) -> torch.Tensor:
+    op = get_instance(instance_key)
+    shapes = op._infer_output_shapes(
+        tuple(mm2_pad.shape), tuple(fwd_idx.shape), tuple(topk_weights.shape))
+    # Manifest dtype: ``same_as(mm2_pad)``.
+    return mm2_pad.new_empty(shapes["output"])
+
+
+@torch.library.custom_op("top::moe_unpermute_fwd_inplace", mutates_args=("out",))
+def _moe_unpermute_fwd_inplace(
+    mm2_pad: torch.Tensor,
+    fwd_idx: torch.Tensor,
+    topk_weights: torch.Tensor,
+    out: torch.Tensor,
+    instance_key: str,
+) -> None:
+    get_instance(instance_key)._eager_forward(mm2_pad, fwd_idx, topk_weights, out=out)
+
+
+# The in-place operator needs no fake body: it returns nothing, and the mutation it
+# declares is all the compiler has to know about ``out``.

--- a/src/tileops/ops/moe/shared_fused_moe.py
+++ b/src/tileops/ops/moe/shared_fused_moe.py
@@ -38,6 +38,7 @@ import torch
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.moe import SharedExpertMLPKernel
+from tileops.ops.moe.abc import FusedMoEExpertsModular, FusedMoEPrepareAndFinalize
 from tileops.ops.moe.fused_moe import FusedMoe
 
 __all__ = ["SharedFusedMoE"]
@@ -61,6 +62,9 @@ class SharedFusedMoE(FusedMoe):
             before TP sharding). If None, no shared expert is computed.
         tp_size: Tensor parallel world size. Default 1 (no TP).
         tp_rank: This rank's index in the TP group. Default 0.
+        prepare_finalize: Override the PrepareAndFinalize implementation.
+        experts: Override the Experts implementation.
+        kernel_map: Override the dispatched kernel map.
         Other args: same as FusedMoe.
 
     Returns:
@@ -83,6 +87,9 @@ class SharedFusedMoE(FusedMoe):
         shared_ffn_size: Optional[int] = None,
         tp_size: int = 1,
         tp_rank: int = 0,
+        prepare_finalize: Optional[FusedMoEPrepareAndFinalize] = None,
+        experts: Optional[FusedMoEExpertsModular] = None,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
         *,
         activation: str = "silu_and_mul",
     ):
@@ -109,6 +116,9 @@ class SharedFusedMoE(FusedMoe):
             renormalize=renormalize,
             routed_scaling_factor=routed_scaling_factor,
             expert_map=expert_map,
+            prepare_finalize=prepare_finalize,
+            experts=experts,
+            kernel_map=kernel_map,
             activation=activation,
         )
 
@@ -138,7 +148,7 @@ class SharedFusedMoE(FusedMoe):
         return self.get_or_build_kernel(
             "shared_expert_mlp",
             key=dtype,
-            build=lambda: SharedExpertMLPKernel(
+            build=lambda: self.kernel_map["shared_expert_mlp"](
                 num_tokens=self.num_tokens,
                 hidden_size=self.hidden_size,
                 ffn_size=self._shared_mlp_shard_ffn,
@@ -148,7 +158,9 @@ class SharedFusedMoE(FusedMoe):
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
-        return {}
+        # The routed half's kernels belong to the sub-ops it builds; this one is the
+        # op's own, so it is declared here and a replacement reaches it.
+        return {"shared_expert_mlp": SharedExpertMLPKernel}
 
     def forward(
         self,

--- a/src/tileops/ops/moe/shared_fused_moe.py
+++ b/src/tileops/ops/moe/shared_fused_moe.py
@@ -62,6 +62,8 @@ class SharedFusedMoE(FusedMoe):
             before TP sharding). If None, no shared expert is computed.
         tp_size: Tensor parallel world size. Default 1 (no TP).
         tp_rank: This rank's index in the TP group. Default 0.
+        num_experts_local: Number of experts this rank owns; required with
+            expert_map. See FusedMoe.
         prepare_finalize: Override the PrepareAndFinalize implementation.
         experts: Override the Experts implementation.
         kernel_map: Override the dispatched kernel map.
@@ -84,6 +86,7 @@ class SharedFusedMoE(FusedMoe):
         renormalize: bool = False,
         routed_scaling_factor: float = 1.0,
         expert_map: Optional[torch.Tensor] = None,
+        num_experts_local: Optional[int] = None,
         shared_ffn_size: Optional[int] = None,
         tp_size: int = 1,
         tp_rank: int = 0,
@@ -116,6 +119,7 @@ class SharedFusedMoE(FusedMoe):
             renormalize=renormalize,
             routed_scaling_factor=routed_scaling_factor,
             expert_map=expert_map,
+            num_experts_local=num_experts_local,
             prepare_finalize=prepare_finalize,
             experts=experts,
             kernel_map=kernel_map,

--- a/src/tileops/perf/formulas.py
+++ b/src/tileops/perf/formulas.py
@@ -72,6 +72,7 @@ __all__ = [
     "mhc_post_roofline",
     "mhc_pre_roofline",
     "minimum_fwd_roofline",
+    "moe_permute_nopad_fwd_roofline",
     "mul_fwd_roofline",
     "ne_fwd_roofline",
     "pow_fwd_roofline",
@@ -863,6 +864,36 @@ def bitwise_xor_fwd_roofline(op: "Op") -> tuple[int, int]:
 
 
 # MoE
+
+
+def moe_permute_nopad_fwd_roofline(op: "Op") -> tuple[int, int]:
+    """Roofline for ``MoePermuteNopadFwdOp``.
+
+    Func-mode: the expert-map plane is read only in calls that supply a map, so
+    the byte count turns on a presence fact rather than on a shape. The op is
+    input-inferred, so the dims are bound during ``forward()``.
+
+    Raises:
+        RuntimeError: If called before ``forward()`` has bound the dims.
+    """
+    if getattr(op, "hidden_states_shape", None) is None or op.dtype is None:
+        raise RuntimeError(
+            "MoePermuteNopadFwdOp.eval_roofline() is valid only after the first "
+            "forward(); T/K/H and dtype are inferred from the inputs."
+        )
+    total_tokens, hidden_size = op.hidden_states_shape
+    top_k = op.topk_ids_shape[1]
+    e_local = int(op.num_experts_local)
+    elem_bytes = _dtype_itemsize(op.dtype)
+
+    # hidden_states read [T, H] + perm_h write [T*K, H]
+    row_bytes = (total_tokens * hidden_size + total_tokens * top_k * hidden_size) * elem_bytes
+    # expert_first_token_offset [E_local+1] int64 + true_offsets / true_sizes int32
+    meta_bytes = (e_local + 1) * 8 + e_local * 8
+    # topk_ids read + fwd_idx write, both [T*K] int32
+    index_bytes = 2 * total_tokens * top_k * 4
+    map_bytes = int(op.num_experts) * 4 if op.used_expert_map else 0
+    return 0, row_bytes + meta_bytes + index_bytes + map_bytes
 
 
 def fused_moe_fwd_bytes(op: "Op") -> tuple[int, int]:

--- a/tests/compile_contract.py
+++ b/tests/compile_contract.py
@@ -12,6 +12,7 @@ contract must not register here.
 """
 
 import importlib
+import operator
 
 import torch
 
@@ -19,6 +20,7 @@ import torch
 # gains contract-backing compile tests.
 _EVIDENCE_MODULES = (
     "tests.ops.test_elementwise_compile",
+    "tests.ops.test_moe_compile",
     "tests.ops.test_pool",
     "tests.ops.test_rms_norm",
     "tests.test_compile",
@@ -36,10 +38,30 @@ def register_compile_contract(op_cls: type) -> None:
     _registered.add(op_cls.__name__)
 
 
-def _overload(name: str):
+def operator_overload(name: str):
     """``"top::foo"`` as the overload object a graph node carries."""
     namespace, _, opname = name.partition("::")
     return getattr(getattr(torch.ops, namespace), opname).default
+
+
+def traced_call_targets(op, *inputs) -> set:
+    """Compile *op* with ``fullgraph=True`` and return the operators its graph calls.
+
+    ``operator.getitem`` is left out: it is how a multi-output operator's results are
+    unpacked, carries no computation, and no target supplies it.
+    """
+    traced: list[list[object]] = []
+
+    def capture(gm, example_inputs):
+        traced.append([node.target for node in gm.graph.nodes
+                       if node.op == "call_function"
+                       and node.target is not operator.getitem])
+        return gm.forward
+
+    torch.compile(op, backend=capture, fullgraph=True)(*inputs)
+
+    (calls,) = traced
+    return set(calls)
 
 
 def assert_op_owns_graph_nodes(op, *inputs) -> None:
@@ -49,23 +71,14 @@ def assert_op_owns_graph_nodes(op, *inputs) -> None:
     here — either means the node identity is not the op's alone, so another target could
     change the graph.
     """
-    declared = {_overload(name) for name in type(op).compile_op_names}
+    declared = {operator_overload(name) for name in type(op).compile_op_names}
     assert declared, f"{type(op).__name__} declares no compile_op_names"
 
-    traced: list[list[object]] = []
-
-    def capture(gm, example_inputs):
-        traced.append([node.target for node in gm.graph.nodes
-                       if node.op == "call_function"])
-        return gm.forward
-
-    torch.compile(op, backend=capture, fullgraph=True)(*inputs)
-
-    (calls,) = traced
+    calls = traced_call_targets(op, *inputs)
     assert calls, "the traced graph called nothing"
-    assert set(calls) <= declared, (
+    assert calls <= declared, (
         f"graph holds nodes this op does not own: "
-        f"{sorted(str(c) for c in set(calls) - declared)}; "
+        f"{sorted(str(c) for c in calls - declared)}; "
         f"declared: {sorted(str(d) for d in declared)}")
 
 

--- a/tests/compile_contract.py
+++ b/tests/compile_contract.py
@@ -44,7 +44,7 @@ def operator_overload(name: str):
     return getattr(getattr(torch.ops, namespace), opname).default
 
 
-def traced_call_targets(op, *inputs) -> set:
+def traced_call_targets(op, *inputs, **kwargs) -> set:
     """Compile *op* with ``fullgraph=True`` and return the operators its graph calls.
 
     ``operator.getitem`` is left out: it is how a multi-output operator's results are
@@ -58,13 +58,13 @@ def traced_call_targets(op, *inputs) -> set:
                        and node.target is not operator.getitem])
         return gm.forward
 
-    torch.compile(op, backend=capture, fullgraph=True)(*inputs)
+    torch.compile(op, backend=capture, fullgraph=True)(*inputs, **kwargs)
 
     (calls,) = traced
     return set(calls)
 
 
-def assert_op_owns_graph_nodes(op, *inputs) -> None:
+def assert_op_owns_graph_nodes(op, *inputs, **kwargs) -> None:
     """Compile *op* once and assert the graph holds nothing but its own operators.
 
     A kernel's own registration, or a tensor op left outside the boundary, would show up
@@ -74,7 +74,7 @@ def assert_op_owns_graph_nodes(op, *inputs) -> None:
     declared = {operator_overload(name) for name in type(op).compile_op_names}
     assert declared, f"{type(op).__name__} declares no compile_op_names"
 
-    calls = traced_call_targets(op, *inputs)
+    calls = traced_call_targets(op, *inputs, **kwargs)
     assert calls, "the traced graph called nothing"
     assert calls <= declared, (
         f"graph holds nodes this op does not own: "

--- a/tests/ops/test_fused_moe_experts.py
+++ b/tests/ops/test_fused_moe_experts.py
@@ -10,7 +10,6 @@ from tileops.ops.moe.abc import (
 )
 from tileops.ops.moe.prepare_finalize.no_dp_ep import MoEPrepareAndFinalizeNoDPEP
 from tileops.ops.moe.routed_expert.fused_routed_expert import (
-    FusedMoEExpertsNopadPersistent3WGEpFwdOp,
     FusedMoEExpertsNopadPersistent3WGFwdOp,
 )
 from tileops.ops.moe.routed_expert.gate_up import (
@@ -171,7 +170,7 @@ class TestFusedMoEExpertsNopadPersistent3WGFwdOp:
         """
         T_count, E, top_k, H, F_dim = 1024, 128, 2, 256, 1152
         experts = FusedMoEExpertsNopadPersistent3WGFwdOp(
-            num_tokens=T_count, num_experts=E, top_k=top_k,
+            num_tokens=T_count, num_experts=E, num_experts_local=E, top_k=top_k,
             hidden_size=H, ffn_size=F_dim,
         )
 
@@ -186,7 +185,7 @@ class TestFusedMoEExpertsNopadPersistent3WGFwdOp:
         out = torch.empty(T_count, H, dtype=dtype, device="cuda")
         ws = torch.empty(0, dtype=dtype, device="cuda")
 
-        experts.forward(out, hidden, w1, w2, weights, ids, ws, ws, E)
+        experts.forward(out, hidden, w1, w2, weights, ids, ws, ws, num_experts=E)
 
         expected = _torch_ref_moe(hidden, w1, w2, weights, ids)
         torch.testing.assert_close(out.float(), expected.float(), rtol=3e-2, atol=3e-2)
@@ -196,7 +195,7 @@ class TestFusedMoEExpertsNopadPersistent3WGFwdOp:
     def test_workspace_shapes(self, moe_meta):
         d = moe_meta
         experts = FusedMoEExpertsNopadPersistent3WGFwdOp(
-            num_tokens=d["T"], num_experts=d["E"], top_k=d["K"],
+            num_tokens=d["T"], num_experts=d["E"], num_experts_local=d["E"], top_k=d["K"],
             hidden_size=d["H"], ffn_size=d["F"],
         )
         ws1, ws2 = experts.workspace_shapes(d["T"], d["F"], d["H"], d["K"], d["E"])
@@ -206,7 +205,7 @@ class TestFusedMoEExpertsNopadPersistent3WGFwdOp:
     def test_output_shape(self, moe_meta):
         d = moe_meta
         experts = FusedMoEExpertsNopadPersistent3WGFwdOp(
-            num_tokens=d["T"], num_experts=d["E"], top_k=d["K"],
+            num_tokens=d["T"], num_experts=d["E"], num_experts_local=d["E"], top_k=d["K"],
             hidden_size=d["H"], ffn_size=d["F"],
         )
         assert experts.output_shape(d["T"], d["H"]) == (d["T"], d["H"])
@@ -215,7 +214,7 @@ class TestFusedMoEExpertsNopadPersistent3WGFwdOp:
     def test_make_weighted_reduce_is_noop(self, moe_meta):
         d = moe_meta
         experts = FusedMoEExpertsNopadPersistent3WGFwdOp(
-            num_tokens=d["T"], num_experts=d["E"], top_k=d["K"],
+            num_tokens=d["T"], num_experts=d["E"], num_experts_local=d["E"], top_k=d["K"],
             hidden_size=d["H"], ffn_size=d["F"],
         )
         assert isinstance(experts.make_weighted_reduce(), WeightedReduceNoOp)
@@ -225,7 +224,7 @@ class TestFusedMoEExpertsNopadPersistent3WGFwdOp:
         """forward() output must match a per-expert PyTorch reference."""
         d = moe_tensors
         experts = FusedMoEExpertsNopadPersistent3WGFwdOp(
-            num_tokens=d["T"], num_experts=d["E"], top_k=d["K"],
+            num_tokens=d["T"], num_experts=d["E"], num_experts_local=d["E"], top_k=d["K"],
             hidden_size=d["H"], ffn_size=d["F"],
         )
 
@@ -236,7 +235,7 @@ class TestFusedMoEExpertsNopadPersistent3WGFwdOp:
         ws2 = torch.empty(0, dtype=d["dtype"], device="cuda")
         experts.forward(
             output, d["hidden"], d["w1"], d["w2"], d["weights"], d["ids"],
-            workspace1=ws1, workspace2=ws2, num_experts=d["E"],
+            expert_map=None, workspace1=ws1, workspace2=ws2, num_experts=d["E"],
         )
 
         assert torch.allclose(output.float(), ref_out.float(), atol=1e-2, rtol=1e-2)
@@ -258,7 +257,7 @@ class TestFusedMoEExpertsNopadPersistent3WGFwdOp:
         ids = torch.randint(0, E, (T, K), dtype=torch.int32, device="cuda")
 
         experts = FusedMoEExpertsNopadPersistent3WGFwdOp(
-            num_tokens=T, num_experts=E, top_k=K,
+            num_tokens=T, num_experts=E, num_experts_local=E, top_k=K,
             hidden_size=H, ffn_size=F_dim,
         )
 
@@ -268,15 +267,15 @@ class TestFusedMoEExpertsNopadPersistent3WGFwdOp:
         ws2 = torch.empty(0, dtype=dtype, device="cuda")
         experts.forward(
             output, hidden, w1, w2, weights, ids,
-            workspace1=ws1, workspace2=ws2, num_experts=E,
+            expert_map=None, workspace1=ws1, workspace2=ws2, num_experts=E,
         )
         assert torch.allclose(output.float(), ref_out.float(), atol=1e-2, rtol=1e-2)
 
     @pytest.mark.smoke
     def test_ep_forward_runs(self):
-        """The EP identity must construct + forward without raising.
+        """Supplying an expert map must construct + forward without raising.
 
-        This is a smoke check that the EP path is wired up. The per-expert
+        This is a smoke check that the expert-parallel path is wired up. The per-expert
         numerical correctness check under expert_map filtering is non-trivial to
         write a torch reference for and is left to an end-to-end test against vLLM.
         """
@@ -295,7 +294,7 @@ class TestFusedMoEExpertsNopadPersistent3WGFwdOp:
         # Mix local + non-local expert ids to exercise the -1 fwd_idx path.
         ids = torch.randint(0, E_global, (T, K), dtype=torch.int32, device="cuda")
 
-        experts = FusedMoEExpertsNopadPersistent3WGEpFwdOp(
+        experts = FusedMoEExpertsNopadPersistent3WGFwdOp(
             num_tokens=T, num_experts=E_global, num_experts_local=E_local,
             top_k=K, hidden_size=H, ffn_size=F_dim,
         )
@@ -319,7 +318,7 @@ class TestFusedMoEExpertsNopadPersistent3WGFwdOp:
         """
         T, H, F_dim, E_global, E_local, K = 64, 128, 64, 8, 4, 2
         dtype = torch.bfloat16
-        experts = FusedMoEExpertsNopadPersistent3WGEpFwdOp(
+        experts = FusedMoEExpertsNopadPersistent3WGFwdOp(
             num_tokens=T, num_experts=E_global, num_experts_local=E_local,
             top_k=K, hidden_size=H, ffn_size=F_dim,
         )
@@ -339,35 +338,12 @@ class TestFusedMoEExpertsNopadPersistent3WGFwdOp:
             )
 
     @pytest.mark.smoke
-    def test_kernel_delegates_are_the_same_before_and_after_a_call(self, moe_tensors):
-        """Enumeration must not depend on execution history.
-
-        Every stage is built at construction, so the delegate set a caller sees
-        before the first forward is the one it sees after.
-        """
-        d = moe_tensors
-        experts = FusedMoEExpertsNopadPersistent3WGFwdOp(
-            num_tokens=d["T"], num_experts=d["E"], top_k=d["K"],
-            hidden_size=d["H"], ffn_size=d["F"],
-        )
-        before = {id(op) for op in experts.kernel_delegates()}
-
-        output = torch.empty(d["T"], d["H"], dtype=d["dtype"], device="cuda")
-        ws = torch.empty(0, dtype=d["dtype"], device="cuda")
-        experts.forward(
-            output, d["hidden"], d["w1"], d["w2"], d["weights"], d["ids"],
-            workspace1=ws, workspace2=ws, num_experts=d["E"],
-        )
-
-        assert {id(op) for op in experts.kernel_delegates()} == before
-
-    @pytest.mark.smoke
     @pytest.mark.parametrize("activation", ["silu_and_mul", "gelu_and_mul"])
     def test_forward_matches_torch_ref_activation(self, moe_tensors, activation):
         """forward() output matches PyTorch reference for each activation."""
         d = moe_tensors
         experts = FusedMoEExpertsNopadPersistent3WGFwdOp(
-            num_tokens=d["T"], num_experts=d["E"], top_k=d["K"],
+            num_tokens=d["T"], num_experts=d["E"], num_experts_local=d["E"], top_k=d["K"],
             hidden_size=d["H"], ffn_size=d["F"],
             activation=activation,
         )
@@ -380,7 +356,7 @@ class TestFusedMoEExpertsNopadPersistent3WGFwdOp:
         ws2 = torch.empty(0, dtype=d["dtype"], device="cuda")
         experts.forward(
             output, d["hidden"], d["w1"], d["w2"], d["weights"], d["ids"],
-            workspace1=ws1, workspace2=ws2, num_experts=d["E"],
+            expert_map=None, workspace1=ws1, workspace2=ws2, num_experts=d["E"],
         )
         assert torch.allclose(output.float(), ref_out.float(), atol=1e-2, rtol=1e-2)
 
@@ -389,7 +365,7 @@ class TestFusedMoeActivationInjection:
 
     def _make_experts(self, activation="silu_and_mul"):
         return FusedMoEExpertsNopadPersistent3WGFwdOp(
-            num_tokens=128, num_experts=4, top_k=2,
+            num_tokens=128, num_experts=4, num_experts_local=4, top_k=2,
             hidden_size=256, ffn_size=128,
             activation=activation,
         )
@@ -470,8 +446,8 @@ class TestFusedMoeActivationInjection:
                 return (T_prime, H)
 
             def forward(self, output, hidden_states, w_gate_up, w_down,
-                        topk_weights, topk_ids, workspace1, workspace2,
-                        num_experts):
+                        topk_weights, topk_ids, expert_map, workspace1,
+                        workspace2, num_experts):
                 pass
 
             def make_weighted_reduce(self):

--- a/tests/ops/test_fused_moe_experts.py
+++ b/tests/ops/test_fused_moe_experts.py
@@ -313,6 +313,29 @@ class TestFusedMoEExpertsNopadPersistent3WGFwdOp:
         assert torch.isfinite(output.float()).all()
 
     @pytest.mark.smoke
+    def test_forward_rejects_a_foreign_expert_map(self, moe_tensors):
+        """forward() must reject a map the op was not built for.
+
+        The local expert count is compiled into the permute kernel and both
+        grouped GEMMs, so a map other than the constructed one cannot be
+        honoured — and must not be silently ignored.
+        """
+        d = moe_tensors
+        experts = FusedMoEExpertsNopadPersistent3WGFwdOp(
+            num_tokens=d["T"], num_experts=d["E"], top_k=d["K"],
+            hidden_size=d["H"], ffn_size=d["F"],
+        )
+        foreign_map = torch.arange(d["E"], dtype=torch.int32, device="cuda")
+        output = torch.empty(d["T"], d["H"], dtype=d["dtype"], device="cuda")
+        ws = torch.empty(0, dtype=d["dtype"], device="cuda")
+        with pytest.raises(ValueError, match="expert_map must be the tensor"):
+            experts.forward(
+                output, d["hidden"], d["w1"], d["w2"], d["weights"], d["ids"],
+                expert_map=foreign_map, workspace1=ws, workspace2=ws,
+                num_experts=d["E"],
+            )
+
+    @pytest.mark.smoke
     @pytest.mark.parametrize("activation", ["silu_and_mul", "gelu_and_mul"])
     def test_forward_matches_torch_ref_activation(self, moe_tensors, activation):
         """forward() output matches PyTorch reference for each activation."""

--- a/tests/ops/test_fused_moe_experts.py
+++ b/tests/ops/test_fused_moe_experts.py
@@ -10,6 +10,7 @@ from tileops.ops.moe.abc import (
 )
 from tileops.ops.moe.prepare_finalize.no_dp_ep import MoEPrepareAndFinalizeNoDPEP
 from tileops.ops.moe.routed_expert.fused_routed_expert import (
+    FusedMoEExpertsNopadPersistent3WGEpFwdOp,
     FusedMoEExpertsNopadPersistent3WGFwdOp,
 )
 from tileops.ops.moe.routed_expert.gate_up import (
@@ -185,7 +186,7 @@ class TestFusedMoEExpertsNopadPersistent3WGFwdOp:
         out = torch.empty(T_count, H, dtype=dtype, device="cuda")
         ws = torch.empty(0, dtype=dtype, device="cuda")
 
-        experts.forward(out, hidden, w1, w2, weights, ids, None, ws, ws, E)
+        experts.forward(out, hidden, w1, w2, weights, ids, ws, ws, E)
 
         expected = _torch_ref_moe(hidden, w1, w2, weights, ids)
         torch.testing.assert_close(out.float(), expected.float(), rtol=3e-2, atol=3e-2)
@@ -235,7 +236,7 @@ class TestFusedMoEExpertsNopadPersistent3WGFwdOp:
         ws2 = torch.empty(0, dtype=d["dtype"], device="cuda")
         experts.forward(
             output, d["hidden"], d["w1"], d["w2"], d["weights"], d["ids"],
-            expert_map=None, workspace1=ws1, workspace2=ws2, num_experts=d["E"],
+            workspace1=ws1, workspace2=ws2, num_experts=d["E"],
         )
 
         assert torch.allclose(output.float(), ref_out.float(), atol=1e-2, rtol=1e-2)
@@ -267,19 +268,17 @@ class TestFusedMoEExpertsNopadPersistent3WGFwdOp:
         ws2 = torch.empty(0, dtype=dtype, device="cuda")
         experts.forward(
             output, hidden, w1, w2, weights, ids,
-            expert_map=None, workspace1=ws1, workspace2=ws2, num_experts=E,
+            workspace1=ws1, workspace2=ws2, num_experts=E,
         )
         assert torch.allclose(output.float(), ref_out.float(), atol=1e-2, rtol=1e-2)
 
     @pytest.mark.smoke
-    def test_forward_with_expert_map_runs(self):
-        """expert_map (EP mode) must construct + forward without raising.
+    def test_ep_forward_runs(self):
+        """The EP identity must construct + forward without raising.
 
-        This is a smoke check that the EP path is wired up — the Nopad+3WG
-        implementation supports expert_map. The
-        per-expert numerical correctness check under expert_map filtering is
-        non-trivial to write a torch reference for and is left to a follow-up
-        end-to-end test against vLLM.
+        This is a smoke check that the EP path is wired up. The per-expert
+        numerical correctness check under expert_map filtering is non-trivial to
+        write a torch reference for and is left to an end-to-end test against vLLM.
         """
         T, H, F_dim, E_global, E_local, K = 64, 128, 64, 8, 4, 2
         dtype = torch.bfloat16
@@ -288,18 +287,17 @@ class TestFusedMoEExpertsNopadPersistent3WGFwdOp:
         expert_map[:E_local] = torch.arange(E_local, dtype=torch.int32, device="cuda")
 
         hidden = torch.randn(T, H, dtype=dtype, device="cuda") * 0.1
-        # Weights sized to local experts only, since nopad's _gemm_gate_up
-        # is constructed with num_experts_local.
+        # Weights sized to local experts only: the grouped GEMMs are built for
+        # num_experts_local.
         w1 = torch.randn(E_local, 2 * F_dim, H, dtype=dtype, device="cuda") * 0.02
         w2 = torch.randn(E_local, H, F_dim, dtype=dtype, device="cuda") * 0.02
         weights = torch.softmax(torch.randn(T, K, dtype=torch.float32, device="cuda"), dim=-1)
         # Mix local + non-local expert ids to exercise the -1 fwd_idx path.
         ids = torch.randint(0, E_global, (T, K), dtype=torch.int32, device="cuda")
 
-        experts = FusedMoEExpertsNopadPersistent3WGFwdOp(
-            num_tokens=T, num_experts=E_global, top_k=K,
-            hidden_size=H, ffn_size=F_dim,
-            expert_map=expert_map,
+        experts = FusedMoEExpertsNopadPersistent3WGEpFwdOp(
+            num_tokens=T, num_experts=E_global, num_experts_local=E_local,
+            top_k=K, hidden_size=H, ffn_size=F_dim,
         )
         output = torch.empty(T, H, dtype=dtype, device="cuda")
         ws1 = torch.empty(0, dtype=dtype, device="cuda")
@@ -313,27 +311,55 @@ class TestFusedMoEExpertsNopadPersistent3WGFwdOp:
         assert torch.isfinite(output.float()).all()
 
     @pytest.mark.smoke
-    def test_forward_rejects_a_foreign_expert_map(self, moe_tensors):
-        """forward() must reject a map the op was not built for.
+    def test_ep_forward_rejects_a_map_of_another_size(self):
+        """A map marking a different number of experts local must be refused.
 
-        The local expert count is compiled into the permute kernel and both
-        grouped GEMMs, so a map other than the constructed one cannot be
-        honoured — and must not be silently ignored.
+        The count is compiled into the permute kernel and both grouped GEMMs, so a
+        map covering more local ids than the op was built for cannot be honoured.
+        """
+        T, H, F_dim, E_global, E_local, K = 64, 128, 64, 8, 4, 2
+        dtype = torch.bfloat16
+        experts = FusedMoEExpertsNopadPersistent3WGEpFwdOp(
+            num_tokens=T, num_experts=E_global, num_experts_local=E_local,
+            top_k=K, hidden_size=H, ffn_size=F_dim,
+        )
+        wider_map = torch.arange(E_global, dtype=torch.int32, device="cuda")
+        hidden = torch.randn(T, H, dtype=dtype, device="cuda") * 0.1
+        w1 = torch.randn(E_local, 2 * F_dim, H, dtype=dtype, device="cuda") * 0.02
+        w2 = torch.randn(E_local, H, F_dim, dtype=dtype, device="cuda") * 0.02
+        weights = torch.softmax(torch.randn(T, K, dtype=torch.float32, device="cuda"), dim=-1)
+        ids = torch.randint(0, E_global, (T, K), dtype=torch.int32, device="cuda")
+        output = torch.empty(T, H, dtype=dtype, device="cuda")
+        ws = torch.empty(0, dtype=dtype, device="cuda")
+        with pytest.raises(ValueError, match="exactly once each"):
+            experts.forward(
+                output, hidden, w1, w2, weights, ids,
+                expert_map=wider_map, workspace1=ws, workspace2=ws,
+                num_experts=E_global,
+            )
+
+    @pytest.mark.smoke
+    def test_kernel_delegates_are_the_same_before_and_after_a_call(self, moe_tensors):
+        """Enumeration must not depend on execution history.
+
+        Every stage is built at construction, so the delegate set a caller sees
+        before the first forward is the one it sees after.
         """
         d = moe_tensors
         experts = FusedMoEExpertsNopadPersistent3WGFwdOp(
             num_tokens=d["T"], num_experts=d["E"], top_k=d["K"],
             hidden_size=d["H"], ffn_size=d["F"],
         )
-        foreign_map = torch.arange(d["E"], dtype=torch.int32, device="cuda")
+        before = {id(op) for op in experts.kernel_delegates()}
+
         output = torch.empty(d["T"], d["H"], dtype=d["dtype"], device="cuda")
         ws = torch.empty(0, dtype=d["dtype"], device="cuda")
-        with pytest.raises(ValueError, match="expert_map must be the tensor"):
-            experts.forward(
-                output, d["hidden"], d["w1"], d["w2"], d["weights"], d["ids"],
-                expert_map=foreign_map, workspace1=ws, workspace2=ws,
-                num_experts=d["E"],
-            )
+        experts.forward(
+            output, d["hidden"], d["w1"], d["w2"], d["weights"], d["ids"],
+            workspace1=ws, workspace2=ws, num_experts=d["E"],
+        )
+
+        assert {id(op) for op in experts.kernel_delegates()} == before
 
     @pytest.mark.smoke
     @pytest.mark.parametrize("activation", ["silu_and_mul", "gelu_and_mul"])
@@ -354,7 +380,7 @@ class TestFusedMoEExpertsNopadPersistent3WGFwdOp:
         ws2 = torch.empty(0, dtype=d["dtype"], device="cuda")
         experts.forward(
             output, d["hidden"], d["w1"], d["w2"], d["weights"], d["ids"],
-            expert_map=None, workspace1=ws1, workspace2=ws2, num_experts=d["E"],
+            workspace1=ws1, workspace2=ws2, num_experts=d["E"],
         )
         assert torch.allclose(output.float(), ref_out.float(), atol=1e-2, rtol=1e-2)
 
@@ -444,8 +470,8 @@ class TestFusedMoeActivationInjection:
                 return (T_prime, H)
 
             def forward(self, output, hidden_states, w_gate_up, w_down,
-                        topk_weights, topk_ids, expert_map, workspace1,
-                        workspace2, num_experts):
+                        topk_weights, topk_ids, workspace1, workspace2,
+                        num_experts):
                 pass
 
             def make_weighted_reduce(self):

--- a/tests/ops/test_moe_compile.py
+++ b/tests/ops/test_moe_compile.py
@@ -31,7 +31,10 @@ from tileops.ops.moe import MoePermuteAlignFwdOp
 from tileops.ops.moe.routed_expert import FusedMoEExpertsNopadPersistent3WGFwdOp
 from tileops.ops.moe.routed_expert.gate_up import MoeGateUpFwdOp
 from tileops.ops.moe.routed_expert.moe_grouped_gemm_nopad import MoeGroupedGemmNopadFwdOp
-from tileops.ops.moe.routed_expert.permute_nopad import MoePermuteNopadFwdOp
+from tileops.ops.moe.routed_expert.permute_nopad import (
+    MoePermuteNopadEpFwdOp,
+    MoePermuteNopadFwdOp,
+)
 from tileops.ops.moe.routed_expert.unpermute import MoeUnpermuteFwdOp
 
 _NUM_EXPERTS = 4
@@ -116,6 +119,37 @@ def test_permute_nopad_owns_its_graph_nodes() -> None:
 
 @pytest.mark.smoke
 @pytest.mark.usefixtures("isolated_dynamo")
+def test_permute_nopad_ep_owns_its_graph_nodes() -> None:
+    """The expert-parallel identity registers its own operator.
+
+    Its fake sizes the four per-expert outputs from ``num_experts_local``, a
+    constructor parameter, so the map's contents never reach a traced region.
+    """
+    local = _NUM_EXPERTS // 2
+
+    def make():
+        return MoePermuteNopadEpFwdOp(
+            num_experts=_NUM_EXPERTS, num_experts_local=local)
+
+    hidden_states = torch.randn(
+        _TOKENS, _HIDDEN, dtype=torch.bfloat16, device="cuda")
+    topk_ids = torch.randint(
+        0, _NUM_EXPERTS, (_TOKENS, _TOP_K), dtype=torch.int32, device="cuda")
+    expert_map = torch.full((_NUM_EXPERTS,), -1, dtype=torch.int32, device="cuda")
+    expert_map[:local] = torch.arange(local, dtype=torch.int32, device="cuda")
+
+    assert_op_owns_graph_nodes(make(), hidden_states, topk_ids, expert_map)
+
+    compiled = _compile_cold(make(), hidden_states, topk_ids, expert_map)
+    eager = tuple(make()(hidden_states, topk_ids, expert_map))
+    _assert_same_layout(compiled, eager)
+    # As above: the counts are reproducible, the slot a token lands in is not.
+    for i in (1, 2, 3):
+        torch.testing.assert_close(compiled[i], eager[i])
+
+
+@pytest.mark.smoke
+@pytest.mark.usefixtures("isolated_dynamo")
 def test_unpermute_owns_its_graph_nodes() -> None:
     """Both registrations, because ``out`` picks between them at call time."""
     numel = _TOKENS * _TOP_K
@@ -187,7 +221,6 @@ def test_the_experts_composite_shows_only_its_leaf_ops() -> None:
         torch.randn(num_experts, hidden, ffn, dtype=torch.bfloat16, device="cuda"),
         torch.rand(tokens, top_k, dtype=torch.float32, device="cuda"),
         torch.randint(0, num_experts, (tokens, top_k), dtype=torch.int32, device="cuda"),
-        None,
         hidden_states.new_empty(0),
         hidden_states.new_empty(0),
         num_experts,
@@ -210,6 +243,7 @@ def test_the_experts_composite_shows_only_its_leaf_ops() -> None:
 for _op_cls in (
     MoePermuteAlignFwdOp,
     MoePermuteNopadFwdOp,
+    MoePermuteNopadEpFwdOp,
     MoeUnpermuteFwdOp,
     MoeGateUpFwdOp,
     MoeGroupedGemmNopadFwdOp,

--- a/tests/ops/test_moe_compile.py
+++ b/tests/ops/test_moe_compile.py
@@ -1,0 +1,221 @@
+"""Compile-boundary tests for the MoE ops that register one.
+
+Two assertions per op, both from a cold instance:
+
+1. Every ``call_function`` node in the traced graph is an operator the op
+   declares in ``compile_op_names``. A kernel's own registration, or a tensor op
+   left outside the boundary, fails here — either means another target could
+   change the graph.
+2. ``torch.compile(op, fullgraph=True)`` returns the shapes and dtypes the fake
+   promised, and the same values eager returns wherever the kernel is
+   reproducible. This is the evidence behind the manifest's
+   ``torch_compile_fullgraph``.
+
+A composite registers no operator of its own (RFC D7), so the last test asserts
+the other half of that decision: the graph of
+``FusedMoEExpertsNopadPersistent3WGFwdOp`` holds its leaves' operators and
+nothing else. ``FusedMoeFwdOp`` and ``FusedMoeFwdCbFwdOp`` are absent because
+the routing op they build has no boundary yet.
+"""
+
+import pytest
+import torch
+
+from tests.compile_contract import (
+    assert_op_owns_graph_nodes,
+    operator_overload,
+    register_compile_contract,
+    traced_call_targets,
+)
+from tileops.ops.moe import MoePermuteAlignFwdOp
+from tileops.ops.moe.routed_expert import FusedMoEExpertsNopadPersistent3WGFwdOp
+from tileops.ops.moe.routed_expert.gate_up import MoeGateUpFwdOp
+from tileops.ops.moe.routed_expert.moe_grouped_gemm_nopad import MoeGroupedGemmNopadFwdOp
+from tileops.ops.moe.routed_expert.permute_nopad import MoePermuteNopadFwdOp
+from tileops.ops.moe.routed_expert.unpermute import MoeUnpermuteFwdOp
+
+_NUM_EXPERTS = 4
+_TOP_K = 2
+_TOKENS = 4
+_HIDDEN = 64
+
+
+def _compile_cold(op, *inputs) -> tuple:
+    """Outputs of one cold ``fullgraph=True`` compile, always as a tuple."""
+    outputs = torch.compile(op, fullgraph=True)(*inputs)
+    return outputs if isinstance(outputs, tuple) else (outputs,)
+
+
+def _assert_same_layout(compiled: tuple, eager: tuple) -> None:
+    """The compiled call produced the shapes and dtypes the fake promised."""
+    for got, want in zip(compiled, eager, strict=True):
+        assert got.shape == want.shape, f"{got.shape} != {want.shape}"
+        assert got.dtype == want.dtype, f"{got.dtype} != {want.dtype}"
+
+
+def _assert_compiles_to_eager(op_factory, *inputs) -> None:
+    """A cold ``fullgraph=True`` compile returns what a cold eager call returns."""
+    compiled = _compile_cold(op_factory(), *inputs)
+    eager = op_factory()(*inputs)
+    eager = eager if isinstance(eager, tuple) else (eager,)
+    _assert_same_layout(compiled, eager)
+    for got, want in zip(compiled, eager, strict=True):
+        torch.testing.assert_close(got, want)
+
+
+def _grouped_gemm_inputs(numel: int, num_experts: int, n: int, k: int):
+    """Tight rows split evenly across experts, plus the two index arrays."""
+    a = torch.randn(numel, k, dtype=torch.bfloat16, device="cuda")
+    b = torch.randn(num_experts, n, k, dtype=torch.bfloat16, device="cuda")
+    per_expert = numel // num_experts
+    sizes = torch.full((num_experts,), per_expert, dtype=torch.int32, device="cuda")
+    offsets = torch.arange(num_experts, dtype=torch.int32, device="cuda") * per_expert
+    return a, b, sizes, offsets
+
+
+@pytest.mark.smoke
+@pytest.mark.usefixtures("isolated_dynamo")
+def test_permute_align_owns_its_graph_nodes() -> None:
+    def make():
+        return MoePermuteAlignFwdOp(_TOKENS, _TOP_K, _NUM_EXPERTS, block_size=4)
+
+    topk_ids = torch.randint(
+        0, _NUM_EXPERTS, (_TOKENS, _TOP_K), dtype=torch.int32, device="cuda")
+
+    assert_op_owns_graph_nodes(make(), topk_ids)
+
+    compiled = _compile_cold(make(), topk_ids)
+    eager = tuple(make()(topk_ids))
+    _assert_same_layout(compiled, eager)
+    # Only the padded token count is reproducible: a slot inside an expert is claimed
+    # by ``atomic_add``, so two runs order the same tokens differently.
+    torch.testing.assert_close(compiled[2], eager[2])
+
+
+@pytest.mark.smoke
+@pytest.mark.usefixtures("isolated_dynamo")
+def test_permute_nopad_owns_its_graph_nodes() -> None:
+    def make():
+        return MoePermuteNopadFwdOp(num_experts=_NUM_EXPERTS)
+
+    hidden_states = torch.randn(
+        _TOKENS, _HIDDEN, dtype=torch.bfloat16, device="cuda")
+    topk_ids = torch.randint(
+        0, _NUM_EXPERTS, (_TOKENS, _TOP_K), dtype=torch.int32, device="cuda")
+
+    assert_op_owns_graph_nodes(make(), hidden_states, topk_ids)
+
+    compiled = _compile_cold(make(), hidden_states, topk_ids)
+    eager = tuple(make()(hidden_states, topk_ids))
+    _assert_same_layout(compiled, eager)
+    # The per-expert offsets, sizes and prefix sum are counts. The gathered rows and
+    # the forward map are not: a slot inside an expert is claimed by ``atomic_add``.
+    for i in (1, 2, 3):
+        torch.testing.assert_close(compiled[i], eager[i])
+
+
+@pytest.mark.smoke
+@pytest.mark.usefixtures("isolated_dynamo")
+def test_unpermute_owns_its_graph_nodes() -> None:
+    """Both registrations, because ``out`` picks between them at call time."""
+    numel = _TOKENS * _TOP_K
+    mm2_pad = torch.randn(numel, _HIDDEN, dtype=torch.bfloat16, device="cuda")
+    fwd_idx = torch.arange(numel, dtype=torch.int32, device="cuda")
+    topk_weights = torch.rand(_TOKENS, _TOP_K, dtype=torch.float32, device="cuda")
+    out = torch.empty(_TOKENS, _HIDDEN, dtype=torch.bfloat16, device="cuda")
+
+    def make():
+        return MoeUnpermuteFwdOp(_TOKENS, _TOP_K, _HIDDEN, padded_batch_sum=numel)
+
+    assert_op_owns_graph_nodes(make(), mm2_pad, fwd_idx, topk_weights)
+    assert_op_owns_graph_nodes(make(), mm2_pad, fwd_idx, topk_weights, out)
+    _assert_compiles_to_eager(make, mm2_pad, fwd_idx, topk_weights)
+
+    out.zero_()
+    torch.compile(make(), fullgraph=True)(mm2_pad, fwd_idx, topk_weights, out)
+    # The in-place operator declares the mutation, so what the compiled call left in
+    # ``out`` is what the allocating path returns.
+    torch.testing.assert_close(out, make()(mm2_pad, fwd_idx, topk_weights))
+
+
+@pytest.mark.smoke
+@pytest.mark.usefixtures("isolated_dynamo")
+def test_gate_up_owns_its_graph_nodes() -> None:
+    numel, ffn, k = 64, 128, 128
+
+    def make():
+        return MoeGateUpFwdOp(numel, _NUM_EXPERTS, ffn, k)
+
+    inputs = _grouped_gemm_inputs(numel, _NUM_EXPERTS, 2 * ffn, k)
+    assert_op_owns_graph_nodes(make(), *inputs)
+    _assert_compiles_to_eager(make, *inputs)
+
+
+@pytest.mark.smoke
+@pytest.mark.usefixtures("isolated_dynamo")
+def test_grouped_gemm_nopad_owns_its_graph_nodes() -> None:
+    numel, n, k = 64, 128, 128
+
+    def make():
+        return MoeGroupedGemmNopadFwdOp(numel, _NUM_EXPERTS, n, k)
+
+    inputs = _grouped_gemm_inputs(numel, _NUM_EXPERTS, n, k)
+    assert_op_owns_graph_nodes(make(), *inputs)
+    _assert_compiles_to_eager(make, *inputs)
+
+
+@pytest.mark.smoke
+@pytest.mark.usefixtures("isolated_dynamo")
+def test_the_experts_composite_shows_only_its_leaf_ops() -> None:
+    """RFC D7: a composite is not the unit of replacement, so it registers nothing.
+
+    Its graph is the leaves' operators, which is what makes the leaf the thing a
+    target replaces.
+    """
+    num_experts, top_k, tokens, hidden, ffn = 4, 2, 4, 128, 128
+    experts = FusedMoEExpertsNopadPersistent3WGFwdOp(
+        num_tokens=tokens, num_experts=num_experts, top_k=top_k,
+        hidden_size=hidden, ffn_size=ffn,
+    )
+    assert experts.compile_op_names == ()
+
+    hidden_states = torch.randn(tokens, hidden, dtype=torch.bfloat16, device="cuda")
+    args = (
+        torch.empty(tokens, hidden, dtype=torch.bfloat16, device="cuda"),
+        hidden_states,
+        torch.randn(num_experts, 2 * ffn, hidden, dtype=torch.bfloat16, device="cuda"),
+        torch.randn(num_experts, hidden, ffn, dtype=torch.bfloat16, device="cuda"),
+        torch.rand(tokens, top_k, dtype=torch.float32, device="cuda"),
+        torch.randint(0, num_experts, (tokens, top_k), dtype=torch.int32, device="cuda"),
+        None,
+        hidden_states.new_empty(0),
+        hidden_states.new_empty(0),
+        num_experts,
+    )
+    owned_by_leaves = {
+        operator_overload(name)
+        for leaf in (experts._permute, experts._gate_up, experts._gemm_down,
+                     experts._unpermute)
+        for name in type(leaf).compile_op_names
+    }
+
+    calls = traced_call_targets(experts, *args)
+
+    assert calls, "the traced graph called nothing"
+    assert calls <= owned_by_leaves, (
+        f"graph holds nodes no leaf op owns: "
+        f"{sorted(str(c) for c in calls - owned_by_leaves)}")
+
+
+for _op_cls in (
+    MoePermuteAlignFwdOp,
+    MoePermuteNopadFwdOp,
+    MoeUnpermuteFwdOp,
+    MoeGateUpFwdOp,
+    MoeGroupedGemmNopadFwdOp,
+):
+    register_compile_contract(_op_cls)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_moe_compile.py
+++ b/tests/ops/test_moe_compile.py
@@ -11,11 +11,10 @@ Two assertions per op, both from a cold instance:
    reproducible. This is the evidence behind the manifest's
    ``torch_compile_fullgraph``.
 
-A composite registers no operator of its own (RFC D7), so the last test asserts
-the other half of that decision: the graph of
-``FusedMoEExpertsNopadPersistent3WGFwdOp`` holds its leaves' operators and
-nothing else. ``FusedMoeFwdOp`` and ``FusedMoeFwdCbFwdOp`` are absent because
-the routing op they build has no boundary yet.
+A composite registers no operator of its own, so the last test asserts the other
+half: the graph of ``FusedMoEExpertsNopadPersistent3WGFwdOp`` holds its leaves'
+operators and nothing else. ``FusedMoeFwdOp`` is absent because the routing op it
+builds has no boundary yet.
 """
 
 import pytest
@@ -31,10 +30,7 @@ from tileops.ops.moe import MoePermuteAlignFwdOp
 from tileops.ops.moe.routed_expert import FusedMoEExpertsNopadPersistent3WGFwdOp
 from tileops.ops.moe.routed_expert.gate_up import MoeGateUpFwdOp
 from tileops.ops.moe.routed_expert.moe_grouped_gemm_nopad import MoeGroupedGemmNopadFwdOp
-from tileops.ops.moe.routed_expert.permute_nopad import (
-    MoePermuteNopadEpFwdOp,
-    MoePermuteNopadFwdOp,
-)
+from tileops.ops.moe.routed_expert.permute_nopad import MoePermuteNopadFwdOp
 from tileops.ops.moe.routed_expert.unpermute import MoeUnpermuteFwdOp
 
 _NUM_EXPERTS = 4
@@ -56,16 +52,6 @@ def _assert_same_layout(compiled: tuple, eager: tuple) -> None:
         assert got.dtype == want.dtype, f"{got.dtype} != {want.dtype}"
 
 
-def _assert_compiles_to_eager(op_factory, *inputs) -> None:
-    """A cold ``fullgraph=True`` compile returns what a cold eager call returns."""
-    compiled = _compile_cold(op_factory(), *inputs)
-    eager = op_factory()(*inputs)
-    eager = eager if isinstance(eager, tuple) else (eager,)
-    _assert_same_layout(compiled, eager)
-    for got, want in zip(compiled, eager, strict=True):
-        torch.testing.assert_close(got, want)
-
-
 def _grouped_gemm_inputs(numel: int, num_experts: int, n: int, k: int):
     """Tight rows split evenly across experts, plus the two index arrays."""
     a = torch.randn(numel, k, dtype=torch.bfloat16, device="cuda")
@@ -76,75 +62,81 @@ def _grouped_gemm_inputs(numel: int, num_experts: int, n: int, k: int):
     return a, b, sizes, offsets
 
 
-@pytest.mark.smoke
-@pytest.mark.usefixtures("isolated_dynamo")
-def test_permute_align_owns_its_graph_nodes() -> None:
+def _permute_align_case():
     def make():
         return MoePermuteAlignFwdOp(_TOKENS, _TOP_K, _NUM_EXPERTS, block_size=4)
 
     topk_ids = torch.randint(
         0, _NUM_EXPERTS, (_TOKENS, _TOP_K), dtype=torch.int32, device="cuda")
-
-    assert_op_owns_graph_nodes(make(), topk_ids)
-
-    compiled = _compile_cold(make(), topk_ids)
-    eager = tuple(make()(topk_ids))
-    _assert_same_layout(compiled, eager)
     # Only the padded token count is reproducible: a slot inside an expert is claimed
     # by ``atomic_add``, so two runs order the same tokens differently.
-    torch.testing.assert_close(compiled[2], eager[2])
+    return make, (topk_ids,), (2,)
 
 
-@pytest.mark.smoke
-@pytest.mark.usefixtures("isolated_dynamo")
-def test_permute_nopad_owns_its_graph_nodes() -> None:
+def _permute_nopad_case(local: int = _NUM_EXPERTS, with_map: bool = False):
     def make():
-        return MoePermuteNopadFwdOp(num_experts=_NUM_EXPERTS)
-
-    hidden_states = torch.randn(
-        _TOKENS, _HIDDEN, dtype=torch.bfloat16, device="cuda")
-    topk_ids = torch.randint(
-        0, _NUM_EXPERTS, (_TOKENS, _TOP_K), dtype=torch.int32, device="cuda")
-
-    assert_op_owns_graph_nodes(make(), hidden_states, topk_ids)
-
-    compiled = _compile_cold(make(), hidden_states, topk_ids)
-    eager = tuple(make()(hidden_states, topk_ids))
-    _assert_same_layout(compiled, eager)
-    # The per-expert offsets, sizes and prefix sum are counts. The gathered rows and
-    # the forward map are not: a slot inside an expert is claimed by ``atomic_add``.
-    for i in (1, 2, 3):
-        torch.testing.assert_close(compiled[i], eager[i])
-
-
-@pytest.mark.smoke
-@pytest.mark.usefixtures("isolated_dynamo")
-def test_permute_nopad_ep_owns_its_graph_nodes() -> None:
-    """The expert-parallel identity registers its own operator.
-
-    Its fake sizes the four per-expert outputs from ``num_experts_local``, a
-    constructor parameter, so the map's contents never reach a traced region.
-    """
-    local = _NUM_EXPERTS // 2
-
-    def make():
-        return MoePermuteNopadEpFwdOp(
+        return MoePermuteNopadFwdOp(
             num_experts=_NUM_EXPERTS, num_experts_local=local)
 
     hidden_states = torch.randn(
         _TOKENS, _HIDDEN, dtype=torch.bfloat16, device="cuda")
     topk_ids = torch.randint(
         0, _NUM_EXPERTS, (_TOKENS, _TOP_K), dtype=torch.int32, device="cuda")
-    expert_map = torch.full((_NUM_EXPERTS,), -1, dtype=torch.int32, device="cuda")
-    expert_map[:local] = torch.arange(local, dtype=torch.int32, device="cuda")
+    inputs = (hidden_states, topk_ids)
+    if with_map:
+        expert_map = torch.full((_NUM_EXPERTS,), -1, dtype=torch.int32, device="cuda")
+        expert_map[:local] = torch.arange(local, dtype=torch.int32, device="cuda")
+        inputs += (expert_map,)
+    # The per-expert offsets, sizes and prefix sum are counts. The gathered rows and
+    # the forward map are not: a slot inside an expert is claimed by ``atomic_add``.
+    return make, inputs, (1, 2, 3)
 
-    assert_op_owns_graph_nodes(make(), hidden_states, topk_ids, expert_map)
 
-    compiled = _compile_cold(make(), hidden_states, topk_ids, expert_map)
-    eager = tuple(make()(hidden_states, topk_ids, expert_map))
+def _gate_up_case():
+    numel, ffn, k = 64, 128, 128
+
+    def make():
+        return MoeGateUpFwdOp(numel, _NUM_EXPERTS, ffn, k)
+
+    return make, _grouped_gemm_inputs(numel, _NUM_EXPERTS, 2 * ffn, k), "all"
+
+
+def _grouped_gemm_nopad_case():
+    numel, n, k = 64, 128, 128
+
+    def make():
+        return MoeGroupedGemmNopadFwdOp(numel, _NUM_EXPERTS, n, k)
+
+    return make, _grouped_gemm_inputs(numel, _NUM_EXPERTS, n, k), "all"
+
+
+_LEAF_CASES = {
+    "permute_align": _permute_align_case,
+    "permute_nopad": _permute_nopad_case,
+    # Supplying the map keeps the graph inside the same operator: the fake sizes the
+    # four per-expert outputs from ``num_experts_local``, a constructor parameter, so
+    # the map's contents never reach a traced region.
+    "permute_nopad_with_a_map": lambda: _permute_nopad_case(
+        local=_NUM_EXPERTS // 2, with_map=True),
+    "gate_up": _gate_up_case,
+    "grouped_gemm_nopad": _grouped_gemm_nopad_case,
+}
+
+
+@pytest.mark.smoke
+@pytest.mark.usefixtures("isolated_dynamo")
+@pytest.mark.parametrize("case", _LEAF_CASES.values(), ids=_LEAF_CASES)
+def test_leaf_op_owns_its_graph_nodes(case) -> None:
+    make, inputs, reproducible = case()
+
+    assert_op_owns_graph_nodes(make(), *inputs)
+
+    compiled = _compile_cold(make(), *inputs)
+    eager = make()(*inputs)
+    eager = tuple(eager) if isinstance(eager, tuple) else (eager,)
     _assert_same_layout(compiled, eager)
-    # As above: the counts are reproducible, the slot a token lands in is not.
-    for i in (1, 2, 3):
+    indices = range(len(compiled)) if reproducible == "all" else reproducible
+    for i in indices:
         torch.testing.assert_close(compiled[i], eager[i])
 
 
@@ -163,7 +155,10 @@ def test_unpermute_owns_its_graph_nodes() -> None:
 
     assert_op_owns_graph_nodes(make(), mm2_pad, fwd_idx, topk_weights)
     assert_op_owns_graph_nodes(make(), mm2_pad, fwd_idx, topk_weights, out)
-    _assert_compiles_to_eager(make, mm2_pad, fwd_idx, topk_weights)
+    compiled = _compile_cold(make(), mm2_pad, fwd_idx, topk_weights)
+    eager = (make()(mm2_pad, fwd_idx, topk_weights),)
+    _assert_same_layout(compiled, eager)
+    torch.testing.assert_close(compiled[0], eager[0])
 
     out.zero_()
     torch.compile(make(), fullgraph=True)(mm2_pad, fwd_idx, topk_weights, out)
@@ -174,42 +169,16 @@ def test_unpermute_owns_its_graph_nodes() -> None:
 
 @pytest.mark.smoke
 @pytest.mark.usefixtures("isolated_dynamo")
-def test_gate_up_owns_its_graph_nodes() -> None:
-    numel, ffn, k = 64, 128, 128
-
-    def make():
-        return MoeGateUpFwdOp(numel, _NUM_EXPERTS, ffn, k)
-
-    inputs = _grouped_gemm_inputs(numel, _NUM_EXPERTS, 2 * ffn, k)
-    assert_op_owns_graph_nodes(make(), *inputs)
-    _assert_compiles_to_eager(make, *inputs)
-
-
-@pytest.mark.smoke
-@pytest.mark.usefixtures("isolated_dynamo")
-def test_grouped_gemm_nopad_owns_its_graph_nodes() -> None:
-    numel, n, k = 64, 128, 128
-
-    def make():
-        return MoeGroupedGemmNopadFwdOp(numel, _NUM_EXPERTS, n, k)
-
-    inputs = _grouped_gemm_inputs(numel, _NUM_EXPERTS, n, k)
-    assert_op_owns_graph_nodes(make(), *inputs)
-    _assert_compiles_to_eager(make, *inputs)
-
-
-@pytest.mark.smoke
-@pytest.mark.usefixtures("isolated_dynamo")
 def test_the_experts_composite_shows_only_its_leaf_ops() -> None:
-    """RFC D7: a composite is not the unit of replacement, so it registers nothing.
+    """A composite is not the unit of replacement, so it registers nothing.
 
     Its graph is the leaves' operators, which is what makes the leaf the thing a
     target replaces.
     """
     num_experts, top_k, tokens, hidden, ffn = 4, 2, 4, 128, 128
     experts = FusedMoEExpertsNopadPersistent3WGFwdOp(
-        num_tokens=tokens, num_experts=num_experts, top_k=top_k,
-        hidden_size=hidden, ffn_size=ffn,
+        num_tokens=tokens, num_experts=num_experts, num_experts_local=num_experts,
+        top_k=top_k, hidden_size=hidden, ffn_size=ffn,
     )
     assert experts.compile_op_names == ()
 
@@ -223,8 +192,8 @@ def test_the_experts_composite_shows_only_its_leaf_ops() -> None:
         torch.randint(0, num_experts, (tokens, top_k), dtype=torch.int32, device="cuda"),
         hidden_states.new_empty(0),
         hidden_states.new_empty(0),
-        num_experts,
     )
+    kwargs = {"num_experts": num_experts}
     owned_by_leaves = {
         operator_overload(name)
         for leaf in (experts._permute, experts._gate_up, experts._gemm_down,
@@ -232,7 +201,7 @@ def test_the_experts_composite_shows_only_its_leaf_ops() -> None:
         for name in type(leaf).compile_op_names
     }
 
-    calls = traced_call_targets(experts, *args)
+    calls = traced_call_targets(experts, *args, **kwargs)
 
     assert calls, "the traced graph called nothing"
     assert calls <= owned_by_leaves, (
@@ -243,7 +212,6 @@ def test_the_experts_composite_shows_only_its_leaf_ops() -> None:
 for _op_cls in (
     MoePermuteAlignFwdOp,
     MoePermuteNopadFwdOp,
-    MoePermuteNopadEpFwdOp,
     MoeUnpermuteFwdOp,
     MoeGateUpFwdOp,
     MoeGroupedGemmNopadFwdOp,

--- a/tests/ops/test_moe_fused_moe.py
+++ b/tests/ops/test_moe_fused_moe.py
@@ -345,7 +345,7 @@ def test_expert_map_local_filter() -> None:
     op_r0 = FusedMoe(
         num_tokens=T, num_experts=E, top_k=K,
         hidden_size=H, ffn_size=F,
-        expert_map=expert_map_rank0,
+        expert_map=expert_map_rank0, num_experts_local=E // 2,
     )
     out_r0 = op_r0(hidden, gating, w_gate_up[:E // 2], w_down[:E // 2])
 
@@ -353,7 +353,7 @@ def test_expert_map_local_filter() -> None:
     op_r1 = FusedMoe(
         num_tokens=T, num_experts=E, top_k=K,
         hidden_size=H, ffn_size=F,
-        expert_map=expert_map_rank1,
+        expert_map=expert_map_rank1, num_experts_local=E // 2,
     )
     out_r1 = op_r1(hidden, gating, w_gate_up[E // 2:], w_down[E // 2:])
 

--- a/tests/ops/test_moe_fused_moe_distributed.py
+++ b/tests/ops/test_moe_fused_moe_distributed.py
@@ -138,6 +138,7 @@ def test_kimi_k2_ep_distributed(T, E_global, K, H, F, world_size):
         scoring_func="sigmoid", renormalize=True,
         routed_scaling_factor=2.827,
         expert_map=expert_map,
+        num_experts_local=E_local,
     )
     out_local = op_local(hidden, gating, w_gate_up_local, w_down_local, correction_bias)
 
@@ -212,6 +213,7 @@ def test_shared_fused_moe_ep_distributed(T, E_global, K, H, F, shared_F, world_s
         scoring_func="sigmoid", renormalize=True,
         routed_scaling_factor=2.827,
         expert_map=expert_map,
+        num_experts_local=E_local,
         shared_ffn_size=shared_F,
     )
     shared_out, routed_out_local = op_local(
@@ -303,6 +305,7 @@ def test_fused_moe_vs_vllm_distributed(T, E_global, K, H, F, world_size):
         scoring_func="sigmoid", renormalize=True,
         routed_scaling_factor=2.827,
         expert_map=expert_map,
+        num_experts_local=E_local,
     )
     out_tileops = op_tileops(hidden, gating, w_gate_up_local, w_down_local, correction_bias)
     dist.all_reduce(out_tileops, op=dist.ReduceOp.SUM)
@@ -377,6 +380,7 @@ def test_fused_moe_vs_vllm_ep_layer(T, E_global, K, H, F, world_size):
         scoring_func="sigmoid", renormalize=True,
         routed_scaling_factor=2.827,
         expert_map=expert_map,
+        num_experts_local=E_local,
     )
     out_tileops = op_tileops(hidden, gating, w_gate_up_local, w_down_local, correction_bias)
 

--- a/tests/ops/test_moe_permute_nopad.py
+++ b/tests/ops/test_moe_permute_nopad.py
@@ -98,6 +98,23 @@ def test_moe_permute_nopad_explicit_shape_mismatch_raises() -> None:
 
 
 @pytest.mark.smoke
+def test_moe_permute_nopad_expert_map_count_change_rebuilds_kernel() -> None:
+    """Editing expert_map so a different number of experts is local must not
+    reuse the kernel built for the old count — that count sizes its buffers."""
+    E, T, K, H = 4, 8, 2, 64
+    expert_map = torch.full((E,), -1, dtype=torch.int32, device="cuda")
+    expert_map[:2] = torch.arange(2, dtype=torch.int32, device="cuda")
+    op = MoePermuteNopadFwdOp(num_experts=E, expert_map=expert_map)
+    hidden_states = torch.randn(T, H, dtype=torch.bfloat16, device="cuda")
+    topk_ids = torch.randint(0, E, (T, K), dtype=torch.int32, device="cuda")
+
+    assert op(hidden_states, topk_ids)[2].shape[0] == 2
+
+    expert_map[2] = 2
+    assert op(hidden_states, topk_ids)[2].shape[0] == 3
+
+
+@pytest.mark.smoke
 def test_moe_permute_nopad_cpu_input_raises() -> None:
     hidden_states = torch.randn(4, 16, dtype=torch.float16)
     topk_ids = torch.randint(0, 4, (4, 2), dtype=torch.int32)

--- a/tests/ops/test_moe_permute_nopad.py
+++ b/tests/ops/test_moe_permute_nopad.py
@@ -11,7 +11,7 @@ import pytest
 import torch
 
 from tests.test_base import FixtureBase, TestBase
-from tileops.ops.moe import MoePermuteNopadFwdOp
+from tileops.ops.moe import MoePermuteNopadEpFwdOp, MoePermuteNopadFwdOp
 from workloads.moe import MoePermuteWorkload
 
 
@@ -98,20 +98,60 @@ def test_moe_permute_nopad_explicit_shape_mismatch_raises() -> None:
 
 
 @pytest.mark.smoke
-def test_moe_permute_nopad_expert_map_count_change_rebuilds_kernel() -> None:
-    """Editing expert_map so a different number of experts is local must not
-    reuse the kernel built for the old count — that count sizes its buffers."""
-    E, T, K, H = 4, 8, 2, 64
+def test_moe_permute_nopad_ep_counts_only_local_experts() -> None:
+    """The EP identity lays out num_experts_local slots and drops the rest.
+
+    Every token routed to a local expert reaches a slot; a token routed elsewhere
+    gets fwd_idx == -1.
+    """
+    E, E_local, T, K, H = 4, 2, 8, 2, 64
     expert_map = torch.full((E,), -1, dtype=torch.int32, device="cuda")
-    expert_map[:2] = torch.arange(2, dtype=torch.int32, device="cuda")
-    op = MoePermuteNopadFwdOp(num_experts=E, expert_map=expert_map)
+    expert_map[:E_local] = torch.arange(E_local, dtype=torch.int32, device="cuda")
+    op = MoePermuteNopadEpFwdOp(num_experts=E, num_experts_local=E_local)
     hidden_states = torch.randn(T, H, dtype=torch.bfloat16, device="cuda")
     topk_ids = torch.randint(0, E, (T, K), dtype=torch.int32, device="cuda")
 
-    assert op(hidden_states, topk_ids)[2].shape[0] == 2
+    _, _, true_sizes, _, fwd_idx = op(hidden_states, topk_ids, expert_map)
+
+    assert true_sizes.shape[0] == E_local
+    local_pairs = int((topk_ids.flatten() < E_local).sum())
+    assert int(true_sizes.sum()) == local_pairs
+    assert int((fwd_idx >= 0).sum()) == local_pairs
+
+
+@pytest.mark.smoke
+def test_moe_permute_nopad_ep_rejects_a_non_dense_map() -> None:
+    """A map whose local ids are not 0..E_local-1 must raise, not miscount.
+
+    ``[-1, 0, 2, -1]`` marks two experts local while naming id 2, which the
+    kernel's two counters cannot hold: the tokens routed there used to be
+    dropped silently.
+    """
+    E, E_local, T, K, H = 4, 2, 8, 2, 64
+    expert_map = torch.tensor([-1, 0, 2, -1], dtype=torch.int32, device="cuda")
+    op = MoePermuteNopadEpFwdOp(num_experts=E, num_experts_local=E_local)
+    hidden_states = torch.randn(T, H, dtype=torch.bfloat16, device="cuda")
+    topk_ids = torch.randint(0, E, (T, K), dtype=torch.int32, device="cuda")
+
+    with pytest.raises(ValueError, match="exactly once each"):
+        op(hidden_states, topk_ids, expert_map)
+
+
+@pytest.mark.smoke
+def test_moe_permute_nopad_ep_rechecks_an_edited_map() -> None:
+    """Editing a valid map into an invalid one must be caught on the next call."""
+    E, E_local, T, K, H = 4, 2, 8, 2, 64
+    expert_map = torch.full((E,), -1, dtype=torch.int32, device="cuda")
+    expert_map[:E_local] = torch.arange(E_local, dtype=torch.int32, device="cuda")
+    op = MoePermuteNopadEpFwdOp(num_experts=E, num_experts_local=E_local)
+    hidden_states = torch.randn(T, H, dtype=torch.bfloat16, device="cuda")
+    topk_ids = torch.randint(0, E, (T, K), dtype=torch.int32, device="cuda")
+
+    op(hidden_states, topk_ids, expert_map)
 
     expert_map[2] = 2
-    assert op(hidden_states, topk_ids)[2].shape[0] == 3
+    with pytest.raises(ValueError, match="exactly once each"):
+        op(hidden_states, topk_ids, expert_map)
 
 
 @pytest.mark.smoke

--- a/tests/ops/test_moe_permute_nopad.py
+++ b/tests/ops/test_moe_permute_nopad.py
@@ -11,7 +11,7 @@ import pytest
 import torch
 
 from tests.test_base import FixtureBase, TestBase
-from tileops.ops.moe import MoePermuteNopadEpFwdOp, MoePermuteNopadFwdOp
+from tileops.ops.moe import MoePermuteNopadFwdOp
 from workloads.moe import MoePermuteWorkload
 
 
@@ -71,7 +71,7 @@ class MoePermuteNopadFixture(FixtureBase):
 @MoePermuteNopadFixture
 def test_moe_permute_nopad_op(total_tokens, top_k, num_experts, hidden_size, dtype):
     test = MoePermuteNopadTest(total_tokens, top_k, num_experts, hidden_size, dtype)
-    op = MoePermuteNopadFwdOp(num_experts=num_experts)
+    op = MoePermuteNopadFwdOp(num_experts=num_experts, num_experts_local=num_experts)
     hidden_states, topk_ids = test.gen_inputs()
 
     outputs = op(hidden_states, topk_ids)
@@ -88,9 +88,10 @@ def test_moe_permute_nopad_explicit_shape_mismatch_raises() -> None:
     hidden_states = torch.randn(4, 16, dtype=torch.float16, device="cuda")
     topk_ids = torch.randint(0, 4, (4, 2), dtype=torch.int32, device="cuda")
     op = MoePermuteNopadFwdOp(
+        num_experts=4,
+        num_experts_local=4,
         total_tokens=5,
         top_k=2,
-        num_experts=4,
         hidden_size=16,
     )
     with pytest.raises(ValueError, match="Expected total_tokens"):
@@ -98,8 +99,36 @@ def test_moe_permute_nopad_explicit_shape_mismatch_raises() -> None:
 
 
 @pytest.mark.smoke
+def test_moe_permute_nopad_without_a_map_builds_the_map_free_scan() -> None:
+    """No map means the map-free scan, whatever num_experts_local says.
+
+    The map-reading scan loads ``expert_map[global_eid]`` twice per token-expert
+    pair. Selecting it for a call that passed no map would pay that for nothing.
+    """
+    op = MoePermuteNopadFwdOp(num_experts=4, num_experts_local=4)
+    hidden_states = torch.randn(8, 64, dtype=torch.bfloat16, device="cuda")
+    topk_ids = torch.randint(0, 4, (8, 2), dtype=torch.int32, device="cuda")
+
+    op(hidden_states, topk_ids)
+
+    (kernel,) = op.iter_kernels()
+    assert not kernel.expert_parallel
+
+
+@pytest.mark.smoke
+def test_moe_permute_nopad_partial_local_without_a_map_raises() -> None:
+    """Owning a slice of the table but naming no map is unsatisfiable."""
+    op = MoePermuteNopadFwdOp(num_experts=4, num_experts_local=2)
+    hidden_states = torch.randn(8, 64, dtype=torch.bfloat16, device="cuda")
+    topk_ids = torch.randint(0, 4, (8, 2), dtype=torch.int32, device="cuda")
+
+    with pytest.raises(ValueError, match="needs an expert_map"):
+        op(hidden_states, topk_ids)
+
+
+@pytest.mark.smoke
 def test_moe_permute_nopad_ep_counts_only_local_experts() -> None:
-    """The EP identity lays out num_experts_local slots and drops the rest.
+    """With a map, the op lays out num_experts_local slots and drops the rest.
 
     Every token routed to a local expert reaches a slot; a token routed elsewhere
     gets fwd_idx == -1.
@@ -107,7 +136,7 @@ def test_moe_permute_nopad_ep_counts_only_local_experts() -> None:
     E, E_local, T, K, H = 4, 2, 8, 2, 64
     expert_map = torch.full((E,), -1, dtype=torch.int32, device="cuda")
     expert_map[:E_local] = torch.arange(E_local, dtype=torch.int32, device="cuda")
-    op = MoePermuteNopadEpFwdOp(num_experts=E, num_experts_local=E_local)
+    op = MoePermuteNopadFwdOp(num_experts=E, num_experts_local=E_local)
     hidden_states = torch.randn(T, H, dtype=torch.bfloat16, device="cuda")
     topk_ids = torch.randint(0, E, (T, K), dtype=torch.int32, device="cuda")
 
@@ -129,7 +158,7 @@ def test_moe_permute_nopad_ep_rejects_a_non_dense_map() -> None:
     """
     E, E_local, T, K, H = 4, 2, 8, 2, 64
     expert_map = torch.tensor([-1, 0, 2, -1], dtype=torch.int32, device="cuda")
-    op = MoePermuteNopadEpFwdOp(num_experts=E, num_experts_local=E_local)
+    op = MoePermuteNopadFwdOp(num_experts=E, num_experts_local=E_local)
     hidden_states = torch.randn(T, H, dtype=torch.bfloat16, device="cuda")
     topk_ids = torch.randint(0, E, (T, K), dtype=torch.int32, device="cuda")
 
@@ -143,7 +172,7 @@ def test_moe_permute_nopad_ep_rechecks_an_edited_map() -> None:
     E, E_local, T, K, H = 4, 2, 8, 2, 64
     expert_map = torch.full((E,), -1, dtype=torch.int32, device="cuda")
     expert_map[:E_local] = torch.arange(E_local, dtype=torch.int32, device="cuda")
-    op = MoePermuteNopadEpFwdOp(num_experts=E, num_experts_local=E_local)
+    op = MoePermuteNopadFwdOp(num_experts=E, num_experts_local=E_local)
     hidden_states = torch.randn(T, H, dtype=torch.bfloat16, device="cuda")
     topk_ids = torch.randint(0, E, (T, K), dtype=torch.int32, device="cuda")
 
@@ -158,7 +187,7 @@ def test_moe_permute_nopad_ep_rechecks_an_edited_map() -> None:
 def test_moe_permute_nopad_cpu_input_raises() -> None:
     hidden_states = torch.randn(4, 16, dtype=torch.float16)
     topk_ids = torch.randint(0, 4, (4, 2), dtype=torch.int32)
-    op = MoePermuteNopadFwdOp(num_experts=4)
+    op = MoePermuteNopadFwdOp(num_experts=4, num_experts_local=4)
     with pytest.raises(ValueError, match="hidden_states must be a CUDA tensor"):
         op(hidden_states, topk_ids)
 
@@ -167,7 +196,7 @@ def test_moe_permute_nopad_cpu_input_raises() -> None:
 def test_moe_permute_nopad_invalid_dtype_raises() -> None:
     hidden_states = torch.randn(4, 16, dtype=torch.float32, device="cuda")
     topk_ids = torch.randint(0, 4, (4, 2), dtype=torch.int32, device="cuda")
-    op = MoePermuteNopadFwdOp(num_experts=4)
+    op = MoePermuteNopadFwdOp(num_experts=4, num_experts_local=4)
     with pytest.raises(ValueError, match="Expected hidden_states.dtype"):
         op(hidden_states, topk_ids)
 

--- a/tests/ops/test_moe_shared_fused_moe.py
+++ b/tests/ops/test_moe_shared_fused_moe.py
@@ -198,3 +198,36 @@ def test_shared_fused_moe_tp_rejects_local_shards():
     with pytest.raises(ValueError, match="full weights"):
         op(hidden, gating, w_gate_up, w_down,
            shared_w_gate_up=good_gate_up, shared_w_down=bad_w_down)
+
+
+@pytest.mark.smoke
+def test_a_replaced_shared_expert_kernel_is_the_one_built():
+    """The shared half is reachable through kernel_map, like the routed half."""
+    from tileops.kernels.moe import SharedExpertMLPKernel
+
+    built = []
+
+    class Replacement(SharedExpertMLPKernel):
+        def __init__(self, **kwargs):
+            built.append(kwargs)
+            super().__init__(**kwargs)
+
+    T, E, K, H, F, F_s = 32, 8, 2, 64, 32, 16
+    op = SharedFusedMoE(
+        num_tokens=T, num_experts=E, top_k=K,
+        hidden_size=H, ffn_size=F, shared_ffn_size=F_s,
+        kernel_map={"shared_expert_mlp": Replacement},
+    )
+    assert op.kernel_map["shared_expert_mlp"] is Replacement
+
+    dtype, dev = torch.bfloat16, "cuda"
+    torch.manual_seed(7)
+    op(
+        torch.randn(T, H, dtype=dtype, device=dev),
+        torch.randn(T, E, dtype=dtype, device=dev),
+        torch.randn(E, F * 2, H, dtype=dtype, device=dev) * 0.02,
+        torch.randn(E, H, F, dtype=dtype, device=dev) * 0.02,
+        shared_w_gate_up=torch.randn(F_s * 2, H, dtype=dtype, device=dev) * 0.02,
+        shared_w_down=torch.randn(H, F_s, dtype=dtype, device=dev) * 0.02,
+    )
+    assert built, "the replacement was never constructed"

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -143,15 +143,18 @@ def _make_bare_op(name="BareOp"):
     })
 
 
-def _infer_parity(validator, infer_fn, sig, *, name="FakeOp"):
+def _infer_parity(validator, infer_fn, sig, *, name="FakeOp", workloads=None):
     """Drive ``check_l2_infer_parity`` with a synthetic op class.
 
     Returns ``(errors, warnings)``.
     """
     cls = _make_op_cls_with_infer(infer_fn, name=name)
     warnings: list[str] = []
+    entry = {"signature": sig}
+    if workloads is not None:
+        entry["workloads"] = workloads
     errors = validator.check_l2_infer_parity(
-        name, {"signature": sig}, cls, warnings=warnings,
+        name, entry, cls, warnings=warnings,
     )
     return errors, warnings
 
@@ -896,6 +899,66 @@ class TestOptionalInputs:
         entry["workloads"] = [{"x_shape": [1, 4096], "dtypes": ["float16"]}]
         errors = validator.check_l0("Op", entry)
         assert not any("workload row" in e for e in errors), errors
+
+    @staticmethod
+    def _sig_with_optional():
+        return _sig(
+            {
+                "x": {"dtype": "float16", "shape": "[M]"},
+                "mask": {"dtype": "int32", "optional": True},
+            },
+            {"y": {"dtype": "same_as(x)"}},
+            params={"n": {"type": "int"}},
+            shape_rules=["mask.shape == (n,)", "y.shape == (n,)"],
+        )
+
+    def test_each_probe_uses_a_row_with_its_presence_pattern(self, validator):
+        """The supplying probe runs under the params of a row that supplies it.
+
+        Both probes drawing from the first row would hide any param whose value
+        only differs on the rows that pass the optional input.
+        """
+        seen: list[int] = []
+
+        def infer(self, x_shape, mask_shape=None):
+            seen.append(self.n)
+            return {"y": (self.n,)}
+
+        errors, _ = _infer_parity(
+            validator, infer, self._sig_with_optional(), name="OptRowOp",
+            workloads=[
+                {"n": 3, "dtypes": ["float16"]},
+                {"n": 7, "dtypes": ["float16"], "mask_shape": [7]},
+            ],
+        )
+        assert errors == [], errors
+        assert seen == [7, 3], seen
+
+    def test_both_presence_cases_are_probed(self, validator):
+        """The absent probe passes ``None`` and skips rules naming the input."""
+        seen: list[object] = []
+
+        def infer(self, x_shape, mask_shape=None):
+            seen.append(mask_shape)
+            return {"y": (self.n,)}
+
+        errors, _ = _infer_parity(
+            validator, infer, self._sig_with_optional(), name="OptProbeOp",
+            workloads=[{"n": 7, "dtypes": ["float16"]}],
+        )
+        assert errors == [], errors
+        assert seen == [(7,), None], seen
+
+    def test_an_absent_probe_failure_names_the_withheld_input(self, validator):
+        """An op that only works with the map supplied must not pass silently."""
+        def infer(self, x_shape, mask_shape=None):
+            return {"y": (mask_shape[0],)}
+
+        errors, _ = _infer_parity(
+            validator, infer, self._sig_with_optional(), name="OptBrokenOp",
+            workloads=[{"n": 7, "dtypes": ["float16"]}],
+        )
+        assert any("mask absent" in e for e in errors), errors
 
 
 # signature: Op.forward() consistency
@@ -2177,6 +2240,78 @@ class TestParamDefaultOutputShapePin:
             validator, good_infer, sig, name="ParamDefaultGoodOp",
         )
         assert errors == [], errors
+
+
+class TestRequiredParamWitness:
+    """A param with no default is probed at a schema-valid witness value."""
+
+    def test_output_sized_by_a_required_param_is_probed_at_the_workload_value(
+        self, validator,
+    ):
+        """``self.<required param>`` must resolve, and to the pinned value."""
+        sig = _sig(
+            {"x": {"dtype": "float16", "shape": "[M]"}},
+            {"y": {"dtype": "same_as(x)"}},
+            params={"n": {"type": "int"}},
+            shape_rules=["y.shape == (n,)"],
+        )
+
+        def infer(self, x_shape):
+            return {"y": (self.n,)}
+
+        errors, warnings = _infer_parity(
+            validator, infer, sig, name="RequiredParamOp",
+            workloads=[{"n": 7, "dtypes": ["float16"]}],
+        )
+        assert errors == [], errors
+        assert not any("AttributeError" in w for w in warnings), warnings
+
+    def test_witness_falls_back_to_a_type_valid_positive_scalar(self, validator):
+        """No workload pins the param, so the probe still supplies a value."""
+        sig = _sig(
+            {"x": {"dtype": "float16", "shape": "[M]"}},
+            {"y": {"dtype": "same_as(x)"}},
+            params={"n": {"type": "int"}},
+            shape_rules=["y.shape == (n,)"],
+        )
+
+        def infer(self, x_shape):
+            return {"y": (self.n,)}
+
+        errors, _ = _infer_parity(validator, infer, sig, name="NoWorkloadOp")
+        assert errors == [], errors
+
+    def test_a_wrong_extent_is_still_a_parity_error(self, validator):
+        """The witness makes the probe run; it must not make it pass."""
+        sig = _sig(
+            {"x": {"dtype": "float16", "shape": "[M]"}},
+            {"y": {"dtype": "same_as(x)"}},
+            params={"n": {"type": "int"}},
+            shape_rules=["y.shape == (n,)"],
+        )
+
+        def infer(self, x_shape):
+            return {"y": (self.n + 1,)}
+
+        errors, _ = _infer_parity(
+            validator, infer, sig, name="WrongExtentOp",
+            workloads=[{"n": 7, "dtypes": ["float16"]}],
+        )
+        assert any("violates shape_rules" in e for e in errors), errors
+
+    def test_mock_input_shapes_take_the_param_value(self, validator):
+        """A dim name that is also a param carries one value throughout."""
+        sig = _sig(
+            {"m": {"dtype": "int32"}},
+            {"y": {"dtype": "int32"}},
+            params={"n": {"type": "int"}},
+            shape_rules=["m.shape == (n,)"],
+        )
+        _, dim_sizes = validator._mock_input_shapes(
+            sig, validator._param_env(sig, [{"n": 7, "dtypes": ["int32"]}]),
+        )
+        assert dim_sizes["n"] == 7
+
 
 
 # Bench checks


### PR DESCRIPTION
## Problems

- Expert parallelism is a deployment topology rather than a different operator, yet each affected op carried a second class and a second manifest entry for it.
- A non-dense `expert_map` silently dropped tokens: the scan kernel guarded `local_eid >= 0` and nothing else, writing past a counter buffer sized by the local expert count.
- The parity probe instantiated only defaulted parameters, so an op whose output extent is a required construction parameter could not be probed.
- The composite built its sub-ops inside `forward`, which `docs/design/ops-design.md` forbids and which made the op untraceable.
- The MoE family had no op-layer compile boundary — no `custom_op`, no `register_fake`, no `compile_op_names`.
- `SharedFusedMoE` declared an empty `default_kernel_map` and built its kernel by name, so `kernel_map={"shared_expert_mlp": X}` was accepted and dropped.

## Changes

- The three EP class pairs collapse to one class each: `expert_map` is an `optional: true` input, `num_experts_local` a constructor parameter equal to `num_experts` off EP. Its presence selects the scan kernel and is part of that kernel's cache key.
- A map whose non-negative entries are not exactly `0 .. num_experts_local - 1` is rejected, and the scan kernel carries the upper bound. The verdict is cached against the map's identity and version, so a captured replay pays no host sync.
- The parity probe installs every manifest parameter on the mock instance, taking each value from a workload row whose presence pattern matches that probe. It runs twice where an optional input exists, once supplying it and once not.
- Sub-ops are built in `__init__`, `kernel_delegates()` is a fixed tuple, and no constructor reads a device property or tensor contents.
- Five leaf ops gain the op-layer compile boundary. The composite registers no operator of its own, and a test asserts its traced graph holds exactly its leaves' operators.
- `SharedFusedMoE` declares the kernel it owns and forwards `prepare_finalize`, `experts` and `kernel_map`.

## Evidence

Four global experts, two owned by this rank, eight tokens routed to the expert the map
names local id 2 — one past the two counters the kernel allocates:

| expert_map | before | after |
| --- | --- | --- |
| `[-1, 0, 1, -1]` | `true_sizes=[8, 8]` | `true_sizes=[8, 8]` |
| `[-1, 0, 2, -1]` | `true_sizes=[8, 0]` — eight tokens lost | `ValueError` naming the ids it requires |

One H200, bf16, three alternating runs per side in fresh processes, `device_busy_ms` medians:

| workload | main (5bcbd75) | this PR |
| --- | ---: | ---: |
| qwen3-235b-decode | 2.7772 | 2.7754 |
| qwen3-235b-prefill | 5.8803 | 5.8955 |
| deepseek-v3-decode | 5.4135 | 5.4152 |
| deepseek-v3-prefill | 8.3341 | 8.2540 |
