### PR TITLE
[Perf][GatedDeltaNet] Accelerate forward on Hopper

### DIFF
--- a/benchmarks/ops/bench_gated_deltanet.py
+++ b/benchmarks/ops/bench_gated_deltanet.py
@@ -6,10 +6,10 @@ FLA is required, not optional: this file exists to compare against
 chunk_gated_delta_rule, and a torch reference is not a comparison worth recording.
 
 Layout convention:
-    TileOPs uses BHSD: q/k [B, H, S, DK], v [B, H, S, DV], g/beta [B, H, S].
-    FLA uses BTHK:     q/k [B, T, H, K],  v [B, T, H, V],  g/beta [B, T, H].
-    Tensors are permuted before calling FLA to ensure both implementations
-    compute the same function.
+    The forward benchmark uses the shared TileOps/FLA BTHD interface:
+    q/k [B, T, H, K], v [B, T, H, V], g/beta [B, T, H].
+    Backward still uses the legacy TileOps BHSD interface and permutes the
+    FLA inputs explicitly.
 """
 
 from typing import Optional
@@ -37,8 +37,8 @@ def _to_fla_layout(q, k, v, g, beta):
 
 # Forward benchmark
 
-class GatedDeltaNetFwdBenchmark(BenchmarkBase[GatedDeltaNetFwdWorkload]):
 
+class GatedDeltaNetFwdBenchmark(BenchmarkBase[GatedDeltaNetFwdWorkload]):
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
         B, H, S, DK, DV = t.batch, t.heads, t.seq_len, t.dim_k, t.dim_v
@@ -53,17 +53,20 @@ class GatedDeltaNetFwdBenchmark(BenchmarkBase[GatedDeltaNetFwdWorkload]):
 
 class GatedDeltaNetVsFlaFwdFixture(FixtureBase):
     PARAMS = [
-        ("batch, seq_len, heads, dim_k, dim_v, chunk_size, dtype, tune", [
-            # chunk_size=32
-            (2, 4096, 4, 64, 64, 32, torch.float16, False),
-            (2, 4096, 4, 64, 64, 32, torch.bfloat16, False),
-            # chunk_size=64
-            (2, 2048, 4, 64, 64, 64, torch.float16, False),
-            (2, 4096, 4, 64, 64, 64, torch.float16, False),
-            (2, 8192, 4, 64, 64, 64, torch.float16, False),
-            (2, 16384, 4, 64, 64, 64, torch.float16, False),
-            (2, 32768, 4, 64, 64, 64, torch.float16, False),
-        ]),
+        (
+            "batch, seq_len, heads, dim_k, dim_v, chunk_size, dtype, tune",
+            [
+                # chunk_size=32
+                (2, 4096, 4, 64, 64, 32, torch.float16, False),
+                (2, 4096, 4, 64, 64, 32, torch.bfloat16, False),
+                # chunk_size=64
+                (2, 2048, 4, 64, 64, 64, torch.float16, False),
+                (2, 4096, 4, 64, 64, 64, torch.float16, False),
+                (2, 8192, 4, 64, 64, 64, torch.float16, False),
+                (2, 16384, 4, 64, 64, 64, torch.float16, False),
+                (2, 32768, 4, 64, 64, 64, torch.float16, False),
+            ],
+        ),
     ]
 
 
@@ -82,27 +85,30 @@ def test_gated_deltanet_vs_fla_fwd(
     bm = GatedDeltaNetFwdBenchmark(test)
     inputs = test.gen_inputs()  # q, k, v, g, beta  (BHSD)
 
-    # --- TileOPs (BHSD) ---
-    op = GatedDeltaNetFwdOp(chunk_size=chunk_size, tune=tune)
-    functors = {"tileops": op}
-
-    # --- FLA (BTHK) ---
+    # Use the same production BTHD layout for TileOps and FLA.  Layout
+    # conversion is deliberately outside the timed region.
     q, k, v, g, beta = inputs
-    scale = dim_k ** -0.5
-    q_fla, k_fla, v_fla, g_fla, beta_fla = _to_fla_layout(q, k, v, g, beta)
+    q_bthd, k_bthd, v_bthd, g_bthd, beta_bthd = _to_fla_layout(q, k, v, g, beta)
+    if chunk_size == 64:
+        op = GatedDeltaNetFwdOp(chunk_size=chunk_size, tune=tune, layout="bthd")
+        tileops_inputs = (q_bthd, k_bthd, v_bthd, g_bthd, beta_bthd)
+    else:
+        op = GatedDeltaNetFwdOp(chunk_size=chunk_size, tune=tune, layout="bhtd")
+        tileops_inputs = inputs
+    functors = {"tileops": (op, tileops_inputs)}
 
     def fla_fwd():
-        return chunk_gated_delta_rule(q_fla, k_fla, v_fla, g_fla, beta_fla, scale=scale)
+        return chunk_gated_delta_rule(q_bthd, k_bthd, v_bthd, g_bthd, beta_bthd, scale=1.0)
 
     functors["fla"] = (fla_fwd, ())
 
-    bm.compare(functors, *inputs, record_as=op, params=locals())
+    bm.compare(functors, record_as=op, params=locals())
 
 
 # Backward benchmark
 
-class GatedDeltaNetBwdBenchmark(BenchmarkBase[GatedDeltaNetFwdWorkload]):
 
+class GatedDeltaNetBwdBenchmark(BenchmarkBase[GatedDeltaNetFwdWorkload]):
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
         B, H, S, DK, DV = t.batch, t.heads, t.seq_len, t.dim_k, t.dim_v
@@ -117,16 +123,19 @@ class GatedDeltaNetBwdBenchmark(BenchmarkBase[GatedDeltaNetFwdWorkload]):
 
 class GatedDeltaNetVsFlaBwdFixture(FixtureBase):
     PARAMS = [
-        ("batch, seq_len, heads, dim_k, dim_v, chunk_size, dtype, tune", [
-            # chunk_size=32
-            (2, 4096, 4, 64, 64, 32, torch.float16, False),
-            (2, 4096, 4, 64, 64, 32, torch.bfloat16, False),
-            # chunk_size=64
-            (2, 2048, 4, 64, 64, 64, torch.float16, False),
-            (2, 4096, 4, 64, 64, 64, torch.float16, False),
-            (2, 8192, 4, 64, 64, 64, torch.float16, False),
-            (2, 16384, 4, 64, 64, 64, torch.float16, False),
-        ]),
+        (
+            "batch, seq_len, heads, dim_k, dim_v, chunk_size, dtype, tune",
+            [
+                # chunk_size=32
+                (2, 4096, 4, 64, 64, 32, torch.float16, False),
+                (2, 4096, 4, 64, 64, 32, torch.bfloat16, False),
+                # chunk_size=64
+                (2, 2048, 4, 64, 64, 64, torch.float16, False),
+                (2, 4096, 4, 64, 64, 64, torch.float16, False),
+                (2, 8192, 4, 64, 64, 64, torch.float16, False),
+                (2, 16384, 4, 64, 64, 64, torch.float16, False),
+            ],
+        ),
     ]
 
 
@@ -160,7 +169,7 @@ def test_gated_deltanet_vs_fla_bwd(
     functors = {"tileops": bwd_op.forward}
 
     # --- FLA (BTHK layout) ---
-    scale = DK ** -0.5
+    scale = DK**-0.5
     q_fla, k_fla, v_fla, g_fla, beta_fla = _to_fla_layout(q, k, v, g, beta)
     do_fla = do.permute(0, 2, 1, 3).contiguous()  # [B,H,S,DV] -> [B,S,H,DV]
 
@@ -177,5 +186,4 @@ def test_gated_deltanet_vs_fla_bwd(
         return fla_backward(do_fla, None)
 
     functors["fla"] = (fla_bwd, ())
-    bm.compare(functors, do, q, k, v, g, beta, S_fwd,
-               record_as=bwd_op, params=locals())
+    bm.compare(functors, do, q, k, v, g, beta, S_fwd, record_as=bwd_op, params=locals())

--- a/benchmarks/ops/bench_gated_deltanet.py
+++ b/benchmarks/ops/bench_gated_deltanet.py
@@ -39,6 +39,7 @@ def _to_fla_layout(q, k, v, g, beta):
 
 
 class GatedDeltaNetFwdBenchmark(BenchmarkBase[GatedDeltaNetFwdWorkload]):
+
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
         B, H, S, DK, DV = t.batch, t.heads, t.seq_len, t.dim_k, t.dim_v
@@ -53,20 +54,17 @@ class GatedDeltaNetFwdBenchmark(BenchmarkBase[GatedDeltaNetFwdWorkload]):
 
 class GatedDeltaNetVsFlaFwdFixture(FixtureBase):
     PARAMS = [
-        (
-            "batch, seq_len, heads, dim_k, dim_v, chunk_size, dtype, tune",
-            [
-                # chunk_size=32
-                (2, 4096, 4, 64, 64, 32, torch.float16, False),
-                (2, 4096, 4, 64, 64, 32, torch.bfloat16, False),
-                # chunk_size=64
-                (2, 2048, 4, 64, 64, 64, torch.float16, False),
-                (2, 4096, 4, 64, 64, 64, torch.float16, False),
-                (2, 8192, 4, 64, 64, 64, torch.float16, False),
-                (2, 16384, 4, 64, 64, 64, torch.float16, False),
-                (2, 32768, 4, 64, 64, 64, torch.float16, False),
-            ],
-        ),
+        ("batch, seq_len, heads, dim_k, dim_v, chunk_size, dtype, tune", [
+            # chunk_size=32
+            (2, 4096, 4, 64, 64, 32, torch.float16, False),
+            (2, 4096, 4, 64, 64, 32, torch.bfloat16, False),
+            # chunk_size=64
+            (2, 2048, 4, 64, 64, 64, torch.float16, False),
+            (2, 4096, 4, 64, 64, 64, torch.float16, False),
+            (2, 8192, 4, 64, 64, 64, torch.float16, False),
+            (2, 16384, 4, 64, 64, 64, torch.float16, False),
+            (2, 32768, 4, 64, 64, 64, torch.float16, False),
+        ]),
     ]
 
 
@@ -109,6 +107,7 @@ def test_gated_deltanet_vs_fla_fwd(
 
 
 class GatedDeltaNetBwdBenchmark(BenchmarkBase[GatedDeltaNetFwdWorkload]):
+
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
         B, H, S, DK, DV = t.batch, t.heads, t.seq_len, t.dim_k, t.dim_v
@@ -123,19 +122,16 @@ class GatedDeltaNetBwdBenchmark(BenchmarkBase[GatedDeltaNetFwdWorkload]):
 
 class GatedDeltaNetVsFlaBwdFixture(FixtureBase):
     PARAMS = [
-        (
-            "batch, seq_len, heads, dim_k, dim_v, chunk_size, dtype, tune",
-            [
-                # chunk_size=32
-                (2, 4096, 4, 64, 64, 32, torch.float16, False),
-                (2, 4096, 4, 64, 64, 32, torch.bfloat16, False),
-                # chunk_size=64
-                (2, 2048, 4, 64, 64, 64, torch.float16, False),
-                (2, 4096, 4, 64, 64, 64, torch.float16, False),
-                (2, 8192, 4, 64, 64, 64, torch.float16, False),
-                (2, 16384, 4, 64, 64, 64, torch.float16, False),
-            ],
-        ),
+        ("batch, seq_len, heads, dim_k, dim_v, chunk_size, dtype, tune", [
+            # chunk_size=32
+            (2, 4096, 4, 64, 64, 32, torch.float16, False),
+            (2, 4096, 4, 64, 64, 32, torch.bfloat16, False),
+            # chunk_size=64
+            (2, 2048, 4, 64, 64, 64, torch.float16, False),
+            (2, 4096, 4, 64, 64, 64, torch.float16, False),
+            (2, 8192, 4, 64, 64, 64, torch.float16, False),
+            (2, 16384, 4, 64, 64, 64, torch.float16, False),
+        ]),
     ]
 
 
@@ -169,7 +165,7 @@ def test_gated_deltanet_vs_fla_bwd(
     functors = {"tileops": bwd_op.forward}
 
     # --- FLA (BTHK layout) ---
-    scale = DK**-0.5
+    scale = DK ** -0.5
     q_fla, k_fla, v_fla, g_fla, beta_fla = _to_fla_layout(q, k, v, g, beta)
     do_fla = do.permute(0, 2, 1, 3).contiguous()  # [B,H,S,DV] -> [B,S,H,DV]
 
@@ -186,4 +182,5 @@ def test_gated_deltanet_vs_fla_bwd(
         return fla_backward(do_fla, None)
 
     functors["fla"] = (fla_bwd, ())
-    bm.compare(functors, do, q, k, v, g, beta, S_fwd, record_as=bwd_op, params=locals())
+    bm.compare(functors, do, q, k, v, g, beta, S_fwd,
+               record_as=bwd_op, params=locals())

--- a/benchmarks/ops/bench_gated_deltanet.py
+++ b/benchmarks/ops/bench_gated_deltanet.py
@@ -18,8 +18,15 @@ import pytest
 import torch
 from fla.ops.gated_delta_rule import chunk_gated_delta_rule
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, backward_of
-from tileops.ops import GatedDeltaNetBwdOp, GatedDeltaNetFwdOp
+from benchmarks.benchmark_base import (
+    BenchmarkBase,
+    BenchmarkReport,
+    ManifestBenchmark,
+    backward_of,
+)
+from benchmarks.ops.attention.manifest_params import manifest_params
+from tileops.manifest import load_workloads
+from tileops.ops import GatedDeltaNetBTHDFwdOp, GatedDeltaNetBwdOp, GatedDeltaNetFwdOp
 from workloads.linear_attention import GatedDeltaNetFwdWorkload
 from workloads.workload_base import FixtureBase
 
@@ -52,27 +59,24 @@ class GatedDeltaNetFwdBenchmark(BenchmarkBase[GatedDeltaNetFwdWorkload]):
         return B * H * S * (2 * DK + 2 * DV + 2) * elem
 
 
-class GatedDeltaNetVsFlaFwdFixture(FixtureBase):
-    PARAMS = [
-        ("batch, seq_len, heads, dim_k, dim_v, chunk_size, dtype, tune", [
-            # chunk_size=32
-            (2, 4096, 4, 64, 64, 32, torch.float16, False),
-            (2, 4096, 4, 64, 64, 32, torch.bfloat16, False),
-            # chunk_size=64
-            (2, 2048, 4, 64, 64, 64, torch.float16, False),
-            (2, 4096, 4, 64, 64, 64, torch.float16, False),
-            (2, 8192, 4, 64, 64, 64, torch.float16, False),
-            (2, 16384, 4, 64, 64, 64, torch.float16, False),
-            (2, 32768, 4, 64, 64, 64, torch.float16, False),
-        ]),
-    ]
+_FWD_OP_NAME = "GatedDeltaNetBTHDFwdOp"
 
 
-@GatedDeltaNetVsFlaFwdFixture
+def _gdn_bthd_args(workload: dict) -> tuple[int, int, int, int, int, int]:
+    """Constructor arguments for one manifest workload row, token-major."""
+    batch, seq_len, heads, dim_k = workload["q_shape"]
+    dim_v = workload["v_shape"][3]
+    return batch, heads, seq_len, dim_k, dim_v, workload.get("chunk_size", 64)
+
+
+@pytest.mark.parametrize(
+    "batch, heads, seq_len, dim_k, dim_v, chunk_size, dtype, tune",
+    manifest_params(load_workloads(_FWD_OP_NAME), _gdn_bthd_args, tune=False),
+)
 def test_gated_deltanet_vs_fla_fwd(
     batch: int,
-    seq_len: int,
     heads: int,
+    seq_len: int,
     dim_k: int,
     dim_v: int,
     chunk_size: int,
@@ -80,27 +84,18 @@ def test_gated_deltanet_vs_fla_fwd(
     tune: bool,
 ) -> None:
     test = GatedDeltaNetFwdWorkload(batch, heads, seq_len, dim_k, dim_v, chunk_size, dtype)
-    bm = GatedDeltaNetFwdBenchmark(test)
-    inputs = test.gen_inputs()  # q, k, v, g, beta  (BHSD)
+    q, k, v, g, beta = test.gen_inputs()  # BHSD
+    # Both sides take the token-major interface; the conversion is outside the
+    # timed region.
+    bthd = _to_fla_layout(q, k, v, g, beta)
 
-    # Use the same production BTHD layout for TileOps and FLA.  Layout
-    # conversion is deliberately outside the timed region.
-    q, k, v, g, beta = inputs
-    q_bthd, k_bthd, v_bthd, g_bthd, beta_bthd = _to_fla_layout(q, k, v, g, beta)
-    if chunk_size == 64:
-        op = GatedDeltaNetFwdOp(chunk_size=chunk_size, tune=tune, layout="bthd")
-        tileops_inputs = (q_bthd, k_bthd, v_bthd, g_bthd, beta_bthd)
-    else:
-        op = GatedDeltaNetFwdOp(chunk_size=chunk_size, tune=tune, layout="bhtd")
-        tileops_inputs = inputs
-    functors = {"tileops": (op, tileops_inputs)}
+    op = GatedDeltaNetBTHDFwdOp(chunk_size=chunk_size, tune=tune)
+    bm = ManifestBenchmark(_FWD_OP_NAME, op, test)
 
     def fla_fwd():
-        return chunk_gated_delta_rule(q_bthd, k_bthd, v_bthd, g_bthd, beta_bthd, scale=1.0)
+        return chunk_gated_delta_rule(*bthd, scale=1.0)
 
-    functors["fla"] = (fla_fwd, ())
-
-    bm.compare(functors, record_as=op, params=locals())
+    bm.compare({"tileops": (op, bthd), "fla": (fla_fwd, ())}, record_as=op, params=locals())
 
 
 # Backward benchmark

--- a/docs/design/manifest.md
+++ b/docs/design/manifest.md
@@ -295,10 +295,17 @@ signature:
 | `layout`      | no       | Memory format when non-default (R19).                                                                                                    |
 | `optional`    | no       | `true` when the op may be called without this input (R18). Inputs only.                                                                  |
 
-**Param fields:** `type` (string: `int`, `float`, `bool`, `"list[int]"`) + optional `default`.
+**Param fields:** `type`, plus optional `default`.
 A param that omits `default` MUST have no `__init__` default either: a
 constructor that accepts a placeholder and rejects it later states a contract
 the signature does not.
+
+`type` is a Python type expression: `int`, `float | None`, `torch.dtype`.
+
+The declared type and the implementation's annotation must agree on one point — whether
+`None` is admitted. Spelling stays the author's: `Number` and `bool | int | float` name one
+domain. `None` is the exception because admitting it decides whether a caller may withhold
+the value. A type that does not admit `None` may not carry `default: null`.
 
 #### Shape Decision Tree
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,4 +174,5 @@ markers = [
     "full: standard correctness coverage",
     "nightly: exhaustive or long-running coverage",
     "packaging: minimal wheel-install sanity check (one case per op family)",
+    "hopper: needs compute capability 9.x; skipped elsewhere, never skipped on Hopper",
 ]

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -601,6 +601,121 @@ def _optional_input_names(sig: dict) -> list[str]:
     ]
 
 
+def _type_parts(text: object) -> "set[str] | None":
+    """Members of a param ``type`` expression, or ``None`` when it does not parse.
+
+    ``Optional[X]``, ``Union[X, Y]`` and ``X | Y`` reduce to the same set, and a module
+    qualifier drops, so ``torch.dtype`` and ``dtype`` name one type.
+    """
+    if not isinstance(text, str):
+        return None
+    try:
+        tree = ast.parse(text.strip(), mode="eval")
+    except (SyntaxError, ValueError):
+        return None
+
+    def walk(node) -> "set[str]":
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+            return walk(node.left) | walk(node.right)
+        if isinstance(node, ast.Subscript):
+            head = ast.unparse(node.value).rsplit(".", 1)[-1]
+            elts = node.slice.elts if isinstance(node.slice, ast.Tuple) else [node.slice]
+            if head == "Optional":
+                return walk(elts[0]) | {"None"}
+            if head == "Union":
+                return set().union(*(walk(e) for e in elts))
+        if isinstance(node, ast.Constant) and node.value is None:
+            return {"None"}
+        return {ast.unparse(node).rsplit(".", 1)[-1]}
+
+    return walk(tree.body)
+
+
+def _admits_none(text: object) -> "bool | None":
+    """Whether *text* admits ``None``; ``None`` when the expression does not parse."""
+    parts = _type_parts(text)
+    return None if parts is None else "None" in parts
+
+
+def _check_param_domain(op_name: str, sig: dict) -> list[str]:
+    """``type`` parses, and a type without ``None`` does not default to it.
+
+    The two together would state that the op both refuses and supplies the same
+    absent value.
+    """
+    errors: list[str] = []
+    err = _emit_to(errors, "schema", op_name)
+    params = sig.get("params")
+    if not isinstance(params, dict):
+        return errors
+    for pname, attrs in params.items():
+        if not isinstance(pname, str) or not isinstance(attrs, dict):
+            continue
+        declared = attrs.get("type")
+        admits_none = _admits_none(declared)
+        if admits_none is None:
+            err(f"params.{pname}.type {declared!r} is not a type expression")
+        elif "default" in attrs and attrs["default"] is None and not admits_none:
+            err(
+                f"params.{pname} defaults to null but its type {declared!r} does not "
+                f"admit None; write it as '{declared} | None'"
+            )
+    return errors
+
+
+def _check_param_optionality_parity(op_name: str, sig: dict, cls: type) -> list[str]:
+    """The manifest and the implementation agree on which params accept ``None``.
+
+    Only optionality is compared, not spelling: ``Number`` and ``bool | int | float``
+    describe one domain and an author may write either. A disagreement here is a real
+    one — the manifest promises a caller may withhold a value the op requires, or the
+    reverse.
+    """
+    errors: list[str] = []
+    err = _emit_to(errors, "signature", op_name)
+    params = sig.get("params")
+    if not isinstance(params, dict):
+        return errors
+    annotations: dict[str, object] = {}
+    for method in ("__init__", "forward"):
+        fn = getattr(cls, method, None)
+        try:
+            hints = getattr(fn, "__annotations__", {}) or {}
+        except Exception:
+            hints = {}
+        for pname, ann in hints.items():
+            annotations.setdefault(pname, ann)
+    for pname, attrs in params.items():
+        if not isinstance(attrs, dict) or pname not in annotations:
+            continue
+        declared = _admits_none(attrs.get("type"))
+        ann = annotations[pname]
+        actual = _admits_none(ann if isinstance(ann, str) else _annotation_text(ann))
+        if declared is None or actual is None or declared == actual:
+            continue
+        if declared:
+            err(
+                f"params.{pname}.type admits None but {cls.__name__} annotates it "
+                f"{_annotation_text(ann)}"
+            )
+        else:
+            err(
+                f"params.{pname}.type is {attrs.get('type')!r} but {cls.__name__} "
+                f"annotates it {_annotation_text(ann)}; write it as "
+                f"'{attrs.get('type')} | None'"
+            )
+    return errors
+
+
+def _annotation_text(ann: object) -> str:
+    """Source-shaped text for an annotation object or string."""
+    if isinstance(ann, str):
+        return ann
+    if isinstance(ann, type):
+        return ann.__name__
+    return str(ann).replace("typing.", "").replace("NoneType", "None")
+
+
 def _check_optional_flag(op_name: str, sig: dict) -> list[str]:
     """``optional`` is literal ``true``, and only on ``signature.inputs``."""
     errors: list[str] = []
@@ -896,6 +1011,7 @@ def _check_optional_workload_coverage(
 def _l0_optional(op_name: str, entry: dict, sig: dict) -> list[str]:
     """All optional-input checks for one entry."""
     errors = _check_optional_flag(op_name, sig)
+    errors.extend(_check_param_domain(op_name, sig))
     optional = _optional_input_names(sig)
     if not optional:
         return errors
@@ -1305,11 +1421,13 @@ def check_l1(
     manifest_static_dims = sig.get("static_dims")
     init_params = _get_init_params(result.cls)
 
-    return check_l1_signature(
+    errors = check_l1_signature(
         op_name, manifest_inputs, manifest_params, forward_params,
         init_params=init_params,
         manifest_static_dims=manifest_static_dims,
     )
+    errors.extend(_check_param_optionality_parity(op_name, sig, result.cls))
+    return errors
 
 
 # ---------------------------------------------------------------------------

--- a/src/tileops/kernels/__init__.py
+++ b/src/tileops/kernels/__init__.py
@@ -46,6 +46,7 @@ from .fp8_quant import FP8QuantKernel
 from .gated_deltanet import (
     GatedDeltaNetBwdKernel,
     GatedDeltaNetFwdKernel,
+    GatedDeltaNetFwdProductionKernel,
     GatedDeltaNetPrefillFwdKernel,
 )
 from .gated_deltanet_recurrence import (
@@ -152,6 +153,7 @@ __all__ = [
     "GatedDeltaNetDecodeKernel",
     "GatedDeltaNetDecodeRawCudaFlaStyleKernel",
     "GatedDeltaNetFwdKernel",
+    "GatedDeltaNetFwdProductionKernel",
     "GatedDeltaNetPrefillFwdKernel",
     "GemmFp8BlockScaledKernel",
     "GemmFp8EpilogueKernel",

--- a/src/tileops/kernels/gated_deltanet/__init__.py
+++ b/src/tileops/kernels/gated_deltanet/__init__.py
@@ -1,9 +1,10 @@
 from .gated_deltanet_bwd import GatedDeltaNetBwdKernel
-from .gated_deltanet_fwd import GatedDeltaNetFwdKernel
+from .gated_deltanet_fwd import GatedDeltaNetFwdKernel, GatedDeltaNetFwdProductionKernel
 from .gated_deltanet_prefill import GatedDeltaNetPrefillFwdKernel
 
 __all__ = [
     "GatedDeltaNetBwdKernel",
     "GatedDeltaNetFwdKernel",
+    "GatedDeltaNetFwdProductionKernel",
     "GatedDeltaNetPrefillFwdKernel",
 ]

--- a/src/tileops/kernels/gated_deltanet/gated_deltanet_fwd.py
+++ b/src/tileops/kernels/gated_deltanet/gated_deltanet_fwd.py
@@ -10,6 +10,7 @@ Splitting kernel2 into h_recurrence + output_o increases SM utilisation:
   - h_recurrence grid: (batch, head) — must be sequential (state dependency)
   - output_o grid:     (num_chunks, batch, head) — fully parallel
 """
+
 import functools
 from typing import Optional, Tuple
 
@@ -27,7 +28,7 @@ from tileops.kernels.v_tile import resolve_block_v
 
 from .fused_prepare_compute_w_u import fused_prepare_compute_w_u_tl
 
-__all__ = ["GatedDeltaNetFwdKernel"]
+__all__ = ["GatedDeltaNetFwdKernel", "GatedDeltaNetFwdProductionKernel"]
 
 _LOG2E = 1.4426950408889634
 
@@ -89,45 +90,43 @@ def _h_recurrence_tl(
                 ws_frag = T.alloc_fragment([block_C, BV], accum_dtype)
                 h_next_frag = T.alloc_fragment([dim_k, BV], accum_dtype)
 
-
                 v_offset = vid * BV
 
                 # Initialise h tile from S_0
-                T.copy(S_0[bid, hid, :, v_offset : v_offset + BV], h_c,
-                       disable_tma=True)
+                T.copy(S_0[bid, hid, :, v_offset : v_offset + BV], h_c, disable_tma=True)
                 for i, j in T.Parallel(dim_k, BV):
                     S[bid, hid, 0, i, v_offset + j] = h_c[i, j]
 
                 for t in T.Pipelined(num_chunks, num_stages=num_stages):
-                    T.copy(k[bid, hid, t * block_C : (t + 1) * block_C, :], k_c,
-                           disable_tma=True)
-                    T.copy(g[bid, hid, t * block_C : (t + 1) * block_C], g_c,
-                           disable_tma=True)
-                    T.copy(w[bid, hid, t * block_C : (t + 1) * block_C, :], w_c,
-                           disable_tma=True)
-                    T.copy(u[bid, hid, t * block_C : (t + 1) * block_C,
-                             v_offset : v_offset + BV], u_c, disable_tma=True)
+                    T.copy(k[bid, hid, t * block_C : (t + 1) * block_C, :], k_c, disable_tma=True)
+                    T.copy(g[bid, hid, t * block_C : (t + 1) * block_C], g_c, disable_tma=True)
+                    T.copy(w[bid, hid, t * block_C : (t + 1) * block_C, :], w_c, disable_tma=True)
+                    T.copy(
+                        u[bid, hid, t * block_C : (t + 1) * block_C, v_offset : v_offset + BV],
+                        u_c,
+                        disable_tma=True,
+                    )
 
                     # v_new_tile = u_tile - (w @ h_tile) * exp(g + g_last)
                     T.clear(ws_frag)
                     T.gemm(w_c, h_c, ws_frag)
                     for i, j in T.Parallel(block_C, BV):
                         v_new_c[i, j] = u_c[i, j] - ws_frag[i, j] * T.exp2(
-                            (g_c[i] + g_c[block_C - 1]) * _LOG2E)
+                            (g_c[i] + g_c[block_C - 1]) * _LOG2E
+                        )
 
                     # Store v_new tile
-                    T.copy(v_new_c,
-                           v_new[bid, hid, t * block_C : (t + 1) * block_C,
-                                 v_offset : v_offset + BV],
-                           disable_tma=True)
+                    T.copy(
+                        v_new_c,
+                        v_new[bid, hid, t * block_C : (t + 1) * block_C, v_offset : v_offset + BV],
+                        disable_tma=True,
+                    )
 
                     # h_tile_next = h_tile * exp(g_last) + k^T @ scaled_v_new_tile
                     for n, j in T.Parallel(block_C, BV):
-                        v_new_c[n, j] = v_new_c[n, j] * T.exp2(
-                            (g_c[block_C - 1] - g_c[n]) * _LOG2E)
+                        v_new_c[n, j] = v_new_c[n, j] * T.exp2((g_c[block_C - 1] - g_c[n]) * _LOG2E)
                     for i, j in T.Parallel(dim_k, BV):
-                        h_next_frag[i, j] = h_c[i, j] * T.exp2(
-                            g_c[block_C - 1] * _LOG2E)
+                        h_next_frag[i, j] = h_c[i, j] * T.exp2(g_c[block_C - 1] * _LOG2E)
                     T.gemm(
                         k_c,
                         v_new_c,
@@ -145,6 +144,7 @@ def _h_recurrence_tl(
 
 
 # Split kernel: output_o  (fully parallel over chunks)
+
 
 @functools.lru_cache(maxsize=32)
 def _output_o_tl(
@@ -193,15 +193,15 @@ def _output_o_tl(
                 o_frag = T.alloc_fragment([block_C, dim_v], accum_dtype)
                 attn_frag = T.alloc_fragment([block_C, block_C], accum_dtype)
 
-                T.copy(q[bid, hid, tid * block_C : (tid + 1) * block_C, :], q_c,
-                       disable_tma=True)
-                T.copy(k[bid, hid, tid * block_C : (tid + 1) * block_C, :], k_c,
-                       disable_tma=True)
-                T.copy(g[bid, hid, tid * block_C : (tid + 1) * block_C], g_c,
-                       disable_tma=True)
+                T.copy(q[bid, hid, tid * block_C : (tid + 1) * block_C, :], q_c, disable_tma=True)
+                T.copy(k[bid, hid, tid * block_C : (tid + 1) * block_C, :], k_c, disable_tma=True)
+                T.copy(g[bid, hid, tid * block_C : (tid + 1) * block_C], g_c, disable_tma=True)
                 T.copy(S[bid, hid, tid, :, :], h_c, disable_tma=True)
-                T.copy(v_new[bid, hid, tid * block_C : (tid + 1) * block_C, :], v_new_c,
-                       disable_tma=True)
+                T.copy(
+                    v_new[bid, hid, tid * block_C : (tid + 1) * block_C, :],
+                    v_new_c,
+                    disable_tma=True,
+                )
 
                 # o = (q @ h) * exp(g)
                 T.clear(o_frag)
@@ -214,14 +214,14 @@ def _output_o_tl(
                 T.gemm(q_c, k_c, attn_frag, transpose_B=True)
                 for i, j in T.Parallel(block_C, block_C):
                     attn[i, j] = T.if_then_else(
-                        i >= j,
-                        attn_frag[i, j] * T.exp2((g_c[i] - g_c[j]) * _LOG2E),
-                        T.float32(0.0))
+                        i >= j, attn_frag[i, j] * T.exp2((g_c[i] - g_c[j]) * _LOG2E), T.float32(0.0)
+                    )
 
                 # o += attn @ v_new
                 T.gemm(attn, v_new_c, o_frag)
-                T.copy(o_frag, o[bid, hid, tid * block_C : (tid + 1) * block_C, :],
-                       disable_tma=True)
+                T.copy(
+                    o_frag, o[bid, hid, tid * block_C : (tid + 1) * block_C, :], disable_tma=True
+                )
 
         return output_o_kernel
 
@@ -236,24 +236,53 @@ def _chunk_local_cumsum(g: torch.Tensor, chunk_size: int) -> torch.Tensor:
 
 @torch.library.custom_op("tileops::gated_deltanet_fwd_kernel", mutates_args=())
 def _gated_deltanet_fwd_wrapped_kernel(
-    batch: int, head: int, seq_len: int, chunk_size: int, dim_k: int, dim_v: int,
+    batch: int,
+    head: int,
+    seq_len: int,
+    chunk_size: int,
+    dim_k: int,
+    dim_v: int,
     dtype: str,
-    fused_num_stages: int, fused_threads: int,
-    h_num_stages: int, h_threads: int, h_block_v: int,
+    fused_num_stages: int,
+    fused_threads: int,
+    h_num_stages: int,
+    h_threads: int,
+    h_block_v: int,
     o_threads: int,
-    q: torch.Tensor, k: torch.Tensor, v: torch.Tensor,
-    g: torch.Tensor, beta: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     g_cum = _chunk_local_cumsum(g.float(), chunk_size).to(g.dtype)
     fused_fn = fused_prepare_compute_w_u_tl(
-        batch, head, seq_len, chunk_size, dim_k, dim_v, dtype,
+        batch,
+        head,
+        seq_len,
+        chunk_size,
+        dim_k,
+        dim_v,
+        dtype,
     )(fused_num_stages, fused_threads)
     h_fn = _h_recurrence_tl(
-        batch, head, seq_len, chunk_size, dim_k, dim_v, dtype,
+        batch,
+        head,
+        seq_len,
+        chunk_size,
+        dim_k,
+        dim_v,
+        dtype,
         block_v=h_block_v,
     )(h_num_stages, h_threads)
     o_fn = _output_o_tl(
-        batch, head, seq_len, chunk_size, dim_k, dim_v, dtype,
+        batch,
+        head,
+        seq_len,
+        chunk_size,
+        dim_k,
+        dim_v,
+        dtype,
     )(o_threads)
     S_0 = torch.zeros(batch, head, dim_k, dim_v, dtype=q.dtype, device=q.device)
     Aw, Au, w, u = fused_fn(k, v, g_cum, beta)
@@ -264,13 +293,24 @@ def _gated_deltanet_fwd_wrapped_kernel(
 
 @_gated_deltanet_fwd_wrapped_kernel.register_fake
 def _gated_deltanet_fwd_wrapped_kernel_fake(
-    batch: int, head: int, seq_len: int, chunk_size: int, dim_k: int, dim_v: int,
+    batch: int,
+    head: int,
+    seq_len: int,
+    chunk_size: int,
+    dim_k: int,
+    dim_v: int,
     dtype: str,
-    fused_num_stages: int, fused_threads: int,
-    h_num_stages: int, h_threads: int, h_block_v: int,
+    fused_num_stages: int,
+    fused_threads: int,
+    h_num_stages: int,
+    h_threads: int,
+    h_block_v: int,
     o_threads: int,
-    q: torch.Tensor, k: torch.Tensor, v: torch.Tensor,
-    g: torch.Tensor, beta: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     num_chunks = seq_len // chunk_size
     o = torch.empty(batch, head, seq_len, dim_v, dtype=q.dtype, device=q.device)
@@ -340,11 +380,182 @@ class GatedDeltaNetFwdKernel(Kernel):
         beta: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         return _gated_deltanet_fwd_wrapped_kernel(
-            self.batch, self.head, self.seq_len, self.chunk_size,
-            self.dim_k, self.dim_v, self.dtype_str,
-            self.config["fused_num_stages"], self.config["fused_threads"],
-            self.config["h_num_stages"], self.config["h_threads"],
+            self.batch,
+            self.head,
+            self.seq_len,
+            self.chunk_size,
+            self.dim_k,
+            self.dim_v,
+            self.dtype_str,
+            self.config["fused_num_stages"],
+            self.config["fused_threads"],
+            self.config["h_num_stages"],
+            self.config["h_threads"],
             self.config.get("h_block_v", 0),
             self.config["o_threads"],
-            q, k, v, g, beta,
+            q,
+            k,
+            v,
+            g,
+            beta,
+        )
+
+
+@torch.library.custom_op("tileops::gated_deltanet_fwd_production_kernel", mutates_args=())
+def _gated_deltanet_fwd_production_wrapped_kernel(
+    batch: int,
+    head: int,
+    seq_len: int,
+    chunk_size: int,
+    dim_k: int,
+    dim_v: int,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Run the partitioned production prefill pipeline with training artifacts."""
+    from .gated_deltanet_prefill import (
+        _prefill_blocksolve_A_bthd,
+        _prefill_chunk_local_cumsum_bthd_tl,
+        _prefill_partitioned_initial_state_bthd,
+    )
+    from .gdn_prefill import fused_gdr_fwd
+
+    dtype = str(q.dtype).split(".")[-1]
+    g_cum = _prefill_chunk_local_cumsum_bthd_tl(batch, head, seq_len, chunk_size, dtype)(g)
+
+    # The warp-specialized production kernel consumes the ungated inverse and
+    # applies the chunk-local gate itself.  Build the gated inverse separately
+    # for the legacy forward ABI's Aw/Au training artifacts.
+    A = _prefill_blocksolve_A_bthd(k, g_cum, beta, chunk_size, use_gate=False)
+
+    total_tokens = batch * seq_len
+    q_flat = q.reshape(1, total_tokens, head, dim_k)
+    k_flat = k.reshape(1, total_tokens, head, dim_k)
+    v_flat = v.reshape(1, total_tokens, head, dim_v)
+    g_flat = g_cum.reshape(1, total_tokens, head)
+    beta_flat = beta.reshape(1, total_tokens, head)
+    A_flat = A.reshape(1, total_tokens, head, chunk_size)
+    initial_state, cu_seqlens, cp_seq_map, raw_cu_seqlens = _prefill_partitioned_initial_state_bthd(
+        k_flat,
+        v_flat,
+        A_flat,
+        g_flat,
+        beta_flat,
+        chunk_size,
+        raw_sequence_lengths=(seq_len,) * batch,
+        min_partition_chunks=512,
+    )
+    o, h, _final_state = fused_gdr_fwd(
+        q=q_flat,
+        k=k_flat,
+        v=v_flat,
+        a=A_flat,
+        g=g_flat,
+        b=beta_flat,
+        scale=1.0,
+        initial_state=initial_state,
+        output_final_state=True,
+        output_h=True,
+        output_o=True,
+        cu_seqlens=cu_seqlens,
+        cp_seq_map=cp_seq_map,
+        raw_cu_seqlens=raw_cu_seqlens,
+        chunk_size=chunk_size,
+        state_head_first=True,
+        chunks_per_sequence=seq_len // chunk_size,
+    )
+
+    o = o.reshape(batch, seq_len, head, dim_v)
+    Aw = _prefill_blocksolve_A_bthd(k, g_cum, beta, chunk_size)
+    Au = Aw.clone()
+    return o, h, Aw, Au
+
+
+@_gated_deltanet_fwd_production_wrapped_kernel.register_fake
+def _gated_deltanet_fwd_production_wrapped_kernel_fake(
+    batch: int,
+    head: int,
+    seq_len: int,
+    chunk_size: int,
+    dim_k: int,
+    dim_v: int,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    del k, v, g, beta
+    num_chunks = seq_len // chunk_size
+    o = torch.empty(batch, seq_len, head, dim_v, dtype=q.dtype, device=q.device)
+    states = torch.empty(
+        batch,
+        head,
+        num_chunks + 1,
+        dim_k,
+        dim_v,
+        dtype=q.dtype,
+        device=q.device,
+    )
+    Aw = torch.empty(batch, seq_len, head, chunk_size, dtype=q.dtype, device=q.device)
+    Au = torch.empty_like(Aw)
+    return o, states, Aw, Au
+
+
+class GatedDeltaNetFwdProductionKernel(Kernel):
+    """Hopper BTHD forward using the partitioned production prefill pipeline."""
+
+    supported_archs: list[int] = [90]
+
+    def __init__(
+        self,
+        batch: int,
+        head: int,
+        seq_len: int,
+        chunk_size: int,
+        dim_k: int,
+        dim_v: int,
+        dtype: str = "float16",
+        config: Optional[dict] = None,
+        tune: bool = False,
+    ) -> None:
+        super().__init__()
+        if tune:
+            raise ValueError("GatedDeltaNetFwdProductionKernel does not support tuning")
+        self.batch = batch
+        self.head = head
+        self.seq_len = seq_len
+        self.chunk_size = chunk_size
+        self.dim_k = dim_k
+        self.dim_v = dim_v
+        self.dtype = dtype
+        self.config = config or {}
+
+    @property
+    def default_config(self) -> dict:
+        return {}
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        return _gated_deltanet_fwd_production_wrapped_kernel(
+            self.batch,
+            self.head,
+            self.seq_len,
+            self.chunk_size,
+            self.dim_k,
+            self.dim_v,
+            q,
+            k,
+            v,
+            g,
+            beta,
         )

--- a/src/tileops/kernels/gated_deltanet/gated_deltanet_fwd.py
+++ b/src/tileops/kernels/gated_deltanet/gated_deltanet_fwd.py
@@ -90,43 +90,45 @@ def _h_recurrence_tl(
                 ws_frag = T.alloc_fragment([block_C, BV], accum_dtype)
                 h_next_frag = T.alloc_fragment([dim_k, BV], accum_dtype)
 
+
                 v_offset = vid * BV
 
                 # Initialise h tile from S_0
-                T.copy(S_0[bid, hid, :, v_offset : v_offset + BV], h_c, disable_tma=True)
+                T.copy(S_0[bid, hid, :, v_offset : v_offset + BV], h_c,
+                       disable_tma=True)
                 for i, j in T.Parallel(dim_k, BV):
                     S[bid, hid, 0, i, v_offset + j] = h_c[i, j]
 
                 for t in T.Pipelined(num_chunks, num_stages=num_stages):
-                    T.copy(k[bid, hid, t * block_C : (t + 1) * block_C, :], k_c, disable_tma=True)
-                    T.copy(g[bid, hid, t * block_C : (t + 1) * block_C], g_c, disable_tma=True)
-                    T.copy(w[bid, hid, t * block_C : (t + 1) * block_C, :], w_c, disable_tma=True)
-                    T.copy(
-                        u[bid, hid, t * block_C : (t + 1) * block_C, v_offset : v_offset + BV],
-                        u_c,
-                        disable_tma=True,
-                    )
+                    T.copy(k[bid, hid, t * block_C : (t + 1) * block_C, :], k_c,
+                           disable_tma=True)
+                    T.copy(g[bid, hid, t * block_C : (t + 1) * block_C], g_c,
+                           disable_tma=True)
+                    T.copy(w[bid, hid, t * block_C : (t + 1) * block_C, :], w_c,
+                           disable_tma=True)
+                    T.copy(u[bid, hid, t * block_C : (t + 1) * block_C,
+                             v_offset : v_offset + BV], u_c, disable_tma=True)
 
                     # v_new_tile = u_tile - (w @ h_tile) * exp(g + g_last)
                     T.clear(ws_frag)
                     T.gemm(w_c, h_c, ws_frag)
                     for i, j in T.Parallel(block_C, BV):
                         v_new_c[i, j] = u_c[i, j] - ws_frag[i, j] * T.exp2(
-                            (g_c[i] + g_c[block_C - 1]) * _LOG2E
-                        )
+                            (g_c[i] + g_c[block_C - 1]) * _LOG2E)
 
                     # Store v_new tile
-                    T.copy(
-                        v_new_c,
-                        v_new[bid, hid, t * block_C : (t + 1) * block_C, v_offset : v_offset + BV],
-                        disable_tma=True,
-                    )
+                    T.copy(v_new_c,
+                           v_new[bid, hid, t * block_C : (t + 1) * block_C,
+                                 v_offset : v_offset + BV],
+                           disable_tma=True)
 
                     # h_tile_next = h_tile * exp(g_last) + k^T @ scaled_v_new_tile
                     for n, j in T.Parallel(block_C, BV):
-                        v_new_c[n, j] = v_new_c[n, j] * T.exp2((g_c[block_C - 1] - g_c[n]) * _LOG2E)
+                        v_new_c[n, j] = v_new_c[n, j] * T.exp2(
+                            (g_c[block_C - 1] - g_c[n]) * _LOG2E)
                     for i, j in T.Parallel(dim_k, BV):
-                        h_next_frag[i, j] = h_c[i, j] * T.exp2(g_c[block_C - 1] * _LOG2E)
+                        h_next_frag[i, j] = h_c[i, j] * T.exp2(
+                            g_c[block_C - 1] * _LOG2E)
                     T.gemm(
                         k_c,
                         v_new_c,
@@ -193,15 +195,15 @@ def _output_o_tl(
                 o_frag = T.alloc_fragment([block_C, dim_v], accum_dtype)
                 attn_frag = T.alloc_fragment([block_C, block_C], accum_dtype)
 
-                T.copy(q[bid, hid, tid * block_C : (tid + 1) * block_C, :], q_c, disable_tma=True)
-                T.copy(k[bid, hid, tid * block_C : (tid + 1) * block_C, :], k_c, disable_tma=True)
-                T.copy(g[bid, hid, tid * block_C : (tid + 1) * block_C], g_c, disable_tma=True)
+                T.copy(q[bid, hid, tid * block_C : (tid + 1) * block_C, :], q_c,
+                       disable_tma=True)
+                T.copy(k[bid, hid, tid * block_C : (tid + 1) * block_C, :], k_c,
+                       disable_tma=True)
+                T.copy(g[bid, hid, tid * block_C : (tid + 1) * block_C], g_c,
+                       disable_tma=True)
                 T.copy(S[bid, hid, tid, :, :], h_c, disable_tma=True)
-                T.copy(
-                    v_new[bid, hid, tid * block_C : (tid + 1) * block_C, :],
-                    v_new_c,
-                    disable_tma=True,
-                )
+                T.copy(v_new[bid, hid, tid * block_C : (tid + 1) * block_C, :], v_new_c,
+                       disable_tma=True)
 
                 # o = (q @ h) * exp(g)
                 T.clear(o_frag)
@@ -214,14 +216,14 @@ def _output_o_tl(
                 T.gemm(q_c, k_c, attn_frag, transpose_B=True)
                 for i, j in T.Parallel(block_C, block_C):
                     attn[i, j] = T.if_then_else(
-                        i >= j, attn_frag[i, j] * T.exp2((g_c[i] - g_c[j]) * _LOG2E), T.float32(0.0)
-                    )
+                        i >= j,
+                        attn_frag[i, j] * T.exp2((g_c[i] - g_c[j]) * _LOG2E),
+                        T.float32(0.0))
 
                 # o += attn @ v_new
                 T.gemm(attn, v_new_c, o_frag)
-                T.copy(
-                    o_frag, o[bid, hid, tid * block_C : (tid + 1) * block_C, :], disable_tma=True
-                )
+                T.copy(o_frag, o[bid, hid, tid * block_C : (tid + 1) * block_C, :],
+                       disable_tma=True)
 
         return output_o_kernel
 
@@ -236,53 +238,24 @@ def _chunk_local_cumsum(g: torch.Tensor, chunk_size: int) -> torch.Tensor:
 
 @torch.library.custom_op("tileops::gated_deltanet_fwd_kernel", mutates_args=())
 def _gated_deltanet_fwd_wrapped_kernel(
-    batch: int,
-    head: int,
-    seq_len: int,
-    chunk_size: int,
-    dim_k: int,
-    dim_v: int,
+    batch: int, head: int, seq_len: int, chunk_size: int, dim_k: int, dim_v: int,
     dtype: str,
-    fused_num_stages: int,
-    fused_threads: int,
-    h_num_stages: int,
-    h_threads: int,
-    h_block_v: int,
+    fused_num_stages: int, fused_threads: int,
+    h_num_stages: int, h_threads: int, h_block_v: int,
     o_threads: int,
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    g: torch.Tensor,
-    beta: torch.Tensor,
+    q: torch.Tensor, k: torch.Tensor, v: torch.Tensor,
+    g: torch.Tensor, beta: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     g_cum = _chunk_local_cumsum(g.float(), chunk_size).to(g.dtype)
     fused_fn = fused_prepare_compute_w_u_tl(
-        batch,
-        head,
-        seq_len,
-        chunk_size,
-        dim_k,
-        dim_v,
-        dtype,
+        batch, head, seq_len, chunk_size, dim_k, dim_v, dtype,
     )(fused_num_stages, fused_threads)
     h_fn = _h_recurrence_tl(
-        batch,
-        head,
-        seq_len,
-        chunk_size,
-        dim_k,
-        dim_v,
-        dtype,
+        batch, head, seq_len, chunk_size, dim_k, dim_v, dtype,
         block_v=h_block_v,
     )(h_num_stages, h_threads)
     o_fn = _output_o_tl(
-        batch,
-        head,
-        seq_len,
-        chunk_size,
-        dim_k,
-        dim_v,
-        dtype,
+        batch, head, seq_len, chunk_size, dim_k, dim_v, dtype,
     )(o_threads)
     S_0 = torch.zeros(batch, head, dim_k, dim_v, dtype=q.dtype, device=q.device)
     Aw, Au, w, u = fused_fn(k, v, g_cum, beta)
@@ -293,24 +266,13 @@ def _gated_deltanet_fwd_wrapped_kernel(
 
 @_gated_deltanet_fwd_wrapped_kernel.register_fake
 def _gated_deltanet_fwd_wrapped_kernel_fake(
-    batch: int,
-    head: int,
-    seq_len: int,
-    chunk_size: int,
-    dim_k: int,
-    dim_v: int,
+    batch: int, head: int, seq_len: int, chunk_size: int, dim_k: int, dim_v: int,
     dtype: str,
-    fused_num_stages: int,
-    fused_threads: int,
-    h_num_stages: int,
-    h_threads: int,
-    h_block_v: int,
+    fused_num_stages: int, fused_threads: int,
+    h_num_stages: int, h_threads: int, h_block_v: int,
     o_threads: int,
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    g: torch.Tensor,
-    beta: torch.Tensor,
+    q: torch.Tensor, k: torch.Tensor, v: torch.Tensor,
+    g: torch.Tensor, beta: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     num_chunks = seq_len // chunk_size
     o = torch.empty(batch, head, seq_len, dim_v, dtype=q.dtype, device=q.device)
@@ -380,24 +342,13 @@ class GatedDeltaNetFwdKernel(Kernel):
         beta: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         return _gated_deltanet_fwd_wrapped_kernel(
-            self.batch,
-            self.head,
-            self.seq_len,
-            self.chunk_size,
-            self.dim_k,
-            self.dim_v,
-            self.dtype_str,
-            self.config["fused_num_stages"],
-            self.config["fused_threads"],
-            self.config["h_num_stages"],
-            self.config["h_threads"],
+            self.batch, self.head, self.seq_len, self.chunk_size,
+            self.dim_k, self.dim_v, self.dtype_str,
+            self.config["fused_num_stages"], self.config["fused_threads"],
+            self.config["h_num_stages"], self.config["h_threads"],
             self.config.get("h_block_v", 0),
             self.config["o_threads"],
-            q,
-            k,
-            v,
-            g,
-            beta,
+            q, k, v, g, beta,
         )
 
 
@@ -467,7 +418,10 @@ def _gated_deltanet_fwd_production_wrapped_kernel_fake(
 
 
 class GatedDeltaNetFwdProductionKernel(Kernel):
-    """Hopper BTHD forward using the partitioned production prefill pipeline."""
+    """Hopper forward over batch-token-head-dim (BTHD) inputs.
+
+    Runs the partitioned production prefill pipeline.
+    """
 
     supported_archs: list[int] = [90]
 

--- a/src/tileops/kernels/gated_deltanet/gated_deltanet_fwd.py
+++ b/src/tileops/kernels/gated_deltanet/gated_deltanet_fwd.py
@@ -415,63 +415,24 @@ def _gated_deltanet_fwd_production_wrapped_kernel(
     g: torch.Tensor,
     beta: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Run the partitioned production prefill pipeline with training artifacts."""
-    from .gated_deltanet_prefill import (
-        _prefill_blocksolve_A_bthd,
-        _prefill_chunk_local_cumsum_bthd_tl,
-        _prefill_partitioned_initial_state_bthd,
-    )
-    from .gdn_prefill import fused_gdr_fwd
+    from .gated_deltanet_prefill import _gated_deltanet_production_bthd, _prefill_blocksolve_A_bthd
 
-    dtype = str(q.dtype).split(".")[-1]
-    g_cum = _prefill_chunk_local_cumsum_bthd_tl(batch, head, seq_len, chunk_size, dtype)(g)
-
-    # The warp-specialized production kernel consumes the ungated inverse and
-    # applies the chunk-local gate itself.  Build the gated inverse separately
-    # for the legacy forward ABI's Aw/Au training artifacts.
-    A = _prefill_blocksolve_A_bthd(k, g_cum, beta, chunk_size, use_gate=False)
-
-    total_tokens = batch * seq_len
-    q_flat = q.reshape(1, total_tokens, head, dim_k)
-    k_flat = k.reshape(1, total_tokens, head, dim_k)
-    v_flat = v.reshape(1, total_tokens, head, dim_v)
-    g_flat = g_cum.reshape(1, total_tokens, head)
-    beta_flat = beta.reshape(1, total_tokens, head)
-    A_flat = A.reshape(1, total_tokens, head, chunk_size)
-    initial_state, cu_seqlens, cp_seq_map, raw_cu_seqlens = _prefill_partitioned_initial_state_bthd(
-        k_flat,
-        v_flat,
-        A_flat,
-        g_flat,
-        beta_flat,
+    o, states, _final_state, g_cum = _gated_deltanet_production_bthd(
+        q,
+        k,
+        v,
+        g,
+        beta,
         chunk_size,
-        raw_sequence_lengths=(seq_len,) * batch,
+        output_states=True,
         min_partition_chunks=512,
     )
-    o, h, _final_state = fused_gdr_fwd(
-        q=q_flat,
-        k=k_flat,
-        v=v_flat,
-        a=A_flat,
-        g=g_flat,
-        b=beta_flat,
-        scale=1.0,
-        initial_state=initial_state,
-        output_final_state=True,
-        output_h=True,
-        output_o=True,
-        cu_seqlens=cu_seqlens,
-        cp_seq_map=cp_seq_map,
-        raw_cu_seqlens=raw_cu_seqlens,
-        chunk_size=chunk_size,
-        state_head_first=True,
-        chunks_per_sequence=seq_len // chunk_size,
-    )
+    assert states is not None
 
-    o = o.reshape(batch, seq_len, head, dim_v)
+    # The legacy forward ABI also needs the gated Aw/Au training artifacts.
     Aw = _prefill_blocksolve_A_bthd(k, g_cum, beta, chunk_size)
     Au = Aw.clone()
-    return o, h, Aw, Au
+    return o, states, Aw, Au
 
 
 @_gated_deltanet_fwd_production_wrapped_kernel.register_fake

--- a/src/tileops/kernels/gated_deltanet/gated_deltanet_prefill.py
+++ b/src/tileops/kernels/gated_deltanet/gated_deltanet_prefill.py
@@ -66,9 +66,7 @@ def _prefill_partition_metadata(
     seq_map_c2r = []
     seq_map_r2c = [0]
     split_tokens = max_local_chunks * chunk_size
-    for raw_idx, (raw_start, raw_end) in enumerate(
-        zip(raw_offsets, raw_offsets[1:], strict=False)
-    ):
+    for raw_idx, (raw_start, raw_end) in enumerate(zip(raw_offsets, raw_offsets[1:], strict=False)):
         start = raw_start
         while start < raw_end:
             cp_cu_seqlens.append(start)
@@ -825,6 +823,61 @@ def _prefill_blocksolve_A_bthd(
     return A
 
 
+def _gated_deltanet_production_bthd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    chunk_size: int,
+    *,
+    output_states: bool = False,
+    min_partition_chunks: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor, torch.Tensor]:
+    """Run the production recurrence shared by BTHD prefill and forward."""
+    from .gdn_prefill import fused_gdr_fwd
+
+    batch, seq_len, head = q.shape[:3]
+    g_cum = _prefill_chunk_local_cumsum_bthd_tl(
+        batch, head, seq_len, chunk_size, str(q.dtype).split(".")[-1]
+    )(g)
+    inverse = _prefill_blocksolve_A_bthd(k, g_cum, beta, chunk_size, use_gate=False)
+    g = g_cum
+    if batch > 1:
+        q, k, v, g, beta, inverse = (
+            tensor.reshape(1, batch * seq_len, *tensor.shape[2:])
+            for tensor in (q, k, v, g, beta, inverse)
+        )
+    initial_state, cu_seqlens, cp_seq_map, raw_cu_seqlens = _prefill_partitioned_initial_state_bthd(
+        k,
+        v,
+        inverse,
+        g,
+        beta,
+        chunk_size,
+        raw_sequence_lengths=None if batch == 1 else (seq_len,) * batch,
+        min_partition_chunks=min_partition_chunks,
+    )
+    o, states, final_state = fused_gdr_fwd(
+        q,
+        k,
+        v,
+        inverse,
+        g,
+        beta,
+        scale=1.0,
+        initial_state=initial_state,
+        output_h=output_states,
+        cu_seqlens=cu_seqlens,
+        cp_seq_map=cp_seq_map,
+        raw_cu_seqlens=raw_cu_seqlens,
+        chunk_size=chunk_size,
+        state_head_first=output_states,
+        chunks_per_sequence=seq_len // chunk_size if output_states else 0,
+    )
+    return o.reshape(batch, seq_len, head, v.shape[-1]), states, final_state, g_cum
+
+
 @functools.lru_cache(maxsize=32)
 def _prefill_recompute_w_u_from_A_bthd_tl(
     batch: int,
@@ -1524,11 +1577,10 @@ def _gated_deltanet_prefill_wrapped_kernel(
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     layout = _normalize_prefill_layout(layout)
     if layout == "bthd":
-        g_cum = _prefill_chunk_local_cumsum_bthd_tl(batch, head, seq_len, chunk_size, dtype)(g)
         use_blocksolve_prepare = (
             chunk_size == 64 and dim_k == 128 and dim_v == 128 and dtype in ("float16", "bfloat16")
         )
-        use_partitioned_prefill = (
+        use_production_pipeline = (
             os.environ.get(
                 "TILEOPS_GDN_PREFILL_PARTITIONED",
                 os.environ.get("TILEOPS_GDN_PREFILL_CP_SPLIT", "1"),
@@ -1537,38 +1589,18 @@ def _gated_deltanet_prefill_wrapped_kernel(
             and batch == 1
             and use_blocksolve_prepare
         )
-        if use_partitioned_prefill:
-            from tileops.kernels.gated_deltanet.gdn_prefill import fused_gdr_fwd
-
-            A = _prefill_blocksolve_A_bthd(k, g_cum, beta, chunk_size, use_gate=False)
-            initial_state, cu_seqlens, cp_seq_map, raw_cu_seqlens = (
-                _prefill_partitioned_initial_state_bthd(
-                    k=k,
-                    v=v,
-                    A=A,
-                    g=g_cum,
-                    beta=beta,
-                    chunk_size=chunk_size,
-                )
-            )
-            o, _h, final_state = fused_gdr_fwd(
-                q=q,
-                k=k,
-                v=v,
-                a=A,
-                g=g_cum,
-                b=beta,
-                scale=1.0,
-                initial_state=initial_state,
-                output_final_state=True,
-                output_h=False,
-                output_o=True,
-                cu_seqlens=cu_seqlens,
-                cp_seq_map=cp_seq_map,
-                raw_cu_seqlens=raw_cu_seqlens,
+        if use_production_pipeline:
+            o, _states, final_state, _g_cum = _gated_deltanet_production_bthd(
+                q,
+                k,
+                v,
+                g,
+                beta,
+                chunk_size,
             )
             return o, final_state.to(q.dtype)
 
+        g_cum = _prefill_chunk_local_cumsum_bthd_tl(batch, head, seq_len, chunk_size, dtype)(g)
         o_fn = _prefill_output_o_bthd_tl(batch, head, seq_len, chunk_size, dim_k, dim_v, dtype)(
             o_threads
         )

--- a/src/tileops/kernels/gated_deltanet/gated_deltanet_prefill.py
+++ b/src/tileops/kernels/gated_deltanet/gated_deltanet_prefill.py
@@ -36,11 +36,55 @@ def _normalize_prefill_layout(layout: str) -> str:
 
 
 @functools.lru_cache(maxsize=32)
-def _prefill_single_batch_cu_seqlens(
-    num_tokens: int,
-    device_idx: int,
-) -> torch.Tensor:
-    return torch.tensor([0, num_tokens], dtype=torch.int32, device=f"cuda:{device_idx}")
+def _prefill_partition_metadata(
+    raw_sequence_lengths: tuple[int, ...],
+    num_heads: int,
+    chunk_size: int,
+    max_local_chunks: int,
+    use_partition: bool,
+    device_idx: int | None,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor | None,
+    torch.Tensor | None,
+    torch.Tensor | None,
+    torch.Tensor | None,
+]:
+    """Build shape-only partition metadata once per static workload."""
+    device = "cuda" if device_idx is None else f"cuda:{device_idx}"
+    raw_offsets = [0]
+    for length in raw_sequence_lengths:
+        raw_offsets.append(raw_offsets[-1] + length)
+    raw_cu_seqlens = torch.tensor(
+        raw_offsets, dtype=torch.int32, device=device, requires_grad=False
+    )
+    if not use_partition:
+        return raw_cu_seqlens, None, None, None, None
+
+    cp_cu_seqlens = []
+    ht_mask = []
+    seq_map_c2r = []
+    seq_map_r2c = [0]
+    split_tokens = max_local_chunks * chunk_size
+    for raw_idx, (raw_start, raw_end) in enumerate(
+        zip(raw_offsets, raw_offsets[1:], strict=False)
+    ):
+        start = raw_start
+        while start < raw_end:
+            cp_cu_seqlens.append(start)
+            ht_mask.append(False)
+            seq_map_c2r.append(raw_idx)
+            start += split_tokens
+        ht_mask[-1] = True
+        seq_map_r2c.append(len(cp_cu_seqlens))
+    cp_cu_seqlens.append(raw_offsets[-1])
+    return (
+        raw_cu_seqlens,
+        torch.tensor(cp_cu_seqlens, dtype=torch.int32, device=device),
+        torch.tensor(seq_map_c2r, dtype=torch.int32, device=device),
+        torch.tensor(seq_map_r2c, dtype=torch.int32, device=device),
+        torch.tensor(ht_mask, dtype=torch.bool, device=device),
+    )
 
 
 def _prefill_auto_cp_local_chunks(num_chunks: int, num_heads: int) -> int:
@@ -52,9 +96,7 @@ def _prefill_auto_cp_local_chunks(num_chunks: int, num_heads: int) -> int:
         max_local_chunks = int(env_max_local_chunks)
     else:
         sm_count = torch.cuda.get_device_properties().multi_processor_count
-        max_local_chunks = 2 ** round(
-            math.log2(math.sqrt(num_heads * num_chunks / sm_count) * 3)
-        )
+        max_local_chunks = 2 ** round(math.log2(math.sqrt(num_heads * num_chunks / sm_count) * 3))
         if num_heads >= 64 and num_chunks >= 512:
             max_local_chunks = max(max_local_chunks, 256)
     return max(max_local_chunks, 4)
@@ -67,6 +109,8 @@ def _prefill_partitioned_initial_state_bthd(
     g: torch.Tensor,
     beta: torch.Tensor,
     chunk_size: int,
+    raw_sequence_lengths: tuple[int, ...] | None = None,
+    min_partition_chunks: int = 0,
 ) -> tuple[torch.Tensor | None, torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
     from tileops.kernels.gated_deltanet.gdn_prefill import (
         correct_initial_states,
@@ -76,7 +120,12 @@ def _prefill_partitioned_initial_state_bthd(
 
     batch, num_tokens, num_heads, _ = k.shape
     assert batch == 1
-    raw_cu_seqlens = _prefill_single_batch_cu_seqlens(num_tokens, k.device.index)
+    if raw_sequence_lengths is None:
+        raw_sequence_lengths = (num_tokens,)
+    if any(length <= 0 or length % chunk_size != 0 for length in raw_sequence_lengths):
+        raise ValueError("raw sequence lengths must be positive multiples of chunk_size")
+    if sum(raw_sequence_lengths) != num_tokens:
+        raise ValueError("raw sequence lengths must sum to the flattened token count")
     num_chunks = tilelang.cdiv(num_tokens, chunk_size)
     max_local_chunks = _prefill_auto_cp_local_chunks(num_chunks, num_heads)
 
@@ -88,37 +137,34 @@ def _prefill_partitioned_initial_state_bthd(
         )
         == "1"
     )
-    use_partition = has_partition and (
-        force_partition or num_heads <= 40 or (num_heads <= 64 and num_chunks >= 128)
+    partition_large_enough = (
+        force_partition or max(raw_sequence_lengths) // chunk_size >= min_partition_chunks
+    )
+    use_partition = (
+        has_partition
+        and partition_large_enough
+        and (force_partition or num_heads <= 40 or (num_heads <= 64 and num_chunks >= 128))
+    )
+    (
+        raw_cu_seqlens,
+        cp_cu_seqlens_t,
+        seq_map_c2r_t,
+        seq_map_r2c_t,
+        ht_mask_t,
+    ) = _prefill_partition_metadata(
+        raw_sequence_lengths,
+        num_heads,
+        chunk_size,
+        max_local_chunks,
+        use_partition,
+        k.device.index,
     )
     if not use_partition:
-        return None, raw_cu_seqlens, None, None
-
-    cp_cu_seqlens = []
-    ht_mask = []
-    seq_map_c2r = []
-    seq_map_r2c = [0]
-    split_tokens = max_local_chunks * chunk_size
-    start = 0
-    while start < num_tokens:
-        cp_cu_seqlens.append(start)
-        ht_mask.append(False)
-        seq_map_c2r.append(0)
-        start += split_tokens
-    ht_mask[-1] = True
-    seq_map_r2c.append(len(cp_cu_seqlens))
-    cp_cu_seqlens.append(num_tokens)
-
-    cp_cu_seqlens_t = torch.tensor(
-        cp_cu_seqlens, dtype=torch.int32, device=k.device, requires_grad=False
-    )
-    seq_map_c2r_t = torch.tensor(seq_map_c2r, dtype=torch.int32, device=k.device)
-    seq_map_r2c_t = torch.tensor(
-        seq_map_r2c, dtype=torch.int32, device=k.device, requires_grad=False
-    )
-    ht_mask_t = torch.tensor(
-        ht_mask, dtype=torch.bool, device=k.device, requires_grad=False
-    )
+        return None, raw_cu_seqlens, None, raw_cu_seqlens
+    assert cp_cu_seqlens_t is not None
+    assert seq_map_c2r_t is not None
+    assert seq_map_r2c_t is not None
+    assert ht_mask_t is not None
 
     num_warmup_chunks, fallback_mask = get_warmup_chunks(
         g=g,
@@ -269,9 +315,7 @@ def _prefill_prepare_w_u_bhtd_tl(
                 for i, j in T.Parallel(block_C, block_C):
                     P_shared[i, j] = T.if_then_else(
                         i > j,
-                        -gram_frag[i, j]
-                        * g_pos_shared[i]
-                        * g_neg_shared[j],
+                        -gram_frag[i, j] * g_pos_shared[i] * g_neg_shared[j],
                         T.float32(0.0),
                     )
                 T.clear(S_shared)
@@ -296,9 +340,7 @@ def _prefill_prepare_w_u_bhtd_tl(
                 )
 
                 for i, j in T.Parallel(block_C, dim_v):
-                    v_beta_shared[i, j] = (
-                        v[bid, hid, by * block_C + i, j] * beta_shared[i]
-                    )
+                    v_beta_shared[i, j] = v[bid, hid, by * block_C + i, j] * beta_shared[i]
                 T.clear(u_frag)
                 T.gemm(S_shared, v_beta_shared, u_frag)
                 T.copy(
@@ -343,9 +385,7 @@ def _prefill_chunk_local_cumsum_bthd_tl(
                     acc_s[hid] = T.float32(0.0)
                 for i in T.Serial(chunk_size):
                     for hid in T.Parallel(head):
-                        acc_s[hid] = acc_s[hid] + T.cast(
-                            g[bid, base + i, hid], "float32"
-                        )
+                        acc_s[hid] = acc_s[hid] + T.cast(g[bid, base + i, hid], "float32")
                         out[bid, base + i, hid] = T.cast(acc_s[hid], dtype)
 
         return chunk_cumsum_bthd_kernel
@@ -361,9 +401,10 @@ def _prefill_blocksolve_A_bthd_tl(
     chunk_size: int,
     dim_k: int,
     dtype: str,
+    use_gate: bool = True,
 ):
-    if chunk_size != 64 or dim_k != 128:
-        raise ValueError("TileLang blocksolve-A currently expects chunk64 and K=128")
+    if chunk_size != 64 or dim_k not in (64, 128):
+        raise ValueError("TileLang blocksolve-A currently expects chunk64 and K in {64, 128}")
 
     block_t = 64
     block_c = 16
@@ -419,17 +460,20 @@ def _prefill_blocksolve_A_bthd_tl(
                 G33 = T.alloc_fragment([block_c, block_c], accum_dtype)
                 tmp = T.alloc_fragment([block_c, block_c], accum_dtype)
 
-                T.annotate_layout({
-                    k0: tilelang.layout.make_swizzled_layout(k0),
-                    k1: tilelang.layout.make_swizzled_layout(k1),
-                    k2: tilelang.layout.make_swizzled_layout(k2),
-                    k3: tilelang.layout.make_swizzled_layout(k3),
-                    a_s: tilelang.layout.make_swizzled_layout(a_s),
-                    i_s: tilelang.layout.make_swizzled_layout(i_s),
-                    work_s: tilelang.layout.make_swizzled_layout(work_s),
-                })
+                T.annotate_layout(
+                    {
+                        k0: tilelang.layout.make_swizzled_layout(k0),
+                        k1: tilelang.layout.make_swizzled_layout(k1),
+                        k2: tilelang.layout.make_swizzled_layout(k2),
+                        k3: tilelang.layout.make_swizzled_layout(k3),
+                        a_s: tilelang.layout.make_swizzled_layout(a_s),
+                        i_s: tilelang.layout.make_swizzled_layout(i_s),
+                        work_s: tilelang.layout.make_swizzled_layout(work_s),
+                    }
+                )
 
-                T.copy(g[bid, base : base + block_t, hid], g_s, disable_tma=True)
+                if use_gate:
+                    T.copy(g[bid, base : base + block_t, hid], g_s, disable_tma=True)
                 T.copy(
                     beta[bid, base : base + block_t, hid],
                     beta_s,
@@ -495,18 +539,39 @@ def _prefill_blocksolve_A_bthd_tl(
                     T.gemm(k3, k3, G33, transpose_B=True)
 
                 for t in T.Parallel(block_t):
-                    g_val = T.cast(g_s[t], accum_dtype)
+                    g_val = T.cast(g_s[t], accum_dtype) if use_gate else T.float32(0.0)
                     gate0_s[t] = T.exp2(
-                        (g_val - T.cast(g_s[0], accum_dtype)) * _LOG2E
+                        (g_val - (T.cast(g_s[0], accum_dtype) if use_gate else T.float32(0.0)))
+                        * _LOG2E
                     )
                     gate1_s[t] = T.exp2(
-                        (g_val - T.cast(g_s[block_c], accum_dtype)) * _LOG2E
+                        (
+                            g_val
+                            - (T.cast(g_s[block_c], accum_dtype) if use_gate else T.float32(0.0))
+                        )
+                        * _LOG2E
                     )
                     gate2_s[t] = T.exp2(
-                        (g_val - T.cast(g_s[2 * block_c], accum_dtype)) * _LOG2E
+                        (
+                            g_val
+                            - (
+                                T.cast(g_s[2 * block_c], accum_dtype)
+                                if use_gate
+                                else T.float32(0.0)
+                            )
+                        )
+                        * _LOG2E
                     )
                     gate3_s[t] = T.exp2(
-                        (g_val - T.cast(g_s[3 * block_c], accum_dtype)) * _LOG2E
+                        (
+                            g_val
+                            - (
+                                T.cast(g_s[3 * block_c], accum_dtype)
+                                if use_gate
+                                else T.float32(0.0)
+                            )
+                        )
+                        * _LOG2E
                     )
                     beta_f_s[t] = beta_s[t]
                 T.sync_threads()
@@ -711,15 +776,27 @@ def _prefill_blocksolve_A_bthd_tl(
 
                 for i, j in T.Parallel(block_c, block_c):
                     A[bid, base + i, hid, j] = T.cast(i_s[0, i, j], dtype)
+                    A[bid, base + i, hid, block_c + j] = T.cast(0, dtype)
+                    A[bid, base + i, hid, 2 * block_c + j] = T.cast(0, dtype)
+                    A[bid, base + i, hid, 3 * block_c + j] = T.cast(0, dtype)
                     A[bid, base + block_c + i, hid, j] = T.cast(a_s[1, i, j], dtype)
                     A[bid, base + block_c + i, hid, block_c + j] = T.cast(i_s[1, i, j], dtype)
+                    A[bid, base + block_c + i, hid, 2 * block_c + j] = T.cast(0, dtype)
+                    A[bid, base + block_c + i, hid, 3 * block_c + j] = T.cast(0, dtype)
                     A[bid, base + 2 * block_c + i, hid, j] = T.cast(a_s[3, i, j], dtype)
                     A[bid, base + 2 * block_c + i, hid, block_c + j] = T.cast(a_s[4, i, j], dtype)
-                    A[bid, base + 2 * block_c + i, hid, 2 * block_c + j] = T.cast(i_s[2, i, j], dtype)
+                    A[bid, base + 2 * block_c + i, hid, 2 * block_c + j] = T.cast(
+                        i_s[2, i, j], dtype
+                    )
+                    A[bid, base + 2 * block_c + i, hid, 3 * block_c + j] = T.cast(0, dtype)
                     A[bid, base + 3 * block_c + i, hid, j] = T.cast(a_s[6, i, j], dtype)
                     A[bid, base + 3 * block_c + i, hid, block_c + j] = T.cast(a_s[7, i, j], dtype)
-                    A[bid, base + 3 * block_c + i, hid, 2 * block_c + j] = T.cast(a_s[8, i, j], dtype)
-                    A[bid, base + 3 * block_c + i, hid, 3 * block_c + j] = T.cast(i_s[3, i, j], dtype)
+                    A[bid, base + 3 * block_c + i, hid, 2 * block_c + j] = T.cast(
+                        a_s[8, i, j], dtype
+                    )
+                    A[bid, base + 3 * block_c + i, hid, 3 * block_c + j] = T.cast(
+                        i_s[3, i, j], dtype
+                    )
 
         return prefill_blocksolve_A_bthd_tl
 
@@ -731,9 +808,10 @@ def _prefill_blocksolve_A_bthd(
     g: torch.Tensor,
     beta: torch.Tensor,
     chunk_size: int,
+    use_gate: bool = True,
 ) -> torch.Tensor:
     batch, seq_len, head, dim_k = k.shape
-    A = torch.zeros(batch, seq_len, head, chunk_size, dtype=k.dtype, device=k.device)
+    A = torch.empty(batch, seq_len, head, chunk_size, dtype=k.dtype, device=k.device)
     kernel = _prefill_blocksolve_A_bthd_tl(
         batch,
         head,
@@ -741,9 +819,11 @@ def _prefill_blocksolve_A_bthd(
         chunk_size,
         dim_k,
         str(k.dtype).split(".")[-1],
+        use_gate,
     )
     kernel(k, g, beta, A)
     return A
+
 
 @functools.lru_cache(maxsize=32)
 def _prefill_recompute_w_u_from_A_bthd_tl(
@@ -790,11 +870,13 @@ def _prefill_recompute_w_u_from_A_bthd_tl(
                 out_s = T.alloc_shared([block_c, block_d], dtype)
                 out_frag = T.alloc_fragment([block_c, block_d], accum_dtype)
 
-                T.annotate_layout({
-                    A_s: tilelang.layout.make_swizzled_layout(A_s),
-                    x_s: tilelang.layout.make_swizzled_layout(x_s),
-                    out_s: tilelang.layout.make_swizzled_layout(out_s),
-                })
+                T.annotate_layout(
+                    {
+                        A_s: tilelang.layout.make_swizzled_layout(A_s),
+                        x_s: tilelang.layout.make_swizzled_layout(x_s),
+                        out_s: tilelang.layout.make_swizzled_layout(out_s),
+                    }
+                )
 
                 T.async_copy(A[bid, base : base + block_c, hid, 0:block_c], A_s)
                 T.ptx_wait_group(0)
@@ -937,9 +1019,7 @@ def _prefill_prepare_w_u_bthd_tl(
                 for i, j in T.Parallel(block_C, block_C):
                     P_shared[i, j] = T.if_then_else(
                         i > j,
-                        -gram_frag[i, j]
-                        * g_pos_shared[i]
-                        * g_neg_shared[j],
+                        -gram_frag[i, j] * g_pos_shared[i] * g_neg_shared[j],
                         T.float32(0.0),
                     )
                 T.clear(S_shared)
@@ -961,9 +1041,7 @@ def _prefill_prepare_w_u_bthd_tl(
                     w[bid, base + i, hid, d] = w_frag[i, d]
 
                 for i, d in T.Parallel(block_C, dim_v):
-                    v_beta_shared[i, d] = (
-                        v[bid, base + i, hid, d] * beta_shared[i]
-                    )
+                    v_beta_shared[i, d] = v[bid, base + i, hid, d] * beta_shared[i]
                 T.clear(u_frag)
                 T.gemm(S_shared, v_beta_shared, u_frag)
                 for i, d in T.Parallel(block_C, dim_v):
@@ -1051,13 +1129,9 @@ def _prefill_h_recurrence_bthd_tl(
                         v_new[bid, base + i, hid, v_offset + j] = v_new_c[i, j]
 
                     for n, j in T.Parallel(block_C, BV):
-                        v_new_c[n, j] = v_new_c[n, j] * T.exp2(
-                            (g_c[block_C - 1] - g_c[n]) * _LOG2E
-                        )
+                        v_new_c[n, j] = v_new_c[n, j] * T.exp2((g_c[block_C - 1] - g_c[n]) * _LOG2E)
                     for i, j in T.Parallel(dim_k, BV):
-                        h_next_frag[i, j] = h_c[i, j] * T.exp2(
-                            g_c[block_C - 1] * _LOG2E
-                        )
+                        h_next_frag[i, j] = h_c[i, j] * T.exp2(g_c[block_C - 1] * _LOG2E)
                     T.gemm(
                         k_c,
                         v_new_c,
@@ -1239,13 +1313,9 @@ def _prefill_group_transition_summary_bthd_tl(
                         )
 
                     for n, j in T.Parallel(block_C, BV):
-                        v_new_c[n, j] = v_new_c[n, j] * T.exp2(
-                            (g_c[block_C - 1] - g_c[n]) * _LOG2E
-                        )
+                        v_new_c[n, j] = v_new_c[n, j] * T.exp2((g_c[block_C - 1] - g_c[n]) * _LOG2E)
                     for i, j in T.Parallel(dim_k, BV):
-                        h_next_frag[i, j] = h_c[i, j] * T.exp2(
-                            g_c[block_C - 1] * _LOG2E
-                        )
+                        h_next_frag[i, j] = h_c[i, j] * T.exp2(g_c[block_C - 1] * _LOG2E)
                     T.gemm(
                         k_c,
                         v_new_c,
@@ -1411,13 +1481,9 @@ def _prefill_grouped_replay_bthd_tl(
                         v_new[bid, base + i, hid, v_offset + j] = v_new_c[i, j]
 
                     for n, j in T.Parallel(block_C, BV):
-                        v_new_c[n, j] = v_new_c[n, j] * T.exp2(
-                            (g_c[block_C - 1] - g_c[n]) * _LOG2E
-                        )
+                        v_new_c[n, j] = v_new_c[n, j] * T.exp2((g_c[block_C - 1] - g_c[n]) * _LOG2E)
                     for i, j in T.Parallel(dim_k, BV):
-                        h_next_frag[i, j] = h_c[i, j] * T.exp2(
-                            g_c[block_C - 1] * _LOG2E
-                        )
+                        h_next_frag[i, j] = h_c[i, j] * T.exp2(g_c[block_C - 1] * _LOG2E)
                     T.gemm(
                         k_c,
                         v_new_c,
@@ -1458,14 +1524,9 @@ def _gated_deltanet_prefill_wrapped_kernel(
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     layout = _normalize_prefill_layout(layout)
     if layout == "bthd":
-        g_cum = _prefill_chunk_local_cumsum_bthd_tl(
-            batch, head, seq_len, chunk_size, dtype
-        )(g)
+        g_cum = _prefill_chunk_local_cumsum_bthd_tl(batch, head, seq_len, chunk_size, dtype)(g)
         use_blocksolve_prepare = (
-            chunk_size == 64
-            and dim_k == 128
-            and dim_v == 128
-            and dtype in ("float16", "bfloat16")
+            chunk_size == 64 and dim_k == 128 and dim_v == 128 and dtype in ("float16", "bfloat16")
         )
         use_partitioned_prefill = (
             os.environ.get(
@@ -1479,8 +1540,7 @@ def _gated_deltanet_prefill_wrapped_kernel(
         if use_partitioned_prefill:
             from tileops.kernels.gated_deltanet.gdn_prefill import fused_gdr_fwd
 
-            g_zero = torch.zeros_like(g_cum)
-            A = _prefill_blocksolve_A_bthd(k, g_zero, beta, chunk_size)
+            A = _prefill_blocksolve_A_bthd(k, g_cum, beta, chunk_size, use_gate=False)
             initial_state, cu_seqlens, cp_seq_map, raw_cu_seqlens = (
                 _prefill_partitioned_initial_state_bthd(
                     k=k,
@@ -1509,9 +1569,9 @@ def _gated_deltanet_prefill_wrapped_kernel(
             )
             return o, final_state.to(q.dtype)
 
-        o_fn = _prefill_output_o_bthd_tl(
-            batch, head, seq_len, chunk_size, dim_k, dim_v, dtype
-        )(o_threads)
+        o_fn = _prefill_output_o_bthd_tl(batch, head, seq_len, chunk_size, dim_k, dim_v, dtype)(
+            o_threads
+        )
         if use_blocksolve_prepare:
             A = _prefill_blocksolve_A_bthd(k, g_cum, beta, chunk_size)
             recompute_fn = _prefill_recompute_w_u_from_A_bthd_tl(
@@ -1590,9 +1650,7 @@ def _gated_deltanet_prefill_wrapped_kernel(
         return o, final_state
 
     if chunk_size == 64 and batch * head > 64:
-        g_cum = _prefill_chunk_local_cumsum_bhtd_tl(
-            batch, head, seq_len, chunk_size, dtype
-        )(g)
+        g_cum = _prefill_chunk_local_cumsum_bhtd_tl(batch, head, seq_len, chunk_size, dtype)(g)
     else:
         g_cum = _chunk_local_cumsum(g.float(), chunk_size).to(g.dtype)
     prepare_fn = _prefill_prepare_w_u_bhtd_tl(
@@ -1608,9 +1666,7 @@ def _gated_deltanet_prefill_wrapped_kernel(
         dtype,
         block_v=h_block_v,
     )(h_num_stages, h_threads)
-    o_fn = _output_o_tl(batch, head, seq_len, chunk_size, dim_k, dim_v, dtype)(
-        o_threads
-    )
+    o_fn = _output_o_tl(batch, head, seq_len, chunk_size, dim_k, dim_v, dtype)(o_threads)
     S_0 = torch.zeros(batch, head, dim_k, dim_v, dtype=q.dtype, device=q.device)
     w, u = prepare_fn(k, v, g_cum, beta)
     states, v_new = h_fn(k, g_cum, w, u, S_0)

--- a/src/tileops/kernels/gated_deltanet/gated_deltanet_prefill.py
+++ b/src/tileops/kernels/gated_deltanet/gated_deltanet_prefill.py
@@ -94,7 +94,9 @@ def _prefill_auto_cp_local_chunks(num_chunks: int, num_heads: int) -> int:
         max_local_chunks = int(env_max_local_chunks)
     else:
         sm_count = torch.cuda.get_device_properties().multi_processor_count
-        max_local_chunks = 2 ** round(math.log2(math.sqrt(num_heads * num_chunks / sm_count) * 3))
+        max_local_chunks = 2 ** round(
+            math.log2(math.sqrt(num_heads * num_chunks / sm_count) * 3)
+        )
         if num_heads >= 64 and num_chunks >= 512:
             max_local_chunks = max(max_local_chunks, 256)
     return max(max_local_chunks, 4)
@@ -313,7 +315,9 @@ def _prefill_prepare_w_u_bhtd_tl(
                 for i, j in T.Parallel(block_C, block_C):
                     P_shared[i, j] = T.if_then_else(
                         i > j,
-                        -gram_frag[i, j] * g_pos_shared[i] * g_neg_shared[j],
+                        -gram_frag[i, j]
+                        * g_pos_shared[i]
+                        * g_neg_shared[j],
                         T.float32(0.0),
                     )
                 T.clear(S_shared)
@@ -338,7 +342,9 @@ def _prefill_prepare_w_u_bhtd_tl(
                 )
 
                 for i, j in T.Parallel(block_C, dim_v):
-                    v_beta_shared[i, j] = v[bid, hid, by * block_C + i, j] * beta_shared[i]
+                    v_beta_shared[i, j] = (
+                        v[bid, hid, by * block_C + i, j] * beta_shared[i]
+                    )
                 T.clear(u_frag)
                 T.gemm(S_shared, v_beta_shared, u_frag)
                 T.copy(
@@ -383,7 +389,9 @@ def _prefill_chunk_local_cumsum_bthd_tl(
                     acc_s[hid] = T.float32(0.0)
                 for i in T.Serial(chunk_size):
                     for hid in T.Parallel(head):
-                        acc_s[hid] = acc_s[hid] + T.cast(g[bid, base + i, hid], "float32")
+                        acc_s[hid] = acc_s[hid] + T.cast(
+                            g[bid, base + i, hid], "float32"
+                        )
                         out[bid, base + i, hid] = T.cast(acc_s[hid], dtype)
 
         return chunk_cumsum_bthd_kernel
@@ -923,13 +931,11 @@ def _prefill_recompute_w_u_from_A_bthd_tl(
                 out_s = T.alloc_shared([block_c, block_d], dtype)
                 out_frag = T.alloc_fragment([block_c, block_d], accum_dtype)
 
-                T.annotate_layout(
-                    {
-                        A_s: tilelang.layout.make_swizzled_layout(A_s),
-                        x_s: tilelang.layout.make_swizzled_layout(x_s),
-                        out_s: tilelang.layout.make_swizzled_layout(out_s),
-                    }
-                )
+                T.annotate_layout({
+                    A_s: tilelang.layout.make_swizzled_layout(A_s),
+                    x_s: tilelang.layout.make_swizzled_layout(x_s),
+                    out_s: tilelang.layout.make_swizzled_layout(out_s),
+                })
 
                 T.async_copy(A[bid, base : base + block_c, hid, 0:block_c], A_s)
                 T.ptx_wait_group(0)
@@ -1072,7 +1078,9 @@ def _prefill_prepare_w_u_bthd_tl(
                 for i, j in T.Parallel(block_C, block_C):
                     P_shared[i, j] = T.if_then_else(
                         i > j,
-                        -gram_frag[i, j] * g_pos_shared[i] * g_neg_shared[j],
+                        -gram_frag[i, j]
+                        * g_pos_shared[i]
+                        * g_neg_shared[j],
                         T.float32(0.0),
                     )
                 T.clear(S_shared)
@@ -1094,7 +1102,9 @@ def _prefill_prepare_w_u_bthd_tl(
                     w[bid, base + i, hid, d] = w_frag[i, d]
 
                 for i, d in T.Parallel(block_C, dim_v):
-                    v_beta_shared[i, d] = v[bid, base + i, hid, d] * beta_shared[i]
+                    v_beta_shared[i, d] = (
+                        v[bid, base + i, hid, d] * beta_shared[i]
+                    )
                 T.clear(u_frag)
                 T.gemm(S_shared, v_beta_shared, u_frag)
                 for i, d in T.Parallel(block_C, dim_v):
@@ -1182,9 +1192,13 @@ def _prefill_h_recurrence_bthd_tl(
                         v_new[bid, base + i, hid, v_offset + j] = v_new_c[i, j]
 
                     for n, j in T.Parallel(block_C, BV):
-                        v_new_c[n, j] = v_new_c[n, j] * T.exp2((g_c[block_C - 1] - g_c[n]) * _LOG2E)
+                        v_new_c[n, j] = v_new_c[n, j] * T.exp2(
+                            (g_c[block_C - 1] - g_c[n]) * _LOG2E
+                        )
                     for i, j in T.Parallel(dim_k, BV):
-                        h_next_frag[i, j] = h_c[i, j] * T.exp2(g_c[block_C - 1] * _LOG2E)
+                        h_next_frag[i, j] = h_c[i, j] * T.exp2(
+                            g_c[block_C - 1] * _LOG2E
+                        )
                     T.gemm(
                         k_c,
                         v_new_c,
@@ -1366,9 +1380,13 @@ def _prefill_group_transition_summary_bthd_tl(
                         )
 
                     for n, j in T.Parallel(block_C, BV):
-                        v_new_c[n, j] = v_new_c[n, j] * T.exp2((g_c[block_C - 1] - g_c[n]) * _LOG2E)
+                        v_new_c[n, j] = v_new_c[n, j] * T.exp2(
+                            (g_c[block_C - 1] - g_c[n]) * _LOG2E
+                        )
                     for i, j in T.Parallel(dim_k, BV):
-                        h_next_frag[i, j] = h_c[i, j] * T.exp2(g_c[block_C - 1] * _LOG2E)
+                        h_next_frag[i, j] = h_c[i, j] * T.exp2(
+                            g_c[block_C - 1] * _LOG2E
+                        )
                     T.gemm(
                         k_c,
                         v_new_c,
@@ -1534,9 +1552,13 @@ def _prefill_grouped_replay_bthd_tl(
                         v_new[bid, base + i, hid, v_offset + j] = v_new_c[i, j]
 
                     for n, j in T.Parallel(block_C, BV):
-                        v_new_c[n, j] = v_new_c[n, j] * T.exp2((g_c[block_C - 1] - g_c[n]) * _LOG2E)
+                        v_new_c[n, j] = v_new_c[n, j] * T.exp2(
+                            (g_c[block_C - 1] - g_c[n]) * _LOG2E
+                        )
                     for i, j in T.Parallel(dim_k, BV):
-                        h_next_frag[i, j] = h_c[i, j] * T.exp2(g_c[block_C - 1] * _LOG2E)
+                        h_next_frag[i, j] = h_c[i, j] * T.exp2(
+                            g_c[block_C - 1] * _LOG2E
+                        )
                     T.gemm(
                         k_c,
                         v_new_c,

--- a/src/tileops/kernels/gated_deltanet/gdn_prefill/cp_fwd.py
+++ b/src/tileops/kernels/gated_deltanet/gdn_prefill/cp_fwd.py
@@ -8,7 +8,7 @@ import torch
 
 
 @tilelang.jit()
-def tilelang_get_warmup_chunks(
+def _build_warmup_chunks_kernel(
     num_heads,
     chunk_size,
     threshold,
@@ -22,7 +22,7 @@ def tilelang_get_warmup_chunks(
     num_threads = tilelang.cdiv(num_heads, 32) * 32
 
     @T.prim_func
-    def tilelang_get_warmup_chunks_kernel(
+    def warmup_chunks_kernel(
         g: T.Tensor([1, num_tokens, num_heads], dtype=g_dtype),
         ht_mask: T.Tensor([batch_size], dtype=mask_dtype),
         cu_seqlens: T.Tensor([batch_size + 1], dtype=seqlen_dtype),
@@ -64,7 +64,7 @@ def tilelang_get_warmup_chunks(
                 for i_h in T.Parallel(num_heads):
                     fallback_mask[bb, i_h] = f_fragment[i_h]
 
-    return tilelang_get_warmup_chunks_kernel
+    return warmup_chunks_kernel
 
 
 def get_warmup_chunks(
@@ -80,7 +80,7 @@ def get_warmup_chunks(
     assert batch_size == 1
     assert chunk_size == 64
 
-    tilelang_get_warmup_chunks_kernel = tilelang_get_warmup_chunks(
+    warmup_chunks_kernel = _build_warmup_chunks_kernel(
         num_heads=num_heads,
         chunk_size=chunk_size,
         threshold=threshold,
@@ -95,13 +95,15 @@ def get_warmup_chunks(
     fallback_mask = torch.empty(
         [real_batch_size, num_heads], dtype=ht_mask.dtype, device=cu_seqlens.device
     )
-    tilelang_get_warmup_chunks_kernel(g, ht_mask, cu_seqlens, num_warmup_chunks, fallback_mask)
+    warmup_chunks_kernel(
+        g, ht_mask, cu_seqlens, num_warmup_chunks, fallback_mask
+    )
 
     return num_warmup_chunks, fallback_mask
 
 
 @tilelang.jit()
-def tilelang_correct_h0(
+def _build_correct_h0_kernel(
     H,
     DK,
     DV,
@@ -144,7 +146,9 @@ def tilelang_correct_h0(
             if fallback_mask[seq_start_idx + i_s, bh]:
                 T.copy(h_fragment, hd_shared)
             T.copy(
-                ht_buffer[seq_start_idx + i_s, bh, 0:DK, bv * block_DV : (bv + 1) * block_DV],
+                ht_buffer[
+                    seq_start_idx + i_s, bh, 0:DK, bv * block_DV : (bv + 1) * block_DV
+                ],
                 h_shared,
             )
             T.copy(h_shared, h_fragment)
@@ -164,7 +168,7 @@ def tilelang_correct_h0(
     if use_raw_h0:
 
         @T.prim_func
-        def tilelang_correct_h0_kernel(
+        def correct_h0_kernel(
             raw_h0: T.Tensor([raw_batch_size, H, DK, DV], dtype=res_dtype),
             ht_buffer: T.Tensor([cp_batch_size, H, DK, DV], dtype=buffer_dtype),
             mt_buffer: T.Tensor([cp_batch_size, H, DK, DK], dtype=buffer_dtype),
@@ -172,7 +176,9 @@ def tilelang_correct_h0(
             seq_map_r2c: T.Tensor([raw_batch_size + 1], dtype=seqlen_dtype),
             cp_h0: T.Tensor([cp_batch_size, H, DK, DV], dtype=res_dtype),
         ):
-            with T.Kernel(T.ceildiv(DV, block_DV) * H * raw_batch_size, threads=128) as (bbhv,):
+            with T.Kernel(
+                T.ceildiv(DV, block_DV) * H * raw_batch_size, threads=128
+            ) as (bbhv,):
                 bbh, bv = (
                     bbhv // T.ceildiv(DV, block_DV),
                     bbhv % T.ceildiv(DV, block_DV),
@@ -207,14 +213,16 @@ def tilelang_correct_h0(
     else:
 
         @T.prim_func
-        def tilelang_correct_h0_kernel(
+        def correct_h0_kernel(
             ht_buffer: T.Tensor([cp_batch_size, H, DK, DV], dtype=buffer_dtype),
             mt_buffer: T.Tensor([cp_batch_size, H, DK, DK], dtype=buffer_dtype),
             fallback_mask: T.Tensor([cp_batch_size, H], dtype=mask_dtype),
             seq_map_r2c: T.Tensor([raw_batch_size + 1], dtype=seqlen_dtype),
             cp_h0: T.Tensor([cp_batch_size, H, DK, DV], dtype=res_dtype),
         ):
-            with T.Kernel(T.ceildiv(DV, block_DV) * H * raw_batch_size, threads=128) as (bbhv,):
+            with T.Kernel(
+                T.ceildiv(DV, block_DV) * H * raw_batch_size, threads=128
+            ) as (bbhv,):
                 bbh, bv = (
                     bbhv // T.ceildiv(DV, block_DV),
                     bbhv % T.ceildiv(DV, block_DV),
@@ -243,7 +251,7 @@ def tilelang_correct_h0(
                     h_fragment,
                 )
 
-    return tilelang_correct_h0_kernel
+    return correct_h0_kernel
 
 
 def correct_initial_states(
@@ -264,7 +272,7 @@ def correct_initial_states(
         res_dtype = raw_h0.dtype
         use_raw_h0 = True
 
-    tilelang_correct_h0_kernel = tilelang_correct_h0(
+    correct_h0_kernel = _build_correct_h0_kernel(
         H=num_heads,
         DK=k_head_dim,
         DV=v_head_dim,
@@ -281,7 +289,7 @@ def correct_initial_states(
         device=ht_buffer.device,
     )
     if use_raw_h0:
-        tilelang_correct_h0_kernel(
+        correct_h0_kernel(
             raw_h0,
             ht_buffer,
             mt_buffer,
@@ -290,7 +298,7 @@ def correct_initial_states(
             cp_h0,
         )
     else:
-        tilelang_correct_h0_kernel(
+        correct_h0_kernel(
             ht_buffer,
             mt_buffer,
             fallback_mask,

--- a/src/tileops/kernels/gated_deltanet/gdn_prefill/cp_fwd.py
+++ b/src/tileops/kernels/gated_deltanet/gdn_prefill/cp_fwd.py
@@ -95,9 +95,7 @@ def get_warmup_chunks(
     fallback_mask = torch.empty(
         [real_batch_size, num_heads], dtype=ht_mask.dtype, device=cu_seqlens.device
     )
-    tilelang_get_warmup_chunks_kernel(
-        g, ht_mask, cu_seqlens, num_warmup_chunks, fallback_mask
-    )
+    tilelang_get_warmup_chunks_kernel(g, ht_mask, cu_seqlens, num_warmup_chunks, fallback_mask)
 
     return num_warmup_chunks, fallback_mask
 
@@ -146,9 +144,7 @@ def tilelang_correct_h0(
             if fallback_mask[seq_start_idx + i_s, bh]:
                 T.copy(h_fragment, hd_shared)
             T.copy(
-                ht_buffer[
-                    seq_start_idx + i_s, bh, 0:DK, bv * block_DV : (bv + 1) * block_DV
-                ],
+                ht_buffer[seq_start_idx + i_s, bh, 0:DK, bv * block_DV : (bv + 1) * block_DV],
                 h_shared,
             )
             T.copy(h_shared, h_fragment)
@@ -176,9 +172,7 @@ def tilelang_correct_h0(
             seq_map_r2c: T.Tensor([raw_batch_size + 1], dtype=seqlen_dtype),
             cp_h0: T.Tensor([cp_batch_size, H, DK, DV], dtype=res_dtype),
         ):
-            with T.Kernel(
-                T.ceildiv(DV, block_DV) * H * raw_batch_size, threads=128
-            ) as (bbhv,):
+            with T.Kernel(T.ceildiv(DV, block_DV) * H * raw_batch_size, threads=128) as (bbhv,):
                 bbh, bv = (
                     bbhv // T.ceildiv(DV, block_DV),
                     bbhv % T.ceildiv(DV, block_DV),
@@ -220,9 +214,7 @@ def tilelang_correct_h0(
             seq_map_r2c: T.Tensor([raw_batch_size + 1], dtype=seqlen_dtype),
             cp_h0: T.Tensor([cp_batch_size, H, DK, DV], dtype=res_dtype),
         ):
-            with T.Kernel(
-                T.ceildiv(DV, block_DV) * H * raw_batch_size, threads=128
-            ) as (bbhv,):
+            with T.Kernel(T.ceildiv(DV, block_DV) * H * raw_batch_size, threads=128) as (bbhv,):
                 bbh, bv = (
                     bbhv // T.ceildiv(DV, block_DV),
                     bbhv % T.ceildiv(DV, block_DV),
@@ -254,41 +246,8 @@ def tilelang_correct_h0(
     return tilelang_correct_h0_kernel
 
 
-@tilelang.jit()
-def tilelang_zero_initial_cp_h0(
-    H,
-    DK,
-    DV,
-    res_dtype,
-    seqlen_dtype,
-    block_DV: int = 32,
-):
-    cp_batch_size = T.dynamic("cp_batch_size")
-    raw_batch_size = T.dynamic("raw_batch_size")
-
-    @T.prim_func
-    def tilelang_zero_initial_cp_h0_kernel(
-        seq_map_r2c: T.Tensor([raw_batch_size + 1], dtype=seqlen_dtype),
-        cp_h0: T.Tensor([cp_batch_size, H, DK, DV], dtype=res_dtype),
-    ):
-        with T.Kernel(
-            T.ceildiv(DV, block_DV) * H * raw_batch_size, threads=128
-        ) as (bbhv,):
-            bbh, bv = (
-                bbhv // T.ceildiv(DV, block_DV),
-                bbhv % T.ceildiv(DV, block_DV),
-            )
-            bb, bh = bbh // H, bbh % H
-            seq_start_idx = seq_map_r2c[bb]
-            for j_k, j_v in T.Parallel(DK, block_DV):
-                cp_h0[seq_start_idx, bh, j_k, bv * block_DV + j_v] = 0.0
-
-    return tilelang_zero_initial_cp_h0_kernel
-
-
 def correct_initial_states(
-    raw_h0: torch.Tensor
-    | None,  # [raw_batch_size, num_v_heads, k_head_dim, v_head_dim]
+    raw_h0: torch.Tensor | None,  # [raw_batch_size, num_v_heads, k_head_dim, v_head_dim]
     ht_buffer: torch.Tensor,  # [cp_batch_size, num_v_heads, k_head_dim, v_head_dim]
     mt_buffer: torch.Tensor,  # [cp_batch_size, num_v_heads, k_head_dim, k_head_dim]
     fallback_mask: torch.Tensor,  # [cp_batch_size, num_v_heads]
@@ -296,7 +255,7 @@ def correct_initial_states(
 ):
     cp_batch_size = fallback_mask.shape[0]
     _, num_heads, k_head_dim, v_head_dim = ht_buffer.shape
-    assert k_head_dim == v_head_dim == 128
+    assert k_head_dim == v_head_dim and k_head_dim in (64, 128)
 
     if raw_h0 is None:
         res_dtype = torch.float32
@@ -321,14 +280,6 @@ def correct_initial_states(
         dtype=res_dtype,
         device=ht_buffer.device,
     )
-    tilelang_zero_initial_cp_h0_kernel = tilelang_zero_initial_cp_h0(
-        H=num_heads,
-        DK=k_head_dim,
-        DV=v_head_dim,
-        res_dtype=res_dtype,
-        seqlen_dtype=seq_map_r2c.dtype,
-    )
-    tilelang_zero_initial_cp_h0_kernel(seq_map_r2c, cp_h0)
     if use_raw_h0:
         tilelang_correct_h0_kernel(
             raw_h0,

--- a/src/tileops/kernels/gated_deltanet/gdn_prefill/fused_fwd.py
+++ b/src/tileops/kernels/gated_deltanet/gdn_prefill/fused_fwd.py
@@ -45,6 +45,8 @@ def tilelang_fused_chunk_gdr_fwd(
     is_varlen,
     is_cp,
     block_DV=128,
+    state_head_first=False,
+    chunks_per_sequence=0,
 ):
     batch_size = T.dynamic("batch_size")
     num_tokens = T.dynamic("num_tokens")
@@ -70,6 +72,8 @@ def tilelang_fused_chunk_gdr_fwd(
         g_shape = (batch_size, num_tokens, H)
         b_shape = (batch_size, num_tokens, H)
         h_shape = (batch_size, num_chunks, H, DK, DV)
+    if state_head_first:
+        h_shape = (raw_batch_size, H, chunks_per_sequence + 1, DK, DV)
     h0_shape = (batch_size, H, DK, DV)
     ht_shape = (raw_batch_size, H, DK, DV)
 
@@ -111,11 +115,13 @@ def tilelang_fused_chunk_gdr_fwd(
             raw_seq_end_idx = T.alloc_var("int32")
             need_store_final_state = T.alloc_var("bool")
             raw_batch_idx = cp_seq_map[bb] if is_cp else bb
-            raw_seq_end_idx = (
-                raw_cu_seqlens[raw_batch_idx + 1] if is_cp else seq_end_idx
-            )
-            need_store_final_state = store_final_state & (
-                raw_seq_end_idx == seq_end_idx
+            raw_seq_end_idx = raw_cu_seqlens[raw_batch_idx + 1] if is_cp else seq_end_idx
+            need_store_final_state = store_final_state & (raw_seq_end_idx == seq_end_idx)
+            state_chunk_start_idx = T.alloc_var("int32")
+            state_chunk_start_idx = (
+                (seq_start_idx - raw_cu_seqlens[raw_batch_idx]) // block_S
+                if state_head_first
+                else 0
             )
 
             num_iters = T.alloc_var("int32")
@@ -136,9 +142,7 @@ def tilelang_fused_chunk_gdr_fwd(
             vn_shared = T.alloc_shared((block_S, block_DV), dtype=qkva_dtype)
             p_shared = T.alloc_shared((block_S, block_S), dtype=qkva_dtype)
             g_exp_shared = T.alloc_shared((block_S), dtype=accum_dtype, scope="shared")
-            g_rev_exp_shared = T.alloc_shared(
-                (block_S), dtype=accum_dtype, scope="shared"
-            )
+            g_rev_exp_shared = T.alloc_shared((block_S), dtype=accum_dtype, scope="shared")
 
             h_fragment = T.alloc_fragment((DK, block_DV), dtype=accum_dtype)
             o_fragment = T.alloc_fragment((block_S, block_DV), dtype=accum_dtype)
@@ -218,10 +222,19 @@ def tilelang_fused_chunk_gdr_fwd(
                 if need_store_final_state:
                     T.copy(
                         h_fragment,
-                        ht[
-                            raw_batch_idx, bh, 0:DK, bv * block_DV : (bv + 1) * block_DV
-                        ],
+                        ht[raw_batch_idx, bh, 0:DK, bv * block_DV : (bv + 1) * block_DV],
                     )
+                    if state_head_first and store_h:
+                        T.copy(
+                            h_fragment,
+                            h[
+                                raw_batch_idx,
+                                bh,
+                                chunks_per_sequence,
+                                0:DK,
+                                bv * block_DV : (bv + 1) * block_DV,
+                            ],
+                        )
 
             elif tx < 256:
                 T.set_max_nreg(CONSUMER_V_NREG, 1)
@@ -241,11 +254,7 @@ def tilelang_fused_chunk_gdr_fwd(
                         g_rev_exp_shared[j_s] = T.if_then_else(
                             seq_start_idx + i_s * block_S + j_s < seq_end_idx,
                             T.exp2(
-                                (
-                                    g_shared[i_s % 2, block_S - 1]
-                                    - g_shared[i_s % 2, j_s]
-                                )
-                                * 1.442695
+                                (g_shared[i_s % 2, block_S - 1] - g_shared[i_s % 2, j_s]) * 1.442695
                             ),
                             0.0,
                         )
@@ -254,9 +263,7 @@ def tilelang_fused_chunk_gdr_fwd(
                     # [STAGE 0] 1
                     T.barrier_wait(bar_1, i_s % 2)
                     # U = K @ S
-                    T.gemm_v1(
-                        k_shared[i_s % 2, :, :], h_shared, u_fragment, clear_accum=True
-                    )
+                    T.gemm_v1(k_shared[i_s % 2, :, :], h_shared, u_fragment, clear_accum=True)
 
                     # [STAGE 0] 2
                     # W = V - g * U
@@ -316,14 +323,10 @@ def tilelang_fused_chunk_gdr_fwd(
                     # [STAGE 0] 1
                     # G = Lower(diag(g) @ I @ diag(1/g))
                     for j_s, j_t in T.Parallel(block_S, block_S):
-                        g_fragment[j_s, j_t] = (
-                            g_shared[i_s % 2, j_s] - g_shared[i_s % 2, j_t]
-                        )
+                        g_fragment[j_s, j_t] = g_shared[i_s % 2, j_s] - g_shared[i_s % 2, j_t]
                     for j_s, j_t in T.Parallel(block_S, block_S):
                         if j_s >= j_t:
-                            g_fragment[j_s, j_t] = T.exp2(
-                                g_fragment[j_s, j_t] * 1.442695
-                            )
+                            g_fragment[j_s, j_t] = T.exp2(g_fragment[j_s, j_t] * 1.442695)
                         else:
                             g_fragment[j_s, j_t] = 0
                     # Ag = G * Ar * b
@@ -339,9 +342,7 @@ def tilelang_fused_chunk_gdr_fwd(
                     # [STAGE 0] 2
                     T.barrier_wait(bar_1, i_s % 2)
                     # O = Q @ S
-                    T.gemm_v1(
-                        q_shared[i_s % 2, :, :], h_shared, o_fragment, clear_accum=True
-                    )
+                    T.gemm_v1(q_shared[i_s % 2, :, :], h_shared, o_fragment, clear_accum=True)
 
                     # [STAGE 0] 3
                     # Pg = s * G * P
@@ -417,9 +418,7 @@ def tilelang_fused_chunk_gdr_fwd(
                         else:
                             for j_s in T.Parallel(block_S):
                                 if left + j_s < seq_end_idx:
-                                    b_shared[i_s % 2, j_s] = b[
-                                        batch_idx, left + j_s, bh
-                                    ]
+                                    b_shared[i_s % 2, j_s] = b[batch_idx, left + j_s, bh]
                                 else:
                                     b_shared[i_s % 2, j_s] = 0
 
@@ -444,13 +443,9 @@ def tilelang_fused_chunk_gdr_fwd(
                         else:
                             for j_s in T.Parallel(block_S):
                                 if left + j_s < seq_end_idx:
-                                    g_shared[i_s % 2, j_s] = g[
-                                        batch_idx, left + j_s, bh
-                                    ]
+                                    g_shared[i_s % 2, j_s] = g[batch_idx, left + j_s, bh]
                                 else:
-                                    g_shared[i_s % 2, j_s] = g[
-                                        batch_idx, seq_end_idx - 1, bh
-                                    ]
+                                    g_shared[i_s % 2, j_s] = g[batch_idx, seq_end_idx - 1, bh]
 
                         T.barrier_arrive(data_is_ready[i_s % 2])
 
@@ -478,16 +473,28 @@ def tilelang_fused_chunk_gdr_fwd(
                         T.barrier_wait(bar_1, i_s % 2)
                         # Store S
                         if store_h:
-                            T.copy(
-                                h_shared,
-                                h[
-                                    batch_idx,
-                                    chunk_start_idx + i_s,
-                                    bh,
-                                    0:DK,
-                                    bv * block_DV : (bv + 1) * block_DV,
-                                ],
-                            )
+                            if state_head_first:
+                                T.copy(
+                                    h_shared,
+                                    h[
+                                        raw_batch_idx,
+                                        bh,
+                                        state_chunk_start_idx + i_s,
+                                        0:DK,
+                                        bv * block_DV : (bv + 1) * block_DV,
+                                    ],
+                                )
+                            else:
+                                T.copy(
+                                    h_shared,
+                                    h[
+                                        batch_idx,
+                                        chunk_start_idx + i_s,
+                                        bh,
+                                        0:DK,
+                                        bv * block_DV : (bv + 1) * block_DV,
+                                    ],
+                                )
 
                     if num_unmasked_iters < num_iters:
                         seq_split_idx = seq_start_idx + num_unmasked_iters * block_S
@@ -512,16 +519,28 @@ def tilelang_fused_chunk_gdr_fwd(
                         T.barrier_wait(bar_1, num_unmasked_iters % 2)
                         # Store S
                         if store_h:
-                            T.copy(
-                                h_shared,
-                                h[
-                                    batch_idx,
-                                    chunk_split_idx,
-                                    bh,
-                                    0:DK,
-                                    bv * block_DV : (bv + 1) * block_DV,
-                                ],
-                            )
+                            if state_head_first:
+                                T.copy(
+                                    h_shared,
+                                    h[
+                                        raw_batch_idx,
+                                        bh,
+                                        state_chunk_start_idx + num_unmasked_iters,
+                                        0:DK,
+                                        bv * block_DV : (bv + 1) * block_DV,
+                                    ],
+                                )
+                            else:
+                                T.copy(
+                                    h_shared,
+                                    h[
+                                        batch_idx,
+                                        chunk_split_idx,
+                                        bh,
+                                        0:DK,
+                                        bv * block_DV : (bv + 1) * block_DV,
+                                    ],
+                                )
 
                     seq_split_idx = seq_start_idx + (num_iters - 1) * block_S
 
@@ -557,20 +576,20 @@ def fused_gdr_fwd(
     cp_seq_map: torch.LongTensor | None = None,
     raw_cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
+    state_head_first: bool = False,
+    chunks_per_sequence: int = 0,
 ):
     batch_size, num_tokens, Hg, K = k.shape
     _, _, H, V = v.shape
     scale = scale or K ** (-0.5)
-    assert K == V == 128
+    assert K == V and K in (64, 128)
     assert chunk_size == 64
 
     if cu_seqlens is None:
         real_batch_size = batch_size
         num_chunks = tilelang.cdiv(num_tokens, chunk_size) if output_h else 0
         cu_seqlens = torch.empty((batch_size + 1), dtype=torch.int32, device=k.device)
-        chunk_offsets = torch.empty(
-            (batch_size + 1), dtype=torch.int32, device=k.device
-        )
+        chunk_offsets = torch.empty((batch_size + 1), dtype=torch.int32, device=k.device)
         seqlen_dtype = torch.int32
         is_varlen = False
     else:
@@ -582,9 +601,7 @@ def fused_gdr_fwd(
         is_varlen = True
 
     if cp_seq_map is None:
-        cp_seq_map = torch.empty(
-            (real_batch_size,), dtype=seqlen_dtype, device=k.device
-        )
+        cp_seq_map = torch.empty((real_batch_size,), dtype=seqlen_dtype, device=k.device)
         is_cp = False
     else:
         is_cp = True
@@ -594,14 +611,24 @@ def fused_gdr_fwd(
         initial_state = torch.empty(
             (real_batch_size, H, K, V), dtype=torch.float32, device=k.device
         )
-    h = torch.empty((batch_size, num_chunks, H, K, V), dtype=k.dtype, device=k.device)
+    if state_head_first and raw_cu_seqlens is None:
+        raw_cu_seqlens = cu_seqlens
+    if state_head_first:
+        if chunks_per_sequence <= 0:
+            raise ValueError("chunks_per_sequence must be positive for head-first states")
+        state_batch_size = (
+            raw_cu_seqlens.shape[0] - 1 if raw_cu_seqlens is not None else real_batch_size
+        )
+        h = torch.empty(
+            (state_batch_size, H, chunks_per_sequence + 1, K, V),
+            dtype=k.dtype,
+            device=k.device,
+        )
+    else:
+        h = torch.empty((batch_size, num_chunks, H, K, V), dtype=k.dtype, device=k.device)
     if raw_cu_seqlens is None:
-        raw_cu_seqlens = torch.empty(
-            (real_batch_size + 1,), dtype=seqlen_dtype, device=k.device
-        )
-        final_state = torch.empty(
-            (real_batch_size, H, K, V), dtype=torch.float32, device=k.device
-        )
+        raw_cu_seqlens = torch.empty((real_batch_size + 1,), dtype=seqlen_dtype, device=k.device)
+        final_state = torch.empty((real_batch_size, H, K, V), dtype=torch.float32, device=k.device)
     else:
         final_state = torch.empty(
             (raw_cu_seqlens.shape[0] - 1, H, K, V), dtype=torch.float32, device=k.device
@@ -615,17 +642,18 @@ def fused_gdr_fwd(
     )
     if block_dv_override:
         block_DV = int(block_dv_override)
-        if block_DV not in (32, 64, 128) or V % block_DV != 0:
+        if block_DV not in (8, 16, 32, 64, 128) or V % block_DV != 0:
             raise ValueError(
-                "TILEOPS_GDN_PREFILL_BLOCK_DV must be one of 32, 64, 128 "
-                "and divide DV"
+                "TILEOPS_GDN_PREFILL_BLOCK_DV must be one of 8, 16, 32, 64, 128 and divide DV"
             )
+    elif V == 64 and not is_cp and chunks_per_sequence > 0:
+        block_DV = 8 if chunks_per_sequence <= 64 else 16
     elif grid_size >= TARGET_NUM_CTAS:
-        block_DV = 128
+        block_DV = min(128, V)
     elif grid_size * 2 >= TARGET_NUM_CTAS:
-        block_DV = 64
+        block_DV = min(64, V)
     else:
-        block_DV = 32
+        block_DV = min(32, V)
 
     tilelang_fused_chunk_gdr_fwd_kernel = tilelang_fused_chunk_gdr_fwd(
         H,
@@ -650,6 +678,8 @@ def fused_gdr_fwd(
         is_varlen=is_varlen,
         is_cp=is_cp,
         block_DV=block_DV,
+        state_head_first=state_head_first,
+        chunks_per_sequence=chunks_per_sequence,
     )
     tilelang_fused_chunk_gdr_fwd_kernel(
         q,

--- a/src/tileops/kernels/gated_deltanet/gdn_prefill/fused_fwd.py
+++ b/src/tileops/kernels/gated_deltanet/gdn_prefill/fused_fwd.py
@@ -22,7 +22,7 @@ TARGET_NUM_CTAS = int(MULTI_PROCESSOR_COUNT * 0.7)
     },
     compile_flags=["-O3", "-DENABLE_BF16", "-include", "tl_templates/cuda/gemm.h"],
 )
-def tilelang_fused_chunk_gdr_fwd(
+def _build_fused_chunk_gdr_fwd_kernel(
     H,
     Hg,
     DK,
@@ -78,7 +78,7 @@ def tilelang_fused_chunk_gdr_fwd(
     ht_shape = (raw_batch_size, H, DK, DV)
 
     @T.prim_func
-    def tilelang_fused_chunk_gdr_fwd_kernel(
+    def fused_chunk_gdr_fwd_kernel(
         q: T.Tensor(q_shape, dtype=qkva_dtype),
         k: T.Tensor(k_shape, dtype=qkva_dtype),
         v: T.Tensor(v_shape, dtype=qkva_dtype),
@@ -557,7 +557,7 @@ def tilelang_fused_chunk_gdr_fwd(
                                         bv * block_DV + j_v,
                                     ] = o_shared[j_s, j_v]
 
-    return tilelang_fused_chunk_gdr_fwd_kernel
+    return fused_chunk_gdr_fwd_kernel
 
 
 def fused_gdr_fwd(
@@ -655,7 +655,7 @@ def fused_gdr_fwd(
     else:
         block_DV = min(32, V)
 
-    tilelang_fused_chunk_gdr_fwd_kernel = tilelang_fused_chunk_gdr_fwd(
+    fused_chunk_gdr_fwd_kernel = _build_fused_chunk_gdr_fwd_kernel(
         H,
         Hg,
         K,
@@ -681,7 +681,7 @@ def fused_gdr_fwd(
         state_head_first=state_head_first,
         chunks_per_sequence=chunks_per_sequence,
     )
-    tilelang_fused_chunk_gdr_fwd_kernel(
+    fused_chunk_gdr_fwd_kernel(
         q,
         k,
         v,

--- a/src/tileops/kernels/gated_deltanet/gdn_prefill/prepare_h.py
+++ b/src/tileops/kernels/gated_deltanet/gdn_prefill/prepare_h.py
@@ -98,22 +98,14 @@ def tilelang_prepare_h(
             )
 
             calc_mt = T.alloc_var("bool")
-            calc_mt = is_cp and num_iters >= T.ceildiv(
-                seq_end_idx - seq_start_idx, block_S
-            )
-            seq_start_idx = (
-                seq_end_idx - num_iters * block_S if is_cp else seq_start_idx
-            )
+            calc_mt = is_cp and num_iters >= T.ceildiv(seq_end_idx - seq_start_idx, block_S)
+            seq_start_idx = seq_end_idx - num_iters * block_S if is_cp else seq_start_idx
 
             k_shared = T.alloc_shared((num_stages, block_S, DK), dtype=qkva_dtype)
             v_shared = T.alloc_shared((num_stages, block_S, DV), dtype=qkva_dtype)
             a_shared = T.alloc_shared((num_stages, block_S, block_S), dtype=qkva_dtype)
-            g_shared = T.alloc_shared(
-                (num_stages, block_S), dtype=accum_dtype, scope="shared"
-            )
-            b_shared = T.alloc_shared(
-                (num_stages, block_S), dtype=accum_dtype, scope="shared"
-            )
+            g_shared = T.alloc_shared((num_stages, block_S), dtype=accum_dtype, scope="shared")
+            b_shared = T.alloc_shared((num_stages, block_S), dtype=accum_dtype, scope="shared")
             h_shared = T.alloc_shared((DK, DV), dtype=qkva_dtype)
             x_shared = T.alloc_shared((block_S, DK), dtype=qkva_dtype)
             y_shared = T.alloc_shared((block_S, DV), dtype=qkva_dtype)
@@ -121,9 +113,7 @@ def tilelang_prepare_h(
             m_shared_R = T.alloc_shared((DK, DK // 2), dtype=qkva_dtype)
             z_shared_L = T.alloc_shared((block_S, DK // 2), dtype=qkva_dtype)
             z_shared_R = T.alloc_shared((block_S, DK // 2), dtype=qkva_dtype)
-            g_rev_exp_shared = T.alloc_shared(
-                (block_S), dtype=accum_dtype, scope="shared"
-            )
+            g_rev_exp_shared = T.alloc_shared((block_S), dtype=accum_dtype, scope="shared")
 
             h_fragment = T.alloc_fragment((DK, DV), dtype=accum_dtype)
             x_fragment = T.alloc_fragment((block_S, DK), dtype=accum_dtype)
@@ -167,9 +157,7 @@ def tilelang_prepare_h(
                 # Main Loop
                 for i_s in T.serial(num_iters):
                     # [STAGE = i_s % num_stages]
-                    T.barrier_wait(
-                        data_is_ready[i_s % num_stages], (i_s // num_stages + 0) % 2
-                    )
+                    T.barrier_wait(data_is_ready[i_s % num_stages], (i_s // num_stages + 0) % 2)
                     T.barrier_arrive(bar_0)
 
                     # [STAGE = i_s % num_stages] 0
@@ -181,9 +169,7 @@ def tilelang_prepare_h(
                     # [STAGE = i_s % num_stages] 1
                     T.barrier_wait(bar_1, i_s % 2)
                     # S = g_last * S
-                    g_last_local_S[0] = T.exp2(
-                        g_shared[i_s % num_stages, block_S - 1] * 1.442695
-                    )
+                    g_last_local_S[0] = T.exp2(g_shared[i_s % num_stages, block_S - 1] * 1.442695)
                     for j_k, j_v in T.Parallel(DK, DV):
                         h_fragment[j_k, j_v] *= g_last_local_S[0]
                     T.barrier_arrive(bar_2)
@@ -220,9 +206,7 @@ def tilelang_prepare_h(
                 # Main Loop
                 for i_s in T.serial(num_iters):
                     # [STAGE = i_s % num_stages]
-                    T.barrier_wait(
-                        data_is_ready[i_s % num_stages], (i_s // num_stages + 0) % 2
-                    )
+                    T.barrier_wait(data_is_ready[i_s % num_stages], (i_s // num_stages + 0) % 2)
                     T.barrier_arrive(bar_0)
 
                     # [STAGE = i_s % num_stages] 0
@@ -292,9 +276,7 @@ def tilelang_prepare_h(
                 # Main Loop
                 for i_s in T.serial(num_iters):
                     # [STAGE = i_s % num_stages]
-                    T.barrier_wait(
-                        data_is_ready[i_s % num_stages], (i_s // num_stages + 0) % 2
-                    )
+                    T.barrier_wait(data_is_ready[i_s % num_stages], (i_s // num_stages + 0) % 2)
                     T.barrier_arrive(bar_0)
 
                     # [STAGE = i_s % num_stages] 0
@@ -303,8 +285,7 @@ def tilelang_prepare_h(
                     g_last_local_Y[0] = g_shared[i_s % num_stages, block_S - 1]
                     for j_s in T.Parallel(block_S):
                         g_rev_exp_shared[j_s] = T.exp2(
-                            (g_last_local_Y[0] - g_shared[i_s % num_stages, j_s])
-                            * 1.442695
+                            (g_last_local_Y[0] - g_shared[i_s % num_stages, j_s]) * 1.442695
                         )
                     g_last_local_Y[0] = T.exp2(g_last_local_Y[0] * 1.442695)
                     T.barrier_arrive(bar_1)
@@ -368,9 +349,7 @@ def tilelang_prepare_h(
 
                 if tx < 384 + 32:
                     for i_s in T.serial(num_iters):
-                        T.barrier_wait(
-                            data_is_free[i_s % num_stages], (i_s // num_stages + 1) % 2
-                        )
+                        T.barrier_wait(data_is_free[i_s % num_stages], (i_s // num_stages + 1) % 2)
                         left = seq_start_idx + i_s * block_S
                         right = left + block_S
 
@@ -385,9 +364,7 @@ def tilelang_prepare_h(
 
                 elif tx < 384 + 64:
                     for i_s in T.serial(num_iters):
-                        T.barrier_wait(
-                            data_is_free[i_s % num_stages], (i_s // num_stages + 1) % 2
-                        )
+                        T.barrier_wait(data_is_free[i_s % num_stages], (i_s // num_stages + 1) % 2)
                         left = seq_start_idx + i_s * block_S
                         right = left + block_S
 
@@ -408,24 +385,18 @@ def tilelang_prepare_h(
 
                 elif tx < 384 + 96:
                     for i_s in T.serial(num_iters):
-                        T.barrier_wait(
-                            data_is_free[i_s % num_stages], (i_s // num_stages + 1) % 2
-                        )
+                        T.barrier_wait(data_is_free[i_s % num_stages], (i_s // num_stages + 1) % 2)
                         left = seq_start_idx + i_s * block_S
                         right = left + block_S
 
                         # Load gamma
                         if right <= seq_end_idx:
                             for j_s in T.Parallel(block_S):
-                                g_shared[i_s % num_stages, j_s] = g[
-                                    batch_idx, left + j_s, bh
-                                ]
+                                g_shared[i_s % num_stages, j_s] = g[batch_idx, left + j_s, bh]
                         else:
                             for j_s in T.Parallel(block_S):
                                 if left + j_s < seq_end_idx:
-                                    g_shared[i_s % num_stages, j_s] = g[
-                                        batch_idx, left + j_s, bh
-                                    ]
+                                    g_shared[i_s % num_stages, j_s] = g[batch_idx, left + j_s, bh]
                                 else:
                                     g_shared[i_s % num_stages, j_s] = g[
                                         batch_idx, seq_end_idx - 1, bh
@@ -433,15 +404,11 @@ def tilelang_prepare_h(
                         # Load beta
                         if right <= seq_end_idx:
                             for j_s in T.Parallel(block_S):
-                                b_shared[i_s % num_stages, j_s] = b[
-                                    batch_idx, left + j_s, bh
-                                ]
+                                b_shared[i_s % num_stages, j_s] = b[batch_idx, left + j_s, bh]
                         else:
                             for j_s in T.Parallel(block_S):
                                 if left + j_s < seq_end_idx:
-                                    b_shared[i_s % num_stages, j_s] = b[
-                                        batch_idx, left + j_s, bh
-                                    ]
+                                    b_shared[i_s % num_stages, j_s] = b[batch_idx, left + j_s, bh]
                                 else:
                                     b_shared[i_s % num_stages, j_s] = 0
 
@@ -478,7 +445,7 @@ def fused_gdr_h(
 ):
     batch_size, num_tokens, Hg, K = k.shape
     _, _, H, V = v.shape
-    assert K == V == 128
+    assert K == V and K in (64, 128)
     assert chunk_size == 64
 
     if cu_seqlens is None:
@@ -486,9 +453,7 @@ def fused_gdr_h(
         real_batch_size = batch_size
         num_chunks = tilelang.cdiv(num_tokens, chunk_size) if output_h else 0
         cu_seqlens = torch.empty((batch_size + 1), dtype=torch.int32, device=k.device)
-        chunk_offsets = torch.empty(
-            (batch_size + 1), dtype=torch.int32, device=k.device
-        )
+        chunk_offsets = torch.empty((batch_size + 1), dtype=torch.int32, device=k.device)
         is_varlen = False
         is_cp = False
     else:
@@ -512,12 +477,8 @@ def fused_gdr_h(
         )
     h = torch.empty((batch_size, num_chunks, H, K, V), dtype=k.dtype, device=k.device)
     ht_dtype = k.dtype if is_cp else torch.float32
-    final_state = torch.empty(
-        (real_batch_size, H, K, V), dtype=ht_dtype, device=k.device
-    )
-    final_correction = torch.empty(
-        (real_batch_size, H, K, K), dtype=ht_dtype, device=k.device
-    )
+    final_state = torch.empty((real_batch_size, H, K, V), dtype=ht_dtype, device=k.device)
+    final_correction = torch.empty((real_batch_size, H, K, K), dtype=ht_dtype, device=k.device)
 
     tilelang_prepare_h_kernel = tilelang_prepare_h(
         H,

--- a/src/tileops/kernels/gated_deltanet/gdn_prefill/prepare_h.py
+++ b/src/tileops/kernels/gated_deltanet/gdn_prefill/prepare_h.py
@@ -15,7 +15,7 @@ from .utils import prepare_chunk_offsets
     },
     compile_flags=["-O3", "-DENABLE_BF16", "-include", "tl_templates/cuda/gemm.h"],
 )
-def tilelang_prepare_h(
+def _build_prepare_h_kernel(
     H,
     Hg,
     DK,
@@ -60,7 +60,7 @@ def tilelang_prepare_h(
     m_shape = (batch_size, H, DK, DK)
 
     @T.prim_func
-    def tilelang_prepare_h_kernel(
+    def prepare_h_kernel(
         k: T.Tensor(k_shape, dtype=qkva_dtype),
         v: T.Tensor(v_shape, dtype=qkva_dtype),
         a: T.Tensor(a_shape, dtype=qkva_dtype),
@@ -98,14 +98,22 @@ def tilelang_prepare_h(
             )
 
             calc_mt = T.alloc_var("bool")
-            calc_mt = is_cp and num_iters >= T.ceildiv(seq_end_idx - seq_start_idx, block_S)
-            seq_start_idx = seq_end_idx - num_iters * block_S if is_cp else seq_start_idx
+            calc_mt = is_cp and num_iters >= T.ceildiv(
+                seq_end_idx - seq_start_idx, block_S
+            )
+            seq_start_idx = (
+                seq_end_idx - num_iters * block_S if is_cp else seq_start_idx
+            )
 
             k_shared = T.alloc_shared((num_stages, block_S, DK), dtype=qkva_dtype)
             v_shared = T.alloc_shared((num_stages, block_S, DV), dtype=qkva_dtype)
             a_shared = T.alloc_shared((num_stages, block_S, block_S), dtype=qkva_dtype)
-            g_shared = T.alloc_shared((num_stages, block_S), dtype=accum_dtype, scope="shared")
-            b_shared = T.alloc_shared((num_stages, block_S), dtype=accum_dtype, scope="shared")
+            g_shared = T.alloc_shared(
+                (num_stages, block_S), dtype=accum_dtype, scope="shared"
+            )
+            b_shared = T.alloc_shared(
+                (num_stages, block_S), dtype=accum_dtype, scope="shared"
+            )
             h_shared = T.alloc_shared((DK, DV), dtype=qkva_dtype)
             x_shared = T.alloc_shared((block_S, DK), dtype=qkva_dtype)
             y_shared = T.alloc_shared((block_S, DV), dtype=qkva_dtype)
@@ -113,7 +121,9 @@ def tilelang_prepare_h(
             m_shared_R = T.alloc_shared((DK, DK // 2), dtype=qkva_dtype)
             z_shared_L = T.alloc_shared((block_S, DK // 2), dtype=qkva_dtype)
             z_shared_R = T.alloc_shared((block_S, DK // 2), dtype=qkva_dtype)
-            g_rev_exp_shared = T.alloc_shared((block_S), dtype=accum_dtype, scope="shared")
+            g_rev_exp_shared = T.alloc_shared(
+                (block_S), dtype=accum_dtype, scope="shared"
+            )
 
             h_fragment = T.alloc_fragment((DK, DV), dtype=accum_dtype)
             x_fragment = T.alloc_fragment((block_S, DK), dtype=accum_dtype)
@@ -157,7 +167,9 @@ def tilelang_prepare_h(
                 # Main Loop
                 for i_s in T.serial(num_iters):
                     # [STAGE = i_s % num_stages]
-                    T.barrier_wait(data_is_ready[i_s % num_stages], (i_s // num_stages + 0) % 2)
+                    T.barrier_wait(
+                        data_is_ready[i_s % num_stages], (i_s // num_stages + 0) % 2
+                    )
                     T.barrier_arrive(bar_0)
 
                     # [STAGE = i_s % num_stages] 0
@@ -169,7 +181,9 @@ def tilelang_prepare_h(
                     # [STAGE = i_s % num_stages] 1
                     T.barrier_wait(bar_1, i_s % 2)
                     # S = g_last * S
-                    g_last_local_S[0] = T.exp2(g_shared[i_s % num_stages, block_S - 1] * 1.442695)
+                    g_last_local_S[0] = T.exp2(
+                        g_shared[i_s % num_stages, block_S - 1] * 1.442695
+                    )
                     for j_k, j_v in T.Parallel(DK, DV):
                         h_fragment[j_k, j_v] *= g_last_local_S[0]
                     T.barrier_arrive(bar_2)
@@ -206,7 +220,9 @@ def tilelang_prepare_h(
                 # Main Loop
                 for i_s in T.serial(num_iters):
                     # [STAGE = i_s % num_stages]
-                    T.barrier_wait(data_is_ready[i_s % num_stages], (i_s // num_stages + 0) % 2)
+                    T.barrier_wait(
+                        data_is_ready[i_s % num_stages], (i_s // num_stages + 0) % 2
+                    )
                     T.barrier_arrive(bar_0)
 
                     # [STAGE = i_s % num_stages] 0
@@ -276,7 +292,9 @@ def tilelang_prepare_h(
                 # Main Loop
                 for i_s in T.serial(num_iters):
                     # [STAGE = i_s % num_stages]
-                    T.barrier_wait(data_is_ready[i_s % num_stages], (i_s // num_stages + 0) % 2)
+                    T.barrier_wait(
+                        data_is_ready[i_s % num_stages], (i_s // num_stages + 0) % 2
+                    )
                     T.barrier_arrive(bar_0)
 
                     # [STAGE = i_s % num_stages] 0
@@ -285,7 +303,8 @@ def tilelang_prepare_h(
                     g_last_local_Y[0] = g_shared[i_s % num_stages, block_S - 1]
                     for j_s in T.Parallel(block_S):
                         g_rev_exp_shared[j_s] = T.exp2(
-                            (g_last_local_Y[0] - g_shared[i_s % num_stages, j_s]) * 1.442695
+                            (g_last_local_Y[0] - g_shared[i_s % num_stages, j_s])
+                            * 1.442695
                         )
                     g_last_local_Y[0] = T.exp2(g_last_local_Y[0] * 1.442695)
                     T.barrier_arrive(bar_1)
@@ -349,7 +368,9 @@ def tilelang_prepare_h(
 
                 if tx < 384 + 32:
                     for i_s in T.serial(num_iters):
-                        T.barrier_wait(data_is_free[i_s % num_stages], (i_s // num_stages + 1) % 2)
+                        T.barrier_wait(
+                            data_is_free[i_s % num_stages], (i_s // num_stages + 1) % 2
+                        )
                         left = seq_start_idx + i_s * block_S
                         right = left + block_S
 
@@ -364,7 +385,9 @@ def tilelang_prepare_h(
 
                 elif tx < 384 + 64:
                     for i_s in T.serial(num_iters):
-                        T.barrier_wait(data_is_free[i_s % num_stages], (i_s // num_stages + 1) % 2)
+                        T.barrier_wait(
+                            data_is_free[i_s % num_stages], (i_s // num_stages + 1) % 2
+                        )
                         left = seq_start_idx + i_s * block_S
                         right = left + block_S
 
@@ -385,18 +408,24 @@ def tilelang_prepare_h(
 
                 elif tx < 384 + 96:
                     for i_s in T.serial(num_iters):
-                        T.barrier_wait(data_is_free[i_s % num_stages], (i_s // num_stages + 1) % 2)
+                        T.barrier_wait(
+                            data_is_free[i_s % num_stages], (i_s // num_stages + 1) % 2
+                        )
                         left = seq_start_idx + i_s * block_S
                         right = left + block_S
 
                         # Load gamma
                         if right <= seq_end_idx:
                             for j_s in T.Parallel(block_S):
-                                g_shared[i_s % num_stages, j_s] = g[batch_idx, left + j_s, bh]
+                                g_shared[i_s % num_stages, j_s] = g[
+                                    batch_idx, left + j_s, bh
+                                ]
                         else:
                             for j_s in T.Parallel(block_S):
                                 if left + j_s < seq_end_idx:
-                                    g_shared[i_s % num_stages, j_s] = g[batch_idx, left + j_s, bh]
+                                    g_shared[i_s % num_stages, j_s] = g[
+                                        batch_idx, left + j_s, bh
+                                    ]
                                 else:
                                     g_shared[i_s % num_stages, j_s] = g[
                                         batch_idx, seq_end_idx - 1, bh
@@ -404,11 +433,15 @@ def tilelang_prepare_h(
                         # Load beta
                         if right <= seq_end_idx:
                             for j_s in T.Parallel(block_S):
-                                b_shared[i_s % num_stages, j_s] = b[batch_idx, left + j_s, bh]
+                                b_shared[i_s % num_stages, j_s] = b[
+                                    batch_idx, left + j_s, bh
+                                ]
                         else:
                             for j_s in T.Parallel(block_S):
                                 if left + j_s < seq_end_idx:
-                                    b_shared[i_s % num_stages, j_s] = b[batch_idx, left + j_s, bh]
+                                    b_shared[i_s % num_stages, j_s] = b[
+                                        batch_idx, left + j_s, bh
+                                    ]
                                 else:
                                     b_shared[i_s % num_stages, j_s] = 0
 
@@ -427,7 +460,7 @@ def tilelang_prepare_h(
                                 h[batch_idx, chunk_start_idx + i_s, bh, 0:DK, 0:DV],
                             )
 
-    return tilelang_prepare_h_kernel
+    return prepare_h_kernel
 
 
 def fused_gdr_h(
@@ -480,7 +513,7 @@ def fused_gdr_h(
     final_state = torch.empty((real_batch_size, H, K, V), dtype=ht_dtype, device=k.device)
     final_correction = torch.empty((real_batch_size, H, K, K), dtype=ht_dtype, device=k.device)
 
-    tilelang_prepare_h_kernel = tilelang_prepare_h(
+    prepare_h_kernel = _build_prepare_h_kernel(
         H,
         Hg,
         K,
@@ -500,7 +533,7 @@ def fused_gdr_h(
         is_varlen=is_varlen,
         is_cp=is_cp,
     )
-    tilelang_prepare_h_kernel(
+    prepare_h_kernel(
         k,
         v,
         a,

--- a/src/tileops/kernels/gated_deltanet/gdn_prefill/utils.py
+++ b/src/tileops/kernels/gated_deltanet/gdn_prefill/utils.py
@@ -86,7 +86,7 @@ def prepare_chunk_indices(
 
 
 @tilelang.jit()
-def tilelang_prepare_chunk_offsets(
+def _build_prepare_chunk_offsets_kernel(
     chunk_size,
     block_size,
     dtype,
@@ -95,7 +95,7 @@ def tilelang_prepare_chunk_offsets(
     num_threads = min(max(block_size, 32), 128)
 
     @T.prim_func
-    def tilelang_prepare_chunk_offsets_kernel(
+    def prepare_chunk_offsets_kernel(
         cu_seqlens: T.Tensor([batch_size_plus_1], dtype=dtype),
         chunk_offsets: T.Tensor([batch_size_plus_1], dtype=dtype),
     ):
@@ -122,7 +122,7 @@ def tilelang_prepare_chunk_offsets(
             chunk_offsets[0] = 0
             T.copy(chunk_offset_fragment, chunk_offsets[1:])
 
-    return tilelang_prepare_chunk_offsets_kernel
+    return prepare_chunk_offsets_kernel
 
 
 @tensor_cache
@@ -131,10 +131,10 @@ def prepare_chunk_offsets(
     chunk_size: int,
 ) -> torch.LongTensor:
     chunk_offsets = torch.empty_like(cu_seqlens)
-    tilelang_prepare_chunk_offsets_kernel = tilelang_prepare_chunk_offsets(
+    prepare_chunk_offsets_kernel = _build_prepare_chunk_offsets_kernel(
         chunk_size=chunk_size,
         block_size=tilelang.next_power_of_2(cu_seqlens.shape[0] - 1),
         dtype=cu_seqlens.dtype,
     )
-    tilelang_prepare_chunk_offsets_kernel(cu_seqlens, chunk_offsets)
+    prepare_chunk_offsets_kernel(cu_seqlens, chunk_offsets)
     return chunk_offsets, chunk_offsets[-1].item()

--- a/src/tileops/manifest/attention.yaml
+++ b/src/tileops/manifest/attention.yaml
@@ -162,8 +162,8 @@ GroupedQueryAttentionPrefillFwdOp:
       max_seqlen_q: {type: int}
       max_seqlen_kv: {type: int}
       is_causal: {type: bool, default: true}
-      sm_scale: {type: float, default: null}
-      softcap: {type: float, default: null}
+      sm_scale: {type: "float | None", default: null}
+      softcap: {type: "float | None", default: null}
       window_size_left: {type: int, default: -1}
       window_size_right: {type: int, default: -1}
       backend: {type: str, default: "auto"}
@@ -250,8 +250,8 @@ GroupedQueryAttentionPrefillPagedWithKVCacheFwdOp:
       max_seqlen_q: {type: int}
       cache_dtype: {type: "dtype | None", default: null}
       is_causal: {type: bool, default: true}
-      sm_scale: {type: float, default: null}
-      softcap: {type: float, default: null}
+      sm_scale: {type: "float | None", default: null}
+      softcap: {type: "float | None", default: null}
       fuse_rope: {type: bool, default: false}
       rope_base: {type: float, default: 10000.0}
       max_position: {type: "int | None", default: null}
@@ -511,8 +511,8 @@ GroupedQueryAttentionDecodePagedWithKVCacheFwdOp:
       o: {dtype: "same_as(q)"}
     params:
       page_size: {type: int}
-      sm_scale: {type: float, default: null}
-      softcap: {type: float, default: null}
+      sm_scale: {type: "float | None", default: null}
+      softcap: {type: "float | None", default: null}
     shape_rules:
       - "q.shape == (B, H, D)"
       - "k.shape == (N_kv, H_kv, D)"
@@ -709,7 +709,7 @@ DeepSeekSparseAttentionDecodeWithKVCacheFwdOp:
       stride_kv: {type: int}
       q_start_index_s: {type: int}
       is_causal: {type: bool, default: true}
-      sm_scale: {type: float, default: null}
+      sm_scale: {type: "float | None", default: null}
     shape_rules:
       - "q.shape == (B, S, H, D + dim_tail)"
       - "kv.shape == (B, S_kv, H_kv, D + dim_tail)"

--- a/src/tileops/manifest/bmm.yaml
+++ b/src/tileops/manifest/bmm.yaml
@@ -63,7 +63,7 @@ BmmFp8Op:
       d: {dtype: "bfloat16 | float16", shape: "[B, M, N]"}
     params:
       out_dtype: {type: dtype, default: bfloat16}
-      b_layout: {type: str, default: "kn", choices: ["kn", "nk"]}
+      b_layout: {type: str, default: "kn"}
     # Only fp8_e4m3fn inputs are supported (fp8_e5m2 is rejected at
     # forward-time by :meth:`BmmFp8Op._validate_dtypes`); output picks
     # a single dtype per compile.  ``dtype_combos`` pins the Cartesian

--- a/src/tileops/manifest/linear_attention.yaml
+++ b/src/tileops/manifest/linear_attention.yaml
@@ -275,7 +275,6 @@ GatedDeltaNetFwdOp:
     - "layout != 'bthd' or o.shape == (B, S, H, DV)"
     - "layout != 'bthd' or Aw.shape == (B, S, H, chunk_size)"
     - "layout != 'bthd' or Au.shape == (B, S, H, chunk_size)"
-    - "S.shape == (B, H, NC + 1, DK, DV)"
     - "S % chunk_size == 0"
     - "NC == S // chunk_size"
   workloads: []

--- a/src/tileops/manifest/linear_attention.yaml
+++ b/src/tileops/manifest/linear_attention.yaml
@@ -251,12 +251,31 @@ GatedDeltaNetFwdOp:
       beta: {dtype: "same_as(q)", shape: "[B, H, S]"}
     outputs:
       o: {dtype: "same_as(q)", shape: "[B, H, S, DV]"}
-      S: {dtype: "float32", shape: "[B, H, NC + 1, DK, DV]"}
-      Aw: {dtype: "float32", shape: "[B, H, S, chunk_size]"}
-      Au: {dtype: "float32", shape: "[B, H, S, chunk_size]"}
+      S: {dtype: "same_as(q)", shape: "[B, H, NC + 1, DK, DV]"}
+      Aw: {dtype: "same_as(q)", shape: "[B, H, S, chunk_size]"}
+      Au: {dtype: "same_as(q)", shape: "[B, H, S, chunk_size]"}
     params:
       chunk_size: {type: int, default: 64}
+      layout: {type: str, default: "bhtd"}
     shape_rules:
+    - "layout in ('bhtd', 'bthd')"
+    - "layout == 'bthd' or q.shape == (B, H, S, DK)"
+    - "layout == 'bthd' or k.shape == (B, H, S, DK)"
+    - "layout == 'bthd' or v.shape == (B, H, S, DV)"
+    - "layout == 'bthd' or g.shape == (B, H, S)"
+    - "layout == 'bthd' or beta.shape == (B, H, S)"
+    - "layout == 'bthd' or o.shape == (B, H, S, DV)"
+    - "layout == 'bthd' or Aw.shape == (B, H, S, chunk_size)"
+    - "layout == 'bthd' or Au.shape == (B, H, S, chunk_size)"
+    - "layout != 'bthd' or q.shape == (B, S, H, DK)"
+    - "layout != 'bthd' or k.shape == (B, S, H, DK)"
+    - "layout != 'bthd' or v.shape == (B, S, H, DV)"
+    - "layout != 'bthd' or g.shape == (B, S, H)"
+    - "layout != 'bthd' or beta.shape == (B, S, H)"
+    - "layout != 'bthd' or o.shape == (B, S, H, DV)"
+    - "layout != 'bthd' or Aw.shape == (B, S, H, chunk_size)"
+    - "layout != 'bthd' or Au.shape == (B, S, H, chunk_size)"
+    - "S.shape == (B, H, NC + 1, DK, DV)"
     - "S % chunk_size == 0"
     - "NC == S // chunk_size"
   workloads: []

--- a/src/tileops/manifest/linear_attention.yaml
+++ b/src/tileops/manifest/linear_attention.yaml
@@ -239,6 +239,8 @@ GLADecodeOp:
 # release-facing wrapper before they should count as implemented manifest ops.
 
 GatedDeltaNetFwdOp:
+  # Training forward in head-major (BHTD) order. GatedDeltaNetBwdOp reads the S
+  # this returns, in this order; token-major callers want GatedDeltaNetBTHDFwdOp.
   ref_api: "none"
   family: linear_attention
   status: spec-only
@@ -256,35 +258,60 @@ GatedDeltaNetFwdOp:
       Au: {dtype: "same_as(q)", shape: "[B, H, S, chunk_size]"}
     params:
       chunk_size: {type: int, default: 64}
-      layout: {type: str, default: "bhtd"}
     shape_rules:
-    - "layout in ('bhtd', 'bthd')"
-    - "layout == 'bthd' or q.shape == (B, H, S, DK)"
-    - "layout == 'bthd' or k.shape == (B, H, S, DK)"
-    - "layout == 'bthd' or v.shape == (B, H, S, DV)"
-    - "layout == 'bthd' or g.shape == (B, H, S)"
-    - "layout == 'bthd' or beta.shape == (B, H, S)"
-    - "layout == 'bthd' or o.shape == (B, H, S, DV)"
-    - "layout == 'bthd' or Aw.shape == (B, H, S, chunk_size)"
-    - "layout == 'bthd' or Au.shape == (B, H, S, chunk_size)"
-    - "layout != 'bthd' or q.shape == (B, S, H, DK)"
-    - "layout != 'bthd' or k.shape == (B, S, H, DK)"
-    - "layout != 'bthd' or v.shape == (B, S, H, DV)"
-    - "layout != 'bthd' or g.shape == (B, S, H)"
-    - "layout != 'bthd' or beta.shape == (B, S, H)"
-    - "layout != 'bthd' or o.shape == (B, S, H, DV)"
-    - "layout != 'bthd' or Aw.shape == (B, S, H, chunk_size)"
-    - "layout != 'bthd' or Au.shape == (B, S, H, chunk_size)"
     - "S % chunk_size == 0"
     - "NC == S // chunk_size"
   workloads: []
-  roofline: {flops: "0", bytes: "0"}
+  roofline: {func: tileops.perf.formulas.gated_deltanet_fwd_roofline}
   source:
     kernel: tileops/kernels/gated_deltanet/gated_deltanet_fwd.py
     op: tileops/ops/gated_deltanet.py
     test: tests/ops/test_gated_deltanet_fwd.py
     bench: benchmarks/ops/bench_gated_deltanet.py
     bench_manifest_driven: false
+
+GatedDeltaNetBTHDFwdOp:
+  # The same operator in token-major (BTHD) order, which is what the FLA
+  # reference uses. Memory order is part of the signature, so it is its own
+  # entry rather than a mode of GatedDeltaNetFwdOp. Runs the warp-specialized
+  # production pipeline, which serves Hopper only.
+  ref_api: "none"
+  family: linear_attention
+  status: implemented
+  signature:
+    inputs:
+      q: {dtype: "float16 | bfloat16", shape: "[B, S, H, DK]"}
+      k: {dtype: "same_as(q)", shape: "[B, S, H, DK]"}
+      v: {dtype: "same_as(q)", shape: "[B, S, H, DV]"}
+      g: {dtype: "same_as(q)", shape: "[B, S, H]"}
+      beta: {dtype: "same_as(q)", shape: "[B, S, H]"}
+    outputs:
+      o: {dtype: "same_as(q)", shape: "[B, S, H, DV]"}
+      S: {dtype: "same_as(q)", shape: "[B, H, NC + 1, DK, DV]"}
+      Aw: {dtype: "same_as(q)", shape: "[B, S, H, chunk_size]"}
+      Au: {dtype: "same_as(q)", shape: "[B, S, H, chunk_size]"}
+    params:
+      chunk_size: {type: int, default: 64}
+    shape_rules:
+    - "S % chunk_size == 0"
+    - "NC == S // chunk_size"
+    - "DK == DV"
+  workloads:
+  - {q_shape: [2, 2048, 4, 64], k_shape: [2, 2048, 4, 64], v_shape: [2, 2048, 4, 64], g_shape: [2, 2048, 4], beta_shape: [2, 2048, 4], chunk_size: 64, dtypes: [float16, bfloat16], label: "gdn-bthd-b2-s2k-h4-d64"}
+  - {q_shape: [2, 4096, 4, 64], k_shape: [2, 4096, 4, 64], v_shape: [2, 4096, 4, 64], g_shape: [2, 4096, 4], beta_shape: [2, 4096, 4], chunk_size: 64, dtypes: [float16, bfloat16], label: "gdn-bthd-b2-s4k-h4-d64"}
+  - {q_shape: [2, 8192, 4, 64], k_shape: [2, 8192, 4, 64], v_shape: [2, 8192, 4, 64], g_shape: [2, 8192, 4], beta_shape: [2, 8192, 4], chunk_size: 64, dtypes: [float16, bfloat16], label: "gdn-bthd-b2-s8k-h4-d64"}
+  - {q_shape: [2, 16384, 4, 64], k_shape: [2, 16384, 4, 64], v_shape: [2, 16384, 4, 64], g_shape: [2, 16384, 4], beta_shape: [2, 16384, 4], chunk_size: 64, dtypes: [float16, bfloat16], label: "gdn-bthd-b2-s16k-h4-d64"}
+  - {q_shape: [2, 32768, 4, 64], k_shape: [2, 32768, 4, 64], v_shape: [2, 32768, 4, 64], g_shape: [2, 32768, 4], beta_shape: [2, 32768, 4], chunk_size: 64, dtypes: [float16, bfloat16], label: "gdn-bthd-b2-s32k-h4-d64"}
+  - {q_shape: [1, 4096, 16, 128], k_shape: [1, 4096, 16, 128], v_shape: [1, 4096, 16, 128], g_shape: [1, 4096, 16], beta_shape: [1, 4096, 16], chunk_size: 64, dtypes: [float16, bfloat16], label: "gdn-bthd-b1-s4k-h16-d128"}
+  roofline: {func: tileops.perf.formulas.gated_deltanet_fwd_roofline}
+  source:
+    kernel: tileops/kernels/gated_deltanet/gated_deltanet_fwd.py
+    kernel_map:
+      GatedDeltaNetFwdProductionKernel: GatedDeltaNetFwdProductionKernel
+    op: tileops/ops/gated_deltanet.py
+    test: tests/ops/test_gated_deltanet_fwd.py
+    bench: benchmarks/ops/bench_gated_deltanet.py
+    bench_manifest_driven: true
 
 GatedDeltaNetBwdOp:
   ref_api: "none"
@@ -298,7 +325,7 @@ GatedDeltaNetBwdOp:
       v: {dtype: "same_as(do)", shape: "[B, H, S, DV]"}
       g: {dtype: "same_as(do)", shape: "[B, H, S]"}
       beta: {dtype: "same_as(do)", shape: "[B, H, S]"}
-      S: {dtype: "float32", shape: "[B, H, NC + 1, DK, DV]"}
+      S: {dtype: "same_as(do)", shape: "[B, H, NC + 1, DK, DV]"}
     outputs:
       dq: {dtype: "same_as(do)", shape: "[B, H, S, DK]"}
       dk: {dtype: "same_as(do)", shape: "[B, H, S, DK]"}
@@ -331,7 +358,7 @@ DeltaNetFwdOp:
       beta: {dtype: "same_as(q)", shape: "[B, H, S]"}
     outputs:
       o: {dtype: "same_as(q)", shape: "[B, H, S, DV]"}
-      S: {dtype: "float32", shape: "[B, H, NC + 1, DK, DV]"}
+      S: {dtype: "same_as(do)", shape: "[B, H, NC + 1, DK, DV]"}
       Aw: {dtype: "float32", shape: "[B, H, S, chunk_size]"}
       Au: {dtype: "float32", shape: "[B, H, S, chunk_size]"}
       w: {dtype: "float32", shape: "[B, H, S, DK]"}
@@ -361,7 +388,7 @@ DeltaNetBwdOp:
       k: {dtype: "same_as(do)", shape: "[B, H, S, DK]"}
       v: {dtype: "same_as(do)", shape: "[B, H, S, DV]"}
       beta: {dtype: "same_as(do)", shape: "[B, H, S]"}
-      S: {dtype: "float32", shape: "[B, H, NC + 1, DK, DV]"}
+      S: {dtype: "same_as(do)", shape: "[B, H, NC + 1, DK, DV]"}
       Aw: {dtype: "float32", shape: "[B, H, S, chunk_size]"}
       Au: {dtype: "float32", shape: "[B, H, S, chunk_size]"}
       w: {dtype: "float32", shape: "[B, H, S, DK]"}

--- a/src/tileops/manifest/moe.yaml
+++ b/src/tileops/manifest/moe.yaml
@@ -148,7 +148,7 @@ MoeUnpermuteFwdOp:
       # Optional caller-provided output buffer (forward(out=...)); when omitted
       # the op allocates. default: null marks it non-required so workloads need
       # not specify it; declared so forward()'s out param matches the spec.
-      out: {type: tensor, default: null}
+      out: {type: "tensor | None", default: null}
     shape_rules:
     - "output.shape == (total_tokens, hidden_size)"
 

--- a/src/tileops/manifest/normalization.yaml
+++ b/src/tileops/manifest/normalization.yaml
@@ -68,7 +68,7 @@ LayerNormFwdOp:
       output: {dtype: "same_as(x)"}
     params:
       normalized_shape: {type: "list[int] | tuple[int, ...]"}
-      eps: {type: float, default: 1.0e-5}
+      eps: {type: "float | None", default: 1.0e-5}
     shape_rules:
       - "len(normalized_shape) > 0"
       - "tuple(x.shape[-len(normalized_shape):]) == tuple(normalized_shape)"

--- a/src/tileops/ops/__init__.py
+++ b/src/tileops/ops/__init__.py
@@ -33,6 +33,7 @@ from .fft import FFTC2COp
 from .fp8_lightning_indexer import FP8LightningIndexerOp
 from .fp8_quant import FP8QuantOp
 from .gated_deltanet import (
+    GatedDeltaNetBTHDFwdOp,
     GatedDeltaNetBwdOp,
     GatedDeltaNetDecodeOp,
     GatedDeltaNetFwdOp,
@@ -145,6 +146,7 @@ __all__ = [
     "DeltaNetDecodeOp",
     "DeltaNetFwdOp",
     "DeltaNetOp",
+    "GatedDeltaNetBTHDFwdOp",
     "GatedDeltaNetBwdOp",
     "GatedDeltaNetDecodeOp",
     "GatedDeltaNetFwdOp",

--- a/src/tileops/ops/gated_deltanet.py
+++ b/src/tileops/ops/gated_deltanet.py
@@ -1,3 +1,4 @@
+import functools
 from typing import Dict, Optional, Tuple
 
 import torch
@@ -101,6 +102,55 @@ def _resolve_gated_bthd(
     return batch, heads, seq_len, dim_k, dim_v, dtype
 
 
+_LAYOUTS = ("bhtd", "bthd")
+
+
+@functools.lru_cache(maxsize=8)
+def _device_capability(device_index: "int | None") -> tuple[int, int]:
+    """Compute capability of *device_index*. A device property, so read it once."""
+    return torch.cuda.get_device_capability(device_index)
+
+
+def _bthd_production_gaps(
+    chunk_size: int,
+    dim_k: int,
+    dim_v: int,
+    dtype: torch.dtype,
+    device_index: "int | None",
+) -> list[str]:
+    """Requirements of the BTHD production pipeline this call does not meet.
+
+    Each entry names one requirement and the value that failed it, so a refusal
+    says which one to change.
+    """
+    gaps = []
+    if chunk_size != 64:
+        gaps.append(f"chunk_size must be 64, got {chunk_size}")
+    if dim_k != dim_v:
+        gaps.append(f"dim_k and dim_v must be equal, got {dim_k} and {dim_v}")
+    if dim_k not in (64, 128):
+        gaps.append(f"dim_k must be 64 or 128, got {dim_k}")
+    if dtype not in (torch.float16, torch.bfloat16):
+        gaps.append(f"dtype must be float16 or bfloat16, got {dtype}")
+    major, minor = _device_capability(device_index)
+    if major != 9:
+        gaps.append(
+            f"the warp-specialized kernel needs Hopper (compute capability 9.x), "
+            f"got {major}.{minor}"
+        )
+    return gaps
+
+
+def _normalize_layout(layout: str) -> str:
+    """Lower-case *layout* and reject anything outside the two this file serves."""
+    normalized = layout.lower()
+    if normalized not in _LAYOUTS:
+        raise ValueError(
+            f"layout must be one of {_LAYOUTS}, got {layout!r}"
+        )
+    return normalized
+
+
 class GatedDeltaNetFwdOp(Op):
     """Gated DeltaNet forward operator.
 
@@ -124,9 +174,7 @@ class GatedDeltaNetFwdOp(Op):
         tune: bool = False,
         layout: str = "bhtd",
     ) -> None:
-        layout = layout.lower()
-        if layout not in ("bhtd", "bthd"):
-            raise ValueError(f"Unsupported layout: {layout}")
+        layout = _normalize_layout(layout)
         self.batch = None
         self.heads = None
         self.seq_len = None
@@ -157,19 +205,15 @@ class GatedDeltaNetFwdOp(Op):
         dtype: torch.dtype,
         device_index: int | None,
     ) -> Kernel:
-        production = (
-            self.layout == "bthd"
-            and self.chunk_size == 64
-            and dim_k == dim_v
-            and dim_k in (64, 128)
-            and dtype in (torch.float16, torch.bfloat16)
-            and torch.cuda.get_device_capability(device_index)[0] == 9
-        )
-        if self.layout == "bthd" and not production:
-            raise ValueError(
-                "BTHD GatedDeltaNet forward currently requires Hopper, chunk_size=64, "
-                "equal K/V dimensions in {64, 128}, and float16 or bfloat16"
-            )
+        production = self.layout == "bthd"
+        if production:
+            gaps = _bthd_production_gaps(
+                self.chunk_size, dim_k, dim_v, dtype, device_index)
+            if gaps:
+                raise ValueError(
+                    "BTHD GatedDeltaNet forward has no kernel for this call: "
+                    + "; ".join(gaps)
+                )
         kernel_name = "GatedDeltaNetFwdProductionKernel" if production else "GatedDeltaNetFwdKernel"
         key = (
             kernel_name,
@@ -231,7 +275,8 @@ class GatedDeltaNetFwdOp(Op):
         self.dim_k = dim_k
         self.dim_v = dim_v
         self.dtype = dtype
-        self.kernel = self._get_kernel(batch, heads, seq_len, dim_k, dim_v, dtype, q.device.index)
+        self.kernel = self._get_kernel(
+            batch, heads, seq_len, dim_k, dim_v, dtype, q.device.index)
         o, S, Aw, Au = self.kernel(q, k, v, g, beta)
         return o, S, Aw, Au
 
@@ -258,7 +303,7 @@ class GatedDeltaNetPrefillFwdOp(Op):
         tune: bool = False,
         layout: str = "bthd",
     ) -> None:
-        layout = self._normalize_layout(layout)
+        layout = _normalize_layout(layout)
         self.batch = None
         self.heads = None
         self.seq_len = None
@@ -280,13 +325,6 @@ class GatedDeltaNetPrefillFwdOp(Op):
             "GatedDeltaNetPrefillFwdKernel": GatedDeltaNetPrefillFwdKernel,
         }
 
-    @staticmethod
-    def _normalize_layout(layout: str) -> str:
-        layout = layout.lower()
-        if layout in ("bhtd", "bthd"):
-            return layout
-        raise ValueError(f"Unsupported layout: {layout}")
-
     def _infer_output_shapes(
         self,
         q_shape: tuple[int, ...],
@@ -296,7 +334,7 @@ class GatedDeltaNetPrefillFwdOp(Op):
         beta_shape: tuple[int, ...],
     ) -> dict[str, tuple[int, ...]]:
         del k_shape, g_shape, beta_shape
-        layout = self._normalize_layout(getattr(self, "layout", "bthd"))
+        layout = _normalize_layout(getattr(self, "layout", "bthd"))
         if layout == "bthd":
             return {
                 "o": (q_shape[0], q_shape[1], q_shape[2], v_shape[-1]),
@@ -410,7 +448,9 @@ class GatedDeltaNetPrefillFwdOp(Op):
             streams = batch * heads
             chunk_size = 128 if streams <= 8 and seq_len % 128 == 0 else 64
         if seq_len % chunk_size != 0:
-            raise ValueError(f"seq_len ({seq_len}) must be divisible by chunk_size ({chunk_size})")
+            raise ValueError(
+                f"seq_len ({seq_len}) must be divisible by chunk_size ({chunk_size})"
+            )
         self.batch = batch
         self.heads = heads
         self.seq_len = seq_len
@@ -419,8 +459,7 @@ class GatedDeltaNetPrefillFwdOp(Op):
         self.chunk_size = chunk_size
         self.dtype = q.dtype
         self.kernel = self._get_kernel(
-            batch, heads, seq_len, chunk_size, dim_k, self.dim_v, q.dtype, q.device.index
-        )
+            batch, heads, seq_len, chunk_size, dim_k, self.dim_v, q.dtype, q.device.index)
 
     def eval_roofline(self) -> tuple[int, int]:
         from tileops.perf.formulas import gated_deltanet_prefill_fwd_roofline
@@ -553,15 +592,15 @@ class GatedDeltaNetBwdOp(Op):
             Tuple of (dq, dk, dv, dg, dbeta).
         """
         batch, heads, seq_len, dim_k, dim_v, dtype = _resolve_gated_bhsd(
-            q, k, v, g, beta, self.chunk_size, do=do
-        )
+            q, k, v, g, beta, self.chunk_size, do=do)
         self.batch = batch
         self.heads = heads
         self.seq_len = seq_len
         self.dim_k = dim_k
         self.dim_v = dim_v
         self.dtype = dtype
-        self.kernel = self._get_kernel(batch, heads, seq_len, dim_k, dim_v, dtype, q.device.index)
+        self.kernel = self._get_kernel(
+            batch, heads, seq_len, dim_k, dim_v, dtype, q.device.index)
         dq, dk, dv, dg, dbeta = self.kernel(do, q, k, v, g, beta, S)
         return dq, dk, dv, dg, dbeta
 
@@ -637,8 +676,7 @@ class GatedDeltaNetOp(Op):
         beta: torch.Tensor,
     ) -> Tuple[Kernel, Kernel]:
         batch, heads, seq_len, dim_k, dim_v, dtype = _resolve_gated_bhsd(
-            q, k, v, g, beta, self.chunk_size
-        )
+            q, k, v, g, beta, self.chunk_size)
         self.batch = batch
         self.heads = heads
         self.seq_len = seq_len

--- a/src/tileops/ops/gated_deltanet.py
+++ b/src/tileops/ops/gated_deltanet.py
@@ -6,6 +6,7 @@ from tileops.kernels.deltanet_call import DeltaNetDecodeCall
 from tileops.kernels.gated_deltanet import (
     GatedDeltaNetBwdKernel,
     GatedDeltaNetFwdKernel,
+    GatedDeltaNetFwdProductionKernel,
     GatedDeltaNetPrefillFwdKernel,
 )
 from tileops.kernels.gated_deltanet_recurrence import (
@@ -69,34 +70,51 @@ def _resolve_gated_bhsd(
     return batch, heads, seq_len, dim_k, dim_v, dtype
 
 
+def _resolve_gated_bthd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    chunk_size: int,
+) -> tuple[int, int, int, int, int, torch.dtype]:
+    if not all(tensor.is_cuda for tensor in (q, k, v, g, beta)):
+        raise ValueError("q, k, v, g, and beta must be CUDA tensors")
+    if q.ndim != 4:
+        raise ValueError("q must have shape [batch, seq_len, heads, dim_k]")
+    batch, seq_len, heads, dim_k = q.shape
+    if k.shape != (batch, seq_len, heads, dim_k):
+        raise ValueError("k must match q shape")
+    if v.ndim != 4 or v.shape[:3] != (batch, seq_len, heads):
+        raise ValueError("v must have shape [batch, seq_len, heads, dim_v]")
+    dim_v = v.shape[-1]
+    if g.shape != (batch, seq_len, heads):
+        raise ValueError("g must have shape [batch, seq_len, heads]")
+    if beta.shape != (batch, seq_len, heads):
+        raise ValueError("beta must have shape [batch, seq_len, heads]")
+    dtype = q.dtype
+    for name, tensor in (("k", k), ("v", v), ("g", g), ("beta", beta)):
+        if tensor.dtype != dtype:
+            raise ValueError(f"{name}.dtype must be {dtype}, got {tensor.dtype}")
+    if seq_len % chunk_size != 0:
+        raise ValueError(f"seq_len ({seq_len}) must be divisible by chunk_size ({chunk_size})")
+    return batch, heads, seq_len, dim_k, dim_v, dtype
+
+
 class GatedDeltaNetFwdOp(Op):
     """Gated DeltaNet forward operator.
 
     Pipeline: prepare_wy_repr(k, g, beta) -> (Aw, Au) -> gated_deltanet_fwd(q, k, v, g, beta, Aw, Au) -> o.
 
-    Layout: BHSD (batch, head, seq_len, dim).
-
-    .. note:: Layout convention difference with FLA
-
-        TileOPs uses **BHSD** layout: ``q/k [B, H, S, DK]``, ``v [B, H, S, DV]``,
-        ``g/beta [B, H, S]``.
-
-        FLA (``fla.ops.gated_delta_rule.chunk_gated_delta_rule``) uses **BTHN**
-        layout: ``q/k [B, T, H, K]``, ``v [B, T, H, V]``, ``g/beta [B, T, H]``.
-
-        When comparing against FLA, tensors must be transposed::
-
-            # TileOPs BHSD -> FLA BTHK
-            q_fla = q.permute(0, 2, 1, 3)   # [B, H, S, DK] -> [B, S, H, DK]
-            g_fla = g.permute(0, 2, 1)       # [B, H, S]     -> [B, S, H]
-
-            # FLA BTHV -> TileOPs BHSD
-            o_tileops = o_fla.permute(0, 2, 1, 3)  # [B, S, H, DV] -> [B, H, S, DV]
+    ``layout="bhtd"`` keeps the legacy TileOps head-major interface.
+    ``layout="bthd"`` selects the FLA-compatible token-major interface and,
+    on Hopper for supported shapes, the production forward pipeline.
 
     Args:
         chunk_size: Chunk size for chunked linear attention.
         kernel_map: Optional kernel overrides.
         tune: Whether to autotune kernels.
+        layout: Input/output layout, either ``"bhtd"`` or ``"bthd"``.
     """
 
     def __init__(
@@ -104,16 +122,20 @@ class GatedDeltaNetFwdOp(Op):
         chunk_size: int = 64,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
+        layout: str = "bhtd",
     ) -> None:
+        layout = layout.lower()
+        if layout not in ("bhtd", "bthd"):
+            raise ValueError(f"Unsupported layout: {layout}")
         self.batch = None
         self.heads = None
         self.seq_len = None
         self.dim_k = None
         self.dim_v = None
-        self._requested_chunk_size = chunk_size
         self.chunk_size = chunk_size
         self.dtype = None
         self.tune = tune
+        self.layout = layout
 
         self.dispatch_kernel(kernel_map)
         self.kernel = None
@@ -122,6 +144,7 @@ class GatedDeltaNetFwdOp(Op):
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {
             "GatedDeltaNetFwdKernel": GatedDeltaNetFwdKernel,
+            "GatedDeltaNetFwdProductionKernel": GatedDeltaNetFwdProductionKernel,
         }
 
     def _get_kernel(
@@ -134,11 +157,36 @@ class GatedDeltaNetFwdOp(Op):
         dtype: torch.dtype,
         device_index: int | None,
     ) -> Kernel:
-        key = (batch, heads, seq_len, self.chunk_size, dim_k, dim_v, dtype, device_index, self.tune)
+        production = (
+            self.layout == "bthd"
+            and self.chunk_size == 64
+            and dim_k == dim_v
+            and dim_k in (64, 128)
+            and dtype in (torch.float16, torch.bfloat16)
+            and torch.cuda.get_device_capability(device_index)[0] == 9
+        )
+        if self.layout == "bthd" and not production:
+            raise ValueError(
+                "BTHD GatedDeltaNet forward currently requires Hopper, chunk_size=64, "
+                "equal K/V dimensions in {64, 128}, and float16 or bfloat16"
+            )
+        kernel_name = "GatedDeltaNetFwdProductionKernel" if production else "GatedDeltaNetFwdKernel"
+        key = (
+            kernel_name,
+            batch,
+            heads,
+            seq_len,
+            self.chunk_size,
+            dim_k,
+            dim_v,
+            dtype,
+            device_index,
+            self.tune,
+        )
         return self.get_or_build_kernel(
-            "GatedDeltaNetFwdKernel",
+            kernel_name,
             key=key,
-            build=lambda: self.kernel_map["GatedDeltaNetFwdKernel"](
+            build=lambda: self.kernel_map[kernel_name](
                 batch,
                 heads,
                 seq_len,
@@ -161,25 +209,29 @@ class GatedDeltaNetFwdOp(Op):
         """Run gated deltanet forward.
 
         Args:
-            q: Query tensor [B, H, S, DK].
-            k: Key tensor [B, H, S, DK].
-            v: Value tensor [B, H, S, DV].
-            g: Gate tensor [B, H, S].
-            beta: Beta tensor [B, H, S].
+            q: Query tensor in the configured layout.
+            k: Key tensor in the configured layout.
+            v: Value tensor in the configured layout.
+            g: Gate tensor in the configured layout without the last dimension.
+            beta: Beta tensor with the same shape as ``g``.
 
         Returns:
             Tuple of (o, S, Aw, Au).
         """
-        batch, heads, seq_len, dim_k, dim_v, dtype = _resolve_gated_bhsd(
-            q, k, v, g, beta, self.chunk_size)
+        q = q.contiguous()
+        k = k.contiguous()
+        v = v.contiguous()
+        g = g.contiguous()
+        beta = beta.contiguous()
+        resolver = _resolve_gated_bthd if self.layout == "bthd" else _resolve_gated_bhsd
+        batch, heads, seq_len, dim_k, dim_v, dtype = resolver(q, k, v, g, beta, self.chunk_size)
         self.batch = batch
         self.heads = heads
         self.seq_len = seq_len
         self.dim_k = dim_k
         self.dim_v = dim_v
         self.dtype = dtype
-        self.kernel = self._get_kernel(
-            batch, heads, seq_len, dim_k, dim_v, dtype, q.device.index)
+        self.kernel = self._get_kernel(batch, heads, seq_len, dim_k, dim_v, dtype, q.device.index)
         o, S, Aw, Au = self.kernel(q, k, v, g, beta)
         return o, S, Aw, Au
 
@@ -358,9 +410,7 @@ class GatedDeltaNetPrefillFwdOp(Op):
             streams = batch * heads
             chunk_size = 128 if streams <= 8 and seq_len % 128 == 0 else 64
         if seq_len % chunk_size != 0:
-            raise ValueError(
-                f"seq_len ({seq_len}) must be divisible by chunk_size ({chunk_size})"
-            )
+            raise ValueError(f"seq_len ({seq_len}) must be divisible by chunk_size ({chunk_size})")
         self.batch = batch
         self.heads = heads
         self.seq_len = seq_len
@@ -369,7 +419,8 @@ class GatedDeltaNetPrefillFwdOp(Op):
         self.chunk_size = chunk_size
         self.dtype = q.dtype
         self.kernel = self._get_kernel(
-            batch, heads, seq_len, chunk_size, dim_k, self.dim_v, q.dtype, q.device.index)
+            batch, heads, seq_len, chunk_size, dim_k, self.dim_v, q.dtype, q.device.index
+        )
 
     def eval_roofline(self) -> tuple[int, int]:
         from tileops.perf.formulas import gated_deltanet_prefill_fwd_roofline
@@ -502,15 +553,15 @@ class GatedDeltaNetBwdOp(Op):
             Tuple of (dq, dk, dv, dg, dbeta).
         """
         batch, heads, seq_len, dim_k, dim_v, dtype = _resolve_gated_bhsd(
-            q, k, v, g, beta, self.chunk_size, do=do)
+            q, k, v, g, beta, self.chunk_size, do=do
+        )
         self.batch = batch
         self.heads = heads
         self.seq_len = seq_len
         self.dim_k = dim_k
         self.dim_v = dim_v
         self.dtype = dtype
-        self.kernel = self._get_kernel(
-            batch, heads, seq_len, dim_k, dim_v, dtype, q.device.index)
+        self.kernel = self._get_kernel(batch, heads, seq_len, dim_k, dim_v, dtype, q.device.index)
         dq, dk, dv, dg, dbeta = self.kernel(do, q, k, v, g, beta, S)
         return dq, dk, dv, dg, dbeta
 
@@ -586,7 +637,8 @@ class GatedDeltaNetOp(Op):
         beta: torch.Tensor,
     ) -> Tuple[Kernel, Kernel]:
         batch, heads, seq_len, dim_k, dim_v, dtype = _resolve_gated_bhsd(
-            q, k, v, g, beta, self.chunk_size)
+            q, k, v, g, beta, self.chunk_size
+        )
         self.batch = batch
         self.heads = heads
         self.seq_len = seq_len
@@ -609,11 +661,25 @@ class GatedDeltaNetOp(Op):
             key=key,
             build=lambda: (
                 self.kernel_map["GatedDeltaNetFwdKernel"](
-                    batch, heads, seq_len, self.chunk_size, dim_k, dim_v,
-                    dtype=Kernel.dtype_to_str(dtype), tune=self.tune),
+                    batch,
+                    heads,
+                    seq_len,
+                    self.chunk_size,
+                    dim_k,
+                    dim_v,
+                    dtype=Kernel.dtype_to_str(dtype),
+                    tune=self.tune,
+                ),
                 self.kernel_map["GatedDeltaNetBwdKernel"](
-                    batch, heads, seq_len, self.chunk_size, dim_k, dim_v,
-                    dtype=Kernel.dtype_to_str(dtype), tune=self.tune),
+                    batch,
+                    heads,
+                    seq_len,
+                    self.chunk_size,
+                    dim_k,
+                    dim_v,
+                    dtype=Kernel.dtype_to_str(dtype),
+                    tune=self.tune,
+                ),
             ),
         )
 
@@ -676,8 +742,7 @@ class GatedDeltaNetDecodeOp(Op):
         return {
             "GatedDeltaNetDecodeKernel": GatedDeltaNetDecodeKernel,
             "GatedDeltaNetDecodeFP32Kernel": GatedDeltaNetDecodeFP32Kernel,
-            "GatedDeltaNetDecodeRawCudaFlaStyleKernel":
-                GatedDeltaNetDecodeRawCudaFlaStyleKernel,
+            "GatedDeltaNetDecodeRawCudaFlaStyleKernel": GatedDeltaNetDecodeRawCudaFlaStyleKernel,
         }
 
     def _get_kernel(
@@ -690,8 +755,9 @@ class GatedDeltaNetDecodeOp(Op):
         device_index: int | None,
     ) -> Kernel:
         key = (batch, heads, dim_k, dim_v, dtype, device_index, self.tune)
-        call = DeltaNetDecodeCall(batch=batch, heads=heads, dim_k=dim_k, dim_v=dim_v,
-                                  dtype=dtype, tune=self.tune)
+        call = DeltaNetDecodeCall(
+            batch=batch, heads=heads, dim_k=dim_k, dim_v=dim_v, dtype=dtype, tune=self.tune
+        )
         chosen = self.select_kernel_key(GATED_DELTANET_DECODE_KEYS, call)
 
         def build() -> Kernel:
@@ -773,9 +839,7 @@ class GatedDeltaNetDecodeOp(Op):
         )
         for name, tensor, expected in expected_shapes:
             if tuple(tensor.shape) != expected:
-                raise ValueError(
-                    f"{name} must have shape {expected}, got {tuple(tensor.shape)}"
-        )
+                raise ValueError(f"{name} must have shape {expected}, got {tuple(tensor.shape)}")
         if not all(tensor.is_cuda for tensor in (q, k, v, g, beta, state)):
             raise ValueError("q, k, v, g, beta, and state must be CUDA tensors")
         self.batch = batch

--- a/src/tileops/ops/gated_deltanet.py
+++ b/src/tileops/ops/gated_deltanet.py
@@ -20,6 +20,7 @@ from tileops.kernels.kernel_base import Kernel
 from .op_base import Op
 
 __all__ = [
+    "GatedDeltaNetBTHDFwdOp",
     "GatedDeltaNetBwdOp",
     "GatedDeltaNetDecodeOp",
     "GatedDeltaNetFwdOp",
@@ -156,15 +157,14 @@ class GatedDeltaNetFwdOp(Op):
 
     Pipeline: prepare_wy_repr(k, g, beta) -> (Aw, Au) -> gated_deltanet_fwd(q, k, v, g, beta, Aw, Au) -> o.
 
-    ``layout="bhtd"`` keeps the legacy TileOps head-major interface.
-    ``layout="bthd"`` selects the FLA-compatible token-major interface and,
-    on Hopper for supported shapes, the production forward pipeline.
+    Head-major (BHTD) inputs: ``q/k [B, H, S, DK]``, ``v [B, H, S, DV]``,
+    ``g/beta [B, H, S]``. ``GatedDeltaNetBwdOp`` consumes the ``S`` this returns,
+    in the same layout. Token-major callers want ``GatedDeltaNetBTHDFwdOp``.
 
     Args:
         chunk_size: Chunk size for chunked linear attention.
         kernel_map: Optional kernel overrides.
         tune: Whether to autotune kernels.
-        layout: Input/output layout, either ``"bhtd"`` or ``"bthd"``.
     """
 
     def __init__(
@@ -172,9 +172,7 @@ class GatedDeltaNetFwdOp(Op):
         chunk_size: int = 64,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
-        layout: str = "bhtd",
     ) -> None:
-        layout = _normalize_layout(layout)
         self.batch = None
         self.heads = None
         self.seq_len = None
@@ -183,17 +181,18 @@ class GatedDeltaNetFwdOp(Op):
         self.chunk_size = chunk_size
         self.dtype = None
         self.tune = tune
-        self.layout = layout
 
         self.dispatch_kernel(kernel_map)
         self.kernel = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
-        return {
-            "GatedDeltaNetFwdKernel": GatedDeltaNetFwdKernel,
-            "GatedDeltaNetFwdProductionKernel": GatedDeltaNetFwdProductionKernel,
-        }
+        return {"GatedDeltaNetFwdKernel": GatedDeltaNetFwdKernel}
+
+    def eval_roofline(self) -> tuple[int, int]:
+        from tileops.perf.formulas import gated_deltanet_fwd_roofline
+
+        return gated_deltanet_fwd_roofline(self)
 
     def _get_kernel(
         self,
@@ -205,18 +204,8 @@ class GatedDeltaNetFwdOp(Op):
         dtype: torch.dtype,
         device_index: int | None,
     ) -> Kernel:
-        production = self.layout == "bthd"
-        if production:
-            gaps = _bthd_production_gaps(
-                self.chunk_size, dim_k, dim_v, dtype, device_index)
-            if gaps:
-                raise ValueError(
-                    "BTHD GatedDeltaNet forward has no kernel for this call: "
-                    + "; ".join(gaps)
-                )
-        kernel_name = "GatedDeltaNetFwdProductionKernel" if production else "GatedDeltaNetFwdKernel"
+        kernel_name = "GatedDeltaNetFwdKernel"
         key = (
-            kernel_name,
             batch,
             heads,
             seq_len,
@@ -253,11 +242,11 @@ class GatedDeltaNetFwdOp(Op):
         """Run gated deltanet forward.
 
         Args:
-            q: Query tensor in the configured layout.
-            k: Key tensor in the configured layout.
-            v: Value tensor in the configured layout.
-            g: Gate tensor in the configured layout without the last dimension.
-            beta: Beta tensor with the same shape as ``g``.
+            q: Query tensor [B, H, S, DK].
+            k: Key tensor [B, H, S, DK].
+            v: Value tensor [B, H, S, DV].
+            g: Gate tensor [B, H, S].
+            beta: Beta tensor [B, H, S].
 
         Returns:
             Tuple of (o, S, Aw, Au).
@@ -267,14 +256,168 @@ class GatedDeltaNetFwdOp(Op):
         v = v.contiguous()
         g = g.contiguous()
         beta = beta.contiguous()
-        resolver = _resolve_gated_bthd if self.layout == "bthd" else _resolve_gated_bhsd
-        batch, heads, seq_len, dim_k, dim_v, dtype = resolver(q, k, v, g, beta, self.chunk_size)
+        batch, heads, seq_len, dim_k, dim_v, dtype = _resolve_gated_bhsd(
+            q, k, v, g, beta, self.chunk_size)
         self.batch = batch
         self.heads = heads
         self.seq_len = seq_len
         self.dim_k = dim_k
         self.dim_v = dim_v
         self.dtype = dtype
+        self.kernel = self._get_kernel(
+            batch, heads, seq_len, dim_k, dim_v, dtype, q.device.index)
+        o, S, Aw, Au = self.kernel(q, k, v, g, beta)
+        return o, S, Aw, Au
+
+
+class GatedDeltaNetBTHDFwdOp(Op):
+    """Gated DeltaNet forward over token-major (BTHD) inputs.
+
+    Same operator as ``GatedDeltaNetFwdOp`` and the same four outputs, over the
+    token-major memory order the FLA reference uses: ``q/k [B, S, H, DK]``,
+    ``v [B, S, H, DV]``, ``g/beta [B, S, H]``. A separate entry because the
+    memory order is part of the signature, not a mode of one signature.
+
+    It runs the warp-specialized production pipeline, so it serves Hopper with
+    ``chunk_size=64``, equal K/V dimensions in {64, 128}, and float16 or
+    bfloat16. Any other call is refused, naming what it failed.
+
+    Args:
+        chunk_size: Chunk size for chunked linear attention.
+        kernel_map: Optional kernel overrides.
+        tune: Whether to autotune kernels.
+    """
+
+    def __init__(
+        self,
+        chunk_size: int = 64,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
+    ) -> None:
+        self.batch = None
+        self.heads = None
+        self.seq_len = None
+        self.dim_k = None
+        self.dim_v = None
+        self.chunk_size = chunk_size
+        self.dtype = None
+        self.tune = tune
+
+        self.dispatch_kernel(kernel_map)
+        self.kernel = None
+
+    @property
+    def default_kernel_map(self) -> Dict[str, Kernel]:
+        return {"GatedDeltaNetFwdProductionKernel": GatedDeltaNetFwdProductionKernel}
+
+    def _validate_dtypes(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+    ) -> None:
+        """Manifest ``dtype``: every input carries q's dtype, which must be half."""
+        if q.dtype not in (torch.float16, torch.bfloat16):
+            raise ValueError(
+                f"Expected q.dtype float16 or bfloat16, got {q.dtype}")
+        for name, tensor in (("k", k), ("v", v), ("g", g), ("beta", beta)):
+            if tensor.dtype != q.dtype:
+                raise ValueError(
+                    f"Expected {name}.dtype {q.dtype}, got {tensor.dtype}")
+        self.dtype = q.dtype
+
+    def _infer_output_shapes(
+        self,
+        q_shape: Tuple[int, ...],
+        k_shape: Tuple[int, ...],
+        v_shape: Tuple[int, ...],
+        g_shape: Tuple[int, ...],
+        beta_shape: Tuple[int, ...],
+    ) -> Dict[str, Tuple[int, ...]]:
+        """Manifest ``shape_rules`` for the four outputs, in token-major order."""
+        batch, seq_len, heads, _ = q_shape
+        dim_k, dim_v = q_shape[3], v_shape[3]
+        num_chunks = seq_len // self.chunk_size
+        return {
+            "o": (batch, seq_len, heads, dim_v),
+            "S": (batch, heads, num_chunks + 1, dim_k, dim_v),
+            "Aw": (batch, seq_len, heads, self.chunk_size),
+            "Au": (batch, seq_len, heads, self.chunk_size),
+        }
+
+    def eval_roofline(self) -> tuple[int, int]:
+        from tileops.perf.formulas import gated_deltanet_fwd_roofline
+
+        return gated_deltanet_fwd_roofline(self)
+
+    def _get_kernel(
+        self,
+        batch: int,
+        heads: int,
+        seq_len: int,
+        dim_k: int,
+        dim_v: int,
+        dtype: torch.dtype,
+        device_index: int | None,
+    ) -> Kernel:
+        gaps = _bthd_production_gaps(self.chunk_size, dim_k, dim_v, dtype, device_index)
+        if gaps:
+            raise ValueError(
+                "BTHD GatedDeltaNet forward has no kernel for this call: "
+                + "; ".join(gaps)
+            )
+        key = (batch, heads, seq_len, self.chunk_size, dim_k, dim_v, dtype,
+               device_index, self.tune)
+        return self.get_or_build_kernel(
+            "GatedDeltaNetFwdProductionKernel",
+            key=key,
+            build=lambda: self.kernel_map["GatedDeltaNetFwdProductionKernel"](
+                batch,
+                heads,
+                seq_len,
+                self.chunk_size,
+                dim_k,
+                dim_v,
+                dtype=Kernel.dtype_to_str(dtype),
+                tune=self.tune,
+            ),
+        )
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+    ) -> torch.Tensor:
+        """Run the token-major forward.
+
+        Args:
+            q: Query tensor [B, S, H, DK].
+            k: Key tensor [B, S, H, DK].
+            v: Value tensor [B, S, H, DV].
+            g: Gate tensor [B, S, H].
+            beta: Beta tensor [B, S, H].
+
+        Returns:
+            Tuple of (o, S, Aw, Au).
+        """
+        q = q.contiguous()
+        k = k.contiguous()
+        v = v.contiguous()
+        g = g.contiguous()
+        beta = beta.contiguous()
+        batch, heads, seq_len, dim_k, dim_v, dtype = _resolve_gated_bthd(
+            q, k, v, g, beta, self.chunk_size)
+        self._validate_dtypes(q, k, v, g, beta)
+        self.batch = batch
+        self.heads = heads
+        self.seq_len = seq_len
+        self.dim_k = dim_k
+        self.dim_v = dim_v
         self.kernel = self._get_kernel(
             batch, heads, seq_len, dim_k, dim_v, dtype, q.device.index)
         o, S, Aw, Au = self.kernel(q, k, v, g, beta)

--- a/src/tileops/perf/formulas.py
+++ b/src/tileops/perf/formulas.py
@@ -41,6 +41,7 @@ __all__ = [
     "fp8_quant_roofline",
     "fused_moe_fwd_bytes",
     "gated_deltanet_decode_roofline",
+    "gated_deltanet_fwd_roofline",
     "gated_deltanet_prefill_fwd_roofline",
     "ge_fwd_roofline",
     "gemm_fwd_roofline",
@@ -208,6 +209,47 @@ def _causal_prefill_visible_scores(seq_len_q: int, seq_len_kv: int) -> int:
     # leading queries see no keys at all, so only the last seq_len_kv rows count.
     rows = min(seq_len_q, seq_len_kv)
     return rows * seq_len_kv - rows * (rows - 1) // 2
+
+
+def gated_deltanet_fwd_roofline(op: Any | None = None, **kwargs: Any) -> tuple[int, int]:
+    """Roofline for the Gated DeltaNet training forward.
+
+    Same chunkwise matmul work as the prefill helper, over the same conservative
+    model. The byte count differs: this forward also materializes the per-chunk
+    state ``S`` and the ``Aw`` / ``Au`` training artifacts that backward reads.
+    """
+    prefill_flops, prefill_bytes = gated_deltanet_prefill_fwd_roofline(op, **kwargs)
+    data = _shape_or_attrs(op, kwargs)
+    if "q_shape" in data:
+        q_shape, v_shape = data["q_shape"], data["v_shape"]
+        layout = str(data.get("layout", "bthd")).lower()
+        if layout == "bthd":
+            batch, seq_len, heads, dim_k = q_shape
+            dim_v = v_shape[3]
+        else:
+            batch, heads, seq_len, dim_k = q_shape
+            dim_v = v_shape[3]
+        chunk_size = data.get("chunk_size", 64) or 64
+    else:
+        batch, heads, seq_len = data["batch"], data["heads"], data["seq_len"]
+        dim_k, dim_v = data["dim_k"], data["dim_v"]
+        chunk_size = data["chunk_size"] or 64
+    elem_bytes = _dtype_itemsize(data.get("dtype", data.get("dtypes", "float16")))
+
+    num_chunks = seq_len // chunk_size
+    # S [B, H, NC + 1, DK, DV] plus Aw and Au, each [B, H, S, chunk_size].
+    state_elems = batch * heads * (num_chunks + 1) * dim_k * dim_v
+    wy_elems = 2 * batch * heads * seq_len * chunk_size
+    # The prefill model already counts one [B, H, DK, DV] final state.
+    prefill_state_elems = batch * heads * dim_k * dim_v
+    extra = (state_elems + wy_elems - prefill_state_elems) * elem_bytes
+
+    # Aw comes from a chunk-local block solve the prefill path does not run:
+    # one triangular inverse per chunk, then applying it across DK.
+    blocksolve_flops = 2 * batch * heads * num_chunks * chunk_size * chunk_size * (
+        chunk_size + dim_k
+    )
+    return int(prefill_flops + blocksolve_flops), int(prefill_bytes + extra)
 
 
 def gated_deltanet_prefill_fwd_roofline(op: Any | None = None, **kwargs: Any) -> tuple[int, int]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,11 +106,47 @@ def _without_dtype(params: dict) -> tuple[tuple[str, object], ...]:
     )
 
 
+def _is_hopper() -> bool:
+    """Whether this machine's first CUDA device is compute capability 9.x."""
+    if not torch.cuda.is_available():
+        return False
+    return torch.cuda.get_device_capability()[0] == 9
+
+
+_hopper_skipped: list[str] = []
+
+
+def pytest_runtest_logreport(report: pytest.TestReport) -> None:
+    """Record a `hopper` test that was skipped, so a Hopper run can refuse it."""
+    if report.when == "setup" and report.skipped and "hopper" in report.keywords:
+        _hopper_skipped.append(report.nodeid)
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    """On Hopper, a `hopper` test that was skipped is a failed run, not a pass.
+
+    The mark exists because the kernel needs Hopper. On the hardware it needs,
+    skipping it would leave the only evidence for that kernel unexercised while
+    the run still reported green. Collection-time skips are covered too: they
+    surface as setup reports. Deselecting the mark outright (``-m "not hopper"``)
+    is not covered, and is not meant to be — that is the operator saying which
+    tests to run, not a run losing its evidence.
+    """
+    if _hopper_skipped and _is_hopper():
+        session.exitstatus = pytest.ExitCode.TESTS_FAILED
+        raise pytest.UsageError(
+            "hopper-marked tests were skipped on a Hopper device: "
+            + ", ".join(_hopper_skipped)
+        )
+
+
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     """Validate explicit test tier assignments."""
     tier_errors: list[str] = []
     tier_names = ("smoke", "full", "nightly")
     tilelang_019_skip = pytest.mark.skip(reason=TILELANG_019_SKIP_REASON)
+    non_hopper_skip = pytest.mark.skip(reason="needs compute capability 9.x")
+    on_hopper = _is_hopper()
 
     for item in items:
         path = str(item.path)
@@ -124,6 +160,9 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
             )
         ):
             item.add_marker(tilelang_019_skip)
+
+        if item.get_closest_marker("hopper") is not None and not on_hopper:
+            item.add_marker(non_hopper_skip)
 
         tiers = [name for name in tier_names if item.get_closest_marker(name) is not None]
         if len(tiers) != 1:

--- a/tests/ops/test_gated_deltanet_fwd.py
+++ b/tests/ops/test_gated_deltanet_fwd.py
@@ -48,31 +48,18 @@ def _get_tolerances(dtype: torch.dtype) -> dict:
 
 class GatedDeltaNetFwdFixture(FixtureBase):
     PARAMS = [
-        (
-            "batch, seq_len, heads, dim_k, dim_v, chunk_size, dtype, tune",
-            [
-                pytest.param(2, 64, 2, 64, 64, 32, torch.float32, False, marks=pytest.mark.smoke),
-                pytest.param(2, 64, 2, 64, 64, 32, torch.float16, False, marks=pytest.mark.smoke),
-                pytest.param(2, 64, 2, 64, 64, 32, torch.bfloat16, False, marks=pytest.mark.smoke),
-                pytest.param(1, 128, 4, 64, 64, 32, torch.float32, False, marks=pytest.mark.full),
-                pytest.param(1, 128, 4, 64, 64, 32, torch.float16, False, marks=pytest.mark.full),
-                pytest.param(1, 128, 4, 64, 64, 32, torch.bfloat16, False, marks=pytest.mark.full),
-                pytest.param(2, 8192, 4, 64, 64, 64, torch.float16, False, marks=pytest.mark.full),
-                pytest.param(2, 16384, 4, 64, 64, 64, torch.float16, False, marks=pytest.mark.full),
-                pytest.param(
-                    2,
-                    64,
-                    2,
-                    64,
-                    64,
-                    32,
-                    torch.bfloat16,
-                    True,
-                    marks=pytest.mark.full,
-                    id="full-bf16-tuned",
-                ),
-            ],
-        ),
+        ("batch, seq_len, heads, dim_k, dim_v, chunk_size, dtype, tune", [
+            pytest.param(2, 64, 2, 64, 64, 32, torch.float32, False, marks=pytest.mark.smoke),
+            pytest.param(2, 64, 2, 64, 64, 32, torch.float16, False, marks=pytest.mark.smoke),
+            pytest.param(2, 64, 2, 64, 64, 32, torch.bfloat16, False, marks=pytest.mark.smoke),
+            pytest.param(1, 128, 4, 64, 64, 32, torch.float32, False, marks=pytest.mark.full),
+            pytest.param(1, 128, 4, 64, 64, 32, torch.float16, False, marks=pytest.mark.full),
+            pytest.param(1, 128, 4, 64, 64, 32, torch.bfloat16, False, marks=pytest.mark.full),
+            pytest.param(2, 8192, 4, 64, 64, 64, torch.float16, False, marks=pytest.mark.full),
+            pytest.param(2, 16384, 4, 64, 64, 64, torch.float16, False, marks=pytest.mark.full),
+            pytest.param(2, 64, 2, 64, 64, 32, torch.bfloat16, True, marks=pytest.mark.full,
+                         id="full-bf16-tuned"),
+        ]),
     ]
 
 

--- a/tests/ops/test_gated_deltanet_fwd.py
+++ b/tests/ops/test_gated_deltanet_fwd.py
@@ -1,4 +1,3 @@
-
 import pytest
 import torch
 
@@ -31,6 +30,7 @@ class GatedDeltaNetFwdTest(GatedDeltaNetFwdWorkload, TestBase):
 
 # Forward correctness tests
 
+
 def _get_tolerances(dtype: torch.dtype) -> dict:
     # Tolerances are looser than docs/design/testing.md defaults (fp16: 1e-3, bf16: 1.6e-2)
     # because Gated DeltaNet uses sequential chunk recurrence: each chunk's hidden
@@ -48,18 +48,31 @@ def _get_tolerances(dtype: torch.dtype) -> dict:
 
 class GatedDeltaNetFwdFixture(FixtureBase):
     PARAMS = [
-        ("batch, seq_len, heads, dim_k, dim_v, chunk_size, dtype, tune", [
-            pytest.param(2, 64, 2, 64, 64, 32, torch.float32, False, marks=pytest.mark.smoke),
-            pytest.param(2, 64, 2, 64, 64, 32, torch.float16, False, marks=pytest.mark.smoke),
-            pytest.param(2, 64, 2, 64, 64, 32, torch.bfloat16, False, marks=pytest.mark.smoke),
-            pytest.param(1, 128, 4, 64, 64, 32, torch.float32, False, marks=pytest.mark.full),
-            pytest.param(1, 128, 4, 64, 64, 32, torch.float16, False, marks=pytest.mark.full),
-            pytest.param(1, 128, 4, 64, 64, 32, torch.bfloat16, False, marks=pytest.mark.full),
-            pytest.param(2, 8192, 4, 64, 64, 64, torch.float16, False, marks=pytest.mark.full),
-            pytest.param(2, 16384, 4, 64, 64, 64, torch.float16, False, marks=pytest.mark.full),
-            pytest.param(2, 64, 2, 64, 64, 32, torch.bfloat16, True, marks=pytest.mark.full,
-                         id="full-bf16-tuned"),
-        ]),
+        (
+            "batch, seq_len, heads, dim_k, dim_v, chunk_size, dtype, tune",
+            [
+                pytest.param(2, 64, 2, 64, 64, 32, torch.float32, False, marks=pytest.mark.smoke),
+                pytest.param(2, 64, 2, 64, 64, 32, torch.float16, False, marks=pytest.mark.smoke),
+                pytest.param(2, 64, 2, 64, 64, 32, torch.bfloat16, False, marks=pytest.mark.smoke),
+                pytest.param(1, 128, 4, 64, 64, 32, torch.float32, False, marks=pytest.mark.full),
+                pytest.param(1, 128, 4, 64, 64, 32, torch.float16, False, marks=pytest.mark.full),
+                pytest.param(1, 128, 4, 64, 64, 32, torch.bfloat16, False, marks=pytest.mark.full),
+                pytest.param(2, 8192, 4, 64, 64, 64, torch.float16, False, marks=pytest.mark.full),
+                pytest.param(2, 16384, 4, 64, 64, 64, torch.float16, False, marks=pytest.mark.full),
+                pytest.param(
+                    2,
+                    64,
+                    2,
+                    64,
+                    64,
+                    32,
+                    torch.bfloat16,
+                    True,
+                    marks=pytest.mark.full,
+                    id="full-bf16-tuned",
+                ),
+            ],
+        ),
     ]
 
 
@@ -84,6 +97,42 @@ def test_gated_deltanet_fwd(
     torch.testing.assert_close(op_o, ref_o, **tols)
     if tune:
         assert op.kernel.config in op.kernel.autotune_configs
+
+
+@pytest.mark.parametrize(
+    "seq_len,dim,dtype",
+    [
+        pytest.param(128, 64, torch.float16, marks=pytest.mark.smoke),
+        pytest.param(128, 64, torch.bfloat16, marks=pytest.mark.smoke),
+        pytest.param(128, 128, torch.float16, marks=pytest.mark.smoke),
+        pytest.param(32768, 64, torch.float16, marks=pytest.mark.full),
+    ],
+)
+def test_gated_deltanet_fwd_bthd_production_matches_legacy(
+    seq_len: int, dim: int, dtype: torch.dtype
+) -> None:
+    if torch.cuda.get_device_capability()[0] != 9:
+        pytest.skip("the warp-specialized BTHD production kernel requires Hopper")
+
+    torch.manual_seed(42)
+    test = GatedDeltaNetFwdTest(2, 4, seq_len, dim, dim, 64, dtype)
+    q, k, v, g, beta = test.gen_inputs()
+    legacy = GatedDeltaNetFwdOp(chunk_size=64, layout="bhtd")(q, k, v, g, beta)
+
+    q_bthd = q.permute(0, 2, 1, 3).contiguous()
+    k_bthd = k.permute(0, 2, 1, 3).contiguous()
+    v_bthd = v.permute(0, 2, 1, 3).contiguous()
+    g_bthd = g.permute(0, 2, 1).contiguous()
+    beta_bthd = beta.permute(0, 2, 1).contiguous()
+    production_op = GatedDeltaNetFwdOp(chunk_size=64, layout="bthd")
+    production = production_op(q_bthd, k_bthd, v_bthd, g_bthd, beta_bthd)
+
+    tols = _get_tolerances(dtype)
+    torch.testing.assert_close(production[0].permute(0, 2, 1, 3), legacy[0], **tols)
+    torch.testing.assert_close(production[1], legacy[1], **tols)
+    torch.testing.assert_close(production[2].permute(0, 2, 1, 3), legacy[2], **tols)
+    torch.testing.assert_close(production[3].permute(0, 2, 1, 3), legacy[3], **tols)
+    assert production_op.kernel.__class__.__name__ == "GatedDeltaNetFwdProductionKernel"
 
 
 if __name__ == "__main__":

--- a/tests/ops/test_gated_deltanet_fwd.py
+++ b/tests/ops/test_gated_deltanet_fwd.py
@@ -2,7 +2,11 @@ import pytest
 import torch
 
 from tests.test_base import FixtureBase, TestBase
-from tileops.ops import GatedDeltaNetFwdOp, GatedDeltaNetPrefillFwdOp
+from tileops.ops import (
+    GatedDeltaNetBTHDFwdOp,
+    GatedDeltaNetFwdOp,
+    GatedDeltaNetPrefillFwdOp,
+)
 from workloads.linear_attention import (
     GatedDeltaNetFwdWorkload,
 )
@@ -86,6 +90,24 @@ def test_gated_deltanet_fwd(
         assert op.kernel.config in op.kernel.autotune_configs
 
 
+@pytest.mark.smoke
+def test_bthd_forward_refuses_a_dtype_it_cannot_serve() -> None:
+    """The dtype contract is checked before a kernel is chosen, and names the value."""
+    q = torch.randn(1, 64, 2, 64, dtype=torch.float32, device="cuda")
+    g = torch.randn(1, 64, 2, dtype=torch.float32, device="cuda")
+    with pytest.raises(ValueError, match="float16 or bfloat16, got torch.float32"):
+        GatedDeltaNetBTHDFwdOp(chunk_size=64)(q, q, q, g, g)
+
+
+@pytest.mark.smoke
+def test_bthd_forward_names_the_requirement_a_call_missed() -> None:
+    """A call the production pipeline has no kernel for is told which one it failed."""
+    q = torch.randn(1, 64, 2, 64, dtype=torch.float16, device="cuda")
+    g = torch.randn(1, 64, 2, dtype=torch.float16, device="cuda")
+    with pytest.raises(ValueError, match="chunk_size must be 64, got 32"):
+        GatedDeltaNetBTHDFwdOp(chunk_size=32)(q, q, q, g, g)
+
+
 @pytest.mark.parametrize(
     "seq_len,dim,dtype",
     [
@@ -95,23 +117,21 @@ def test_gated_deltanet_fwd(
         pytest.param(32768, 64, torch.float16, marks=pytest.mark.full),
     ],
 )
-def test_gated_deltanet_fwd_bthd_production_matches_legacy(
+@pytest.mark.hopper
+def test_gated_deltanet_bthd_matches_the_head_major_op(
     seq_len: int, dim: int, dtype: torch.dtype
 ) -> None:
-    if torch.cuda.get_device_capability()[0] != 9:
-        pytest.skip("the warp-specialized BTHD production kernel requires Hopper")
-
     torch.manual_seed(42)
     test = GatedDeltaNetFwdTest(2, 4, seq_len, dim, dim, 64, dtype)
     q, k, v, g, beta = test.gen_inputs()
-    legacy = GatedDeltaNetFwdOp(chunk_size=64, layout="bhtd")(q, k, v, g, beta)
+    legacy = GatedDeltaNetFwdOp(chunk_size=64)(q, k, v, g, beta)
 
     q_bthd = q.permute(0, 2, 1, 3).contiguous()
     k_bthd = k.permute(0, 2, 1, 3).contiguous()
     v_bthd = v.permute(0, 2, 1, 3).contiguous()
     g_bthd = g.permute(0, 2, 1).contiguous()
     beta_bthd = beta.permute(0, 2, 1).contiguous()
-    production_op = GatedDeltaNetFwdOp(chunk_size=64, layout="bthd")
+    production_op = GatedDeltaNetBTHDFwdOp(chunk_size=64)
     production = production_op(q_bthd, k_bthd, v_bthd, g_bthd, beta_bthd)
 
     tols = _get_tolerances(dtype)

--- a/tests/ops/test_gated_deltanet_fwd.py
+++ b/tests/ops/test_gated_deltanet_fwd.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 
 from tests.test_base import FixtureBase, TestBase
-from tileops.ops import GatedDeltaNetFwdOp
+from tileops.ops import GatedDeltaNetFwdOp, GatedDeltaNetPrefillFwdOp
 from workloads.linear_attention import (
     GatedDeltaNetFwdWorkload,
 )
@@ -133,6 +133,12 @@ def test_gated_deltanet_fwd_bthd_production_matches_legacy(
     torch.testing.assert_close(production[2].permute(0, 2, 1, 3), legacy[2], **tols)
     torch.testing.assert_close(production[3].permute(0, 2, 1, 3), legacy[3], **tols)
     assert production_op.kernel.__class__.__name__ == "GatedDeltaNetFwdProductionKernel"
+    if (seq_len, dim, dtype) == (128, 128, torch.float16):
+        prefill_o, final_state = GatedDeltaNetPrefillFwdOp(chunk_size=64, layout="bthd")(
+            q_bthd[:1], k_bthd[:1], v_bthd[:1], g_bthd[:1], beta_bthd[:1]
+        )
+        torch.testing.assert_close(prefill_o, production[0][:1], **tols)
+        torch.testing.assert_close(final_state, production[1][:1, :, -1], **tols)
 
 
 if __name__ == "__main__":

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -705,6 +705,39 @@ class TestTorchCompileFullgraph:
         ), errors
 
 
+class TestParamDomain:
+    """A param's type parses and covers its default."""
+
+    @staticmethod
+    def _entry(**param_attrs):
+        entry = _make_entry(status="implemented", kernel_map={"k": "K"})
+        entry["signature"]["params"] = {"p": param_attrs}
+        return entry
+
+    def test_a_type_that_admits_none_may_default_to_null(self, validator):
+        entry = self._entry(type="float | None", default=None)
+        assert validator.check_l0("Op", entry) == []
+
+    def test_a_type_without_none_may_not_default_to_null(self, validator):
+        errors = validator.check_l0("Op", self._entry(type="float", default=None))
+        assert any("does not admit None" in e for e in errors), errors
+
+    def test_an_unparsable_type_is_rejected(self, validator):
+        errors = validator.check_l0("Op", self._entry(type="float |", default=1.0))
+        assert any("is not a type expression" in e for e in errors), errors
+
+    def test_spelling_of_the_same_domain_is_the_authors(self, validator):
+        """``Optional[X]``, ``Union[X, None]`` and ``X | None`` state one thing."""
+        for spelling in ("Optional[float]", "Union[float, None]", "float | None"):
+            entry = self._entry(type=spelling, default=None)
+            assert validator.check_l0("Op", entry) == [], spelling
+
+    def test_a_type_that_is_not_text_is_rejected(self, validator):
+        """A YAML scalar that is not a string cannot be a type expression."""
+        for written in (None, 123):
+            errors = validator.check_l0("Op", self._entry(type=written, default="x"))
+            assert any("is not a type expression" in e for e in errors), written
+
 class TestOptionalInputs:
     """R18: optional tensor inputs, where the name may appear, coverage."""
 


### PR DESCRIPTION
Accelerate the Gated DeltaNet forward on Hopper by giving the token-major path the production prefill pipeline, and put the result under the manifest's own checking.

## Problems

- The Hopper forward went through the legacy chunk path; the faster production prefill pipeline was in the tree but unused by this op.
- The manifest said an op serves two memory layouts in two contradicting ways: a `layout` param with sixteen conditional shape rules, while each tensor's `shape` declared head-major only. The probe binds a param to its default, so only the head-major half was ever evaluated and the token-major contract was checked by nothing.
- `GatedDeltaNetFwdOp` was `spec-only` with no workloads and `roofline: {flops: "0", bytes: "0"}`, and the benchmark computed FLOPs and bytes beside itself, so a performance claim could not be reproduced through `op.eval_roofline()`.
- The only correctness oracle for the new kernel skipped unless the device was Hopper, and a skip is not a failure, so a green run could not be told from one where it never executed.
- `type` was declared on every param and read by nothing: the spec named four types while 108 of 320 params used others, and nine entries disagreed with their own implementation about whether `None` is admitted.

## Changes

- The token-major forward is its own op and entry, `GatedDeltaNetBTHDFwdOp`, running the warp-specialized pipeline. Memory order is part of the signature, so one entry declares one order; `GatedDeltaNetFwdOp` keeps head-major, which `GatedDeltaNetBwdOp` reads. The layout param, the sixteen conditional rules and the layout branching in the op layer are gone.
- The new entry is `implemented`: six workload rows, dtype and shape parity methods, and a roofline counting the per-chunk state, the wy-repr artifacts and the block solve that produces them. The forward benchmark draws its parameters from `load_workloads` and reports through `ManifestBenchmark`.
- A refused call names the requirement it missed and the value it supplied, rather than listing every requirement.
- A `hopper` mark carries the skip, and a session hook fails a Hopper run that skipped one.
- A param's `type` is a type expression checked against the implementation's annotation on whether `None` is admitted; a type that does not admit it may not carry `default: null`. Spelling stays the author's. Nine entries are corrected, including `GatedDeltaNetBwdOp.S`, which the kernel allocates in the input dtype rather than float32.

## Evidence

One H200, bf16 and fp16, `B=2, H=4, DK=DV=64, chunk_size=64`, CUPTI timing:

| sequence length | this PR (ms) | FLA (ms) |
| ---: | ---: | ---: |
| 2,048 | 0.2756 | 0.5083 |
| 4,096 | 0.3271 | 0.5048 |
| 8,192 | 0.4303 | 0.5397 |
| 16,384 | 0.6284 | 0.6617 |
| 32,768 | 0.4618 | 0.9066 |

At 32,768 the previous TileOps path took 1.4401 ms against this PR's 0.4618 ms.

In `ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-afcebed1-dev` on an H200: `validate_manifest.py --strict` passes, and the validator, forward, prefill and backward suites are 189 passed.
