### PR TITLE
[Chore][Repo] Drop .git-blame-ignore-revs, which has nothing left to ignore

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,0 @@
-# Repo-wide ruff format; no change of meaning.
-70b01c3dc636551c9de74e6b9f78db395fb58d6d

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -17,4 +17,3 @@ exclude CLAUDE.md
 exclude constraints.txt
 exclude constraints-runner-lock.txt
 exclude .gitattributes
-exclude .git-blame-ignore-revs


### PR DESCRIPTION
## Problems

- `.git-blame-ignore-revs` names the format-only commit of #1939, which does not exist: that PR was squashed.
- The squash leaves nothing to name in its place. The single commit that landed carries the 400-file reformat together with the R8 and R19 rules, the optional-input change, the six ops that moved to `implemented`, and 25 renames, so listing it would make blame skip those too.

## Changes

- Remove the file and its `MANIFEST.in` exclude. Nothing consumed it — no `blame.ignoreRevsFile` setting, no CI step — and git tolerates the dead SHA silently, so no behaviour changes.
