### PR TITLE
[Perf][Mamba] Expand SSD decode autotune configs

### DIFF
--- a/src/tileops/kernels/mamba/ssd_decode.py
+++ b/src/tileops/kernels/mamba/ssd_decode.py
@@ -383,10 +383,14 @@ class SSDDecodeKernel(Kernel):
     @property
     def autotune_configs(self) -> list[dict]:
         # threads = block_p * block_n.  block_n must be a power of 2.
+        # Keep blocks at or below 256 threads: half-warp N tiles and wider P
+        # tiles improve several production decode shapes, while the larger
+        # cross-products tend to hurt occupancy.
         return [
             {"block_p": bp, "block_n": bn, "threads": bp * bn}
-            for bn in [32, 64, 128]
-            for bp in [1, 2, 4]
+            for bn in [16, 32, 64, 128]
+            for bp in [1, 2, 4, 8]
+            if bp * bn <= 256
         ]
 
     def forward(


### PR DESCRIPTION
## Summary

Expand the Mamba-2 SSD decode autotuning space to cover half-warp `d_state`
tiles and wider `d_head` tiles.

- Add `block_n=16`
- Add `block_p=8`
- Limit candidate thread blocks to at most 256 threads
- Increase the autotune space from 9 to 13 valid configurations

## Motivation

The previous search space consistently favored `block_p=4, block_n=32`, but
left out configurations that can reduce per-block overhead and improve
occupancy for production Mamba decode shapes.

CUPTI profiling on an NVIDIA H200 showed that the new candidates improve
several 130M and 2.7B decode workloads.

## Performance

| Workload | Before | After | Improvement |
|---|---:|---:|---:|
| Mamba-2 130M, batch 64 | 36.4 μs | 34.5 μs | 5.2% |
| Mamba-2 2.7B, batch 1 | 4.7 μs | 4.5 μs | 4.3% |
| Mamba-2 2.7B, batch 4 | 9.3 μs | 9.2 μs | 1.1% |
| Mamba-2 2.7B, batch 8 | 16.2 μs | 15.6 μs | 3.7% |

Other tested workloads remained performance-neutral. Peak effective bandwidth
increased to approximately 2.97 TB/s.

## Validation

- `python -m pytest -q tests/ops/test_mamba.py -k ssd_decode`
  - 4 passed
- Full SSD decode benchmark
  - 10 passed
- Verified output and in-place state against the PyTorch reference for every
  newly selected configuration
  - Maximum observed error below `9e-8`