### PR TITLE
[Fix][Mamba] Bound SSD chunk-state specialized paths

### DIFF
--- a/src/tileops/kernels/mamba/ssd_chunk_state.py
+++ b/src/tileops/kernels/mamba/ssd_chunk_state.py
@@ -389,8 +389,9 @@ class SSDChunkStateFwdKernel(Kernel):
         )
         if primary_mamba_geometry:
             small_grid = grid_size <= 640
+            launch_shape = (self.batch, self.num_chunks, self.n_heads)
             if small_grid and not self.has_seq_idx and self.dt_dtype == torch.float32:
-                if self.dtype == torch.float16 and grid_size == 512:
+                if self.dtype == torch.float16 and launch_shape == (1, 8, 64):
                     return {
                         "block_n": 128,
                         "block_p": 64,
@@ -398,7 +399,7 @@ class SSDChunkStateFwdKernel(Kernel):
                         "threads": 256,
                         "num_stages": 2,
                     }
-                if self.dtype == torch.bfloat16 and grid_size == 640:
+                if self.dtype == torch.bfloat16 and launch_shape == (1, 8, 80):
                     return {
                         "block_n": 64,
                         "block_p": 64,

--- a/src/tileops/ops/ssd_chunk_state.py
+++ b/src/tileops/ops/ssd_chunk_state.py
@@ -158,7 +158,14 @@ class SSDChunkStateFwdOp(Op):
         dA_cumsum = dA_cumsum.contiguous()
 
         if seq_idx is None:
-            seq_idx = x.new_empty(self.batch, self.num_chunks * self.chunk_len, dtype=torch.int32)
+            if self.has_seq_idx:
+                seq_idx = x.new_zeros(
+                    self.batch, self.num_chunks * self.chunk_len, dtype=torch.int32,
+                )
+            else:
+                seq_idx = x.new_empty(
+                    self.batch, self.num_chunks * self.chunk_len, dtype=torch.int32,
+                )
         else:
             seq_idx = seq_idx.contiguous()
 

--- a/tests/ops/test_mamba.py
+++ b/tests/ops/test_mamba.py
@@ -191,8 +191,8 @@ def test_ssd_chunk_state_fwd(
 
 
 @pytest.mark.smoke
-def test_ssd_chunk_state_fwd_seq_end_negative():
-    """Kernel must zero the whole chunk when the last token's seq_idx is -1."""
+def test_ssd_chunk_state_fwd_seq_idx_semantics():
+    """Exercise negative chunk ends and the optional unmasked path."""
     batch, num_chunks, chunk_len = 1, 2, 64
     n_heads, d_head, d_state, n_groups = 4, 64, 32, 1
     dtype = torch.float16
@@ -222,6 +222,13 @@ def test_ssd_chunk_state_fwd_seq_end_negative():
     # chunk 1 (seq_idx == 1 throughout) must have non-zero state.
     allclose_compare(out[:, 0], torch.zeros_like(out[:, 0]), atol=0.0, rtol=0.0)
     assert out[:, 1].abs().max().item() > 0
+
+    poison = torch.full((b, seq_len), -1, dtype=torch.int32, device="cuda")
+    torch.cuda.synchronize()
+    del poison
+    out = op(x, Bmat, dt, dA_cumsum)
+    ref = ssd_chunk_state_fwd_ref(x, Bmat, dt, dA_cumsum, g)
+    allclose_compare(out, ref, atol=atol, rtol=rtol)
 
 
 class SSDStatePassingFwdTest(SSDStatePassingFwdWorkload, TestBase):


### PR DESCRIPTION
## Summary

- Restrict SSD chunk-state specialized configs to the exact production shapes.
- Preserve `seq_idx=None` semantics when `has_seq_idx=True`.
- Extend the existing `seq_idx` semantics test.