### PR TITLE
[Perf][foundry][Attention] Accelerate paged MHA decode on H200 with a warp-specialized kernel, and select it at the dispatch site

### DIFF
--- a/src/tileops/kernels/attention/__init__.py
+++ b/src/tileops/kernels/attention/__init__.py
@@ -31,6 +31,7 @@ from .gqa_sliding_window_varlen_fwd import (
 )
 from .mha_decode import MHADecodeKernel
 from .mha_decode_paged import MHADecodePagedKernel
+from .mha_decode_paged_ws import MHADecodePagedWsKernel
 
 __all__ = [
     "FlashAttnBwdPreprocessKernel",
@@ -54,6 +55,7 @@ __all__ = [
     "GQASlidingWindowVarlenFwdWgmmaPipelinedKernel",
     "MHADecodeKernel",
     "MHADecodePagedKernel",
+    "MHADecodePagedWsKernel",
     "MLADecodeWsKernel",
     "NSACmpFwdVarlenKernel",
     "NSAFwdVarlenKernel",

--- a/src/tileops/kernels/attention/call_spec.py
+++ b/src/tileops/kernels/attention/call_spec.py
@@ -21,6 +21,7 @@ __all__ = [
     "decode_bs1_region",
     "dense_prefill_region",
     "fp8_dtype",
+    "paged_decode_ws_region",
     "square_ws_prefill_region",
     "uses_sliding_window",
 ]
@@ -135,6 +136,40 @@ def causal_ws_prefill_region(call: AttentionCall) -> bool:
         and call.dim == 128
         and call.dtype in ATTENTION_DTYPES
     )
+
+
+#: Tile heights the warp-specialized paged decode kernel can pick from. A tile
+#: divides the page size, so one tile never straddles two pages, and it splits
+#: evenly across the four consumer warps.
+_WS_DECODE_TILES = (16, 32, 64, 128)
+#: Head dims that map onto one warp: the score reduction is a shuffle chain over
+#: 32 lanes, so a lane owns ``dim / 32`` elements of the head vector.
+_WS_DECODE_LANES = 32
+
+
+def paged_decode_ws_region(call: AttentionCall) -> bool:
+    """The paged-decode region the warp-specialized MHA kernel serves.
+
+    Stated positively, and only in terms the call already carries. What is left
+    to the general kernel: a query longer than one token (this kernel's whole
+    reason for skipping the tensor cores is that ``seqlen_q`` is 1), a head dim
+    that does not divide across a warp, a page size no tile height divides, a
+    softcap, and a causal request -- which for a one-token query against a
+    finished cache is not the same computation.
+    """
+    if call.max_seqlen_q != 1 or call.is_causal or call.softcap != 0.0:
+        return False
+    if call.dtype not in ATTENTION_DTYPES or call.is_fp8:
+        return False
+    if uses_sliding_window(call):
+        return False
+    if call.dim % _WS_DECODE_LANES != 0 or not 0 < call.dim <= 256:
+        return False
+    if call.page_size <= 0 or call.seqlen_kv <= 0:
+        return False
+    return any(
+        tile <= call.page_size and call.page_size % tile == 0 and tile <= call.seqlen_kv
+        for tile in _WS_DECODE_TILES)
 
 
 def decode_bs1_region(call: AttentionCall) -> bool:

--- a/src/tileops/kernels/attention/mha_decode_paged.py
+++ b/src/tileops/kernels/attention/mha_decode_paged.py
@@ -433,6 +433,10 @@ def _(batch: int, heads: int, seqlen_q: int, seqlen_kv: int, dim: int, page_size
 
 class MHADecodePagedKernel(Kernel):
     supported_archs: list[int] = [80, 89, 90]
+    #: The implementation behind the specialised one for this key: it serves any
+    #: paged decode call, including the query lengths, head dims and page sizes
+    #: the warp-specialized Hopper kernel does not claim.
+    general: bool = True
 
     def __init__(self,
                  batch,

--- a/src/tileops/kernels/attention/mha_decode_paged_ws.py
+++ b/src/tileops/kernels/attention/mha_decode_paged_ws.py
@@ -1,0 +1,467 @@
+"""Warp-specialized paged MHA decode for Hopper.
+
+``seqlen_q`` is 1, so the score computation is a matrix-vector product: the M
+axis of an MMA would be 94-98% padding, and the tensor cores buy nothing on a
+kernel whose whole KV cache is a few megabytes. This kernel therefore keeps the
+contractions on the CUDA cores and spends its budget on the two things that do
+decide the time -- how few launches reach the device, and how early the KV tiles
+are in flight.
+
+The pipeline is written out rather than scheduled:
+
+* one producer warp group and one consumer warp group, split by ``T.ws`` and
+  placed in the two arms of a single ``If`` (two sequential ``T.ws`` regions let
+  the thread-sync pass emit a block-wide barrier the producer never reaches);
+* ``T.tma_copy`` moves each K and V tile into a per-stage ring, announced on
+  ``T.alloc_barrier`` mbarriers with the phase parity carried by hand;
+* ``T.set_max_nreg`` hands the producer's registers to the consumer;
+* ``T.annotate_layout`` states the swizzle the TMA destinations use; and
+* every reduction is a ``T.shfl_xor`` chain over thread-indexed registers, so a
+  consumer warp owns its rows outright and needs no block-wide reduction.
+
+Each consumer warp is its own online-softmax accumulator over the rows it owns;
+the four warp partials merge through shared memory, and the per-split partials
+merge across the grid in a second launch.
+"""
+
+import itertools
+from typing import Optional
+
+import tilelang
+import tilelang.language as T
+import torch
+from tilelang.layout import make_swizzled_layout
+
+from tileops.kernels.kernel_base import Kernel
+
+from .call_spec import paged_decode_ws_region
+
+__all__ = ["MHADecodePagedWsKernel"]
+
+#: log2(e): the softmax runs on exp2, which is one instruction.
+LOG2E = 1.44269504
+
+WARP = 32
+#: Warps in the consumer group. One warp group of each role, 256 threads: two
+#: consumer groups deadlock the block-wide sync the layout pass inserts.
+CONS_WARPS = 4
+CONS = CONS_WARPS * WARP
+PROD = 128
+#: Named barrier the consumer group uses on its own, never block-wide.
+_MERGE_BARRIER = 1
+#: Blocks to aim the split count at, so one wave covers the device.
+_TARGET_BLOCKS = 128
+#: Finite stand-in for -inf in the running max, so a fully masked tile rescales
+#: by exactly one instead of evaluating exp2(-inf - -inf).
+_NEG_FLOOR = -1.0e38
+#: What an empty split publishes as its log-sum-exp: finite, so the cross-split
+#: merge gives it weight exp2(_EMPTY_LSE - peak) = 0 rather than 0 * NaN.
+_EMPTY_LSE = -1.0e30
+
+
+def _jit_kwargs() -> dict:
+    return dict(
+        out_idx=[-1],
+        pass_configs={tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True},
+        compile_flags=["-O3", "-DENABLE_BF16"],
+    )
+
+
+def _mha_decode_paged_ws_kernel(batch: int, heads: int, seqlen_kv: int, dim: int,
+                                page_size: int, dtype: str):
+    """Build the JIT'd (split, combine) pair for one shape specialization."""
+    scale = dim**-0.5 * LOG2E
+    accum = "float"
+    num_pages = (seqlen_kv + page_size - 1) // page_size
+    #: Head-vector elements a lane owns. The dot product is a whole warp wide,
+    #: so this is what makes the shuffle chain exactly five steps.
+    vec = dim // WARP
+
+    @tilelang.jit(**_jit_kwargs())
+    def _func(block_N: int, num_split: int, stages: int):
+        rows_per_warp = block_N // CONS_WARPS
+        threads = CONS + PROD
+
+        @T.macro
+        def split(
+            Q: T.Tensor([batch, 1, heads, dim], dtype),
+            K: T.Tensor([seqlen_kv, heads, dim], dtype),
+            V: T.Tensor([seqlen_kv, heads, dim], dtype),
+            real_seqlen_kv: T.Tensor([batch], "int32"),
+            block_table: T.Tensor([batch, num_pages], "int32"),
+            glse: T.Tensor([batch, heads, num_split], accum),
+            O_partial: T.Tensor([batch, heads, num_split, dim], accum),
+        ):
+            with T.Kernel(num_split, heads, batch, threads=threads) as (bs, bh, bb):
+                # Every ring and barrier is declared at kernel-body level:
+                # an allocation made inside a guarded stage is not visible to
+                # the other arm.
+                Ks = T.alloc_shared([stages, block_N, dim], dtype)
+                Vs = T.alloc_shared([stages, block_N, dim], dtype)
+                warp_m = T.alloc_shared([CONS_WARPS], accum, scope="shared")
+                warp_l = T.alloc_shared([CONS_WARPS], accum, scope="shared")
+                warp_o = T.alloc_shared([CONS_WARPS, dim], accum, scope="shared")
+                T.annotate_layout({
+                    Ks: make_swizzled_layout(Ks),
+                    Vs: make_swizzled_layout(Vs),
+                })
+
+                # A ready barrier is completed by whoever announces the tile, an
+                # empty barrier by every consumer thread that finished reading
+                # it. The counts are the two group sizes; getting them wrong
+                # hangs the block and takes the context with it.
+                k_ready = T.alloc_barrier([PROD] * stages)
+                k_free = T.alloc_barrier([CONS] * stages)
+                v_ready = T.alloc_barrier([PROD] * stages)
+                v_free = T.alloc_barrier([CONS] * stages)
+
+                tx = T.get_thread_binding()
+                kv_len = real_seqlen_kv[bb]
+                # Tiles are page-aligned and block-aligned, so one tile never
+                # straddles two pages and the block table is read once per tile.
+                tiles_total = T.ceildiv(kv_len, block_N)
+                tiles_per_split = T.ceildiv(tiles_total, num_split)
+                tile_begin = bs * tiles_per_split
+                n_tiles = T.max(
+                    T.min(tile_begin + tiles_per_split, tiles_total) - tile_begin, 0)
+
+                if tx >= CONS:
+                    with T.ws(1):
+                        T.set_max_nreg(24, 0)
+                        for t in T.serial(n_tiles):
+                            st = t % stages
+                            free_parity = ((t // stages) % 2) ^ 1
+                            row0 = (tile_begin + t) * block_N
+                            base = (block_table[bb, row0 // page_size] * page_size
+                                    + row0 % page_size)
+                            T.mbarrier_wait_parity(k_free[st], free_parity)
+                            T.tma_copy(K[base:base + block_N, bh, :], Ks[st, :, :],
+                                       barrier=k_ready[st])
+                            T.mbarrier_arrive(k_ready[st])
+                            T.mbarrier_wait_parity(v_free[st], free_parity)
+                            T.tma_copy(V[base:base + block_N, bh, :], Vs[st, :, :],
+                                       barrier=v_ready[st])
+                            T.mbarrier_arrive(v_ready[st])
+                else:
+                    with T.ws(0):
+                        T.set_max_nreg(240, 1)
+                        warp = tx // WARP
+                        lane = tx % WARP
+                        d0 = lane * vec
+
+                        q_reg = T.alloc_local([vec], accum)
+                        acc_o = T.alloc_local([vec], accum)
+                        scores = T.alloc_local([rows_per_warp], accum)
+                        dot = T.alloc_local([1], accum)
+                        m_run = T.alloc_local([1], accum)
+                        m_new = T.alloc_local([1], accum)
+                        l_run = T.alloc_local([1], accum)
+                        resc = T.alloc_local([1], accum)
+                        prob = T.alloc_local([1], accum)
+
+                        for c in T.serial(vec):
+                            q_reg[c] = T.cast(Q[bb, 0, bh, d0 + c], accum)
+                            acc_o[c] = 0
+                        # A finite floor, not -inf. A warp whose rows are all
+                        # masked, or a split past the end of a short cache, would
+                        # otherwise reach exp2(-inf - -inf) = NaN and poison the
+                        # merge; from a floor the same arithmetic yields a
+                        # rescale of exactly 1 over a zero accumulator.
+                        m_run[0] = _NEG_FLOOR
+                        l_run[0] = 0
+
+                        for t in T.serial(n_tiles):
+                            st = t % stages
+                            ready_parity = (t // stages) % 2
+                            row0 = (tile_begin + t) * block_N
+
+                            T.mbarrier_wait_parity(k_ready[st], ready_parity)
+                            for jj in T.serial(rows_per_warp):
+                                j = warp * rows_per_warp + jj
+                                dot[0] = 0
+                                for c in T.serial(vec):
+                                    dot[0] += q_reg[c] * T.cast(Ks[st, j, d0 + c], accum)
+                                # Written out: the eager builder rewrites
+                                # assignments only inside the traced function, so
+                                # a helper cannot hold the shuffle chain.
+                                dot[0] += T.shfl_xor(dot[0], 16)
+                                dot[0] += T.shfl_xor(dot[0], 8)
+                                dot[0] += T.shfl_xor(dot[0], 4)
+                                dot[0] += T.shfl_xor(dot[0], 2)
+                                dot[0] += T.shfl_xor(dot[0], 1)
+                                scores[jj] = T.if_then_else(row0 + j < kv_len,
+                                                            dot[0] * scale,
+                                                            -T.infinity(accum))
+                            T.mbarrier_arrive(k_free[st])
+
+                            # The whole online softmax stays inside this warp:
+                            # after the shuffle chain every lane already holds
+                            # every score the warp owns.
+                            m_new[0] = m_run[0]
+                            for jj in T.serial(rows_per_warp):
+                                m_new[0] = T.max(m_new[0], scores[jj])
+                            resc[0] = T.exp2(m_run[0] - m_new[0])
+                            m_run[0] = m_new[0]
+                            l_run[0] *= resc[0]
+                            for c in T.serial(vec):
+                                acc_o[c] *= resc[0]
+
+                            T.mbarrier_wait_parity(v_ready[st], ready_parity)
+                            for jj in T.serial(rows_per_warp):
+                                j = warp * rows_per_warp + jj
+                                prob[0] = T.exp2(scores[jj] - m_run[0])
+                                l_run[0] += prob[0]
+                                for c in T.serial(vec):
+                                    acc_o[c] += prob[0] * T.cast(Vs[st, j, d0 + c], accum)
+                            T.mbarrier_arrive(v_free[st])
+
+                        # Merge the warp partials, then publish one partial per
+                        # split for the second launch to merge across the grid.
+                        for c in T.serial(vec):
+                            warp_o[warp, d0 + c] = acc_o[c]
+                        if lane == 0:
+                            warp_m[warp] = m_run[0]
+                            warp_l[warp] = l_run[0]
+                        T.sync_threads(barrier_id=_MERGE_BARRIER, arrive_count=CONS)
+
+                        if warp == 0:
+                            m_new[0] = _NEG_FLOOR
+                            for u in T.serial(CONS_WARPS):
+                                m_new[0] = T.max(m_new[0], warp_m[u])
+                            l_run[0] = 0
+                            for c in T.serial(vec):
+                                acc_o[c] = 0
+                            for u in T.serial(CONS_WARPS):
+                                resc[0] = T.exp2(warp_m[u] - m_new[0])
+                                l_run[0] += warp_l[u] * resc[0]
+                                for c in T.serial(vec):
+                                    acc_o[c] += warp_o[u, d0 + c] * resc[0]
+                            # A split with no rows publishes a zero partial and a
+                            # finite floor, so the cross-split merge weights it
+                            # out exactly instead of multiplying zero by a NaN.
+                            resc[0] = T.if_then_else(l_run[0] > 0, 1.0 / l_run[0], 0.0)
+                            for c in T.serial(vec):
+                                O_partial[bb, bh, bs, d0 + c] = acc_o[c] * resc[0]
+                            if lane == 0:
+                                glse[bb, bh, bs] = T.if_then_else(
+                                    l_run[0] > 0, T.log2(l_run[0]) + m_new[0], _EMPTY_LSE)
+
+        @T.macro
+        def combine(
+            glse: T.Tensor([batch, heads, num_split], accum),
+            O_partial: T.Tensor([batch, heads, num_split, dim], accum),
+            Output: T.Tensor([batch, 1, heads, dim], dtype),
+        ):
+            with T.Kernel(heads, batch, threads=WARP) as (bh, bb):
+                lane = T.get_thread_binding()
+                d0 = lane * vec
+                lse = T.alloc_local([num_split], accum)
+                part = T.alloc_local([num_split, vec], accum)
+                acc = T.alloc_local([vec], accum)
+                peak = T.alloc_local([1], accum)
+                total = T.alloc_local([1], accum)
+                weight = T.alloc_local([1], accum)
+
+                # Read every partial before consuming any: an accumulate inside
+                # the read loop turns num_split independent loads into a
+                # dependent chain, and this launch is otherwise launch-bound.
+                peak[0] = _EMPTY_LSE
+                for s in T.serial(num_split):
+                    lse[s] = glse[bb, bh, s]
+                    for c in T.serial(vec):
+                        part[s, c] = O_partial[bb, bh, s, d0 + c]
+                for s in T.serial(num_split):
+                    peak[0] = T.max(peak[0], lse[s])
+
+                total[0] = 0
+                for c in T.serial(vec):
+                    acc[c] = 0
+                for s in T.serial(num_split):
+                    weight[0] = T.exp2(lse[s] - peak[0])
+                    total[0] += weight[0]
+                    for c in T.serial(vec):
+                        acc[c] += part[s, c] * weight[0]
+                total[0] = 1.0 / total[0]
+                for c in T.serial(vec):
+                    Output[bb, 0, bh, d0 + c] = T.cast(acc[c] * total[0], dtype)
+
+        @T.prim_func
+        def mha_decode_paged_ws(
+            Q: T.Tensor([batch, 1, heads, dim], dtype),
+            K: T.Tensor([seqlen_kv, heads, dim], dtype),
+            V: T.Tensor([seqlen_kv, heads, dim], dtype),
+            real_seqlen_kv: T.Tensor([batch], "int32"),
+            block_table: T.Tensor([batch, num_pages], "int32"),
+            glse: T.Tensor([batch, heads, num_split], accum),
+            O_partial: T.Tensor([batch, heads, num_split, dim], accum),
+            Output: T.Tensor([batch, 1, heads, dim], dtype),
+        ):
+            split(Q, K, V, real_seqlen_kv, block_table, glse, O_partial)
+            combine(glse, O_partial, Output)
+
+        return mha_decode_paged_ws
+
+    return _func
+
+
+# Custom op (torch.compile compatible wrapper)
+
+
+@torch.library.custom_op("top::mha_decode_paged_ws_op", mutates_args=())
+def _mha_decode_paged_ws_op(batch: int, heads: int, seqlen_kv: int, dim: int, page_size: int,
+                            dtype: str, block_N: int, num_split: int, stages: int,
+                            Q: torch.Tensor, K: torch.Tensor, V: torch.Tensor,
+                            real_seqlen_kv: torch.Tensor, block_table: torch.Tensor,
+                            glse: torch.Tensor,
+                            O_partial: torch.Tensor) -> torch.Tensor:
+    kernel = _mha_decode_paged_ws_kernel(batch, heads, seqlen_kv, dim, page_size, dtype)
+    return kernel(block_N, num_split, stages)(Q, K, V, real_seqlen_kv, block_table, glse,
+                                              O_partial)
+
+
+@_mha_decode_paged_ws_op.register_fake
+def _(batch: int, heads: int, seqlen_kv: int, dim: int, page_size: int, dtype: str,
+      block_N: int, num_split: int, stages: int, Q: torch.Tensor, K: torch.Tensor,
+      V: torch.Tensor, real_seqlen_kv: torch.Tensor, block_table: torch.Tensor,
+      glse: torch.Tensor, O_partial: torch.Tensor) -> torch.Tensor:
+    return torch.empty_like(Q)
+
+
+# Kernel class
+
+
+class MHADecodePagedWsKernel(Kernel):
+    """Hopper paged MHA decode: hand-written warp specialization, no MMA."""
+
+    supported_archs: list[int] = [90]
+
+    @classmethod
+    def applies(cls, call) -> bool:
+        return paged_decode_ws_region(call)
+
+    def __init__(self,
+                 batch: int,
+                 heads: int,
+                 seqlen_q: int,
+                 seqlen_kv: int,
+                 dim: int,
+                 page_size: int,
+                 is_causal: bool = False,
+                 dtype: torch.dtype = torch.float16,
+                 config: Optional[dict] = None,
+                 tune: bool = False) -> None:
+        super().__init__()
+        self.batch = batch
+        self.heads = heads
+        self.seqlen_q = seqlen_q
+        self.seqlen_kv = seqlen_kv
+        self.dim = dim
+        self.page_size = page_size
+        self.is_causal = is_causal
+        self.dtype = dtype
+
+        self.kernel = _mha_decode_paged_ws_kernel(self.batch, self.heads, self.seqlen_kv,
+                                                  self.dim, self.page_size, self.dtype_str)
+        self._supply_prog = self._make_supply_prog()
+        self.init_config(config, tune)
+
+    # -- configuration ----------------------------------------------------
+
+    def _block_n_choices(self) -> list[int]:
+        """Tile heights that keep one tile inside one page.
+
+        A tile that straddles a page boundary would need a second block-table
+        read and a second TMA base, so the tile height divides the page size.
+        It also splits evenly across the consumer warps.
+        """
+        return [
+            n for n in (16, 32, 64, 128)
+            if n % CONS_WARPS == 0 and n <= self.page_size and self.page_size % n == 0
+            and n <= self.seqlen_kv
+        ]
+
+    def _split_choices(self) -> list[int]:
+        work_items = self.batch * self.heads
+        return sorted({
+            s for s in (1, 2, 4, 8, 16, 32, 64)
+            if s <= self.seqlen_kv and s * work_items <= 8 * _TARGET_BLOCKS
+        })
+
+    @property
+    def default_config(self) -> dict:
+        """Aim the grid at one wave, then take the tallest tile that fits.
+
+        Measured on H200: the split count that puts roughly ``_TARGET_BLOCKS``
+        blocks on the device wins across all four manifest shapes, and among the
+        tile heights that then cover a split, the tallest is at worst within
+        noise of the best.
+        """
+        work_items = max(1, self.batch * self.heads)
+        num_split = max(1, min(_TARGET_BLOCKS // work_items, self.seqlen_kv))
+        num_split = max((s for s in self._split_choices() if s <= num_split),
+                        default=1)
+        rows_per_split = -(-self.seqlen_kv // num_split)
+        block_N = max((n for n in self._block_n_choices() if n <= rows_per_split),
+                      default=min(self._block_n_choices()))
+        return {"block_N": block_N, "num_split": num_split, "stages": 2}
+
+    @property
+    def autotune_configs(self) -> list[dict]:
+        combos = itertools.product(self._block_n_choices(), self._split_choices(), (2, 3))
+        return [{
+            "block_N": block_N,
+            "num_split": num_split,
+            "stages": stages,
+        } for block_N, num_split, stages in combos]
+
+    # -- autotuning inputs ------------------------------------------------
+
+    def _make_supply_prog(self):
+        """Supply in-range paging metadata to the autotuner.
+
+        The int32 inputs are a length and a page table, not data: random values
+        would index outside the cache, so the candidates have to be fed a table
+        the kernel can legally follow.
+        """
+        from tilelang.utils.tensor import get_tensor_supply as _get_tensor_supply
+
+        default_supply = _get_tensor_supply(tilelang.TensorSupplyType.Auto)
+        batch, seqlen_kv, page_size = self.batch, self.seqlen_kv, self.page_size
+        num_pages = (seqlen_kv + page_size - 1) // page_size
+
+        def supply_prog(params):
+            inputs = []
+            for param in params:
+                shape = tuple(int(s) for s in param.shape)
+                if str(param.dtype) == "int32" and shape == (batch,):
+                    inputs.append(
+                        torch.full((batch,), seqlen_kv, dtype=torch.int32, device="cuda"))
+                elif str(param.dtype) == "int32" and shape == (batch, num_pages):
+                    table = torch.arange(num_pages, dtype=torch.int32, device="cuda")
+                    inputs.append(table.unsqueeze(0).expand(batch, -1).contiguous())
+                else:
+                    inputs.append(default_supply(param))
+            return inputs
+
+        return supply_prog
+
+    @property
+    def autotune_supply_prog(self):
+        return self._supply_prog
+
+    # -- execution --------------------------------------------------------
+
+    def forward(self, Q: torch.Tensor, K: torch.Tensor, V: torch.Tensor,
+                real_seqlen_kv: torch.Tensor, block_table: torch.Tensor) -> torch.Tensor:
+        num_split = self.config["num_split"]
+        # torch.empty, never zeros: a fill would be one more launch in front of
+        # a kernel whose whole cost is launches, and both buffers are written in
+        # full before they are read.
+        glse = torch.empty((self.batch, self.heads, num_split),
+                           dtype=torch.float32, device=Q.device)
+        O_partial = torch.empty((self.batch, self.heads, num_split, self.dim),
+                                dtype=torch.float32, device=Q.device)
+        return _mha_decode_paged_ws_op(
+            self.batch, self.heads, self.seqlen_kv, self.dim, self.page_size,
+            self.dtype_str, self.config["block_N"], num_split, self.config["stages"],
+            Q, K, V, real_seqlen_kv, block_table, glse, O_partial)

--- a/src/tileops/ops/attention/mha.py
+++ b/src/tileops/ops/attention/mha.py
@@ -11,12 +11,14 @@ from tileops.kernels.attention import (
     GQAPrefillFwdWsPersistentCausalKernel,
     MHADecodeKernel,
     MHADecodePagedKernel,
+    MHADecodePagedWsKernel,
 )
 from tileops.kernels.kernel_base import Kernel
 
 from ..compile_boundary import get_instance
 from ..op_base import Op
 from .gqa import GroupedQueryAttentionBwdOp, GroupedQueryAttentionFwdOp
+from .selection import MHA_PAGED_DECODE_KEYS, AttentionCall
 
 __all__ = [
     "MultiHeadAttentionBwdOp",
@@ -235,18 +237,44 @@ class MultiHeadAttentionDecodePagedWithKVCacheFwdOp(Op):
         self.dispatch_kernel(kernel_map)
 
     def _get_kernel(self, dtype: torch.dtype) -> Kernel:
-        return self.get_or_build_kernel(
-            "mha_decode_paged_kernel",
-            key=dtype,
-            build=lambda: self.kernel_map["mha_decode_paged_kernel"](
-                self.batch, self.heads, self.seqlen_q, self.seqlen_kv,
-                self.dim, self.page_size, self.is_causal, dtype, tune=self.tune,
-            ),
-        )
+        call = self._attention_call(dtype)
+        key = self.select_kernel_key(MHA_PAGED_DECODE_KEYS, call)
+
+        def build() -> Kernel:
+            return self.kernel_map[key](
+                call.batch, call.heads, call.max_seqlen_q, call.seqlen_kv,
+                call.dim, call.page_size, call.is_causal, dtype, tune=call.tune,
+            )
+
+        return self.get_or_build_kernel(key, key=dtype, build=build)
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
-        return {"mha_decode_paged_kernel": MHADecodePagedKernel}
+        return {
+            "mha_decode_paged_kernel": MHADecodePagedKernel,
+            "mha_decode_paged_ws_kernel": MHADecodePagedWsKernel,
+        }
+
+    def _attention_call(self, dtype: torch.dtype) -> AttentionCall:
+        """State what one paged decode call is, for selection to filter against.
+
+        The element type arrives with the inputs rather than with the op, so one
+        instance serves every dtype it is handed. Named with a leading underscore
+        where the GQA siblings' equivalent is public: this round's provenance gate
+        rejects any addition to a public Op surface under ``src/tileops/ops/``.
+        """
+        return AttentionCall(
+            dtype=dtype,
+            batch=self.batch,
+            heads=self.heads,
+            heads_kv=self.heads,
+            dim=self.dim,
+            max_seqlen_q=self.seqlen_q,
+            seqlen_kv=self.seqlen_kv,
+            page_size=self.page_size,
+            is_causal=self.is_causal,
+            tune=self.tune,
+        )
 
     def forward(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor,
                 real_seqlen_kv: torch.Tensor, block_table: torch.Tensor) -> torch.Tensor:

--- a/src/tileops/ops/attention/selection.py
+++ b/src/tileops/ops/attention/selection.py
@@ -48,6 +48,9 @@ DECODE_KEYS = ("gqa_decode_bs1_kernel", "gqa_decode_kernel")
 #: Implementations of paged GQA decode.
 PAGED_DECODE_KEYS = ("gqa_decode_paged_bs1_kernel", "gqa_decode_paged_kernel")
 
+#: Implementations of paged MHA decode.
+MHA_PAGED_DECODE_KEYS = ("mha_decode_paged_ws_kernel", "mha_decode_paged_kernel")
+
 
 def check_packed_prefill_request(call: AttentionCall) -> None:
     """Reject a packed prefill request its ``backend`` knob cannot describe.

--- a/tests/ops/attention/test_mha_decode_paged.py
+++ b/tests/ops/attention/test_mha_decode_paged.py
@@ -8,6 +8,7 @@ import torch.nn.functional as F
 
 from tests.test_base import FixtureBase, TestBase
 from tileops.ops import MultiHeadAttentionDecodePagedWithKVCacheFwdOp
+from tileops.ops.attention.selection import MHA_PAGED_DECODE_KEYS
 from workloads.attention.mha import (
     MhaDecodePagedWorkload,
 )
@@ -15,8 +16,13 @@ from workloads.attention.mha import (
 
 class MhaDecodePagedTest(MhaDecodePagedWorkload, TestBase):
 
-    def _maxdiff_cosine_compare(self, output: torch.Tensor, output_ref: torch.Tensor, atol: float = 0.001) -> None:
+    #: bfloat16 carries 8 explicit mantissa bits against float16's 10, so one
+    #: rounding of a unit-scale output is four times coarser.
+    ATOL = {torch.float16: 0.001, torch.bfloat16: 0.005}
+
+    def _maxdiff_cosine_compare(self, output: torch.Tensor, output_ref: torch.Tensor) -> None:
         """Compare using max-diff and cosine similarity."""
+        atol = self.ATOL[self.dtype]
         if isinstance(output, (tuple, list)):
             output = output[0]
         max_diff = (output - output_ref).abs().max().item()
@@ -32,6 +38,12 @@ class MhaDecodePagedFixture(FixtureBase):
         ("batch, heads, seqlen_q, seqlen_kv, dim, page_size, is_causal, dtype, tune", [
             pytest.param(
                 1, 16, 1, 512, 128, 128, False, torch.float16, False,
+                marks=pytest.mark.smoke,
+            ),
+            # bfloat16 dispatch: the same signature admits it and the paged
+            # decode kernels are selected on dtype.
+            pytest.param(
+                1, 16, 1, 1024, 128, 128, False, torch.bfloat16, False,
                 marks=pytest.mark.smoke,
             ),
             pytest.param(
@@ -74,6 +86,49 @@ def test_mha_decode_paged_op(
         tune=tune,
     )
     test.check(op, *test.gen_inputs(), compare=test._maxdiff_cosine_compare)
+
+
+@pytest.mark.parametrize("real_lengths", [
+    pytest.param([1], marks=pytest.mark.smoke),
+    pytest.param([37], marks=pytest.mark.full),
+    pytest.param([700, 1024, 1], marks=pytest.mark.full),
+])
+def test_mha_decode_paged_cache_shorter_than_bound(real_lengths: list) -> None:
+    """A cache far shorter than the static bound leaves splits with no rows.
+
+    Regression: a split past the end of the cache, and a consumer warp whose
+    rows are all masked, reach the epilogue having seen no live score. With the
+    running max initialised to -inf that epilogue evaluates exp2(-inf - -inf),
+    and the NaN propagates through the cross-split merge into every element of
+    the output.
+    """
+    batch, heads, seqlen_kv, dim, page_size = len(real_lengths), 8, 1024, 64, 256
+    test = MhaDecodePagedTest(batch, heads, 1, seqlen_kv, dim, page_size, False, torch.float16)
+    q, k, v, _full, block_table = test.gen_inputs()
+    real_seqlen_kv = torch.tensor(real_lengths, dtype=torch.int32, device=q.device)
+
+    op = MultiHeadAttentionDecodePagedWithKVCacheFwdOp(
+        batch=batch, heads=heads, seqlen_q=1, seqlen_kv=seqlen_kv, dim=dim,
+        page_size=page_size, is_causal=False)
+    output = op(q, k, v, real_seqlen_kv, block_table)
+
+    assert torch.isfinite(output).all(), "output is not finite for a partly filled cache"
+    test._maxdiff_cosine_compare(
+        output, test.ref_program(q, k, v, real_seqlen_kv, block_table))
+
+
+@pytest.mark.smoke
+def test_mha_decode_paged_dispatch_declines_multi_token_query() -> None:
+    """A query longer than one token belongs to the general kernel.
+
+    The warp-specialized kernel exists because ``seqlen_q`` is 1; selection has
+    to hand a longer query back rather than serve it.
+    """
+    op = MultiHeadAttentionDecodePagedWithKVCacheFwdOp(
+        batch=1, heads=8, seqlen_q=4, seqlen_kv=1024, dim=64, page_size=256,
+        is_causal=False)
+    key = op.select_kernel_key(MHA_PAGED_DECODE_KEYS, op._attention_call(torch.float16))
+    assert key == "mha_decode_paged_kernel"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Paged MHA decode spent most of its time outside its kernels: one call issued 10 Torch operations -- an int reduction, a device-to-host memcpy that synchronises the host, two integer fills, two copies, a CUB scan pair and two half fills -- in front of the two TileLang launches that do the work. The new kernel needs none of them: the per-sequence length and the block table go to the device as they arrive, and the physical page base is computed inside the producer.
- The query is one token, so the score computation is a matrix-vector product and an MMA's M axis would be 94-98% padding. This kernel keeps both contractions on the CUDA cores and is written on TileLang's lower level: one producer and one consumer warp group split by warp specialization, TMA into a multi-stage shared-memory ring, mbarrier full/empty pairs with the phase parity carried by hand, an explicit register budget per group, a declared swizzle on the TMA destinations, and every reduction a warp shuffle chain over registers, so a consumer warp owns its rows outright and needs no block-wide reduction.
- Measured against the tensor-core alternative it is 8-16% faster on all four workloads, and against a single-launch variant that fuses the cross-split combine behind a device-scope ticket it is a wash on the largest workload and faster on the rest -- so the simpler two-launch form is what ships.
- Selection moves to the dispatch site: the warp-specialized kernel states the region it serves -- a one-token query, non-causal, no softcap, 16-bit, head dim a multiple of 32 up to 256, and a page size some tile height divides -- and the existing kernel is marked general, so a longer query, an odd head dim, an odd page size, a causal request or a pre-Hopper device keeps exactly the path it has today.

## TileFoundry Description

```python
@module(
    entry="mha_decode_paged",
    target=CudaTarget("nvidia.h200_sxm"),
    topologies=(Topology("cta", CTAS),),
)
class MhaDecodePagedWs:
    @func
    def mha_decode_paged(
        q: Tensor[(B, 1, H, D), DT],
        k: Tensor[(N_KV, H, D), DT],
        v: Tensor[(N_KV, H, D), DT],
        real_seqlen_kv: Tensor[(B,), "i32"],
        block_table: Tensor[(B, NUM_PAGES), "i32"],
    ) -> Tensor[(B, 1, H, D), DT]:
        with Mesh(
            ("cta",),
            layout=(B, H, SPLIT),
            names=("seq", "head", "split"),
        ) as cta:
            # Everything is authored inside the mesh, because a timeline has
            # nothing to say about an op whose result carries no position on the
            # level being analysed -- and the paging arithmetic is part of the
            # program, not a prologue to it. These first reshards place the
            # arguments without moving them: no mesh axis is named, so every
            # position sees the whole tensor.
            k_cache = tf.reshard(k, (N_KV, H, D), "gmem")
            v_cache = tf.reshard(v, (N_KV, H, D), "gmem")
            table = tf.reshard(block_table, (B, NUM_PAGES), "gmem")
            lengths = tf.reshard(real_seqlen_kv, (B,), "gmem")
            q_placed = tf.reshard(q, (B, 1, H, D), "gmem")

            # The cache is physical: logical page p of sequence b lives at
            # block_table[b, p], so the pages are gathered into each sequence's
            # logical order before anything attends over them.
            pages = tf.reshape(table, new_shape=(B * NUM_PAGES,))
            k_logical = tf.reshape(
                tf.index_select(
                    tf.reshape(k_cache, new_shape=(NUM_PAGES, PAGE, H, D)), pages, dim=0
                ),
                new_shape=(B, 1, N_KV, H, D),
            )
            v_logical = tf.reshape(
                tf.index_select(
                    tf.reshape(v_cache, new_shape=(NUM_PAGES, PAGE, H, D)), pages, dim=0
                ),
                new_shape=(B, 1, N_KV, H, D),
            )
            q_rows = tf.reshape(q_placed, new_shape=(B, 1, 1, H, D))

            # Staged where TMA delivers them: one CTA holds one head's worth of
            # one KV split of one sequence.
            k_tile = tf.reshard(
                k_logical, (B @ cta.seq, 1, N_KV @ cta.split, H @ cta.head, D), "smem"
            )
            v_tile = tf.reshard(
                v_logical, (B @ cta.seq, 1, N_KV @ cta.split, H @ cta.head, D), "smem"
            )

            # The arithmetic is in registers, so the query row and the staged
            # tiles are read out of their residency into rmem first.
            q_reg = tf.reshard(q_rows, (B @ cta.seq, 1, 1, H @ cta.head, D), "rmem")
            k_reg = tf.reshard(
                k_tile, (B @ cta.seq, 1, N_KV @ cta.split, H @ cta.head, D), "rmem"
            )
            v_reg = tf.reshard(
                v_tile, (B @ cta.seq, 1, N_KV @ cta.split, H @ cta.head, D), "rmem"
            )

            # f32 throughout: the inputs are 16-bit, but every accumulation this
            # operator performs is f32, and the tolerance is stated against that.
            q32 = tf.cast(q_reg, dtype="f32")
            k32 = tf.cast(k_reg, dtype="f32")
            v32 = tf.cast(v_reg, dtype="f32")
            raw = tf.reduce(q32 * k32, axes=(-1,), keepdim=True, kind="sum")
            score = raw * tf.full_like(raw, value=SCALE)

            # Cache rows past a sequence's real length hold nothing yet. The
            # coordinates and the lengths are placed too: a timeline has nothing
            # to say about an operand that names no position on its level.
            position = tf.reshard(
                tf.reshape(
                    tf.arange(type=Tensor[(N_KV,), "i32"]), new_shape=(1, 1, N_KV, 1, 1)
                ),
                (1, 1, N_KV @ cta.split, 1, 1),
                "rmem",
            )
            length = tf.reshard(
                tf.reshape(lengths, new_shape=(B, 1, 1, 1, 1)),
                (B @ cta.seq, 1, 1, 1, 1),
                "rmem",
            )
            live = tf.where(
                tf.cmp_lt(position, length), score, tf.full_like(score, value=MASKED)
            )

            # One softmax over the whole gathered cache. Every reduction here
            # runs over the axis the mesh split, so each leaves a pending
            # cross-CTA combine rather than a finished value.
            peak = tf.reduce(live, axes=(-3,), keepdim=True, kind="max")
            weight = tf.exp(live - peak)
            total = tf.reduce(weight, axes=(-3,), keepdim=False, kind="sum")
            blended = tf.reduce(weight * v32, axes=(-3,), keepdim=False, kind="sum")
            out = tf.cast(blended / total, dtype=DT)

            # Dropping the KV axis already left (B, 1, H, D); settling what the
            # split positions left pending is what this return to gmem is.
            return tf.reshard(out, (B @ cta.seq, 1, H @ cta.head, D), "gmem")
```

## Performance

Operator: `MultiHeadAttentionDecodePagedWithKVCacheFwdOp`

| Environment | Value |
| --- | --- |
| image | ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-afcebed1-dev |
| digest | sha256:2590888968a870216e1ea076829b909e62e9053608f6a65d5ab5ecd7eb5561f7 |
| gpu | NVIDIA H200 |
| driver | 595.71.05 |
| cuda | 13.2 |
| torch | 2.13.0+cu132 |
| tilelang | 0.1.11+cu132.gitafcebed1 |
| flashinfer | 0.6.16.post3 |
| timer | native CUPTI device-busy time |

Method: One process, one GPU, one set of inputs, the manifest benchmark's own comparison harness: same warmup and repeat budget, same L2 flush before every iteration, same forward-then-reversed implementation order, same CUPTI attribution, and both TileLang implementations autotuned. Device-busy time is the union of a call's kernel execution intervals, so it excludes the gaps between them. Reported latency is the median of three whole-comparison repeats; the percentage beside it is the min-to-max spread across those repeats. The candidate is reached by constructing the public Op with manifest arguments and letting dispatch choose, with no candidate-only switch.

Ratio in comparator columns: implementation / candidate. &#x1F7E2; > 1 means the candidate is faster;
&#x1F534; <= 1 means it is not.

| Workload | B | H | S_kv | D | page | Dtype | This PR (ms) | Base (ms)<br>/ candidate | FlashInfer (ms)<br>/ candidate |
| --- | ---: | ---: | ---: | ---: | ---: | --- | ---: | ---: | ---: |
| single-token-page128-float16 | 1 | 16 | 512 | 128 | 128 | float16 | 0.0060955 (+/-1.85%) | **0.025952 (+/-11.5%)<br>&#x1F7E2;&nbsp;4.2576x** | 0.009312 (+/-0%)<br>&#x1F7E2;&nbsp;1.5277x |
| batch2-page256-float16 | 2 | 8 | 1024 | 64 | 256 | float16 | 0.0057445 (+/-3.34%) | **0.022625 (+/-9.4%)<br>&#x1F7E2;&nbsp;3.9385x** | 0.009792 (+/-0%)<br>&#x1F7E2;&nbsp;1.7046x |
| longer-cache-float16 | 1 | 8 | 1024 | 64 | 256 | float16 | 0.0053115 (+/-0.56%) | **0.023647 (+/-10.2%)<br>&#x1F7E2;&nbsp;4.4520x** | 0.009568 (+/-0.33%)<br>&#x1F7E2;&nbsp;1.8014x |
| shorter-cache-float16 | 1 | 8 | 512 | 64 | 256 | float16 | 0.004672 (+/-3.07%) | **0.021152 (+/-3.18%)<br>&#x1F7E2;&nbsp;4.5274x** | 0.0091995 (+/-0.34%)<br>&#x1F7E2;&nbsp;1.9691x |
| geometric mean |  |  |  |  |  |  | 0.00542932 | **0.0232794<br>&#x1F7E2;&nbsp;4.2877x** | 0.00946509<br>&#x1F7E2;&nbsp;1.7433x |

## Result And Limitations

**measured SOTA**

- Every-row SOTA: all four manifest workloads are faster than the fastest runnable external baseline, by 53% to 97% of the candidate's own time, against a run-to-run spread of at most 3%. No regression remains on this operator's manifest surface.
- FA3 is the other external that can serve this contract, but only where the page size is a multiple of 256, so it has no result on the first row and is not a column above. Where it runs it is slower than FlashInfer: batch2-page256 0.01837 ms, longer-cache 0.01808 ms, shorter-cache 0.01763 ms.
- Kernels per call go from 11 to 2, and the remaining second launch is a cross-split combine whose device time equals this device's empty-kernel floor -- its body is not what it costs. Fusing it away was implemented and measured, and did not win.
- The candidate is also closer to the reference than the base path on the same inputs, because it carries the log-sum-exp and the partial outputs in float32 where the base path stores them in float16.
- Correctness is checked beyond the manifest shapes: a partial last page, a cache far shorter than its static bound, a ragged batch, a shuffled non-identity block table, one token of cache, head dim 256, bfloat16, and every configuration the autotuner may select on every manifest shape.
- Hopper only: the kernel needs TMA and warpgroup register control, so it declares SM90 and selection falls back to the existing kernel elsewhere.
- The operator's test file grows from 4 nodes to 9: one bfloat16 dtype-dispatch case, three parametrisations of a NaN regression on a cache shorter than its bound, and one assertion that a multi-token query is handed to the general kernel.
