### PR TITLE
[Perf][Convolution] Split Conv2d kernels on has_bias at compile time

### DIFF
--- a/src/tileops/kernels/convolution.py
+++ b/src/tileops/kernels/convolution.py
@@ -118,6 +118,70 @@ def _conv1d_kernel(
             x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
             weight_flat: T.Tensor((c_out, k_total), dtype),  # type: ignore
             out: T.Tensor((n, c_out, out_l), dtype),  # type: ignore
+        ):
+            with T.Kernel(
+                T.ceildiv(out_l, block_n),
+                T.ceildiv(c_out, block_m),
+                n,
+                threads=threads,
+            ) as (bx, by, bz):
+                weight_shared = T.alloc_shared((block_m, block_k), dtype)
+                data_shared = T.alloc_shared((block_k, block_n), dtype)
+                out_local = T.alloc_fragment((block_m, block_n), accum_dtype)
+                out_shared = T.alloc_shared((block_m, block_n), dtype)
+
+                T.use_swizzle(10, enable=enable_rasterization)
+                T.clear(out_local)
+
+                tile_ol_start = bx * block_n
+                tile_ol_end = tile_ol_start + block_n - 1
+                tile_input_start = tile_ol_start * stride_l - pad_left
+                tile_input_end = tile_ol_end * stride_l + (kernel_l - 1) * dilation_l - pad_left
+                tile_spatial_full = (
+                    (tile_ol_end < out_l) & (tile_input_start >= 0) & (tile_input_end < l_in)
+                )
+
+                for k_iter in T.Pipelined(T.ceildiv(k_total, block_k), num_stages=num_stages):
+                    T.copy(weight_flat[by * block_m, k_iter * block_k], weight_shared)
+
+                    for i, j in T.Parallel(block_k, block_n):
+                        k_idx = k_iter * block_k + i
+                        ol = bx * block_n + j
+                        kw = k_idx // c_in
+                        ci = k_idx % c_in
+                        il = ol * stride_l + kw * dilation_l - pad_left
+                        if tile_spatial_full & ((k_iter + 1) * block_k <= k_total):
+                            data_shared[i, j] = x[bz, ci, il]
+                        else:
+                            in_bound = (k_idx < k_total) & (ol < out_l) & (il >= 0) & (il < l_in)
+                            data_shared[i, j] = T.if_then_else(
+                                in_bound,
+                                x[bz, ci, il],
+                                T.cast(0.0, dtype),
+                            )
+
+                    T.gemm(weight_shared, data_shared, out_local)
+
+                for i, j in T.Parallel(block_m, block_n):
+                    oc = by * block_m + i
+                    ol = bx * block_n + j
+                    out_shared[i, j] = T.if_then_else(
+                        (oc < c_out) & (ol < out_l),
+                        T.cast(out_local[i, j], dtype),
+                        T.cast(0.0, dtype),
+                    )
+
+                for i, j in T.Parallel(block_m, block_n):
+                    oc = by * block_m + i
+                    ol = bx * block_n + j
+                    if oc < c_out and ol < out_l:
+                        out[bz, oc, ol] = out_shared[i, j]
+
+        @T.prim_func
+        def _conv1d_bias_main(
+            x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
+            weight_flat: T.Tensor((c_out, k_total), dtype),  # type: ignore
+            out: T.Tensor((n, c_out, out_l), dtype),  # type: ignore
             bias: T.Tensor((c_out,), dtype),  # type: ignore
         ):
             with T.Kernel(
@@ -166,18 +230,11 @@ def _conv1d_kernel(
                 for i, j in T.Parallel(block_m, block_n):
                     oc = by * block_m + i
                     ol = bx * block_n + j
-                    if has_bias:
-                        out_shared[i, j] = T.if_then_else(
-                            (oc < c_out) & (ol < out_l),
-                            T.cast(out_local[i, j] + T.cast(bias[oc], accum_dtype), dtype),
-                            T.cast(0.0, dtype),
-                        )
-                    else:
-                        out_shared[i, j] = T.if_then_else(
-                            (oc < c_out) & (ol < out_l),
-                            T.cast(out_local[i, j], dtype),
-                            T.cast(0.0, dtype),
-                        )
+                    out_shared[i, j] = T.if_then_else(
+                        (oc < c_out) & (ol < out_l),
+                        T.cast(out_local[i, j] + T.cast(bias[oc], accum_dtype), dtype),
+                        T.cast(0.0, dtype),
+                    )
 
                 for i, j in T.Parallel(block_m, block_n):
                     oc = by * block_m + i
@@ -185,7 +242,7 @@ def _conv1d_kernel(
                     if oc < c_out and ol < out_l:
                         out[bz, oc, ol] = out_shared[i, j]
 
-        return _conv1d_main
+        return _conv1d_bias_main if has_bias else _conv1d_main
 
     return _conv1d_func
 
@@ -221,6 +278,41 @@ def _conv1d_direct_kernel(
             x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
             weight: T.Tensor((c_out, 1, kernel_l), dtype),  # type: ignore
             out: T.Tensor((n, c_out, out_l), dtype),  # type: ignore
+        ):
+            with T.Kernel(
+                T.ceildiv(out_l, block_n),
+                T.ceildiv(c_out, block_m),
+                n,
+                threads=threads,
+            ) as (bx, by, bz):
+                out_local = T.alloc_fragment((block_m, block_n), accum_dtype)
+                T.use_swizzle(10, enable=enable_rasterization)
+                T.clear(out_local)
+
+                for kw in T.serial(kernel_l):
+                    for i, j in T.Parallel(block_m, block_n):
+                        oc = by * block_m + i
+                        ol = bx * block_n + j
+                        il = ol * stride_l + kw * dilation_l - pad_left
+                        valid = (oc < c_out) & (ol < out_l) & (il >= 0) & (il < l_in)
+                        out_local[i, j] += T.if_then_else(
+                            valid,
+                            T.cast(x[bz, oc, il], accum_dtype)
+                            * T.cast(weight[oc, 0, kw], accum_dtype),
+                            T.cast(0.0, accum_dtype),
+                        )
+
+                for i, j in T.Parallel(block_m, block_n):
+                    oc = by * block_m + i
+                    ol = bx * block_n + j
+                    if oc < c_out and ol < out_l:
+                        out[bz, oc, ol] = T.cast(out_local[i, j], dtype)
+
+        @T.prim_func
+        def _conv1d_direct_bias_main(
+            x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
+            weight: T.Tensor((c_out, 1, kernel_l), dtype),  # type: ignore
+            out: T.Tensor((n, c_out, out_l), dtype),  # type: ignore
             bias: T.Tensor((c_out,), dtype),  # type: ignore
         ):
             with T.Kernel(
@@ -250,15 +342,12 @@ def _conv1d_direct_kernel(
                     oc = by * block_m + i
                     ol = bx * block_n + j
                     if oc < c_out and ol < out_l:
-                        if has_bias:
-                            out[bz, oc, ol] = T.cast(
-                                out_local[i, j] + T.cast(bias[oc], accum_dtype),
-                                dtype,
-                            )
-                        else:
-                            out[bz, oc, ol] = T.cast(out_local[i, j], dtype)
+                        out[bz, oc, ol] = T.cast(
+                            out_local[i, j] + T.cast(bias[oc], accum_dtype),
+                            dtype,
+                        )
 
-        return _conv1d_direct_main
+        return _conv1d_direct_bias_main if has_bias else _conv1d_direct_main
 
     return _conv1d_direct_func
 
@@ -297,6 +386,73 @@ def _conv1d_group_kernel(
     ):
         @T.prim_func
         def _conv1d_group_main(
+            x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
+            weight: T.Tensor((c_out, c_in_g, kernel_l), dtype),  # type: ignore
+            out: T.Tensor((n, c_out, out_l), dtype),  # type: ignore
+        ):
+            with T.Kernel(
+                T.ceildiv(out_l, block_n),
+                T.ceildiv(c_out_g, block_m),
+                n * groups,
+                threads=threads,
+            ) as (bx, by, bz):
+                weight_shared = T.alloc_shared((block_m, block_k), dtype)
+                data_shared = T.alloc_shared((block_k, block_n), dtype)
+                out_local = T.alloc_fragment((block_m, block_n), accum_dtype)
+                out_shared = T.alloc_shared((block_m, block_n), dtype)
+
+                T.use_swizzle(10, enable=enable_rasterization)
+                T.clear(out_local)
+
+                batch_id = bz // groups
+                group_id = bz % groups
+
+                for k_iter in T.Pipelined(T.ceildiv(k_total, block_k), num_stages=num_stages):
+                    for i, k in T.Parallel(block_m, block_k):
+                        oc_g = by * block_m + i
+                        oc = group_id * c_out_g + oc_g
+                        k_idx = k_iter * block_k + k
+                        kw = k_idx // c_in_g
+                        ci_g = k_idx % c_in_g
+                        weight_shared[i, k] = T.if_then_else(
+                            (oc_g < c_out_g) & (k_idx < k_total),
+                            weight[oc, ci_g, kw],
+                            T.cast(0.0, dtype),
+                        )
+
+                    for k, j in T.Parallel(block_k, block_n):
+                        k_idx = k_iter * block_k + k
+                        ol = bx * block_n + j
+                        kw = k_idx // c_in_g
+                        ci_g = k_idx % c_in_g
+                        il = ol * stride_l + kw * dilation_l - pad_left
+                        data_shared[k, j] = T.if_then_else(
+                            (k_idx < k_total) & (ol < out_l) & (il >= 0) & (il < l_in),
+                            x[batch_id, group_id * c_in_g + ci_g, il],
+                            T.cast(0.0, dtype),
+                        )
+
+                    T.gemm(weight_shared, data_shared, out_local)
+
+                for i, j in T.Parallel(block_m, block_n):
+                    oc_g = by * block_m + i
+                    oc = group_id * c_out_g + oc_g
+                    ol = bx * block_n + j
+                    out_shared[i, j] = T.if_then_else(
+                        (oc_g < c_out_g) & (ol < out_l),
+                        T.cast(out_local[i, j], dtype),
+                        T.cast(0.0, dtype),
+                    )
+
+                for i, j in T.Parallel(block_m, block_n):
+                    oc_g = by * block_m + i
+                    oc = group_id * c_out_g + oc_g
+                    ol = bx * block_n + j
+                    if oc_g < c_out_g and ol < out_l:
+                        out[batch_id, oc, ol] = out_shared[i, j]
+
+        @T.prim_func
+        def _conv1d_group_bias_main(
             x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
             weight: T.Tensor((c_out, c_in_g, kernel_l), dtype),  # type: ignore
             out: T.Tensor((n, c_out, out_l), dtype),  # type: ignore
@@ -350,18 +506,11 @@ def _conv1d_group_kernel(
                     oc_g = by * block_m + i
                     oc = group_id * c_out_g + oc_g
                     ol = bx * block_n + j
-                    if has_bias:
-                        out_shared[i, j] = T.if_then_else(
-                            (oc_g < c_out_g) & (ol < out_l),
-                            T.cast(out_local[i, j] + T.cast(bias[oc], accum_dtype), dtype),
-                            T.cast(0.0, dtype),
-                        )
-                    else:
-                        out_shared[i, j] = T.if_then_else(
-                            (oc_g < c_out_g) & (ol < out_l),
-                            T.cast(out_local[i, j], dtype),
-                            T.cast(0.0, dtype),
-                        )
+                    out_shared[i, j] = T.if_then_else(
+                        (oc_g < c_out_g) & (ol < out_l),
+                        T.cast(out_local[i, j] + T.cast(bias[oc], accum_dtype), dtype),
+                        T.cast(0.0, dtype),
+                    )
 
                 for i, j in T.Parallel(block_m, block_n):
                     oc_g = by * block_m + i
@@ -370,7 +519,7 @@ def _conv1d_group_kernel(
                     if oc_g < c_out_g and ol < out_l:
                         out[batch_id, oc, ol] = out_shared[i, j]
 
-        return _conv1d_group_main
+        return _conv1d_group_bias_main if has_bias else _conv1d_group_main
 
     return _conv1d_group_func
 
@@ -397,6 +546,56 @@ def _conv1d_pointwise_kernel(
     ):
         @T.prim_func
         def _conv1d_pointwise_main(
+            x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
+            weight: T.Tensor((c_out, c_in), dtype),  # type: ignore
+            out: T.Tensor((n, c_out, l_in), dtype),  # type: ignore
+        ):
+            with T.Kernel(
+                T.ceildiv(l_in, block_n),
+                T.ceildiv(c_out, block_m),
+                n,
+                threads=threads,
+            ) as (bx, by, bz):
+                weight_shared = T.alloc_shared((block_m, block_k), dtype)
+                data_shared = T.alloc_shared((block_k, block_n), dtype)
+                out_local = T.alloc_fragment((block_m, block_n), accum_dtype)
+                out_shared = T.alloc_shared((block_m, block_n), dtype)
+
+                T.use_swizzle(10, enable=enable_rasterization)
+                T.clear(out_local)
+
+                tile_l_end = bx * block_n + block_n - 1
+                tile_spatial_full = tile_l_end < l_in
+                for k_iter in T.Pipelined(T.ceildiv(c_in, block_k), num_stages=num_stages):
+                    T.copy(weight[by * block_m, k_iter * block_k], weight_shared)
+
+                    if tile_spatial_full & ((k_iter + 1) * block_k <= c_in):
+                        T.copy(x[bz, k_iter * block_k, bx * block_n], data_shared)
+                    else:
+                        for i, j in T.Parallel(block_k, block_n):
+                            ci = k_iter * block_k + i
+                            l_idx = bx * block_n + j
+                            data_shared[i, j] = T.if_then_else(
+                                (ci < c_in) & (l_idx < l_in),
+                                x[bz, ci, l_idx],
+                                T.cast(0.0, dtype),
+                            )
+
+                    T.gemm(weight_shared, data_shared, out_local)
+
+                for i, j in T.Parallel(block_m, block_n):
+                    oc = by * block_m + i
+                    l_idx = bx * block_n + j
+                    out_shared[i, j] = T.if_then_else(
+                        (oc < c_out) & (l_idx < l_in),
+                        T.cast(out_local[i, j], dtype),
+                        T.cast(0.0, dtype),
+                    )
+
+                T.copy(out_shared, out[bz, by * block_m, bx * block_n])
+
+        @T.prim_func
+        def _conv1d_pointwise_bias_main(
             x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
             weight: T.Tensor((c_out, c_in), dtype),  # type: ignore
             out: T.Tensor((n, c_out, l_in), dtype),  # type: ignore
@@ -438,22 +637,15 @@ def _conv1d_pointwise_kernel(
                 for i, j in T.Parallel(block_m, block_n):
                     oc = by * block_m + i
                     l_idx = bx * block_n + j
-                    if has_bias:
-                        out_shared[i, j] = T.if_then_else(
-                            (oc < c_out) & (l_idx < l_in),
-                            T.cast(out_local[i, j] + T.cast(bias[oc], accum_dtype), dtype),
-                            T.cast(0.0, dtype),
-                        )
-                    else:
-                        out_shared[i, j] = T.if_then_else(
-                            (oc < c_out) & (l_idx < l_in),
-                            T.cast(out_local[i, j], dtype),
-                            T.cast(0.0, dtype),
-                        )
+                    out_shared[i, j] = T.if_then_else(
+                        (oc < c_out) & (l_idx < l_in),
+                        T.cast(out_local[i, j] + T.cast(bias[oc], accum_dtype), dtype),
+                        T.cast(0.0, dtype),
+                    )
 
                 T.copy(out_shared, out[bz, by * block_m, bx * block_n])
 
-        return _conv1d_pointwise_main
+        return _conv1d_pointwise_bias_main if has_bias else _conv1d_pointwise_main
 
     return _conv1d_pointwise_func
 
@@ -479,11 +671,14 @@ def _conv1d_wrapped_kernel(
     enable_rasterization: bool,
     x: torch.Tensor,
     weight: torch.Tensor,
-    bias: torch.Tensor,
+    bias: Optional[torch.Tensor],
 ) -> torch.Tensor:
-    return _conv1d_kernel(
+    kernel = _conv1d_kernel(
         n, c_in, l_in, c_out, kernel_l, stride_l, pad_left, pad_right, dilation_l, has_bias, dtype
-    )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)(x, weight, bias)
+    )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)
+    if bias is not None:
+        return kernel(x, weight, bias)
+    return kernel(x, weight)
 
 
 @torch.library.custom_op("top::conv1d_direct_wrapped_kernel", mutates_args=())
@@ -507,11 +702,14 @@ def _conv1d_direct_wrapped_kernel(
     enable_rasterization: bool,
     x: torch.Tensor,
     weight: torch.Tensor,
-    bias: torch.Tensor,
+    bias: Optional[torch.Tensor],
 ) -> torch.Tensor:
-    return _conv1d_direct_kernel(
+    kernel = _conv1d_direct_kernel(
         n, c_in, l_in, c_out, kernel_l, stride_l, pad_left, pad_right, dilation_l, has_bias, dtype
-    )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)(x, weight, bias)
+    )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)
+    if bias is not None:
+        return kernel(x, weight, bias)
+    return kernel(x, weight)
 
 
 @torch.library.custom_op("top::conv1d_group_wrapped_kernel", mutates_args=())
@@ -538,9 +736,9 @@ def _conv1d_group_wrapped_kernel(
     enable_rasterization: bool,
     x: torch.Tensor,
     weight: torch.Tensor,
-    bias: torch.Tensor,
+    bias: Optional[torch.Tensor],
 ) -> torch.Tensor:
-    return _conv1d_group_kernel(
+    kernel = _conv1d_group_kernel(
         n,
         c_in,
         l_in,
@@ -555,7 +753,10 @@ def _conv1d_group_wrapped_kernel(
         groups,
         c_in_g,
         c_out_g,
-    )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)(x, weight, bias)
+    )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)
+    if bias is not None:
+        return kernel(x, weight, bias)
+    return kernel(x, weight)
 
 
 @torch.library.custom_op("top::conv1d_pointwise_wrapped_kernel", mutates_args=())
@@ -574,11 +775,14 @@ def _conv1d_pointwise_wrapped_kernel(
     enable_rasterization: bool,
     x: torch.Tensor,
     weight: torch.Tensor,
-    bias: torch.Tensor,
+    bias: Optional[torch.Tensor],
 ) -> torch.Tensor:
-    return _conv1d_pointwise_kernel(n, c_in, l_in, c_out, has_bias, dtype)(
+    kernel = _conv1d_pointwise_kernel(n, c_in, l_in, c_out, has_bias, dtype)(
         block_m, block_n, block_k, num_stages, threads, enable_rasterization
-    )(x, weight, bias)
+    )
+    if bias is not None:
+        return kernel(x, weight, bias)
+    return kernel(x, weight)
 
 
 @_conv1d_wrapped_kernel.register_fake
@@ -742,8 +946,6 @@ class Conv1dPointwiseKernel(Kernel):
         weight: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        if bias is None:
-            bias = torch.zeros(self.c_out, device=x.device, dtype=x.dtype)
         weight_2d = weight[:, :, 0].contiguous()
         return _conv1d_pointwise_wrapped_kernel(
             self.n,
@@ -861,8 +1063,6 @@ class Conv1dKernel(Kernel):
         weight: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        if bias is None:
-            bias = torch.zeros(self.c_out, device=x.device, dtype=x.dtype)
         weight_flat = self._get_weight_flat(weight)
         return _conv1d_wrapped_kernel(
             self.n,
@@ -1035,8 +1235,6 @@ class GroupConv1dKernel(Kernel):
         weight: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        if bias is None:
-            bias = torch.zeros(self.c_out, device=x.device, dtype=x.dtype)
         if self.use_direct:
             return _conv1d_direct_wrapped_kernel(
                 self.n,
@@ -2694,6 +2892,75 @@ def _conv3d_kernel(
             x: T.Tensor((n, c_in, d_in, h_in, w_in), dtype),  # type: ignore
             weight: T.Tensor((c_out, c_in, kernel_d, kernel_h, kernel_w), dtype),  # type: ignore
             out: T.Tensor((n, c_out, out_d, out_h, out_w), dtype),  # type: ignore
+        ):
+            out_dhw = out_d * out_h * out_w
+            with T.Kernel(
+                T.ceildiv(out_dhw, block_n),
+                T.ceildiv(c_out, block_m),
+                n,
+                threads=threads,
+            ) as (bx, by, bz):
+                weight_shared = T.alloc_shared((block_m, block_k), dtype)
+                data_shared = T.alloc_shared((block_k, block_n), dtype)
+                out_local = T.alloc_fragment((block_m, block_n), accum_dtype)
+                out_shared = T.alloc_shared((block_m, block_n), dtype)
+
+                weight_flat = T.Tensor((c_out, k_total), dtype, weight.data)
+                out_flat = T.Tensor((n, c_out, out_dhw), dtype, out.data)
+
+                T.use_swizzle(10, enable=enable_rasterization)
+                T.clear(out_local)
+
+                for k_iter in T.Pipelined(T.ceildiv(k_total, block_k), num_stages=num_stages):
+                    for i, j in T.Parallel(block_k, block_n):
+                        k_idx = k_iter * block_k + i
+                        spatial_idx = bx * block_n + j
+                        ci = k_idx // (kernel_d * kernel_h * kernel_w)
+                        kernel_idx = k_idx % (kernel_d * kernel_h * kernel_w)
+                        kd = kernel_idx // (kernel_h * kernel_w)
+                        kh = (kernel_idx // kernel_w) % kernel_h
+                        kw = kernel_idx % kernel_w
+                        od = spatial_idx // (out_h * out_w)
+                        oh = (spatial_idx // out_w) % out_h
+                        ow = spatial_idx % out_w
+                        id_ = od * stride_d + kd * dilation_d - pad_d
+                        ih = oh * stride_h + kh * dilation_h - pad_h
+                        iw = ow * stride_w + kw * dilation_w - pad_w
+                        in_bound = (
+                            (spatial_idx < out_dhw)
+                            & (k_idx < k_total)
+                            & (id_ >= 0)
+                            & (ih >= 0)
+                            & (iw >= 0)
+                            & (id_ < d_in)
+                            & (ih < h_in)
+                            & (iw < w_in)
+                        )
+                        data_shared[i, j] = T.if_then_else(
+                            in_bound,
+                            x[bz, ci, id_, ih, iw],
+                            T.cast(0.0, dtype),
+                        )
+
+                    T.copy(weight_flat[by * block_m, k_iter * block_k], weight_shared)
+                    T.gemm(weight_shared, data_shared, out_local)
+
+                for i, j in T.Parallel(block_m, block_n):
+                    oc = by * block_m + i
+                    spatial_idx = bx * block_n + j
+                    out_shared[i, j] = T.if_then_else(
+                        (oc < c_out) & (spatial_idx < out_dhw),
+                        T.cast(out_local[i, j], dtype),
+                        T.cast(0.0, dtype),
+                    )
+
+                T.copy(out_shared, out_flat[bz, by * block_m, bx * block_n])
+
+        @T.prim_func
+        def _conv3d_bias_main(
+            x: T.Tensor((n, c_in, d_in, h_in, w_in), dtype),  # type: ignore
+            weight: T.Tensor((c_out, c_in, kernel_d, kernel_h, kernel_w), dtype),  # type: ignore
+            out: T.Tensor((n, c_out, out_d, out_h, out_w), dtype),  # type: ignore
             bias: T.Tensor((c_out,), dtype),  # type: ignore
         ):
             out_dhw = out_d * out_h * out_w
@@ -2751,22 +3018,15 @@ def _conv3d_kernel(
                 for i, j in T.Parallel(block_m, block_n):
                     oc = by * block_m + i
                     spatial_idx = bx * block_n + j
-                    if has_bias:
-                        out_shared[i, j] = T.if_then_else(
-                            (oc < c_out) & (spatial_idx < out_dhw),
-                            T.cast(out_local[i, j] + T.cast(bias[oc], accum_dtype), dtype),
-                            T.cast(0.0, dtype),
-                        )
-                    else:
-                        out_shared[i, j] = T.if_then_else(
-                            (oc < c_out) & (spatial_idx < out_dhw),
-                            T.cast(out_local[i, j], dtype),
-                            T.cast(0.0, dtype),
-                        )
+                    out_shared[i, j] = T.if_then_else(
+                        (oc < c_out) & (spatial_idx < out_dhw),
+                        T.cast(out_local[i, j] + T.cast(bias[oc], accum_dtype), dtype),
+                        T.cast(0.0, dtype),
+                    )
 
                 T.copy(out_shared, out_flat[bz, by * block_m, bx * block_n])
 
-        return _conv3d_main
+        return _conv3d_bias_main if has_bias else _conv3d_main
 
     return _conv3d_func
 
@@ -2821,6 +3081,95 @@ def _conv3d_group_kernel(
     ):
         @T.prim_func
         def _conv3d_group_main(
+            x: T.Tensor((n, c_in, d_in, h_in, w_in), dtype),  # type: ignore
+            weight: T.Tensor((c_out, c_in_g, kernel_d, kernel_h, kernel_w), dtype),  # type: ignore
+            out: T.Tensor((n, c_out, out_d, out_h, out_w), dtype),  # type: ignore
+        ):
+            with T.Kernel(
+                T.ceildiv(out_dhw, block_n),
+                T.ceildiv(c_out_g, block_m),
+                n * groups,
+                threads=threads,
+            ) as (bx, by, bz):
+                weight_shared = T.alloc_shared((block_m, block_k), dtype)
+                data_shared = T.alloc_shared((block_k, block_n), dtype)
+                out_local = T.alloc_fragment((block_m, block_n), accum_dtype)
+                out_shared = T.alloc_shared((block_m, block_n), dtype)
+
+                T.use_swizzle(10, enable=enable_rasterization)
+                T.clear(out_local)
+
+                batch_id = bz // groups
+                group_id = bz % groups
+
+                for k_iter in T.Pipelined(T.ceildiv(k_total, block_k), num_stages=num_stages):
+                    for i, k in T.Parallel(block_m, block_k):
+                        oc_g = by * block_m + i
+                        oc = group_id * c_out_g + oc_g
+                        k_idx = k_iter * block_k + k
+                        ci_g = k_idx // (kernel_d * kernel_h * kernel_w)
+                        kernel_idx = k_idx % (kernel_d * kernel_h * kernel_w)
+                        kd = kernel_idx // (kernel_h * kernel_w)
+                        kh = (kernel_idx // kernel_w) % kernel_h
+                        kw = kernel_idx % kernel_w
+                        weight_shared[i, k] = T.if_then_else(
+                            (oc_g < c_out_g) & (k_idx < k_total),
+                            weight[oc, ci_g, kd, kh, kw],
+                            T.cast(0.0, dtype),
+                        )
+
+                    for k, j in T.Parallel(block_k, block_n):
+                        k_idx = k_iter * block_k + k
+                        spatial_idx = bx * block_n + j
+                        ci_g = k_idx // (kernel_d * kernel_h * kernel_w)
+                        ci = group_id * c_in_g + ci_g
+                        kernel_idx = k_idx % (kernel_d * kernel_h * kernel_w)
+                        kd = kernel_idx // (kernel_h * kernel_w)
+                        kh = (kernel_idx // kernel_w) % kernel_h
+                        kw = kernel_idx % kernel_w
+                        od = spatial_idx // (out_h * out_w)
+                        oh = (spatial_idx // out_w) % out_h
+                        ow = spatial_idx % out_w
+                        id_ = od * stride_d + kd * dilation_d - pad_d
+                        ih = oh * stride_h + kh * dilation_h - pad_h
+                        iw = ow * stride_w + kw * dilation_w - pad_w
+                        data_shared[k, j] = T.if_then_else(
+                            (spatial_idx < out_dhw)
+                            & (k_idx < k_total)
+                            & (id_ >= 0)
+                            & (ih >= 0)
+                            & (iw >= 0)
+                            & (id_ < d_in)
+                            & (ih < h_in)
+                            & (iw < w_in),
+                            x[batch_id, ci, id_, ih, iw],
+                            T.cast(0.0, dtype),
+                        )
+
+                    T.gemm(weight_shared, data_shared, out_local)
+
+                for i, j in T.Parallel(block_m, block_n):
+                    oc_g = by * block_m + i
+                    oc = group_id * c_out_g + oc_g
+                    spatial_idx = bx * block_n + j
+                    out_shared[i, j] = T.if_then_else(
+                        (oc_g < c_out_g) & (spatial_idx < out_dhw),
+                        T.cast(out_local[i, j], dtype),
+                        T.cast(0.0, dtype),
+                    )
+
+                for i, j in T.Parallel(block_m, block_n):
+                    oc_g = by * block_m + i
+                    oc = group_id * c_out_g + oc_g
+                    spatial_idx = bx * block_n + j
+                    od = spatial_idx // (out_h * out_w)
+                    oh = (spatial_idx // out_w) % out_h
+                    ow = spatial_idx % out_w
+                    if oc_g < c_out_g and spatial_idx < out_dhw:
+                        out[batch_id, oc, od, oh, ow] = out_shared[i, j]
+
+        @T.prim_func
+        def _conv3d_group_bias_main(
             x: T.Tensor((n, c_in, d_in, h_in, w_in), dtype),  # type: ignore
             weight: T.Tensor((c_out, c_in_g, kernel_d, kernel_h, kernel_w), dtype),  # type: ignore
             out: T.Tensor((n, c_out, out_d, out_h, out_w), dtype),  # type: ignore
@@ -2893,18 +3242,11 @@ def _conv3d_group_kernel(
                     oc_g = by * block_m + i
                     oc = group_id * c_out_g + oc_g
                     spatial_idx = bx * block_n + j
-                    if has_bias:
-                        out_shared[i, j] = T.if_then_else(
-                            (oc_g < c_out_g) & (spatial_idx < out_dhw),
-                            T.cast(out_local[i, j] + T.cast(bias[oc], accum_dtype), dtype),
-                            T.cast(0.0, dtype),
-                        )
-                    else:
-                        out_shared[i, j] = T.if_then_else(
-                            (oc_g < c_out_g) & (spatial_idx < out_dhw),
-                            T.cast(out_local[i, j], dtype),
-                            T.cast(0.0, dtype),
-                        )
+                    out_shared[i, j] = T.if_then_else(
+                        (oc_g < c_out_g) & (spatial_idx < out_dhw),
+                        T.cast(out_local[i, j] + T.cast(bias[oc], accum_dtype), dtype),
+                        T.cast(0.0, dtype),
+                    )
 
                 for i, j in T.Parallel(block_m, block_n):
                     oc_g = by * block_m + i
@@ -2916,7 +3258,7 @@ def _conv3d_group_kernel(
                     if oc_g < c_out_g and spatial_idx < out_dhw:
                         out[batch_id, oc, od, oh, ow] = out_shared[i, j]
 
-        return _conv3d_group_main
+        return _conv3d_group_bias_main if has_bias else _conv3d_group_main
 
     return _conv3d_group_func
 
@@ -2951,9 +3293,9 @@ def _conv3d_wrapped_kernel(
     enable_rasterization: bool,
     x: torch.Tensor,
     weight: torch.Tensor,
-    bias: torch.Tensor,
+    bias: Optional[torch.Tensor],
 ) -> torch.Tensor:
-    return _conv3d_kernel(
+    kernel = _conv3d_kernel(
         n,
         c_in,
         d_in,
@@ -2974,7 +3316,10 @@ def _conv3d_wrapped_kernel(
         dilation_w,
         has_bias,
         dtype,
-    )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)(x, weight, bias)
+    )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)
+    if bias is not None:
+        return kernel(x, weight, bias)
+    return kernel(x, weight)
 
 
 @torch.library.custom_op("top::conv3d_group_wrapped_kernel", mutates_args=())
@@ -3010,9 +3355,9 @@ def _conv3d_group_wrapped_kernel(
     enable_rasterization: bool,
     x: torch.Tensor,
     weight: torch.Tensor,
-    bias: torch.Tensor,
+    bias: Optional[torch.Tensor],
 ) -> torch.Tensor:
-    return _conv3d_group_kernel(
+    kernel = _conv3d_group_kernel(
         n,
         c_in,
         d_in,
@@ -3036,7 +3381,10 @@ def _conv3d_group_wrapped_kernel(
         groups,
         c_in_g,
         c_out_g,
-    )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)(x, weight, bias)
+    )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)
+    if bias is not None:
+        return kernel(x, weight, bias)
+    return kernel(x, weight)
 
 
 @_conv3d_wrapped_kernel.register_fake
@@ -3236,8 +3584,6 @@ class Conv3dKernel(Kernel):
         weight: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        if bias is None:
-            bias = torch.zeros(self.c_out, device=x.device, dtype=x.dtype)
         return _conv3d_wrapped_kernel(
             self.n,
             self.c_in,
@@ -3403,8 +3749,6 @@ class GroupConv3dKernel(Kernel):
         weight: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        if bias is None:
-            bias = torch.zeros(self.c_out, device=x.device, dtype=x.dtype)
         return _conv3d_group_wrapped_kernel(
             self.n,
             self.c_in,

--- a/src/tileops/kernels/convolution.py
+++ b/src/tileops/kernels/convolution.py
@@ -1243,6 +1243,71 @@ def _conv2d_kernel(
             x: T.Tensor((n, c_in, h, w), dtype),  # type: ignore
             weight: T.Tensor((c_out, c_in, kernel_h, kernel_w), dtype),  # type: ignore
             out: T.Tensor((n, c_out, out_h, out_w), dtype),  # type: ignore
+        ):
+            out_hw = out_h * out_w
+            with T.Kernel(
+                T.ceildiv(out_hw, block_n),
+                T.ceildiv(c_out, block_m),
+                n,
+                threads=threads,
+            ) as (bx, by, bz):
+                weight_shared = T.alloc_shared((block_m, block_k), dtype)
+                data_shared = T.alloc_shared((block_k, block_n), dtype)
+                out_local = T.alloc_fragment((block_m, block_n), accum_dtype)
+                out_shared = T.alloc_shared((block_m, block_n), dtype)
+
+                weight_flat = T.Tensor((c_out, k_total), dtype, weight.data)
+                out_flat = T.Tensor((n, c_out, out_hw), dtype, out.data)
+
+                T.use_swizzle(10, enable=enable_rasterization)
+                T.clear(out_local)
+
+                for k_iter in T.Pipelined(T.ceildiv(k_total, block_k), num_stages=num_stages):
+                    for i, j in T.Parallel(block_k, block_n):
+                        k_idx = k_iter * block_k + i
+                        spatial_idx = bx * block_n + j
+                        ci = k_idx // (kernel_h * kernel_w)
+                        kernel_idx = k_idx % (kernel_h * kernel_w)
+                        kh = kernel_idx // kernel_w
+                        kw = kernel_idx % kernel_w
+                        oh = spatial_idx // out_w
+                        ow = spatial_idx % out_w
+                        ih = oh * stride_h + kh * dilation_h - pad_h
+                        iw = ow * stride_w + kw * dilation_w - pad_w
+                        in_bound = (
+                            (spatial_idx < out_hw)
+                            & (k_idx < k_total)
+                            & (ih >= 0)
+                            & (iw >= 0)
+                            & (ih < h)
+                            & (iw < w)
+                        )
+                        data_shared[i, j] = T.if_then_else(
+                            in_bound,
+                            x[bz, ci, ih, iw],
+                            T.cast(0.0, dtype),
+                        )
+
+                    T.copy(weight_flat[by * block_m, k_iter * block_k], weight_shared)
+
+                    T.gemm(weight_shared, data_shared, out_local)
+
+                for i, j in T.Parallel(block_m, block_n):
+                    oc = by * block_m + i
+                    spatial_idx = bx * block_n + j
+                    out_shared[i, j] = T.if_then_else(
+                        (oc < c_out) & (spatial_idx < out_hw),
+                        T.cast(out_local[i, j], dtype),
+                        T.cast(0.0, dtype),
+                    )
+
+                T.copy(out_shared, out_flat[bz, by * block_m, bx * block_n])
+
+        @T.prim_func
+        def _conv2d_bias_main(
+            x: T.Tensor((n, c_in, h, w), dtype),  # type: ignore
+            weight: T.Tensor((c_out, c_in, kernel_h, kernel_w), dtype),  # type: ignore
+            out: T.Tensor((n, c_out, out_h, out_w), dtype),  # type: ignore
             bias: T.Tensor((c_out,), dtype),  # type: ignore
         ):
             out_hw = out_h * out_w
@@ -1296,22 +1361,15 @@ def _conv2d_kernel(
                 for i, j in T.Parallel(block_m, block_n):
                     oc = by * block_m + i
                     spatial_idx = bx * block_n + j
-                    if has_bias:
-                        out_shared[i, j] = T.if_then_else(
-                            (oc < c_out) & (spatial_idx < out_hw),
-                            T.cast(out_local[i, j] + T.cast(bias[oc], accum_dtype), dtype),
-                            T.cast(0.0, dtype),
-                        )
-                    else:
-                        out_shared[i, j] = T.if_then_else(
-                            (oc < c_out) & (spatial_idx < out_hw),
-                            T.cast(out_local[i, j], dtype),
-                            T.cast(0.0, dtype),
-                        )
+                    out_shared[i, j] = T.if_then_else(
+                        (oc < c_out) & (spatial_idx < out_hw),
+                        T.cast(out_local[i, j] + T.cast(bias[oc], accum_dtype), dtype),
+                        T.cast(0.0, dtype),
+                    )
 
                 T.copy(out_shared, out_flat[bz, by * block_m, bx * block_n])
 
-        return _conv2d_main
+        return _conv2d_bias_main if has_bias else _conv2d_main
 
     return _conv2d_func
 
@@ -1360,6 +1418,87 @@ def _conv2d_group_kernel(
     ):
         @T.prim_func
         def _conv2d_group_main(
+            x: T.Tensor((n, c_in, h, w), dtype),  # type: ignore
+            weight: T.Tensor((c_out, c_in_g, kernel_h, kernel_w), dtype),  # type: ignore
+            out: T.Tensor((n, c_out, out_h, out_w), dtype),  # type: ignore
+        ):
+            with T.Kernel(
+                T.ceildiv(out_hw, block_n),
+                T.ceildiv(c_out_g, block_m),
+                n * groups,
+                threads=threads,
+            ) as (bx, by, bz):
+                weight_shared = T.alloc_shared((block_m, block_k), dtype)
+                data_shared = T.alloc_shared((block_k, block_n), dtype)
+                out_local = T.alloc_fragment((block_m, block_n), accum_dtype)
+                out_shared = T.alloc_shared((block_m, block_n), dtype)
+
+                T.use_swizzle(10, enable=enable_rasterization)
+                T.clear(out_local)
+
+                batch_id = bz // groups
+                group_id = bz % groups
+
+                for k_iter in T.Pipelined(T.ceildiv(k_total, block_k), num_stages=num_stages):
+                    for i, k in T.Parallel(block_m, block_k):
+                        oc_g = by * block_m + i
+                        oc = group_id * c_out_g + oc_g
+                        k_idx = k_iter * block_k + k
+                        ci_g = k_idx // (kernel_h * kernel_w)
+                        kernel_idx = k_idx % (kernel_h * kernel_w)
+                        kh = kernel_idx // kernel_w
+                        kw = kernel_idx % kernel_w
+                        weight_shared[i, k] = T.if_then_else(
+                            (oc_g < c_out_g) & (k_idx < k_total),
+                            weight[oc, ci_g, kh, kw],
+                            T.cast(0.0, dtype),
+                        )
+
+                    for k, j in T.Parallel(block_k, block_n):
+                        k_idx = k_iter * block_k + k
+                        spatial_idx = bx * block_n + j
+                        ci_g = k_idx // (kernel_h * kernel_w)
+                        ci = group_id * c_in_g + ci_g
+                        kernel_idx = k_idx % (kernel_h * kernel_w)
+                        kh = kernel_idx // kernel_w
+                        kw = kernel_idx % kernel_w
+                        oh = spatial_idx // out_w
+                        ow = spatial_idx % out_w
+                        ih = oh * stride_h + kh * dilation_h - pad_h
+                        iw = ow * stride_w + kw * dilation_w - pad_w
+                        data_shared[k, j] = T.if_then_else(
+                            (spatial_idx < out_hw)
+                            & (k_idx < k_total)
+                            & (ih >= 0)
+                            & (iw >= 0)
+                            & (ih < h)
+                            & (iw < w),
+                            x[batch_id, ci, ih, iw],
+                            T.cast(0.0, dtype),
+                        )
+
+                    T.gemm(weight_shared, data_shared, out_local)
+
+                for i, j in T.Parallel(block_m, block_n):
+                    oc_g = by * block_m + i
+                    spatial_idx = bx * block_n + j
+                    out_shared[i, j] = T.if_then_else(
+                        (oc_g < c_out_g) & (spatial_idx < out_hw),
+                        T.cast(out_local[i, j], dtype),
+                        T.cast(0.0, dtype),
+                    )
+
+                for i, j in T.Parallel(block_m, block_n):
+                    oc_g = by * block_m + i
+                    oc = group_id * c_out_g + oc_g
+                    spatial_idx = bx * block_n + j
+                    oh = spatial_idx // out_w
+                    ow = spatial_idx % out_w
+                    if oc_g < c_out_g and spatial_idx < out_hw:
+                        out[batch_id, oc, oh, ow] = out_shared[i, j]
+
+        @T.prim_func
+        def _conv2d_group_bias_main(
             x: T.Tensor((n, c_in, h, w), dtype),  # type: ignore
             weight: T.Tensor((c_out, c_in_g, kernel_h, kernel_w), dtype),  # type: ignore
             out: T.Tensor((n, c_out, out_h, out_w), dtype),  # type: ignore
@@ -1426,18 +1565,11 @@ def _conv2d_group_kernel(
                     oc_g = by * block_m + i
                     oc = group_id * c_out_g + oc_g
                     spatial_idx = bx * block_n + j
-                    if has_bias:
-                        out_shared[i, j] = T.if_then_else(
-                            (oc_g < c_out_g) & (spatial_idx < out_hw),
-                            T.cast(out_local[i, j] + T.cast(bias[oc], accum_dtype), dtype),
-                            T.cast(0.0, dtype),
-                        )
-                    else:
-                        out_shared[i, j] = T.if_then_else(
-                            (oc_g < c_out_g) & (spatial_idx < out_hw),
-                            T.cast(out_local[i, j], dtype),
-                            T.cast(0.0, dtype),
-                        )
+                    out_shared[i, j] = T.if_then_else(
+                        (oc_g < c_out_g) & (spatial_idx < out_hw),
+                        T.cast(out_local[i, j] + T.cast(bias[oc], accum_dtype), dtype),
+                        T.cast(0.0, dtype),
+                    )
 
                 for i, j in T.Parallel(block_m, block_n):
                     oc_g = by * block_m + i
@@ -1448,7 +1580,7 @@ def _conv2d_group_kernel(
                     if oc_g < c_out_g and spatial_idx < out_hw:
                         out[batch_id, oc, oh, ow] = out_shared[i, j]
 
-        return _conv2d_group_main
+        return _conv2d_group_bias_main if has_bias else _conv2d_group_main
 
     return _conv2d_group_func
 
@@ -1474,7 +1606,7 @@ def _conv2d_symmetric_kernel(
     k_total = c_in * kernel_size * kernel_size
 
     @tilelang.jit(
-        out_idx=[6],
+        out_idx=[5],
         compile_flags=["-O3", "-DENABLE_BF16"],
         pass_configs={"tl.enable_async_copy": False},
     )
@@ -1542,12 +1674,10 @@ def _conv2d_symmetric_kernel(
                                 dst[bz, c, h_idx, w_idx] = src[bz, h_idx, w_idx, c]
 
         @T.macro
-        def conv_nhwc_implicit_gemm_bias(
+        def conv_nhwc_implicit_gemm(
             x_nhwc: T.Tensor((n, h, w, c_in), dtype),
             weight_krsc: T.Tensor((c_out, kernel_size, kernel_size, c_in), dtype),
-            bias: T.Tensor((c_out,), dtype),
             out_nhwc: T.Tensor((n, out_h, out_w, c_out), dtype),
-            has_bias: bool,
         ):
             with T.Kernel(
                 T.ceildiv(c_out, block_n),
@@ -1573,18 +1703,50 @@ def _conv2d_symmetric_kernel(
                 for i, j in T.Parallel(block_m, block_n):
                     spatial_idx = by * block_m + i
                     oc = bx * block_n + j
-                    if has_bias:
-                        out_shared[i, j] = T.if_then_else(
-                            (spatial_idx < n * out_hw) & (oc < c_out),
-                            T.cast(out_local[i, j] + T.cast(bias[oc], accum_dtype), dtype),
-                            T.cast(0.0, dtype),
-                        )
-                    else:
-                        out_shared[i, j] = T.if_then_else(
-                            (spatial_idx < n * out_hw) & (oc < c_out),
-                            T.cast(out_local[i, j], dtype),
-                            T.cast(0.0, dtype),
-                        )
+                    out_shared[i, j] = T.if_then_else(
+                        (spatial_idx < n * out_hw) & (oc < c_out),
+                        T.cast(out_local[i, j], dtype),
+                        T.cast(0.0, dtype),
+                    )
+
+                T.copy(out_shared, out_flat[by * block_m, bx * block_n])
+
+        @T.macro
+        def conv_nhwc_implicit_gemm_bias(
+            x_nhwc: T.Tensor((n, h, w, c_in), dtype),
+            weight_krsc: T.Tensor((c_out, kernel_size, kernel_size, c_in), dtype),
+            bias: T.Tensor((c_out,), dtype),
+            out_nhwc: T.Tensor((n, out_h, out_w, c_out), dtype),
+        ):
+            with T.Kernel(
+                T.ceildiv(c_out, block_n),
+                T.ceildiv(n * out_h * out_w, block_m),
+                threads=threads,
+            ) as (bx, by):
+                data_shared = T.alloc_shared((block_m, block_k), dtype)
+                weight_shared = T.alloc_shared((block_n, block_k), dtype)
+                out_local = T.alloc_fragment((block_m, block_n), accum_dtype)
+                out_shared = T.alloc_shared((block_m, block_n), dtype)
+
+                weight_flat = T.Tensor((c_out, k_total), dtype, weight_krsc.data)
+                out_flat = T.Tensor((n * out_h * out_w, c_out), dtype, out_nhwc.data)
+
+                T.use_swizzle(10, enable=enable_rasterization)
+                T.clear(out_local)
+
+                for k_iter in T.Pipelined(T.ceildiv(k_total, block_k), num_stages=num_stages):
+                    T.im2col(x_nhwc, data_shared, by, k_iter, kernel_size, stride, dilation, pad)
+                    T.copy(weight_flat[bx * block_n, k_iter * block_k], weight_shared)
+                    T.gemm(data_shared, weight_shared, out_local, transpose_B=True)
+
+                for i, j in T.Parallel(block_m, block_n):
+                    spatial_idx = by * block_m + i
+                    oc = bx * block_n + j
+                    out_shared[i, j] = T.if_then_else(
+                        (spatial_idx < n * out_hw) & (oc < c_out),
+                        T.cast(out_local[i, j] + T.cast(bias[oc], accum_dtype), dtype),
+                        T.cast(0.0, dtype),
+                    )
 
                 T.copy(out_shared, out_flat[by * block_m, bx * block_n])
 
@@ -1592,7 +1754,6 @@ def _conv2d_symmetric_kernel(
         def _conv2d_symmetric_main(
             x: T.Tensor((n, c_in, h, w), dtype),
             weight: T.Tensor((c_out, c_in, kernel_size, kernel_size), dtype),
-            bias: T.Tensor((c_out,), dtype),
             x_nhwc: T.Tensor((n, h, w, c_in), dtype),
             weight_krsc: T.Tensor((c_out, kernel_size, kernel_size, c_in), dtype),
             out_nhwc: T.Tensor((n, out_h, out_w, c_out), dtype),
@@ -1624,7 +1785,7 @@ def _conv2d_symmetric_kernel(
                 channel_fastest=True,
                 is_nchw_to_nhwc=True,
             )
-            conv_nhwc_implicit_gemm_bias(x_nhwc, weight_krsc, bias, out_nhwc, has_bias)
+            conv_nhwc_implicit_gemm(x_nhwc, weight_krsc, out_nhwc)
             transpose_spatial_channel(
                 out_nhwc,
                 out,
@@ -1639,7 +1800,58 @@ def _conv2d_symmetric_kernel(
                 is_nchw_to_nhwc=False,
             )
 
-        return _conv2d_symmetric_main
+        @T.prim_func
+        def _conv2d_symmetric_bias_main(
+            x: T.Tensor((n, c_in, h, w), dtype),
+            weight: T.Tensor((c_out, c_in, kernel_size, kernel_size), dtype),
+            x_nhwc: T.Tensor((n, h, w, c_in), dtype),
+            weight_krsc: T.Tensor((c_out, kernel_size, kernel_size, c_in), dtype),
+            out_nhwc: T.Tensor((n, out_h, out_w, c_out), dtype),
+            out: T.Tensor((n, c_out, out_h, out_w), dtype),
+            bias: T.Tensor((c_out,), dtype),
+        ):
+            transpose_spatial_channel(
+                x,
+                x_nhwc,
+                batch_size=n,
+                spatial_size=h * w,
+                channel_size=c_in,
+                width=w,
+                spatial_block=32,
+                channel_block=32,
+                channel_lanes=8,
+                channel_fastest=True,
+                is_nchw_to_nhwc=True,
+            )
+            transpose_spatial_channel(
+                weight,
+                weight_krsc,
+                batch_size=c_out,
+                spatial_size=kernel_size * kernel_size,
+                channel_size=c_in,
+                width=kernel_size,
+                spatial_block=16,
+                channel_block=32,
+                channel_lanes=16,
+                channel_fastest=True,
+                is_nchw_to_nhwc=True,
+            )
+            conv_nhwc_implicit_gemm_bias(x_nhwc, weight_krsc, bias, out_nhwc)
+            transpose_spatial_channel(
+                out_nhwc,
+                out,
+                batch_size=n,
+                spatial_size=out_h * out_w,
+                channel_size=c_out,
+                width=out_w,
+                spatial_block=128,
+                channel_block=2,
+                channel_lanes=2,
+                channel_fastest=False,
+                is_nchw_to_nhwc=False,
+            )
+
+        return _conv2d_symmetric_bias_main if has_bias else _conv2d_symmetric_main
 
     return _conv2d_symmetric_func
 
@@ -1712,16 +1924,17 @@ def _conv2d_symmetric_wrapped_kernel(
     enable_rasterization: bool,
     x: torch.Tensor,
     weight: torch.Tensor,
-    bias: torch.Tensor,
+    bias: Optional[torch.Tensor],
     x_nhwc: torch.Tensor,
     weight_krsc: torch.Tensor,
     out_nhwc: torch.Tensor,
 ) -> torch.Tensor:
-    return _conv2d_symmetric_kernel(
+    kernel = _conv2d_symmetric_kernel(
         n, c_in, h, w, c_out, kernel_size, stride, pad, dilation, has_bias, dtype
-    )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)(
-        x, weight, bias, x_nhwc, weight_krsc, out_nhwc
-    )
+    )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)
+    if bias is not None:
+        return kernel(x, weight, x_nhwc, weight_krsc, out_nhwc, bias)
+    return kernel(x, weight, x_nhwc, weight_krsc, out_nhwc)
 
 
 @_conv2d_symmetric_wrapped_kernel.register_fake
@@ -1776,9 +1989,9 @@ def _conv2d_wrapped_kernel(
     enable_rasterization: bool,
     x: torch.Tensor,
     weight: torch.Tensor,
-    bias: torch.Tensor,
+    bias: Optional[torch.Tensor],
 ) -> torch.Tensor:
-    return _conv2d_kernel(
+    kernel = _conv2d_kernel(
         n,
         c_in,
         h,
@@ -1794,7 +2007,10 @@ def _conv2d_wrapped_kernel(
         dilation_w,
         has_bias,
         dtype,
-    )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)(x, weight, bias)
+    )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)
+    if bias is not None:
+        return kernel(x, weight, bias)
+    return kernel(x, weight)
 
 
 @torch.library.custom_op("top::conv2d_group_wrapped_kernel", mutates_args=())
@@ -1825,9 +2041,9 @@ def _conv2d_group_wrapped_kernel(
     enable_rasterization: bool,
     x: torch.Tensor,
     weight: torch.Tensor,
-    bias: torch.Tensor,
+    bias: Optional[torch.Tensor],
 ) -> torch.Tensor:
-    return _conv2d_group_kernel(
+    kernel = _conv2d_group_kernel(
         n,
         c_in,
         h,
@@ -1846,7 +2062,10 @@ def _conv2d_group_wrapped_kernel(
         groups,
         c_in_g,
         c_out_g,
-    )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)(x, weight, bias)
+    )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)
+    if bias is not None:
+        return kernel(x, weight, bias)
+    return kernel(x, weight)
 
 
 @_conv2d_wrapped_kernel.register_fake
@@ -1990,8 +2209,6 @@ class Conv2dSymmetricKernel(Kernel):
         weight: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        if bias is None:
-            bias = torch.zeros(self.c_out, device=x.device, dtype=x.dtype)
         x_nhwc = torch.empty(
             (self.n, self.h, self.w, self.c_in),
             device=x.device,
@@ -2141,8 +2358,6 @@ class Conv2dKernel(Kernel):
         weight: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        if bias is None:
-            bias = torch.zeros(self.c_out, device=x.device, dtype=x.dtype)
         return _conv2d_wrapped_kernel(
             self.n,
             self.c_in,
@@ -2284,8 +2499,6 @@ class GroupConv2dKernel(Kernel):
         weight: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        if bias is None:
-            bias = torch.zeros(self.c_out, device=x.device, dtype=x.dtype)
         return _conv2d_group_wrapped_kernel(
             self.n,
             self.c_in,

--- a/src/tileops/kernels/convolution.py
+++ b/src/tileops/kernels/convolution.py
@@ -1123,6 +1123,44 @@ def _conv2d_1x1_kernel(
             x: T.Tensor((n, c_in, h, w), dtype),  # type: ignore
             weight: T.Tensor((c_out, c_in), dtype),  # type: ignore
             out: T.Tensor((n, c_out, h, w), dtype),  # type: ignore
+        ):
+            x_flat = T.Tensor((n, c_in, hw), dtype, x.data)
+            out_flat = T.Tensor((n, c_out, hw), dtype, out.data)
+            with T.Kernel(
+                T.ceildiv(hw, block_n),
+                T.ceildiv(c_out, block_m),
+                n,
+                threads=threads,
+            ) as (bx, by, bz):
+                weight_shared = T.alloc_shared((block_m, block_k), dtype)
+                data_shared = T.alloc_shared((block_k, block_n), dtype)
+                out_shared = T.alloc_shared((block_m, block_n), dtype)
+                out_local = T.alloc_fragment((block_m, block_n), accum_dtype)
+
+                T.use_swizzle(10, enable=enable_rasterization)
+                T.clear(out_local)
+
+                for k_iter in T.Pipelined(T.ceildiv(c_in, block_k), num_stages=num_stages):
+                    T.copy(weight[by * block_m, k_iter * block_k], weight_shared)
+                    T.copy(x_flat[bz, k_iter * block_k, bx * block_n], data_shared)
+                    T.gemm(weight_shared, data_shared, out_local)
+
+                for i, j in T.Parallel(block_m, block_n):
+                    oc = by * block_m + i
+                    hw_idx = bx * block_n + j
+                    out_shared[i, j] = T.if_then_else(
+                        (oc < c_out) & (hw_idx < hw),
+                        T.cast(out_local[i, j], dtype),
+                        T.cast(0.0, dtype),
+                    )
+
+                T.copy(out_shared, out_flat[bz, by * block_m, bx * block_n])
+
+        @T.prim_func
+        def _conv2d_1x1_bias_main(
+            x: T.Tensor((n, c_in, h, w), dtype),  # type: ignore
+            weight: T.Tensor((c_out, c_in), dtype),  # type: ignore
+            out: T.Tensor((n, c_out, h, w), dtype),  # type: ignore
             bias: T.Tensor((c_out,), dtype),  # type: ignore
         ):
             x_flat = T.Tensor((n, c_in, hw), dtype, x.data)
@@ -1149,22 +1187,15 @@ def _conv2d_1x1_kernel(
                 for i, j in T.Parallel(block_m, block_n):
                     oc = by * block_m + i
                     hw_idx = bx * block_n + j
-                    if has_bias:
-                        out_shared[i, j] = T.if_then_else(
-                            (oc < c_out) & (hw_idx < hw),
-                            T.cast(out_local[i, j] + T.cast(bias[oc], accum_dtype), dtype),
-                            T.cast(0.0, dtype),
-                        )
-                    else:
-                        out_shared[i, j] = T.if_then_else(
-                            (oc < c_out) & (hw_idx < hw),
-                            T.cast(out_local[i, j], dtype),
-                            T.cast(0.0, dtype),
-                        )
+                    out_shared[i, j] = T.if_then_else(
+                        (oc < c_out) & (hw_idx < hw),
+                        T.cast(out_local[i, j] + T.cast(bias[oc], accum_dtype), dtype),
+                        T.cast(0.0, dtype),
+                    )
 
                 T.copy(out_shared, out_flat[bz, by * block_m, bx * block_n])
 
-        return _conv2d_1x1_main
+        return _conv2d_1x1_bias_main if has_bias else _conv2d_1x1_main
 
     return _conv2d_1x1_func
 
@@ -1630,11 +1661,14 @@ def _conv2d_1x1_wrapped_kernel(
     enable_rasterization: bool,
     x: torch.Tensor,
     weight: torch.Tensor,
-    bias: torch.Tensor,
+    bias: Optional[torch.Tensor],
 ) -> torch.Tensor:
-    return _conv2d_1x1_kernel(n, c_in, h, w, c_out, 1, 1, 0, 0, has_bias, dtype)(
+    kernel = _conv2d_1x1_kernel(n, c_in, h, w, c_out, 1, 1, 0, 0, has_bias, dtype)(
         block_m, block_n, block_k, num_stages, threads, enable_rasterization
-    )(x, weight, bias)
+    )
+    if bias is not None:
+        return kernel(x, weight, bias)
+    return kernel(x, weight)
 
 
 @_conv2d_1x1_wrapped_kernel.register_fake
@@ -2314,7 +2348,6 @@ class Conv2d1x1Kernel(Kernel):
         self.pad_w = pad_w
         self.dtype = dtype
         self.has_bias = has_bias
-        self._zero_bias_cache: Optional[torch.Tensor] = None
 
         self.kernel = _conv2d_1x1_kernel(
             n,
@@ -2374,12 +2407,6 @@ class Conv2d1x1Kernel(Kernel):
         weight: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        if bias is None:
-            if self._zero_bias_cache is None or self._zero_bias_cache.device != x.device:
-                self._zero_bias_cache = torch.zeros(
-                    self.c_out, device=x.device, dtype=x.dtype,
-                )
-            bias = self._zero_bias_cache
         # OIHW -> OC,IC since the 1x1 kernel consumes a dense [C_out, C_in] weight matrix.
         weight_oc_ci = weight.view(self.c_out, self.c_in).contiguous()
         return _conv2d_1x1_wrapped_kernel(

--- a/src/tileops/kernels/convolution.py
+++ b/src/tileops/kernels/convolution.py
@@ -2314,6 +2314,7 @@ class Conv2d1x1Kernel(Kernel):
         self.pad_w = pad_w
         self.dtype = dtype
         self.has_bias = has_bias
+        self._zero_bias_cache: Optional[torch.Tensor] = None
 
         self.kernel = _conv2d_1x1_kernel(
             n,
@@ -2374,7 +2375,11 @@ class Conv2d1x1Kernel(Kernel):
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         if bias is None:
-            bias = torch.zeros(self.c_out, device=x.device, dtype=x.dtype)
+            if self._zero_bias_cache is None or self._zero_bias_cache.device != x.device:
+                self._zero_bias_cache = torch.zeros(
+                    self.c_out, device=x.device, dtype=x.dtype,
+                )
+            bias = self._zero_bias_cache
         # OIHW -> OC,IC since the 1x1 kernel consumes a dense [C_out, C_in] weight matrix.
         weight_oc_ci = weight.view(self.c_out, self.c_in).contiguous()
         return _conv2d_1x1_wrapped_kernel(


### PR DESCRIPTION
## Motivation

Closes #1937

Every Conv2d kernel declared `bias` as a mandatory prim_func parameter, so no-bias calls materialized `torch.zeros(c_out)` on every invocation — one allocation plus one fill kernel launch of dead work per call. This PR gives each Conv2d kernel two prim_func variants (with/without the bias parameter) selected by `has_bias` at trace time, aligning with PyTorch's zero-overhead `bias=None` handling and the existing GEMM FP8 pattern in this repo.

## Changes

- `src/tileops/kernels/convolution.py` only; no interface changes.
- `Conv2d1x1Kernel`, `Conv2dKernel`, `GroupConv2dKernel`: prim_func split into `_main` / `_bias_main`; wrapped custom op's `bias` parameter becomes `Optional[torch.Tensor]`; `forward()` passes `None` through instead of allocating a zero bias.
- `Conv2dSymmetricKernel`: same split, with `bias` moved to the last prim_func parameter so both variants share `out_idx=[5]`; the implicit-GEMM macro is split into bias / no-bias variants accordingly.

## Testing

- Unit tests (isolated processes): all conv2d dispatch/numerics tests pass, including `test_conv2d_no_bias_matches_torch`, `test_conv2d_no_bias_grouped_matches_torch`, and the 1x1/3x3/5x5 dispatch tests; verified numerics against `F.conv2d` for every kernel × {bias, no-bias}.
- Verified via profiler and kernel counts that the no-bias path launches exactly one kernel (no fill) and never calls `torch.zeros`.
- Full conv benchmark suite (`benchmarks/ops/bench_convolution.py`, 57 cases, single-process nightly-style run on H200): **57/57 PASS**.

## Performance (H200, tilelang @ afcebed1, torch 2.13.0+cu132)

No-bias workloads vs the published numbers (bias variants unchanged, within ±1.6%):

| workload | before (ms) | after (ms) | delta | ratio before→after |
|---|---|---|---|---|
| resnext-grouped-3x3-float16 | 0.00509 | 0.00400 | -21.4% | 3.74 → 4.71 |
| bottleneck-expand-1x1-fp16-float16 | 0.00486 | 0.00390 | -19.8% | 0.82 → 1.04 |
| stem-3x3-s2-fp16-float16 | 0.00445 | 0.00360 | -19.1% | 1.45 → 1.83 |
| resnet-1x1-fp16-float16 | 0.00534 | 0.00440 | -17.6% | 0.80 → 0.97 |
| bottleneck-reduce-1x1-fp16-float16 | 0.00551 | 0.00470 | -14.7% | 0.79 → 0.94 |
| late-stage-1x1-fp16-float16 | 0.00589 | 0.00510 | -13.4% | 1.08 → 1.25 |
| mobilenetv2-depthwise-float16 | 0.00765 | 0.00670 | -12.4% | 0.40 → 0.46 |
| classifier-1x1-fp16-float16 | 0.01020 | 0.00910 | -10.8% | 0.90 → 0.99 |
| midres-5x5-s1-fp16-float16 | 0.01700 | 0.01610 | -5.3% | 1.12 → 1.19 |

No workload regresses beyond noise (±3%).

## Checklist

- [x] PR title and commits follow the `[Perf][Scope]` convention.
- [x] Implementation follows Google Python Style; `ruff check` passes.
- [x] No manifest changes (no interface or signature change).
- [x] No new public tests; existing conv2d tests cover both bias modes.
- [x] Benchmarks record the `torch` baseline for every workload.

---

## Update: extended to Conv1d/Conv3d per review feedback

@superAngGao pointed out the Conv2d-only coverage left the optimization inconsistent — the Op layer already accepts an optional bias for all three dimensions, but the Conv1d/Conv3d kernel layer still allocated a zero bias on every no-bias call. Commit `7526f71` extends the identical treatment to `Conv1dPointwiseKernel`, `Conv1dKernel`, `GroupConv1dKernel` (group + direct paths), `Conv3dKernel`, and `GroupConv3dKernel`, making the optimization consistent across all convolution dimensions.

### Conv1d/Conv3d no-bias workloads vs the published numbers

| workload | before (ms) | after (ms) | delta | ratio before→after |
|---|---|---|---|---|
| encodec-init-bfloat16 | 0.00445 | 0.00355 | -20.2% | 1.51 → 1.88 |
| encodec-init-float16 | 0.00445 | 0.00355 | -20.2% | 1.50 → 1.86 |
| wav2vec2-layer1-bfloat16 | 0.00765 | 0.00662 | -13.4% | 2.46 → 2.83 |
| wav2vec2-layer1-float16 | 0.00765 | 0.00666 | -13.0% | 2.43 → 2.79 |
| encodec-deep-bfloat16 | 0.01290 | 0.01194 | -7.5% | 1.32 → 1.43 |
| encodec-deep-float16 | 0.01290 | 0.01200 | -7.0% | 1.32 → 1.42 |
| 3d-resnext-grouped-k3-float16 | 0.01600 | 0.01511 | -5.6% | 16.22 → 16.76 |
| r3d-stem-k3-s1-fp16-float16 | 0.02380 | 0.02262 | -4.9% | 4.81 → 5.05 |
| whisper-large-conv1-float16 | 0.04980 | 0.04787 | -3.9% | 1.14 → 1.18 |
| video-stage-downsample-k3-s2-fp16-float16 | 0.03580 | 0.03462 | -3.3% | 0.74 → 0.76 |

Within ±3% (unchanged): whisper-large-conv1-bfloat16 (-2.3%), 3d-unet-aspp-3x3x3-rate6-float16 (-2.8%), unet-encoder-k3-s1-bf16-bfloat16 (-0.3%).

### Conv1d/Conv3d bias variants (control group, generated code unchanged)

| workload | before (ms) | after (ms) | delta |
|---|---|---|---|
| encodec-deep-bfloat16 | 0.0124 | 0.01232 | -0.6% |
| encodec-deep-float16 | 0.0124 | 0.01232 | -0.6% |
| encodec-init-bfloat16 | 0.00358 | 0.00358 | 0.0% |
| encodec-init-float16 | 0.00362 | 0.00358 | -1.1% |
| wav2vec2-layer1-bfloat16 | 0.00691 | 0.00691 | 0.0% |
| wav2vec2-layer1-float16 | 0.00688 | 0.00691 | +0.4% |
| whisper-large-conv1-bfloat16 | 0.0482 | 0.04762 | -1.2% |
| whisper-large-conv1-float16 | 0.0482 | 0.04758 | -1.3% |
| r3d-stem-k3-s1-fp16-float16 | 0.0231 | 0.02291 | -0.8% |
| unet-encoder-k3-s1-bf16-bfloat16 | 0.3537 | 0.35314 | -0.2% |
| video-stage-downsample-k3-s2-fp16-float16 | 0.0354 | 0.03507 | -0.9% |

### Verification for the extension

- Numerics vs `F.conv1d`/`F.conv3d` for every Conv1d/Conv3d kernel path (pointwise, general, group, depthwise-direct, 3d general, 3d group) × {bias, no-bias}: all match.
- No-bias path verified to launch exactly one kernel and never call `torch.zeros`.
- Existing conv1d/conv3d unit tests: 33/33 pass.
- Full conv benchmark suite re-run (57 cases, single-process nightly-style, H200): **57/57 PASS**; no workload regresses beyond noise.
