### PR TITLE
[Refactor][Ops] Move conv and pool onto the op/backend boundary, and make conv bias optional

### DIFF
--- a/src/tileops/kernels/convolution.py
+++ b/src/tileops/kernels/convolution.py
@@ -113,13 +113,8 @@ def _conv1d_kernel(
         threads: int,
         enable_rasterization: bool,
     ):
-        @T.prim_func
-        def _conv1d_main(
-            x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
-            weight_flat: T.Tensor((c_out, k_total), dtype),  # type: ignore
-            out: T.Tensor((n, c_out, out_l), dtype),  # type: ignore
-            bias: T.Tensor((c_out,), dtype),  # type: ignore
-        ):
+        @T.macro
+        def _conv1d_body(x, weight_flat, out, bias):
             with T.Kernel(
                 T.ceildiv(out_l, block_n),
                 T.ceildiv(c_out, block_m),
@@ -185,6 +180,27 @@ def _conv1d_kernel(
                     if oc < c_out and ol < out_l:
                         out[bz, oc, ol] = out_shared[i, j]
 
+        if has_bias:
+
+            @T.prim_func
+            def _conv1d_bias_main(
+                x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
+                weight_flat: T.Tensor((c_out, k_total), dtype),  # type: ignore
+                out: T.Tensor((n, c_out, out_l), dtype),  # type: ignore
+                bias: T.Tensor((c_out,), dtype),  # type: ignore
+            ):
+                _conv1d_body(x, weight_flat, out, bias)
+
+            return _conv1d_bias_main
+
+        @T.prim_func
+        def _conv1d_main(
+            x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
+            weight_flat: T.Tensor((c_out, k_total), dtype),  # type: ignore
+            out: T.Tensor((n, c_out, out_l), dtype),  # type: ignore
+        ):
+            _conv1d_body(x, weight_flat, out, None)
+
         return _conv1d_main
 
     return _conv1d_func
@@ -216,13 +232,8 @@ def _conv1d_direct_kernel(
         threads: int,
         enable_rasterization: bool,
     ):
-        @T.prim_func
-        def _conv1d_direct_main(
-            x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
-            weight: T.Tensor((c_out, 1, kernel_l), dtype),  # type: ignore
-            out: T.Tensor((n, c_out, out_l), dtype),  # type: ignore
-            bias: T.Tensor((c_out,), dtype),  # type: ignore
-        ):
+        @T.macro
+        def _conv1d_direct_body(x, weight, out, bias):
             with T.Kernel(
                 T.ceildiv(out_l, block_n),
                 T.ceildiv(c_out, block_m),
@@ -257,6 +268,27 @@ def _conv1d_direct_kernel(
                             )
                         else:
                             out[bz, oc, ol] = T.cast(out_local[i, j], dtype)
+
+        if has_bias:
+
+            @T.prim_func
+            def _conv1d_direct_bias_main(
+                x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
+                weight: T.Tensor((c_out, 1, kernel_l), dtype),  # type: ignore
+                out: T.Tensor((n, c_out, out_l), dtype),  # type: ignore
+                bias: T.Tensor((c_out,), dtype),  # type: ignore
+            ):
+                _conv1d_direct_body(x, weight, out, bias)
+
+            return _conv1d_direct_bias_main
+
+        @T.prim_func
+        def _conv1d_direct_main(
+            x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
+            weight: T.Tensor((c_out, 1, kernel_l), dtype),  # type: ignore
+            out: T.Tensor((n, c_out, out_l), dtype),  # type: ignore
+        ):
+            _conv1d_direct_body(x, weight, out, None)
 
         return _conv1d_direct_main
 
@@ -295,13 +327,8 @@ def _conv1d_group_kernel(
         threads: int,
         enable_rasterization: bool,
     ):
-        @T.prim_func
-        def _conv1d_group_main(
-            x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
-            weight: T.Tensor((c_out, c_in_g, kernel_l), dtype),  # type: ignore
-            out: T.Tensor((n, c_out, out_l), dtype),  # type: ignore
-            bias: T.Tensor((c_out,), dtype),  # type: ignore
-        ):
+        @T.macro
+        def _conv1d_group_body(x, weight, out, bias):
             with T.Kernel(
                 T.ceildiv(out_l, block_n),
                 T.ceildiv(c_out_g, block_m),
@@ -370,6 +397,27 @@ def _conv1d_group_kernel(
                     if oc_g < c_out_g and ol < out_l:
                         out[batch_id, oc, ol] = out_shared[i, j]
 
+        if has_bias:
+
+            @T.prim_func
+            def _conv1d_group_bias_main(
+                x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
+                weight: T.Tensor((c_out, c_in_g, kernel_l), dtype),  # type: ignore
+                out: T.Tensor((n, c_out, out_l), dtype),  # type: ignore
+                bias: T.Tensor((c_out,), dtype),  # type: ignore
+            ):
+                _conv1d_group_body(x, weight, out, bias)
+
+            return _conv1d_group_bias_main
+
+        @T.prim_func
+        def _conv1d_group_main(
+            x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
+            weight: T.Tensor((c_out, c_in_g, kernel_l), dtype),  # type: ignore
+            out: T.Tensor((n, c_out, out_l), dtype),  # type: ignore
+        ):
+            _conv1d_group_body(x, weight, out, None)
+
         return _conv1d_group_main
 
     return _conv1d_group_func
@@ -395,13 +443,8 @@ def _conv1d_pointwise_kernel(
         threads: int,
         enable_rasterization: bool,
     ):
-        @T.prim_func
-        def _conv1d_pointwise_main(
-            x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
-            weight: T.Tensor((c_out, c_in), dtype),  # type: ignore
-            out: T.Tensor((n, c_out, l_in), dtype),  # type: ignore
-            bias: T.Tensor((c_out,), dtype),  # type: ignore
-        ):
+        @T.macro
+        def _conv1d_pointwise_body(x, weight, out, bias):
             with T.Kernel(
                 T.ceildiv(l_in, block_n),
                 T.ceildiv(c_out, block_m),
@@ -453,229 +496,72 @@ def _conv1d_pointwise_kernel(
 
                 T.copy(out_shared, out[bz, by * block_m, bx * block_n])
 
+        if has_bias:
+
+            @T.prim_func
+            def _conv1d_pointwise_bias_main(
+                x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
+                weight: T.Tensor((c_out, c_in), dtype),  # type: ignore
+                out: T.Tensor((n, c_out, l_in), dtype),  # type: ignore
+                bias: T.Tensor((c_out,), dtype),  # type: ignore
+            ):
+                _conv1d_pointwise_body(x, weight, out, bias)
+
+            return _conv1d_pointwise_bias_main
+
+        @T.prim_func
+        def _conv1d_pointwise_main(
+            x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
+            weight: T.Tensor((c_out, c_in), dtype),  # type: ignore
+            out: T.Tensor((n, c_out, l_in), dtype),  # type: ignore
+        ):
+            _conv1d_pointwise_body(x, weight, out, None)
+
         return _conv1d_pointwise_main
 
     return _conv1d_pointwise_func
 
 
-@torch.library.custom_op("top::conv1d_wrapped_kernel", mutates_args=())
-def _conv1d_wrapped_kernel(
-    n: int,
-    c_in: int,
-    l_in: int,
-    c_out: int,
-    kernel_l: int,
-    stride_l: int,
-    pad_left: int,
-    pad_right: int,
-    dilation_l: int,
-    has_bias: bool,
-    dtype: str,
-    block_m: int,
-    block_n: int,
-    block_k: int,
-    num_stages: int,
-    threads: int,
-    enable_rasterization: bool,
-    x: torch.Tensor,
-    weight: torch.Tensor,
-    bias: torch.Tensor,
+def _launch(
+    kernel: Kernel,
+    *tensors: torch.Tensor,
+    bias: Optional[torch.Tensor],
 ) -> torch.Tensor:
-    return _conv1d_kernel(
-        n, c_in, l_in, c_out, kernel_l, stride_l, pad_left, pad_right, dilation_l, has_bias, dtype
-    )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)(x, weight, bias)
+    """Run *kernel*'s compiled program, passing *bias* only when the call carries one.
 
+    The program was traced for one side of ``has_bias``: the no-bias variant has no bias
+    parameter at all, so what the call carries has to agree with what was built.
 
-@torch.library.custom_op("top::conv1d_direct_wrapped_kernel", mutates_args=())
-def _conv1d_direct_wrapped_kernel(
-    n: int,
-    c_in: int,
-    l_in: int,
-    c_out: int,
-    kernel_l: int,
-    stride_l: int,
-    pad_left: int,
-    pad_right: int,
-    dilation_l: int,
-    has_bias: bool,
-    dtype: str,
-    block_m: int,
-    block_n: int,
-    block_k: int,
-    num_stages: int,
-    threads: int,
-    enable_rasterization: bool,
-    x: torch.Tensor,
-    weight: torch.Tensor,
-    bias: torch.Tensor,
-) -> torch.Tensor:
-    return _conv1d_direct_kernel(
-        n, c_in, l_in, c_out, kernel_l, stride_l, pad_left, pad_right, dilation_l, has_bias, dtype
-    )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)(x, weight, bias)
+    Args:
+        kernel: The kernel whose ``self.kernel`` builder and ``self.config`` are used.
+        *tensors: The program's inputs in prim_func order, bias excluded.
+        bias: The bias this call carries, or ``None``.
 
+    Returns:
+        The output tensor the program allocated.
 
-@torch.library.custom_op("top::conv1d_group_wrapped_kernel", mutates_args=())
-def _conv1d_group_wrapped_kernel(
-    n: int,
-    c_in: int,
-    l_in: int,
-    c_out: int,
-    kernel_l: int,
-    stride_l: int,
-    pad_left: int,
-    pad_right: int,
-    dilation_l: int,
-    has_bias: bool,
-    dtype: str,
-    groups: int,
-    c_in_g: int,
-    c_out_g: int,
-    block_m: int,
-    block_n: int,
-    block_k: int,
-    num_stages: int,
-    threads: int,
-    enable_rasterization: bool,
-    x: torch.Tensor,
-    weight: torch.Tensor,
-    bias: torch.Tensor,
-) -> torch.Tensor:
-    return _conv1d_group_kernel(
-        n,
-        c_in,
-        l_in,
-        c_out,
-        kernel_l,
-        stride_l,
-        pad_left,
-        pad_right,
-        dilation_l,
-        has_bias,
-        dtype,
-        groups,
-        c_in_g,
-        c_out_g,
-    )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)(x, weight, bias)
-
-
-@torch.library.custom_op("top::conv1d_pointwise_wrapped_kernel", mutates_args=())
-def _conv1d_pointwise_wrapped_kernel(
-    n: int,
-    c_in: int,
-    l_in: int,
-    c_out: int,
-    has_bias: bool,
-    dtype: str,
-    block_m: int,
-    block_n: int,
-    block_k: int,
-    num_stages: int,
-    threads: int,
-    enable_rasterization: bool,
-    x: torch.Tensor,
-    weight: torch.Tensor,
-    bias: torch.Tensor,
-) -> torch.Tensor:
-    return _conv1d_pointwise_kernel(n, c_in, l_in, c_out, has_bias, dtype)(
-        block_m, block_n, block_k, num_stages, threads, enable_rasterization
-    )(x, weight, bias)
-
-
-@_conv1d_wrapped_kernel.register_fake
-def _(
-    n: int,
-    c_in: int,
-    l_in: int,
-    c_out: int,
-    kernel_l: int,
-    stride_l: int,
-    pad_left: int,
-    pad_right: int,
-    dilation_l: int,
-    has_bias: bool,
-    dtype: str,
-    block_m: int,
-    block_n: int,
-    block_k: int,
-    num_stages: int,
-    threads: int,
-    enable_rasterization: bool,
-    *inputs: tuple[torch.Tensor, ...],
-) -> torch.Tensor:
-    out_l = (l_in + pad_left + pad_right - dilation_l * (kernel_l - 1) - 1) // stride_l + 1
-    return torch.empty((n, c_out, out_l), dtype=inputs[0].dtype, device=inputs[0].device)
-
-
-@_conv1d_direct_wrapped_kernel.register_fake
-def _(
-    n: int,
-    c_in: int,
-    l_in: int,
-    c_out: int,
-    kernel_l: int,
-    stride_l: int,
-    pad_left: int,
-    pad_right: int,
-    dilation_l: int,
-    has_bias: bool,
-    dtype: str,
-    block_m: int,
-    block_n: int,
-    block_k: int,
-    num_stages: int,
-    threads: int,
-    enable_rasterization: bool,
-    *inputs: tuple[torch.Tensor, ...],
-) -> torch.Tensor:
-    out_l = (l_in + pad_left + pad_right - dilation_l * (kernel_l - 1) - 1) // stride_l + 1
-    return torch.empty((n, c_out, out_l), dtype=inputs[0].dtype, device=inputs[0].device)
-
-
-@_conv1d_group_wrapped_kernel.register_fake
-def _(
-    n: int,
-    c_in: int,
-    l_in: int,
-    c_out: int,
-    kernel_l: int,
-    stride_l: int,
-    pad_left: int,
-    pad_right: int,
-    dilation_l: int,
-    has_bias: bool,
-    dtype: str,
-    groups: int,
-    c_in_g: int,
-    c_out_g: int,
-    block_m: int,
-    block_n: int,
-    block_k: int,
-    num_stages: int,
-    threads: int,
-    enable_rasterization: bool,
-    *inputs: tuple[torch.Tensor, ...],
-) -> torch.Tensor:
-    out_l = (l_in + pad_left + pad_right - dilation_l * (kernel_l - 1) - 1) // stride_l + 1
-    return torch.empty((n, c_out, out_l), dtype=inputs[0].dtype, device=inputs[0].device)
-
-
-@_conv1d_pointwise_wrapped_kernel.register_fake
-def _(
-    n: int,
-    c_in: int,
-    l_in: int,
-    c_out: int,
-    has_bias: bool,
-    dtype: str,
-    block_m: int,
-    block_n: int,
-    block_k: int,
-    num_stages: int,
-    threads: int,
-    enable_rasterization: bool,
-    *inputs: tuple[torch.Tensor, ...],
-) -> torch.Tensor:
-    return torch.empty((n, c_out, l_in), dtype=inputs[0].dtype, device=inputs[0].device)
+    Raises:
+        ValueError: The call's bias presence differs from the one the kernel was built for.
+    """
+    if (bias is not None) != kernel.has_bias:
+        built, given = ("with", "without") if kernel.has_bias else ("without", "with")
+        raise ValueError(
+            f"{type(kernel).__name__} was built {built} a bias and was called {given} one; "
+            f"bias presence is part of what the program is compiled for, so the op layer "
+            f"builds one kernel per side"
+        )
+    config = kernel.config
+    program = kernel.kernel(
+        config["block_m"],
+        config["block_n"],
+        config["block_k"],
+        config["num_stages"],
+        config["threads"],
+        config["enable_rasterization"],
+    )
+    if bias is None:
+        return program(*tensors)
+    return program(*tensors, bias)
 
 
 class Conv1dPointwiseKernel(Kernel):
@@ -742,26 +628,8 @@ class Conv1dPointwiseKernel(Kernel):
         weight: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        if bias is None:
-            bias = torch.zeros(self.c_out, device=x.device, dtype=x.dtype)
         weight_2d = weight[:, :, 0].contiguous()
-        return _conv1d_pointwise_wrapped_kernel(
-            self.n,
-            self.c_in,
-            self.l_in,
-            self.c_out,
-            self.has_bias,
-            self.dtype_str,
-            self.config["block_m"],
-            self.config["block_n"],
-            self.config["block_k"],
-            self.config["num_stages"],
-            self.config["threads"],
-            self.config["enable_rasterization"],
-            x,
-            weight_2d,
-            bias,
-        )
+        return _launch(self, x, weight_2d, bias=bias)
 
 
 class Conv1dKernel(Kernel):
@@ -861,31 +729,8 @@ class Conv1dKernel(Kernel):
         weight: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        if bias is None:
-            bias = torch.zeros(self.c_out, device=x.device, dtype=x.dtype)
         weight_flat = self._get_weight_flat(weight)
-        return _conv1d_wrapped_kernel(
-            self.n,
-            self.c_in,
-            self.l_in,
-            self.c_out,
-            self.kernel_l,
-            self.stride_l,
-            self.pad_left,
-            self.pad_right,
-            self.dilation_l,
-            self.has_bias,
-            self.dtype_str,
-            self.config["block_m"],
-            self.config["block_n"],
-            self.config["block_k"],
-            self.config["num_stages"],
-            self.config["threads"],
-            self.config["enable_rasterization"],
-            x,
-            weight_flat,
-            bias,
-        )
+        return _launch(self, x, weight_flat, bias=bias)
 
 
 class GroupConv1dKernel(Kernel):
@@ -1035,56 +880,9 @@ class GroupConv1dKernel(Kernel):
         weight: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        if bias is None:
-            bias = torch.zeros(self.c_out, device=x.device, dtype=x.dtype)
-        if self.use_direct:
-            return _conv1d_direct_wrapped_kernel(
-                self.n,
-                self.c_in,
-                self.l_in,
-                self.c_out,
-                self.kernel_l,
-                self.stride_l,
-                self.pad_left,
-                self.pad_right,
-                self.dilation_l,
-                self.has_bias,
-                self.dtype_str,
-                self.config["block_m"],
-                self.config["block_n"],
-                self.config["block_k"],
-                self.config["num_stages"],
-                self.config["threads"],
-                self.config["enable_rasterization"],
-                x,
-                weight,
-                bias,
-            )
-        return _conv1d_group_wrapped_kernel(
-            self.n,
-            self.c_in,
-            self.l_in,
-            self.c_out,
-            self.kernel_l,
-            self.stride_l,
-            self.pad_left,
-            self.pad_right,
-            self.dilation_l,
-            self.has_bias,
-            self.dtype_str,
-            self.groups,
-            self.c_in_g,
-            self.c_out_g,
-            self.config["block_m"],
-            self.config["block_n"],
-            self.config["block_k"],
-            self.config["num_stages"],
-            self.config["threads"],
-            self.config["enable_rasterization"],
-            x,
-            weight,
-            bias,
-        )
+        # ``self.kernel`` already is the direct or the group builder; ``use_direct`` picked
+        # it at construction.
+        return _launch(self, x, weight, bias=bias)
 
 
 # Conv2d
@@ -1118,13 +916,8 @@ def _conv2d_1x1_kernel(
         threads: int,
         enable_rasterization: bool,
     ):
-        @T.prim_func
-        def _conv2d_1x1_main(
-            x: T.Tensor((n, c_in, h, w), dtype),  # type: ignore
-            weight: T.Tensor((c_out, c_in), dtype),  # type: ignore
-            out: T.Tensor((n, c_out, h, w), dtype),  # type: ignore
-            bias: T.Tensor((c_out,), dtype),  # type: ignore
-        ):
+        @T.macro
+        def _conv2d_1x1_body(x, weight, out, bias):
             x_flat = T.Tensor((n, c_in, hw), dtype, x.data)
             out_flat = T.Tensor((n, c_out, hw), dtype, out.data)
             with T.Kernel(
@@ -1163,6 +956,27 @@ def _conv2d_1x1_kernel(
                         )
 
                 T.copy(out_shared, out_flat[bz, by * block_m, bx * block_n])
+
+        if has_bias:
+
+            @T.prim_func
+            def _conv2d_1x1_bias_main(
+                x: T.Tensor((n, c_in, h, w), dtype),  # type: ignore
+                weight: T.Tensor((c_out, c_in), dtype),  # type: ignore
+                out: T.Tensor((n, c_out, h, w), dtype),  # type: ignore
+                bias: T.Tensor((c_out,), dtype),  # type: ignore
+            ):
+                _conv2d_1x1_body(x, weight, out, bias)
+
+            return _conv2d_1x1_bias_main
+
+        @T.prim_func
+        def _conv2d_1x1_main(
+            x: T.Tensor((n, c_in, h, w), dtype),  # type: ignore
+            weight: T.Tensor((c_out, c_in), dtype),  # type: ignore
+            out: T.Tensor((n, c_out, h, w), dtype),  # type: ignore
+        ):
+            _conv2d_1x1_body(x, weight, out, None)
 
         return _conv2d_1x1_main
 
@@ -1207,13 +1021,8 @@ def _conv2d_kernel(
         threads: int,
         enable_rasterization: bool,
     ):
-        @T.prim_func
-        def _conv2d_main(
-            x: T.Tensor((n, c_in, h, w), dtype),  # type: ignore
-            weight: T.Tensor((c_out, c_in, kernel_h, kernel_w), dtype),  # type: ignore
-            out: T.Tensor((n, c_out, out_h, out_w), dtype),  # type: ignore
-            bias: T.Tensor((c_out,), dtype),  # type: ignore
-        ):
+        @T.macro
+        def _conv2d_body(x, weight, out, bias):
             out_hw = out_h * out_w
             with T.Kernel(
                 T.ceildiv(out_hw, block_n),
@@ -1280,6 +1089,27 @@ def _conv2d_kernel(
 
                 T.copy(out_shared, out_flat[bz, by * block_m, bx * block_n])
 
+        if has_bias:
+
+            @T.prim_func
+            def _conv2d_bias_main(
+                x: T.Tensor((n, c_in, h, w), dtype),  # type: ignore
+                weight: T.Tensor((c_out, c_in, kernel_h, kernel_w), dtype),  # type: ignore
+                out: T.Tensor((n, c_out, out_h, out_w), dtype),  # type: ignore
+                bias: T.Tensor((c_out,), dtype),  # type: ignore
+            ):
+                _conv2d_body(x, weight, out, bias)
+
+            return _conv2d_bias_main
+
+        @T.prim_func
+        def _conv2d_main(
+            x: T.Tensor((n, c_in, h, w), dtype),  # type: ignore
+            weight: T.Tensor((c_out, c_in, kernel_h, kernel_w), dtype),  # type: ignore
+            out: T.Tensor((n, c_out, out_h, out_w), dtype),  # type: ignore
+        ):
+            _conv2d_body(x, weight, out, None)
+
         return _conv2d_main
 
     return _conv2d_func
@@ -1327,13 +1157,8 @@ def _conv2d_group_kernel(
         threads: int,
         enable_rasterization: bool,
     ):
-        @T.prim_func
-        def _conv2d_group_main(
-            x: T.Tensor((n, c_in, h, w), dtype),  # type: ignore
-            weight: T.Tensor((c_out, c_in_g, kernel_h, kernel_w), dtype),  # type: ignore
-            out: T.Tensor((n, c_out, out_h, out_w), dtype),  # type: ignore
-            bias: T.Tensor((c_out,), dtype),  # type: ignore
-        ):
+        @T.macro
+        def _conv2d_group_body(x, weight, out, bias):
             with T.Kernel(
                 T.ceildiv(out_hw, block_n),
                 T.ceildiv(c_out_g, block_m),
@@ -1417,6 +1242,27 @@ def _conv2d_group_kernel(
                     if oc_g < c_out_g and spatial_idx < out_hw:
                         out[batch_id, oc, oh, ow] = out_shared[i, j]
 
+        if has_bias:
+
+            @T.prim_func
+            def _conv2d_group_bias_main(
+                x: T.Tensor((n, c_in, h, w), dtype),  # type: ignore
+                weight: T.Tensor((c_out, c_in_g, kernel_h, kernel_w), dtype),  # type: ignore
+                out: T.Tensor((n, c_out, out_h, out_w), dtype),  # type: ignore
+                bias: T.Tensor((c_out,), dtype),  # type: ignore
+            ):
+                _conv2d_group_body(x, weight, out, bias)
+
+            return _conv2d_group_bias_main
+
+        @T.prim_func
+        def _conv2d_group_main(
+            x: T.Tensor((n, c_in, h, w), dtype),  # type: ignore
+            weight: T.Tensor((c_out, c_in_g, kernel_h, kernel_w), dtype),  # type: ignore
+            out: T.Tensor((n, c_out, out_h, out_w), dtype),  # type: ignore
+        ):
+            _conv2d_group_body(x, weight, out, None)
+
         return _conv2d_group_main
 
     return _conv2d_group_func
@@ -1443,7 +1289,7 @@ def _conv2d_symmetric_kernel(
     k_total = c_in * kernel_size * kernel_size
 
     @tilelang.jit(
-        out_idx=[6],
+        out_idx=[5],
         compile_flags=["-O3", "-DENABLE_BF16"],
         pass_configs={"tl.enable_async_copy": False},
     )
@@ -1511,13 +1357,7 @@ def _conv2d_symmetric_kernel(
                                 dst[bz, c, h_idx, w_idx] = src[bz, h_idx, w_idx, c]
 
         @T.macro
-        def conv_nhwc_implicit_gemm_bias(
-            x_nhwc: T.Tensor((n, h, w, c_in), dtype),
-            weight_krsc: T.Tensor((c_out, kernel_size, kernel_size, c_in), dtype),
-            bias: T.Tensor((c_out,), dtype),
-            out_nhwc: T.Tensor((n, out_h, out_w, c_out), dtype),
-            has_bias: bool,
-        ):
+        def conv_nhwc_implicit_gemm(x_nhwc, weight_krsc, out_nhwc, bias):
             with T.Kernel(
                 T.ceildiv(c_out, block_n),
                 T.ceildiv(n * out_h * out_w, block_m),
@@ -1557,16 +1397,8 @@ def _conv2d_symmetric_kernel(
 
                 T.copy(out_shared, out_flat[by * block_m, bx * block_n])
 
-        @T.prim_func
-        def _conv2d_symmetric_main(
-            x: T.Tensor((n, c_in, h, w), dtype),
-            weight: T.Tensor((c_out, c_in, kernel_size, kernel_size), dtype),
-            bias: T.Tensor((c_out,), dtype),
-            x_nhwc: T.Tensor((n, h, w, c_in), dtype),
-            weight_krsc: T.Tensor((c_out, kernel_size, kernel_size, c_in), dtype),
-            out_nhwc: T.Tensor((n, out_h, out_w, c_out), dtype),
-            out: T.Tensor((n, c_out, out_h, out_w), dtype),
-        ):
+        @T.macro
+        def _conv2d_symmetric_body(x, weight, x_nhwc, weight_krsc, out_nhwc, out, bias):
             transpose_spatial_channel(
                 x,
                 x_nhwc,
@@ -1593,7 +1425,7 @@ def _conv2d_symmetric_kernel(
                 channel_fastest=True,
                 is_nchw_to_nhwc=True,
             )
-            conv_nhwc_implicit_gemm_bias(x_nhwc, weight_krsc, bias, out_nhwc, has_bias)
+            conv_nhwc_implicit_gemm(x_nhwc, weight_krsc, out_nhwc, bias)
             transpose_spatial_channel(
                 out_nhwc,
                 out,
@@ -1608,275 +1440,36 @@ def _conv2d_symmetric_kernel(
                 is_nchw_to_nhwc=False,
             )
 
+        if has_bias:
+
+            @T.prim_func
+            def _conv2d_symmetric_bias_main(
+                x: T.Tensor((n, c_in, h, w), dtype),
+                weight: T.Tensor((c_out, c_in, kernel_size, kernel_size), dtype),
+                x_nhwc: T.Tensor((n, h, w, c_in), dtype),
+                weight_krsc: T.Tensor((c_out, kernel_size, kernel_size, c_in), dtype),
+                out_nhwc: T.Tensor((n, out_h, out_w, c_out), dtype),
+                out: T.Tensor((n, c_out, out_h, out_w), dtype),
+                bias: T.Tensor((c_out,), dtype),
+            ):
+                _conv2d_symmetric_body(x, weight, x_nhwc, weight_krsc, out_nhwc, out, bias)
+
+            return _conv2d_symmetric_bias_main
+
+        @T.prim_func
+        def _conv2d_symmetric_main(
+            x: T.Tensor((n, c_in, h, w), dtype),
+            weight: T.Tensor((c_out, c_in, kernel_size, kernel_size), dtype),
+            x_nhwc: T.Tensor((n, h, w, c_in), dtype),
+            weight_krsc: T.Tensor((c_out, kernel_size, kernel_size, c_in), dtype),
+            out_nhwc: T.Tensor((n, out_h, out_w, c_out), dtype),
+            out: T.Tensor((n, c_out, out_h, out_w), dtype),
+        ):
+            _conv2d_symmetric_body(x, weight, x_nhwc, weight_krsc, out_nhwc, out, None)
+
         return _conv2d_symmetric_main
 
     return _conv2d_symmetric_func
-
-
-@torch.library.custom_op("top::conv2d_1x1_wrapped_kernel", mutates_args=())
-def _conv2d_1x1_wrapped_kernel(
-    n: int,
-    c_in: int,
-    h: int,
-    w: int,
-    c_out: int,
-    has_bias: bool,
-    dtype: str,
-    block_m: int,
-    block_n: int,
-    block_k: int,
-    num_stages: int,
-    threads: int,
-    enable_rasterization: bool,
-    x: torch.Tensor,
-    weight: torch.Tensor,
-    bias: torch.Tensor,
-) -> torch.Tensor:
-    return _conv2d_1x1_kernel(n, c_in, h, w, c_out, 1, 1, 0, 0, has_bias, dtype)(
-        block_m, block_n, block_k, num_stages, threads, enable_rasterization
-    )(x, weight, bias)
-
-
-@_conv2d_1x1_wrapped_kernel.register_fake
-def _(
-    n: int,
-    c_in: int,
-    h: int,
-    w: int,
-    c_out: int,
-    has_bias: bool,
-    dtype: str,
-    block_m: int,
-    block_n: int,
-    block_k: int,
-    num_stages: int,
-    threads: int,
-    enable_rasterization: bool,
-    *inputs: tuple[torch.Tensor, ...],
-) -> torch.Tensor:
-    return torch.empty((n, c_out, h, w), dtype=inputs[0].dtype, device=inputs[0].device)
-
-
-@torch.library.custom_op("top::conv2d_symmetric_wrapped_kernel", mutates_args=())
-def _conv2d_symmetric_wrapped_kernel(
-    n: int,
-    c_in: int,
-    h: int,
-    w: int,
-    c_out: int,
-    kernel_size: int,
-    stride: int,
-    pad: int,
-    dilation: int,
-    has_bias: bool,
-    dtype: str,
-    block_m: int,
-    block_n: int,
-    block_k: int,
-    num_stages: int,
-    threads: int,
-    enable_rasterization: bool,
-    x: torch.Tensor,
-    weight: torch.Tensor,
-    bias: torch.Tensor,
-    x_nhwc: torch.Tensor,
-    weight_krsc: torch.Tensor,
-    out_nhwc: torch.Tensor,
-) -> torch.Tensor:
-    return _conv2d_symmetric_kernel(
-        n, c_in, h, w, c_out, kernel_size, stride, pad, dilation, has_bias, dtype
-    )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)(
-        x, weight, bias, x_nhwc, weight_krsc, out_nhwc
-    )
-
-
-@_conv2d_symmetric_wrapped_kernel.register_fake
-def _(
-    n: int,
-    c_in: int,
-    h: int,
-    w: int,
-    c_out: int,
-    kernel_size: int,
-    stride: int,
-    pad: int,
-    dilation: int,
-    has_bias: bool,
-    dtype: str,
-    block_m: int,
-    block_n: int,
-    block_k: int,
-    num_stages: int,
-    threads: int,
-    enable_rasterization: bool,
-    *inputs: tuple[torch.Tensor, ...],
-) -> torch.Tensor:
-    x = inputs[0]
-    out_h = (h + 2 * pad - dilation * (kernel_size - 1) - 1) // stride + 1
-    out_w = (w + 2 * pad - dilation * (kernel_size - 1) - 1) // stride + 1
-    return torch.empty((n, c_out, out_h, out_w), dtype=x.dtype, device=x.device)
-
-
-@torch.library.custom_op("top::conv2d_wrapped_kernel", mutates_args=())
-def _conv2d_wrapped_kernel(
-    n: int,
-    c_in: int,
-    h: int,
-    w: int,
-    c_out: int,
-    kernel_h: int,
-    kernel_w: int,
-    stride_h: int,
-    stride_w: int,
-    pad_h: int,
-    pad_w: int,
-    dilation_h: int,
-    dilation_w: int,
-    has_bias: bool,
-    dtype: str,
-    block_m: int,
-    block_n: int,
-    block_k: int,
-    num_stages: int,
-    threads: int,
-    enable_rasterization: bool,
-    x: torch.Tensor,
-    weight: torch.Tensor,
-    bias: torch.Tensor,
-) -> torch.Tensor:
-    return _conv2d_kernel(
-        n,
-        c_in,
-        h,
-        w,
-        c_out,
-        kernel_h,
-        kernel_w,
-        stride_h,
-        stride_w,
-        pad_h,
-        pad_w,
-        dilation_h,
-        dilation_w,
-        has_bias,
-        dtype,
-    )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)(x, weight, bias)
-
-
-@torch.library.custom_op("top::conv2d_group_wrapped_kernel", mutates_args=())
-def _conv2d_group_wrapped_kernel(
-    n: int,
-    c_in: int,
-    h: int,
-    w: int,
-    c_out: int,
-    kernel_h: int,
-    kernel_w: int,
-    stride_h: int,
-    stride_w: int,
-    pad_h: int,
-    pad_w: int,
-    dilation_h: int,
-    dilation_w: int,
-    has_bias: bool,
-    dtype: str,
-    groups: int,
-    c_in_g: int,
-    c_out_g: int,
-    block_m: int,
-    block_n: int,
-    block_k: int,
-    num_stages: int,
-    threads: int,
-    enable_rasterization: bool,
-    x: torch.Tensor,
-    weight: torch.Tensor,
-    bias: torch.Tensor,
-) -> torch.Tensor:
-    return _conv2d_group_kernel(
-        n,
-        c_in,
-        h,
-        w,
-        c_out,
-        kernel_h,
-        kernel_w,
-        stride_h,
-        stride_w,
-        pad_h,
-        pad_w,
-        dilation_h,
-        dilation_w,
-        has_bias,
-        dtype,
-        groups,
-        c_in_g,
-        c_out_g,
-    )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)(x, weight, bias)
-
-
-@_conv2d_wrapped_kernel.register_fake
-def _(
-    n: int,
-    c_in: int,
-    h: int,
-    w: int,
-    c_out: int,
-    kernel_h: int,
-    kernel_w: int,
-    stride_h: int,
-    stride_w: int,
-    pad_h: int,
-    pad_w: int,
-    dilation_h: int,
-    dilation_w: int,
-    has_bias: bool,
-    dtype: str,
-    block_m: int,
-    block_n: int,
-    block_k: int,
-    num_stages: int,
-    threads: int,
-    enable_rasterization: bool,
-    *inputs: tuple[torch.Tensor, ...],
-) -> torch.Tensor:
-    out_h = (h + 2 * pad_h - dilation_h * (kernel_h - 1) - 1) // stride_h + 1
-    out_w = (w + 2 * pad_w - dilation_w * (kernel_w - 1) - 1) // stride_w + 1
-    return torch.empty((n, c_out, out_h, out_w), dtype=inputs[0].dtype, device=inputs[0].device)
-
-
-@_conv2d_group_wrapped_kernel.register_fake
-def _(
-    n: int,
-    c_in: int,
-    h: int,
-    w: int,
-    c_out: int,
-    kernel_h: int,
-    kernel_w: int,
-    stride_h: int,
-    stride_w: int,
-    pad_h: int,
-    pad_w: int,
-    dilation_h: int,
-    dilation_w: int,
-    has_bias: bool,
-    dtype: str,
-    groups: int,
-    c_in_g: int,
-    c_out_g: int,
-    block_m: int,
-    block_n: int,
-    block_k: int,
-    num_stages: int,
-    threads: int,
-    enable_rasterization: bool,
-    *inputs: tuple[torch.Tensor, ...],
-) -> torch.Tensor:
-    del groups, c_in_g, c_out_g
-    out_h = (h + 2 * pad_h - dilation_h * (kernel_h - 1) - 1) // stride_h + 1
-    out_w = (w + 2 * pad_w - dilation_w * (kernel_w - 1) - 1) // stride_w + 1
-    return torch.empty((n, c_out, out_h, out_w), dtype=inputs[0].dtype, device=inputs[0].device)
 
 
 class Conv2dSymmetricKernel(Kernel):
@@ -1956,8 +1549,6 @@ class Conv2dSymmetricKernel(Kernel):
         weight: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        if bias is None:
-            bias = torch.zeros(self.c_out, device=x.device, dtype=x.dtype)
         x_nhwc = torch.empty(
             (self.n, self.h, self.w, self.c_in),
             device=x.device,
@@ -1973,31 +1564,7 @@ class Conv2dSymmetricKernel(Kernel):
             device=x.device,
             dtype=x.dtype,
         )
-        return _conv2d_symmetric_wrapped_kernel(
-            self.n,
-            self.c_in,
-            self.h,
-            self.w,
-            self.c_out,
-            self.kernel_size,
-            self.stride,
-            self.pad,
-            self.dilation,
-            self.has_bias,
-            self.dtype_str,
-            self.config["block_m"],
-            self.config["block_n"],
-            self.config["block_k"],
-            self.config["num_stages"],
-            self.config["threads"],
-            self.config["enable_rasterization"],
-            x,
-            weight,
-            bias,
-            x_nhwc,
-            weight_krsc,
-            out_nhwc,
-        )
+        return _launch(self, x, weight, x_nhwc, weight_krsc, out_nhwc, bias=bias)
 
 
 class Conv2dKernel(Kernel):
@@ -2107,34 +1674,7 @@ class Conv2dKernel(Kernel):
         weight: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        if bias is None:
-            bias = torch.zeros(self.c_out, device=x.device, dtype=x.dtype)
-        return _conv2d_wrapped_kernel(
-            self.n,
-            self.c_in,
-            self.h,
-            self.w,
-            self.c_out,
-            self.kernel_h,
-            self.kernel_w,
-            self.stride_h,
-            self.stride_w,
-            self.pad_h,
-            self.pad_w,
-            self.dilation_h,
-            self.dilation_w,
-            self.has_bias,
-            self.dtype_str,
-            self.config["block_m"],
-            self.config["block_n"],
-            self.config["block_k"],
-            self.config["num_stages"],
-            self.config["threads"],
-            self.config["enable_rasterization"],
-            x,
-            weight,
-            bias,
-        )
+        return _launch(self, x, weight, bias=bias)
 
 
 class GroupConv2dKernel(Kernel):
@@ -2250,37 +1790,7 @@ class GroupConv2dKernel(Kernel):
         weight: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        if bias is None:
-            bias = torch.zeros(self.c_out, device=x.device, dtype=x.dtype)
-        return _conv2d_group_wrapped_kernel(
-            self.n,
-            self.c_in,
-            self.h,
-            self.w,
-            self.c_out,
-            self.kernel_h,
-            self.kernel_w,
-            self.stride_h,
-            self.stride_w,
-            self.pad_h,
-            self.pad_w,
-            self.dilation_h,
-            self.dilation_w,
-            self.has_bias,
-            self.dtype_str,
-            self.groups,
-            self.c_in_g,
-            self.c_out_g,
-            self.config["block_m"],
-            self.config["block_n"],
-            self.config["block_k"],
-            self.config["num_stages"],
-            self.config["threads"],
-            self.config["enable_rasterization"],
-            x,
-            weight,
-            bias,
-        )
+        return _launch(self, x, weight, bias=bias)
 
 
 class Conv2d1x1Kernel(Kernel):
@@ -2373,28 +1883,9 @@ class Conv2d1x1Kernel(Kernel):
         weight: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        if bias is None:
-            bias = torch.zeros(self.c_out, device=x.device, dtype=x.dtype)
         # OIHW -> OC,IC since the 1x1 kernel consumes a dense [C_out, C_in] weight matrix.
         weight_oc_ci = weight.view(self.c_out, self.c_in).contiguous()
-        return _conv2d_1x1_wrapped_kernel(
-            self.n,
-            self.c_in,
-            self.h,
-            self.w,
-            self.c_out,
-            self.has_bias,
-            self.dtype_str,
-            self.config["block_m"],
-            self.config["block_n"],
-            self.config["block_k"],
-            self.config["num_stages"],
-            self.config["threads"],
-            self.config["enable_rasterization"],
-            x,
-            weight_oc_ci,
-            bias,
-        )
+        return _launch(self, x, weight_oc_ci, bias=bias)
 
 
 # Conv3d
@@ -2444,13 +1935,8 @@ def _conv3d_kernel(
         threads: int,
         enable_rasterization: bool,
     ):
-        @T.prim_func
-        def _conv3d_main(
-            x: T.Tensor((n, c_in, d_in, h_in, w_in), dtype),  # type: ignore
-            weight: T.Tensor((c_out, c_in, kernel_d, kernel_h, kernel_w), dtype),  # type: ignore
-            out: T.Tensor((n, c_out, out_d, out_h, out_w), dtype),  # type: ignore
-            bias: T.Tensor((c_out,), dtype),  # type: ignore
-        ):
+        @T.macro
+        def _conv3d_body(x, weight, out, bias):
             out_dhw = out_d * out_h * out_w
             with T.Kernel(
                 T.ceildiv(out_dhw, block_n),
@@ -2521,6 +2007,27 @@ def _conv3d_kernel(
 
                 T.copy(out_shared, out_flat[bz, by * block_m, bx * block_n])
 
+        if has_bias:
+
+            @T.prim_func
+            def _conv3d_bias_main(
+                x: T.Tensor((n, c_in, d_in, h_in, w_in), dtype),  # type: ignore
+                weight: T.Tensor((c_out, c_in, kernel_d, kernel_h, kernel_w), dtype),  # type: ignore
+                out: T.Tensor((n, c_out, out_d, out_h, out_w), dtype),  # type: ignore
+                bias: T.Tensor((c_out,), dtype),  # type: ignore
+            ):
+                _conv3d_body(x, weight, out, bias)
+
+            return _conv3d_bias_main
+
+        @T.prim_func
+        def _conv3d_main(
+            x: T.Tensor((n, c_in, d_in, h_in, w_in), dtype),  # type: ignore
+            weight: T.Tensor((c_out, c_in, kernel_d, kernel_h, kernel_w), dtype),  # type: ignore
+            out: T.Tensor((n, c_out, out_d, out_h, out_w), dtype),  # type: ignore
+        ):
+            _conv3d_body(x, weight, out, None)
+
         return _conv3d_main
 
     return _conv3d_func
@@ -2574,13 +2081,8 @@ def _conv3d_group_kernel(
         threads: int,
         enable_rasterization: bool,
     ):
-        @T.prim_func
-        def _conv3d_group_main(
-            x: T.Tensor((n, c_in, d_in, h_in, w_in), dtype),  # type: ignore
-            weight: T.Tensor((c_out, c_in_g, kernel_d, kernel_h, kernel_w), dtype),  # type: ignore
-            out: T.Tensor((n, c_out, out_d, out_h, out_w), dtype),  # type: ignore
-            bias: T.Tensor((c_out,), dtype),  # type: ignore
-        ):
+        @T.macro
+        def _conv3d_group_body(x, weight, out, bias):
             with T.Kernel(
                 T.ceildiv(out_dhw, block_n),
                 T.ceildiv(c_out_g, block_m),
@@ -2671,211 +2173,30 @@ def _conv3d_group_kernel(
                     if oc_g < c_out_g and spatial_idx < out_dhw:
                         out[batch_id, oc, od, oh, ow] = out_shared[i, j]
 
+        if has_bias:
+
+            @T.prim_func
+            def _conv3d_group_bias_main(
+                x: T.Tensor((n, c_in, d_in, h_in, w_in), dtype),  # type: ignore
+                weight: T.Tensor((c_out, c_in_g, kernel_d, kernel_h, kernel_w), dtype),  # type: ignore
+                out: T.Tensor((n, c_out, out_d, out_h, out_w), dtype),  # type: ignore
+                bias: T.Tensor((c_out,), dtype),  # type: ignore
+            ):
+                _conv3d_group_body(x, weight, out, bias)
+
+            return _conv3d_group_bias_main
+
+        @T.prim_func
+        def _conv3d_group_main(
+            x: T.Tensor((n, c_in, d_in, h_in, w_in), dtype),  # type: ignore
+            weight: T.Tensor((c_out, c_in_g, kernel_d, kernel_h, kernel_w), dtype),  # type: ignore
+            out: T.Tensor((n, c_out, out_d, out_h, out_w), dtype),  # type: ignore
+        ):
+            _conv3d_group_body(x, weight, out, None)
+
         return _conv3d_group_main
 
     return _conv3d_group_func
-
-
-@torch.library.custom_op("top::conv3d_wrapped_kernel", mutates_args=())
-def _conv3d_wrapped_kernel(
-    n: int,
-    c_in: int,
-    d_in: int,
-    h_in: int,
-    w_in: int,
-    c_out: int,
-    kernel_d: int,
-    kernel_h: int,
-    kernel_w: int,
-    stride_d: int,
-    stride_h: int,
-    stride_w: int,
-    pad_d: int,
-    pad_h: int,
-    pad_w: int,
-    dilation_d: int,
-    dilation_h: int,
-    dilation_w: int,
-    has_bias: bool,
-    dtype: str,
-    block_m: int,
-    block_n: int,
-    block_k: int,
-    num_stages: int,
-    threads: int,
-    enable_rasterization: bool,
-    x: torch.Tensor,
-    weight: torch.Tensor,
-    bias: torch.Tensor,
-) -> torch.Tensor:
-    return _conv3d_kernel(
-        n,
-        c_in,
-        d_in,
-        h_in,
-        w_in,
-        c_out,
-        kernel_d,
-        kernel_h,
-        kernel_w,
-        stride_d,
-        stride_h,
-        stride_w,
-        pad_d,
-        pad_h,
-        pad_w,
-        dilation_d,
-        dilation_h,
-        dilation_w,
-        has_bias,
-        dtype,
-    )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)(x, weight, bias)
-
-
-@torch.library.custom_op("top::conv3d_group_wrapped_kernel", mutates_args=())
-def _conv3d_group_wrapped_kernel(
-    n: int,
-    c_in: int,
-    d_in: int,
-    h_in: int,
-    w_in: int,
-    c_out: int,
-    kernel_d: int,
-    kernel_h: int,
-    kernel_w: int,
-    stride_d: int,
-    stride_h: int,
-    stride_w: int,
-    pad_d: int,
-    pad_h: int,
-    pad_w: int,
-    dilation_d: int,
-    dilation_h: int,
-    dilation_w: int,
-    has_bias: bool,
-    dtype: str,
-    groups: int,
-    c_in_g: int,
-    c_out_g: int,
-    block_m: int,
-    block_n: int,
-    block_k: int,
-    num_stages: int,
-    threads: int,
-    enable_rasterization: bool,
-    x: torch.Tensor,
-    weight: torch.Tensor,
-    bias: torch.Tensor,
-) -> torch.Tensor:
-    return _conv3d_group_kernel(
-        n,
-        c_in,
-        d_in,
-        h_in,
-        w_in,
-        c_out,
-        kernel_d,
-        kernel_h,
-        kernel_w,
-        stride_d,
-        stride_h,
-        stride_w,
-        pad_d,
-        pad_h,
-        pad_w,
-        dilation_d,
-        dilation_h,
-        dilation_w,
-        has_bias,
-        dtype,
-        groups,
-        c_in_g,
-        c_out_g,
-    )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)(x, weight, bias)
-
-
-@_conv3d_wrapped_kernel.register_fake
-def _(
-    n: int,
-    c_in: int,
-    d_in: int,
-    h_in: int,
-    w_in: int,
-    c_out: int,
-    kernel_d: int,
-    kernel_h: int,
-    kernel_w: int,
-    stride_d: int,
-    stride_h: int,
-    stride_w: int,
-    pad_d: int,
-    pad_h: int,
-    pad_w: int,
-    dilation_d: int,
-    dilation_h: int,
-    dilation_w: int,
-    has_bias: bool,
-    dtype: str,
-    block_m: int,
-    block_n: int,
-    block_k: int,
-    num_stages: int,
-    threads: int,
-    enable_rasterization: bool,
-    *inputs: tuple[torch.Tensor, ...],
-) -> torch.Tensor:
-    out_d = (d_in + 2 * pad_d - dilation_d * (kernel_d - 1) - 1) // stride_d + 1
-    out_h = (h_in + 2 * pad_h - dilation_h * (kernel_h - 1) - 1) // stride_h + 1
-    out_w = (w_in + 2 * pad_w - dilation_w * (kernel_w - 1) - 1) // stride_w + 1
-    return torch.empty(
-        (n, c_out, out_d, out_h, out_w),
-        dtype=inputs[0].dtype,
-        device=inputs[0].device,
-    )
-
-
-@_conv3d_group_wrapped_kernel.register_fake
-def _(
-    n: int,
-    c_in: int,
-    d_in: int,
-    h_in: int,
-    w_in: int,
-    c_out: int,
-    kernel_d: int,
-    kernel_h: int,
-    kernel_w: int,
-    stride_d: int,
-    stride_h: int,
-    stride_w: int,
-    pad_d: int,
-    pad_h: int,
-    pad_w: int,
-    dilation_d: int,
-    dilation_h: int,
-    dilation_w: int,
-    has_bias: bool,
-    dtype: str,
-    groups: int,
-    c_in_g: int,
-    c_out_g: int,
-    block_m: int,
-    block_n: int,
-    block_k: int,
-    num_stages: int,
-    threads: int,
-    enable_rasterization: bool,
-    *inputs: tuple[torch.Tensor, ...],
-) -> torch.Tensor:
-    del groups, c_in_g, c_out_g
-    out_d = (d_in + 2 * pad_d - dilation_d * (kernel_d - 1) - 1) // stride_d + 1
-    out_h = (h_in + 2 * pad_h - dilation_h * (kernel_h - 1) - 1) // stride_h + 1
-    out_w = (w_in + 2 * pad_w - dilation_w * (kernel_w - 1) - 1) // stride_w + 1
-    return torch.empty(
-        (n, c_out, out_d, out_h, out_w),
-        dtype=inputs[0].dtype,
-        device=inputs[0].device,
-    )
 
 
 class Conv3dKernel(Kernel):
@@ -2991,39 +2312,7 @@ class Conv3dKernel(Kernel):
         weight: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        if bias is None:
-            bias = torch.zeros(self.c_out, device=x.device, dtype=x.dtype)
-        return _conv3d_wrapped_kernel(
-            self.n,
-            self.c_in,
-            self.d_in,
-            self.h_in,
-            self.w_in,
-            self.c_out,
-            self.kernel_d,
-            self.kernel_h,
-            self.kernel_w,
-            self.stride_d,
-            self.stride_h,
-            self.stride_w,
-            self.pad_d,
-            self.pad_h,
-            self.pad_w,
-            self.dilation_d,
-            self.dilation_h,
-            self.dilation_w,
-            self.has_bias,
-            self.dtype_str,
-            self.config["block_m"],
-            self.config["block_n"],
-            self.config["block_k"],
-            self.config["num_stages"],
-            self.config["threads"],
-            self.config["enable_rasterization"],
-            x,
-            weight,
-            bias,
-        )
+        return _launch(self, x, weight, bias=bias)
 
 
 class GroupConv3dKernel(Kernel):
@@ -3158,39 +2447,4 @@ class GroupConv3dKernel(Kernel):
         weight: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        if bias is None:
-            bias = torch.zeros(self.c_out, device=x.device, dtype=x.dtype)
-        return _conv3d_group_wrapped_kernel(
-            self.n,
-            self.c_in,
-            self.d_in,
-            self.h_in,
-            self.w_in,
-            self.c_out,
-            self.kernel_d,
-            self.kernel_h,
-            self.kernel_w,
-            self.stride_d,
-            self.stride_h,
-            self.stride_w,
-            self.pad_d,
-            self.pad_h,
-            self.pad_w,
-            self.dilation_d,
-            self.dilation_h,
-            self.dilation_w,
-            self.has_bias,
-            self.dtype_str,
-            self.groups,
-            self.c_in_g,
-            self.c_out_g,
-            self.config["block_m"],
-            self.config["block_n"],
-            self.config["block_k"],
-            self.config["num_stages"],
-            self.config["threads"],
-            self.config["enable_rasterization"],
-            x,
-            weight,
-            bias,
-        )
+        return _launch(self, x, weight, bias=bias)

--- a/src/tileops/kernels/convolution.py
+++ b/src/tileops/kernels/convolution.py
@@ -114,7 +114,7 @@ def _conv1d_kernel(
         enable_rasterization: bool,
     ):
         @T.macro
-        def _conv1d_body(x, weight, out, bias):
+        def _conv1d_body(x, weight_flat, out, bias):
             with T.Kernel(
                 T.ceildiv(out_l, block_n),
                 T.ceildiv(c_out, block_m),
@@ -125,11 +125,6 @@ def _conv1d_kernel(
                 data_shared = T.alloc_shared((block_k, block_n), dtype)
                 out_local = T.alloc_fragment((block_m, block_n), accum_dtype)
                 out_shared = T.alloc_shared((block_m, block_n), dtype)
-
-                # k runs over (c_in, kernel_l) in that order, which is how the weight is
-                # already laid out, so the kernel takes it as it comes and stages it with a
-                # tile copy.
-                weight_flat = T.Tensor((c_out, k_total), dtype, weight.data)
 
                 T.use_swizzle(10, enable=enable_rasterization)
                 T.clear(out_local)
@@ -148,8 +143,11 @@ def _conv1d_kernel(
                     for i, j in T.Parallel(block_k, block_n):
                         k_idx = k_iter * block_k + i
                         ol = bx * block_n + j
-                        ci = k_idx // kernel_l
-                        kw = k_idx % kernel_l
+                        # k runs over (kernel_l, c_in): one k tile then covers a single
+                        # tap across every input channel, which is one rectangle of x.
+                        # Laying it out the other way costs 50% on c_in=128, kernel 10.
+                        kw = k_idx // c_in
+                        ci = k_idx % c_in
                         il = ol * stride_l + kw * dilation_l - pad_left
                         if tile_spatial_full & ((k_iter + 1) * block_k <= k_total):
                             data_shared[i, j] = x[bz, ci, il]
@@ -186,21 +184,21 @@ def _conv1d_kernel(
             @T.prim_func
             def _conv1d_bias_main(
                 x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
-                weight: T.Tensor((c_out, c_in, kernel_l), dtype),  # type: ignore
+                weight_flat: T.Tensor((c_out, k_total), dtype),  # type: ignore
                 out: T.Tensor((n, c_out, out_l), dtype),  # type: ignore
                 bias: T.Tensor((c_out,), dtype),  # type: ignore
             ):
-                _conv1d_body(x, weight, out, bias)
+                _conv1d_body(x, weight_flat, out, bias)
 
             return _conv1d_bias_main
 
         @T.prim_func
         def _conv1d_main(
             x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
-            weight: T.Tensor((c_out, c_in, kernel_l), dtype),  # type: ignore
+            weight_flat: T.Tensor((c_out, k_total), dtype),  # type: ignore
             out: T.Tensor((n, c_out, out_l), dtype),  # type: ignore
         ):
-            _conv1d_body(x, weight, out, None)
+            _conv1d_body(x, weight_flat, out, None)
 
         return _conv1d_main
 
@@ -341,12 +339,6 @@ def _conv1d_group_kernel(
                 out_local = T.alloc_fragment((block_m, block_n), accum_dtype)
                 out_shared = T.alloc_shared((block_m, block_n), dtype)
 
-                # k runs over (c_in_g, kernel_l) in that order, which is how the weight is
-                # already laid out, so staging it is a tile copy rather than a gather. The
-                # rows past this group's c_out_g read the next group's weights; the
-                # epilogue masks the accumulator rows they feed.
-                weight_flat = T.Tensor((c_out, k_total), dtype, weight.data)
-
                 T.use_swizzle(10, enable=enable_rasterization)
                 T.clear(out_local)
 
@@ -355,16 +347,27 @@ def _conv1d_group_kernel(
                 oc_base = group_id * c_out_g + by * block_m
 
                 for k_iter in T.Pipelined(T.ceildiv(k_total, block_k), num_stages=num_stages):
-                    T.copy(weight_flat[oc_base, k_iter * block_k], weight_shared)
+                    for i, k in T.Parallel(block_m, block_k):
+                        oc_g = by * block_m + i
+                        oc = group_id * c_out_g + oc_g
+                        k_idx = k_iter * block_k + k
+                        kw = k_idx // c_in_g
+                        ci_g = k_idx % c_in_g
+                        weight_shared[i, k] = T.if_then_else(
+                            (oc_g < c_out_g) & (k_idx < k_total),
+                            weight[oc, ci_g, kw],
+                            T.cast(0.0, dtype),
+                        )
 
                     for k, j in T.Parallel(block_k, block_n):
                         k_idx = k_iter * block_k + k
                         ol = bx * block_n + j
-                        ci_g = k_idx // kernel_l
-                        kw = k_idx % kernel_l
+                        # k runs over (kernel_l, c_in_g), matching the general Conv1d
+                        # kernel; the weight is staged by gather because that order is not
+                        # the one it is stored in.
+                        kw = k_idx // c_in_g
+                        ci_g = k_idx % c_in_g
                         il = ol * stride_l + kw * dilation_l - pad_left
-                        # k past k_total is zeroed here, which is what keeps the weight
-                        # tile's own tail out of the product.
                         data_shared[k, j] = T.if_then_else(
                             (k_idx < k_total) & (ol < out_l) & (il >= 0) & (il < l_in),
                             x[batch_id, group_id * c_in_g + ci_g, il],
@@ -670,6 +673,9 @@ class Conv1dKernel(Kernel):
         self.out_l = (l_in + sum(pad_l) - dilation_l * (kernel_l - 1) - 1) // stride_l + 1
         self.m = n * self.out_l
         self.k_total = c_in * kernel_l
+        self._weight_flat_cache_source: Optional[torch.Tensor] = None
+        self._weight_flat_cache_version: Optional[int] = None
+        self._weight_flat_cache: Optional[torch.Tensor] = None
         self.kernel = _conv1d_kernel(
             n,
             c_in,
@@ -710,13 +716,34 @@ class Conv1dKernel(Kernel):
     def autotune_configs(self) -> list[dict]:
         return conv_autotune_configs(self.dtype)
 
+    def _get_weight_flat(self, weight: torch.Tensor) -> torch.Tensor:
+        """Return the weight laid out as the prim_func's ``(c_out, k_total)``.
+
+        k runs over ``(kernel_l, c_in)``, so this is a permute the caller's
+        ``(c_out, c_in, kernel_l)`` cannot alias. Held per weight identity and version:
+        a weight is a parameter, so it repeats across calls.
+        """
+        weight_version = weight._version
+        if (
+            self._weight_flat_cache_source is weight
+            and self._weight_flat_cache_version == weight_version
+            and self._weight_flat_cache is not None
+        ):
+            return self._weight_flat_cache
+
+        weight_flat = weight.permute(0, 2, 1).contiguous().view(self.c_out, self.k_total)
+        self._weight_flat_cache_source = weight
+        self._weight_flat_cache_version = weight_version
+        self._weight_flat_cache = weight_flat
+        return weight_flat
+
     def forward(
         self,
         x: torch.Tensor,
         weight: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        return _launch(self, x, weight, bias=bias)
+        return _launch(self, x, self._get_weight_flat(weight), bias=bias)
 
 
 class GroupConv1dKernel(Kernel):

--- a/src/tileops/kernels/convolution.py
+++ b/src/tileops/kernels/convolution.py
@@ -114,7 +114,7 @@ def _conv1d_kernel(
         enable_rasterization: bool,
     ):
         @T.macro
-        def _conv1d_body(x, weight_flat, out, bias):
+        def _conv1d_body(x, weight, out, bias):
             with T.Kernel(
                 T.ceildiv(out_l, block_n),
                 T.ceildiv(c_out, block_m),
@@ -125,6 +125,11 @@ def _conv1d_kernel(
                 data_shared = T.alloc_shared((block_k, block_n), dtype)
                 out_local = T.alloc_fragment((block_m, block_n), accum_dtype)
                 out_shared = T.alloc_shared((block_m, block_n), dtype)
+
+                # k runs over (c_in, kernel_l) in that order, which is how the weight is
+                # already laid out, so the kernel takes it as it comes and stages it with a
+                # tile copy.
+                weight_flat = T.Tensor((c_out, k_total), dtype, weight.data)
 
                 T.use_swizzle(10, enable=enable_rasterization)
                 T.clear(out_local)
@@ -143,8 +148,8 @@ def _conv1d_kernel(
                     for i, j in T.Parallel(block_k, block_n):
                         k_idx = k_iter * block_k + i
                         ol = bx * block_n + j
-                        kw = k_idx // c_in
-                        ci = k_idx % c_in
+                        ci = k_idx // kernel_l
+                        kw = k_idx % kernel_l
                         il = ol * stride_l + kw * dilation_l - pad_left
                         if tile_spatial_full & ((k_iter + 1) * block_k <= k_total):
                             data_shared[i, j] = x[bz, ci, il]
@@ -174,32 +179,28 @@ def _conv1d_kernel(
                             T.cast(0.0, dtype),
                         )
 
-                for i, j in T.Parallel(block_m, block_n):
-                    oc = by * block_m + i
-                    ol = bx * block_n + j
-                    if oc < c_out and ol < out_l:
-                        out[bz, oc, ol] = out_shared[i, j]
+                T.copy(out_shared, out[bz, by * block_m, bx * block_n])
 
         if has_bias:
 
             @T.prim_func
             def _conv1d_bias_main(
                 x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
-                weight_flat: T.Tensor((c_out, k_total), dtype),  # type: ignore
+                weight: T.Tensor((c_out, c_in, kernel_l), dtype),  # type: ignore
                 out: T.Tensor((n, c_out, out_l), dtype),  # type: ignore
                 bias: T.Tensor((c_out,), dtype),  # type: ignore
             ):
-                _conv1d_body(x, weight_flat, out, bias)
+                _conv1d_body(x, weight, out, bias)
 
             return _conv1d_bias_main
 
         @T.prim_func
         def _conv1d_main(
             x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
-            weight_flat: T.Tensor((c_out, k_total), dtype),  # type: ignore
+            weight: T.Tensor((c_out, c_in, kernel_l), dtype),  # type: ignore
             out: T.Tensor((n, c_out, out_l), dtype),  # type: ignore
         ):
-            _conv1d_body(x, weight_flat, out, None)
+            _conv1d_body(x, weight, out, None)
 
         return _conv1d_main
 
@@ -340,31 +341,30 @@ def _conv1d_group_kernel(
                 out_local = T.alloc_fragment((block_m, block_n), accum_dtype)
                 out_shared = T.alloc_shared((block_m, block_n), dtype)
 
+                # k runs over (c_in_g, kernel_l) in that order, which is how the weight is
+                # already laid out, so staging it is a tile copy rather than a gather. The
+                # rows past this group's c_out_g read the next group's weights; the
+                # epilogue masks the accumulator rows they feed.
+                weight_flat = T.Tensor((c_out, k_total), dtype, weight.data)
+
                 T.use_swizzle(10, enable=enable_rasterization)
                 T.clear(out_local)
 
                 batch_id = bz // groups
                 group_id = bz % groups
+                oc_base = group_id * c_out_g + by * block_m
 
                 for k_iter in T.Pipelined(T.ceildiv(k_total, block_k), num_stages=num_stages):
-                    for i, k in T.Parallel(block_m, block_k):
-                        oc_g = by * block_m + i
-                        oc = group_id * c_out_g + oc_g
-                        k_idx = k_iter * block_k + k
-                        kw = k_idx // c_in_g
-                        ci_g = k_idx % c_in_g
-                        weight_shared[i, k] = T.if_then_else(
-                            (oc_g < c_out_g) & (k_idx < k_total),
-                            weight[oc, ci_g, kw],
-                            T.cast(0.0, dtype),
-                        )
+                    T.copy(weight_flat[oc_base, k_iter * block_k], weight_shared)
 
                     for k, j in T.Parallel(block_k, block_n):
                         k_idx = k_iter * block_k + k
                         ol = bx * block_n + j
-                        kw = k_idx // c_in_g
-                        ci_g = k_idx % c_in_g
+                        ci_g = k_idx // kernel_l
+                        kw = k_idx % kernel_l
                         il = ol * stride_l + kw * dilation_l - pad_left
+                        # k past k_total is zeroed here, which is what keeps the weight
+                        # tile's own tail out of the product.
                         data_shared[k, j] = T.if_then_else(
                             (k_idx < k_total) & (ol < out_l) & (il >= 0) & (il < l_in),
                             x[batch_id, group_id * c_in_g + ci_g, il],
@@ -390,12 +390,17 @@ def _conv1d_group_kernel(
                             T.cast(0.0, dtype),
                         )
 
-                for i, j in T.Parallel(block_m, block_n):
-                    oc_g = by * block_m + i
-                    oc = group_id * c_out_g + oc_g
-                    ol = bx * block_n + j
-                    if oc_g < c_out_g and ol < out_l:
-                        out[batch_id, oc, ol] = out_shared[i, j]
+                if c_out_g % block_m == 0:
+                    # The tile ends on this group's last channel, so the copy cannot spill
+                    # into the next group's rows.
+                    T.copy(out_shared, out[batch_id, oc_base, bx * block_n])
+                else:
+                    for i, j in T.Parallel(block_m, block_n):
+                        oc_g = by * block_m + i
+                        oc = group_id * c_out_g + oc_g
+                        ol = bx * block_n + j
+                        if oc_g < c_out_g and ol < out_l:
+                            out[batch_id, oc, ol] = out_shared[i, j]
 
         if has_bias:
 
@@ -665,9 +670,6 @@ class Conv1dKernel(Kernel):
         self.out_l = (l_in + sum(pad_l) - dilation_l * (kernel_l - 1) - 1) // stride_l + 1
         self.m = n * self.out_l
         self.k_total = c_in * kernel_l
-        self._weight_flat_cache_source: Optional[torch.Tensor] = None
-        self._weight_flat_cache_version: Optional[int] = None
-        self._weight_flat_cache: Optional[torch.Tensor] = None
         self.kernel = _conv1d_kernel(
             n,
             c_in,
@@ -708,29 +710,13 @@ class Conv1dKernel(Kernel):
     def autotune_configs(self) -> list[dict]:
         return conv_autotune_configs(self.dtype)
 
-    def _get_weight_flat(self, weight: torch.Tensor) -> torch.Tensor:
-        weight_version = weight._version
-        if (
-            self._weight_flat_cache_source is weight
-            and self._weight_flat_cache_version == weight_version
-            and self._weight_flat_cache is not None
-        ):
-            return self._weight_flat_cache
-
-        weight_flat = weight.permute(0, 2, 1).contiguous().view(self.c_out, self.k_total)
-        self._weight_flat_cache_source = weight
-        self._weight_flat_cache_version = weight_version
-        self._weight_flat_cache = weight_flat
-        return weight_flat
-
     def forward(
         self,
         x: torch.Tensor,
         weight: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        weight_flat = self._get_weight_flat(weight)
-        return _launch(self, x, weight_flat, bias=bias)
+        return _launch(self, x, weight, bias=bias)
 
 
 class GroupConv1dKernel(Kernel):
@@ -1170,26 +1156,22 @@ def _conv2d_group_kernel(
                 out_local = T.alloc_fragment((block_m, block_n), accum_dtype)
                 out_shared = T.alloc_shared((block_m, block_n), dtype)
 
+                # k runs over (c_in_g, kernel_h, kernel_w) in that order, which is how the
+                # weight is already laid out, so staging it is a tile copy rather than a
+                # gather. The rows past this group's c_out_g read the next group's weights;
+                # the epilogue masks the accumulator rows they feed.
+                weight_flat = T.Tensor((c_out, k_total), dtype, weight.data)
+                out_flat = T.Tensor((n, c_out, out_hw), dtype, out.data)
+
                 T.use_swizzle(10, enable=enable_rasterization)
                 T.clear(out_local)
 
                 batch_id = bz // groups
                 group_id = bz % groups
+                oc_base = group_id * c_out_g + by * block_m
 
                 for k_iter in T.Pipelined(T.ceildiv(k_total, block_k), num_stages=num_stages):
-                    for i, k in T.Parallel(block_m, block_k):
-                        oc_g = by * block_m + i
-                        oc = group_id * c_out_g + oc_g
-                        k_idx = k_iter * block_k + k
-                        ci_g = k_idx // (kernel_h * kernel_w)
-                        kernel_idx = k_idx % (kernel_h * kernel_w)
-                        kh = kernel_idx // kernel_w
-                        kw = kernel_idx % kernel_w
-                        weight_shared[i, k] = T.if_then_else(
-                            (oc_g < c_out_g) & (k_idx < k_total),
-                            weight[oc, ci_g, kh, kw],
-                            T.cast(0.0, dtype),
-                        )
+                    T.copy(weight_flat[oc_base, k_iter * block_k], weight_shared)
 
                     for k, j in T.Parallel(block_k, block_n):
                         k_idx = k_iter * block_k + k
@@ -1233,14 +1215,19 @@ def _conv2d_group_kernel(
                             T.cast(0.0, dtype),
                         )
 
-                for i, j in T.Parallel(block_m, block_n):
-                    oc_g = by * block_m + i
-                    oc = group_id * c_out_g + oc_g
-                    spatial_idx = bx * block_n + j
-                    oh = spatial_idx // out_w
-                    ow = spatial_idx % out_w
-                    if oc_g < c_out_g and spatial_idx < out_hw:
-                        out[batch_id, oc, oh, ow] = out_shared[i, j]
+                if c_out_g % block_m == 0:
+                    # The tile ends on this group's last channel, so the copy cannot spill
+                    # into the next group's rows.
+                    T.copy(out_shared, out_flat[batch_id, oc_base, bx * block_n])
+                else:
+                    for i, j in T.Parallel(block_m, block_n):
+                        oc_g = by * block_m + i
+                        oc = group_id * c_out_g + oc_g
+                        spatial_idx = bx * block_n + j
+                        oh = spatial_idx // out_w
+                        ow = spatial_idx % out_w
+                        if oc_g < c_out_g and spatial_idx < out_hw:
+                            out[batch_id, oc, oh, ow] = out_shared[i, j]
 
         if has_bias:
 
@@ -1266,6 +1253,118 @@ def _conv2d_group_kernel(
         return _conv2d_group_main
 
     return _conv2d_group_func
+
+
+@functools.lru_cache(maxsize=32)
+def _conv2d_depthwise_kernel(
+    n: int,
+    c_in: int,
+    h: int,
+    w: int,
+    c_out: int,
+    kernel_h: int,
+    kernel_w: int,
+    stride_h: int,
+    stride_w: int,
+    pad_h: int,
+    pad_w: int,
+    dilation_h: int,
+    dilation_w: int,
+    has_bias: bool,
+    dtype: str = "float16",
+):
+    """Build the depthwise Conv2d program: one input channel feeds one output channel.
+
+    The grouped kernel reaches this shape with a GEMM whose M is the group's one output
+    channel, so a tile of ``block_m`` rows carries one useful row. This one multiplies and
+    accumulates directly instead, the way the Conv1d depthwise path does.
+    """
+    accum_dtype = "float"
+    out_h = (h + 2 * pad_h - dilation_h * (kernel_h - 1) - 1) // stride_h + 1
+    out_w = (w + 2 * pad_w - dilation_w * (kernel_w - 1) - 1) // stride_w + 1
+    out_hw = out_h * out_w
+
+    @tilelang.jit(out_idx=[2], compile_flags=["-O3", "-DENABLE_BF16"])
+    def _conv2d_depthwise_func(
+        block_m: int,
+        block_n: int,
+        block_k: int,
+        num_stages: int,
+        threads: int,
+        enable_rasterization: bool,
+    ):
+        @T.macro
+        def _conv2d_depthwise_body(x, weight, out, bias):
+            out_flat = T.Tensor((n, c_out, out_hw), dtype, out.data)
+            with T.Kernel(
+                T.ceildiv(out_hw, block_n),
+                T.ceildiv(c_out, block_m),
+                n,
+                threads=threads,
+            ) as (bx, by, bz):
+                out_local = T.alloc_fragment((block_m, block_n), accum_dtype)
+                T.use_swizzle(10, enable=enable_rasterization)
+                T.clear(out_local)
+
+                for kh, kw in T.grid(kernel_h, kernel_w):
+                    for i, j in T.Parallel(block_m, block_n):
+                        oc = by * block_m + i
+                        spatial_idx = bx * block_n + j
+                        oh = spatial_idx // out_w
+                        ow = spatial_idx % out_w
+                        ih = oh * stride_h + kh * dilation_h - pad_h
+                        iw = ow * stride_w + kw * dilation_w - pad_w
+                        valid = (
+                            (oc < c_out)
+                            & (spatial_idx < out_hw)
+                            & (ih >= 0)
+                            & (iw >= 0)
+                            & (ih < h)
+                            & (iw < w)
+                        )
+                        out_local[i, j] += T.if_then_else(
+                            valid,
+                            T.cast(x[bz, oc, ih, iw], accum_dtype)
+                            * T.cast(weight[oc, 0, kh, kw], accum_dtype),
+                            T.cast(0.0, accum_dtype),
+                        )
+
+                for i, j in T.Parallel(block_m, block_n):
+                    oc = by * block_m + i
+                    spatial_idx = bx * block_n + j
+                    if oc < c_out and spatial_idx < out_hw:
+                        if has_bias:
+                            out_flat[bz, oc, spatial_idx] = T.cast(
+                                out_local[i, j] + T.cast(bias[oc], accum_dtype),
+                                dtype,
+                            )
+                        else:
+                            out_flat[bz, oc, spatial_idx] = T.cast(out_local[i, j], dtype)
+
+        if has_bias:
+
+            @T.prim_func
+            def _conv2d_depthwise_bias_main(
+                x: T.Tensor((n, c_in, h, w), dtype),  # type: ignore
+                weight: T.Tensor((c_out, 1, kernel_h, kernel_w), dtype),  # type: ignore
+                out: T.Tensor((n, c_out, out_h, out_w), dtype),  # type: ignore
+                bias: T.Tensor((c_out,), dtype),  # type: ignore
+            ):
+                _conv2d_depthwise_body(x, weight, out, bias)
+
+            return _conv2d_depthwise_bias_main
+
+        @T.prim_func
+        def _conv2d_depthwise_main(
+            x: T.Tensor((n, c_in, h, w), dtype),  # type: ignore
+            weight: T.Tensor((c_out, 1, kernel_h, kernel_w), dtype),  # type: ignore
+            out: T.Tensor((n, c_out, out_h, out_w), dtype),  # type: ignore
+        ):
+            _conv2d_depthwise_body(x, weight, out, None)
+
+        return _conv2d_depthwise_main
+
+    return _conv2d_depthwise_func
 
 
 @functools.lru_cache(maxsize=8)
@@ -1726,28 +1825,48 @@ class GroupConv2dKernel(Kernel):
         self.out_w = (w + 2 * pad_w - dilation_w * (kernel_w - 1) - 1) // stride_w + 1
         self.m = n * self.groups * self.out_h * self.out_w
         self.k_total = self.c_in_g * kernel_h * kernel_w
+        self.use_direct = self.c_in_g == 1 and self.c_out_g == 1
         self._validate_group_shape()
 
-        self.kernel = _conv2d_group_kernel(
-            n,
-            c_in,
-            h,
-            w,
-            c_out,
-            kernel_h,
-            kernel_w,
-            stride_h,
-            stride_w,
-            pad_h,
-            pad_w,
-            dilation_h,
-            dilation_w,
-            has_bias,
-            self.dtype_str,
-            groups,
-            self.c_in_g,
-            self.c_out_g,
-        )
+        if self.use_direct:
+            self.kernel = _conv2d_depthwise_kernel(
+                n,
+                c_in,
+                h,
+                w,
+                c_out,
+                kernel_h,
+                kernel_w,
+                stride_h,
+                stride_w,
+                pad_h,
+                pad_w,
+                dilation_h,
+                dilation_w,
+                has_bias,
+                self.dtype_str,
+            )
+        else:
+            self.kernel = _conv2d_group_kernel(
+                n,
+                c_in,
+                h,
+                w,
+                c_out,
+                kernel_h,
+                kernel_w,
+                stride_h,
+                stride_w,
+                pad_h,
+                pad_w,
+                dilation_h,
+                dilation_w,
+                has_bias,
+                self.dtype_str,
+                groups,
+                self.c_in_g,
+                self.c_out_g,
+            )
         self.init_config(config, tune)
 
     def _validate_group_shape(self) -> None:
@@ -1761,6 +1880,17 @@ class GroupConv2dKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
+        if self.use_direct:
+            # No GEMM here, so block_k and num_stages carry nothing: one channel per block
+            # row, a strip of outputs per block column.
+            return {
+                "block_m": 1,
+                "block_n": 128,
+                "block_k": 1,
+                "num_stages": 1,
+                "threads": 128,
+                "enable_rasterization": True,
+            }
         sm_version = get_sm_version()
         if sm_version in {90}:
             return {
@@ -1782,6 +1912,8 @@ class GroupConv2dKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
+        if self.use_direct:
+            return [self.default_config]
         return conv_autotune_configs(self.dtype)
 
     def forward(
@@ -2094,27 +2226,22 @@ def _conv3d_group_kernel(
                 out_local = T.alloc_fragment((block_m, block_n), accum_dtype)
                 out_shared = T.alloc_shared((block_m, block_n), dtype)
 
+                # k runs over (c_in_g, kernel_d, kernel_h, kernel_w) in that order, which is
+                # how the weight is already laid out, so staging it is a tile copy rather
+                # than a gather. The rows past this group's c_out_g read the next group's
+                # weights; the epilogue masks the accumulator rows they feed.
+                weight_flat = T.Tensor((c_out, k_total), dtype, weight.data)
+                out_flat = T.Tensor((n, c_out, out_dhw), dtype, out.data)
+
                 T.use_swizzle(10, enable=enable_rasterization)
                 T.clear(out_local)
 
                 batch_id = bz // groups
                 group_id = bz % groups
+                oc_base = group_id * c_out_g + by * block_m
 
                 for k_iter in T.Pipelined(T.ceildiv(k_total, block_k), num_stages=num_stages):
-                    for i, k in T.Parallel(block_m, block_k):
-                        oc_g = by * block_m + i
-                        oc = group_id * c_out_g + oc_g
-                        k_idx = k_iter * block_k + k
-                        ci_g = k_idx // (kernel_d * kernel_h * kernel_w)
-                        kernel_idx = k_idx % (kernel_d * kernel_h * kernel_w)
-                        kd = kernel_idx // (kernel_h * kernel_w)
-                        kh = (kernel_idx // kernel_w) % kernel_h
-                        kw = kernel_idx % kernel_w
-                        weight_shared[i, k] = T.if_then_else(
-                            (oc_g < c_out_g) & (k_idx < k_total),
-                            weight[oc, ci_g, kd, kh, kw],
-                            T.cast(0.0, dtype),
-                        )
+                    T.copy(weight_flat[oc_base, k_iter * block_k], weight_shared)
 
                     for k, j in T.Parallel(block_k, block_n):
                         k_idx = k_iter * block_k + k
@@ -2163,15 +2290,20 @@ def _conv3d_group_kernel(
                             T.cast(0.0, dtype),
                         )
 
-                for i, j in T.Parallel(block_m, block_n):
-                    oc_g = by * block_m + i
-                    oc = group_id * c_out_g + oc_g
-                    spatial_idx = bx * block_n + j
-                    od = spatial_idx // (out_h * out_w)
-                    oh = (spatial_idx // out_w) % out_h
-                    ow = spatial_idx % out_w
-                    if oc_g < c_out_g and spatial_idx < out_dhw:
-                        out[batch_id, oc, od, oh, ow] = out_shared[i, j]
+                if c_out_g % block_m == 0:
+                    # The tile ends on this group's last channel, so the copy cannot spill
+                    # into the next group's rows.
+                    T.copy(out_shared, out_flat[batch_id, oc_base, bx * block_n])
+                else:
+                    for i, j in T.Parallel(block_m, block_n):
+                        oc_g = by * block_m + i
+                        oc = group_id * c_out_g + oc_g
+                        spatial_idx = bx * block_n + j
+                        od = spatial_idx // (out_h * out_w)
+                        oh = (spatial_idx // out_w) % out_h
+                        ow = spatial_idx % out_w
+                        if oc_g < c_out_g and spatial_idx < out_dhw:
+                            out[batch_id, oc, od, oh, ow] = out_shared[i, j]
 
         if has_bias:
 

--- a/src/tileops/kernels/pool/adaptive_avg_pool2d.py
+++ b/src/tileops/kernels/pool/adaptive_avg_pool2d.py
@@ -68,8 +68,7 @@ def _adaptive_avg_pool2d_kernel(
     return _adaptive_avg_pool2d_func
 
 
-@torch.library.custom_op("top::adaptive_avg_pool2d_wrapped_kernel", mutates_args=())
-def _adaptive_avg_pool2d_wrapped_kernel(
+def _launch_adaptive_avg_pool2d(
     n: int,
     c_in: int,
     h_in: int,
@@ -86,25 +85,8 @@ def _adaptive_avg_pool2d_wrapped_kernel(
     )
 
 
-@_adaptive_avg_pool2d_wrapped_kernel.register_fake
-def _(
-    n: int,
-    c_in: int,
-    h_in: int,
-    w_in: int,
-    out_h: int,
-    out_w: int,
-    dtype: str,
-    block_m: int,
-    threads: int,
-    x: torch.Tensor,
-) -> torch.Tensor:
-    _ = (dtype, block_m, threads)
-    return torch.empty((n, c_in, out_h, out_w), dtype=x.dtype, device=x.device)
-
-
 class AdaptiveAvgPool2dKernel(AdaptivePool2dKernelBase):
     """Adaptive average pooling forward kernel for NCHW inputs."""
 
     _build = staticmethod(_adaptive_avg_pool2d_kernel)
-    _dispatch = staticmethod(_adaptive_avg_pool2d_wrapped_kernel)
+    _dispatch = staticmethod(_launch_adaptive_avg_pool2d)

--- a/src/tileops/kernels/pool/adaptive_max_pool2d.py
+++ b/src/tileops/kernels/pool/adaptive_max_pool2d.py
@@ -74,8 +74,7 @@ def _adaptive_max_pool2d_kernel(
     return _adaptive_max_pool2d_func
 
 
-@torch.library.custom_op("top::adaptive_max_pool2d_wrapped_kernel", mutates_args=())
-def _adaptive_max_pool2d_wrapped_kernel(
+def _launch_adaptive_max_pool2d(
     n: int,
     c_in: int,
     h_in: int,
@@ -92,28 +91,11 @@ def _adaptive_max_pool2d_wrapped_kernel(
     )
 
 
-@_adaptive_max_pool2d_wrapped_kernel.register_fake
-def _(
-    n: int,
-    c_in: int,
-    h_in: int,
-    w_in: int,
-    out_h: int,
-    out_w: int,
-    dtype: str,
-    block_m: int,
-    threads: int,
-    x: torch.Tensor,
-) -> torch.Tensor:
-    _ = (dtype, block_m, threads)
-    return torch.empty((n, c_in, out_h, out_w), dtype=x.dtype, device=x.device)
-
-
 class AdaptiveMaxPool2dKernel(AdaptivePool2dKernelBase):
     """Adaptive max pooling forward kernel for NCHW inputs."""
 
     _build = staticmethod(_adaptive_max_pool2d_kernel)
-    _dispatch = staticmethod(_adaptive_max_pool2d_wrapped_kernel)
+    _dispatch = staticmethod(_launch_adaptive_max_pool2d)
 
 
 @functools.lru_cache(maxsize=32)
@@ -206,8 +188,7 @@ def _adaptive_max_pool2d_with_indices_kernel(
     return _adaptive_max_pool2d_with_indices_func
 
 
-@torch.library.custom_op("top::adaptive_max_pool2d_with_indices_wrapped_kernel", mutates_args=())
-def _adaptive_max_pool2d_with_indices_wrapped_kernel(
+def _launch_adaptive_max_pool2d_with_indices(
     n: int,
     c_in: int,
     h_in: int,
@@ -224,28 +205,8 @@ def _adaptive_max_pool2d_with_indices_wrapped_kernel(
     )(x)
 
 
-@_adaptive_max_pool2d_with_indices_wrapped_kernel.register_fake
-def _(
-    n: int,
-    c_in: int,
-    h_in: int,
-    w_in: int,
-    out_h: int,
-    out_w: int,
-    dtype: str,
-    block_m: int,
-    threads: int,
-    x: torch.Tensor,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    _ = (dtype, block_m, threads)
-    return (
-        torch.empty((n, c_in, out_h, out_w), dtype=x.dtype, device=x.device),
-        torch.empty((n, c_in, out_h, out_w), dtype=torch.int64, device=x.device),
-    )
-
-
 class AdaptiveMaxPool2dWithIndicesKernel(AdaptivePool2dKernelBase):
     """Adaptive max pooling forward kernel returning values and int64 indices."""
 
     _build = staticmethod(_adaptive_max_pool2d_with_indices_kernel)
-    _dispatch = staticmethod(_adaptive_max_pool2d_with_indices_wrapped_kernel)
+    _dispatch = staticmethod(_launch_adaptive_max_pool2d_with_indices)

--- a/src/tileops/kernels/pool/avg_pool1d.py
+++ b/src/tileops/kernels/pool/avg_pool1d.py
@@ -158,8 +158,7 @@ def _avg_pool1d_spatial_kernel(
     return _avg_pool1d_spatial_func
 
 
-@torch.library.custom_op("top::avg_pool1d_spatial_wrapped_kernel", mutates_args=())
-def _avg_pool1d_spatial_wrapped_kernel(
+def _launch_avg_pool1d_spatial(
     n: int,
     c_in: int,
     l_in: int,
@@ -182,26 +181,7 @@ def _avg_pool1d_spatial_wrapped_kernel(
     )(block_m, threads)(x)
 
 
-@_avg_pool1d_spatial_wrapped_kernel.register_fake
-def _(
-    n: int,
-    c_in: int,
-    l_in: int,
-    kernel_l: int,
-    stride_l: int,
-    pad_l: int,
-    dtype: str,
-    block_m: int,
-    threads: int,
-    x: torch.Tensor,
-) -> torch.Tensor:
-    _ = (dtype, block_m, threads)
-    out_l = pool_output_dim(l_in, kernel_l, stride_l, pad_l, False)
-    return torch.empty((n, c_in, out_l), dtype=x.dtype, device=x.device)
-
-
-@torch.library.custom_op("top::avg_pool1d_wrapped_kernel", mutates_args=())
-def _avg_pool1d_wrapped_kernel(
+def _launch_avg_pool1d(
     n: int,
     c_in: int,
     l_in: int,
@@ -226,26 +206,6 @@ def _avg_pool1d_wrapped_kernel(
         count_include_pad,
         dtype,
     )(block_m, threads)(x)
-
-
-@_avg_pool1d_wrapped_kernel.register_fake
-def _(
-    n: int,
-    c_in: int,
-    l_in: int,
-    kernel_l: int,
-    stride_l: int,
-    pad_l: int,
-    ceil_mode: bool,
-    count_include_pad: bool,
-    dtype: str,
-    block_m: int,
-    threads: int,
-    x: torch.Tensor,
-) -> torch.Tensor:
-    _ = (count_include_pad, dtype, block_m, threads)
-    out_l = pool_output_dim(l_in, kernel_l, stride_l, pad_l, ceil_mode)
-    return torch.empty((n, c_in, out_l), dtype=x.dtype, device=x.device)
 
 
 class AvgPool1dSpatialKernel(Kernel):
@@ -302,7 +262,7 @@ class AvgPool1dSpatialKernel(Kernel):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         require_cuda(self, x=x)
-        return _avg_pool1d_spatial_wrapped_kernel(
+        return _launch_avg_pool1d_spatial(
             self.n,
             self.c_in,
             self.l_in,
@@ -374,7 +334,7 @@ class AvgPool1dKernel(Kernel):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         require_cuda(self, x=x)
-        return _avg_pool1d_wrapped_kernel(
+        return _launch_avg_pool1d(
             self.n,
             self.c_in,
             self.l_in,

--- a/src/tileops/kernels/pool/avg_pool1d.py
+++ b/src/tileops/kernels/pool/avg_pool1d.py
@@ -301,7 +301,7 @@ class AvgPool1dSpatialKernel(Kernel):
         ]
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        require_cuda(self, x)
+        require_cuda(self, x=x)
         return _avg_pool1d_spatial_wrapped_kernel(
             self.n,
             self.c_in,
@@ -373,7 +373,7 @@ class AvgPool1dKernel(Kernel):
         ]
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        require_cuda(self, x)
+        require_cuda(self, x=x)
         return _avg_pool1d_wrapped_kernel(
             self.n,
             self.c_in,

--- a/src/tileops/kernels/pool/avg_pool1d.py
+++ b/src/tileops/kernels/pool/avg_pool1d.py
@@ -7,7 +7,7 @@ import tilelang.language as T
 import torch
 
 from tileops.kernels.kernel_base import Kernel
-from tileops.kernels.pool.common import pool_output_dim
+from tileops.kernels.pool.common import pool_output_dim, require_cuda
 
 __all__ = ["AvgPool1dKernel", "AvgPool1dSpatialKernel"]
 
@@ -301,6 +301,7 @@ class AvgPool1dSpatialKernel(Kernel):
         ]
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        require_cuda(self, x)
         return _avg_pool1d_spatial_wrapped_kernel(
             self.n,
             self.c_in,
@@ -372,6 +373,7 @@ class AvgPool1dKernel(Kernel):
         ]
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        require_cuda(self, x)
         return _avg_pool1d_wrapped_kernel(
             self.n,
             self.c_in,

--- a/src/tileops/kernels/pool/avg_pool2d.py
+++ b/src/tileops/kernels/pool/avg_pool2d.py
@@ -345,7 +345,7 @@ class AvgPool2dSpatialKernel(Kernel):
         ]
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        require_cuda(self, x)
+        require_cuda(self, x=x)
         return _avg_pool2d_spatial_wrapped_kernel(
             self.n,
             self.c_in,
@@ -439,7 +439,7 @@ class AvgPool2dKernel(Kernel):
         ]
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        require_cuda(self, x)
+        require_cuda(self, x=x)
         return _avg_pool2d_wrapped_kernel(
             self.n,
             self.c_in,

--- a/src/tileops/kernels/pool/avg_pool2d.py
+++ b/src/tileops/kernels/pool/avg_pool2d.py
@@ -147,8 +147,7 @@ def _avg_pool2d_spatial_kernel(
     return _avg_pool2d_spatial_func
 
 
-@torch.library.custom_op("top::avg_pool2d_spatial_wrapped_kernel", mutates_args=())
-def _avg_pool2d_spatial_wrapped_kernel(
+def _launch_avg_pool2d_spatial(
     n: int,
     c_in: int,
     h_in: int,
@@ -179,35 +178,7 @@ def _avg_pool2d_spatial_wrapped_kernel(
     )(block_m, threads)(x)
 
 
-@_avg_pool2d_spatial_wrapped_kernel.register_fake
-def _(
-    n: int,
-    c_in: int,
-    h_in: int,
-    w_in: int,
-    kernel_h: int,
-    kernel_w: int,
-    stride_h: int,
-    stride_w: int,
-    pad_h: int,
-    pad_w: int,
-    dtype: str,
-    block_m: int,
-    threads: int,
-    x: torch.Tensor,
-) -> torch.Tensor:
-    _ = (
-        dtype,
-        block_m,
-        threads,
-    )
-    out_h = pool_output_dim(h_in, kernel_h, stride_h, pad_h, False)
-    out_w = pool_output_dim(w_in, kernel_w, stride_w, pad_w, False)
-    return torch.empty((n, c_in, out_h, out_w), dtype=x.dtype, device=x.device)
-
-
-@torch.library.custom_op("top::avg_pool2d_wrapped_kernel", mutates_args=())
-def _avg_pool2d_wrapped_kernel(
+def _launch_avg_pool2d(
     n: int,
     c_in: int,
     h_in: int,
@@ -244,40 +215,6 @@ def _avg_pool2d_wrapped_kernel(
         divisor_override,
         dtype,
     )(block_m, threads)(x)
-
-
-@_avg_pool2d_wrapped_kernel.register_fake
-def _(
-    n: int,
-    c_in: int,
-    h_in: int,
-    w_in: int,
-    kernel_h: int,
-    kernel_w: int,
-    stride_h: int,
-    stride_w: int,
-    pad_h: int,
-    pad_w: int,
-    ceil_mode: bool,
-    count_include_pad: bool,
-    use_divisor_override: bool,
-    divisor_override: int,
-    dtype: str,
-    block_m: int,
-    threads: int,
-    x: torch.Tensor,
-) -> torch.Tensor:
-    _ = (
-        count_include_pad,
-        use_divisor_override,
-        divisor_override,
-        dtype,
-        block_m,
-        threads,
-    )
-    out_h = pool_output_dim(h_in, kernel_h, stride_h, pad_h, ceil_mode)
-    out_w = pool_output_dim(w_in, kernel_w, stride_w, pad_w, ceil_mode)
-    return torch.empty((n, c_in, out_h, out_w), dtype=x.dtype, device=x.device)
 
 
 class AvgPool2dSpatialKernel(Kernel):
@@ -346,7 +283,7 @@ class AvgPool2dSpatialKernel(Kernel):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         require_cuda(self, x=x)
-        return _avg_pool2d_spatial_wrapped_kernel(
+        return _launch_avg_pool2d_spatial(
             self.n,
             self.c_in,
             self.h_in,
@@ -440,7 +377,7 @@ class AvgPool2dKernel(Kernel):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         require_cuda(self, x=x)
-        return _avg_pool2d_wrapped_kernel(
+        return _launch_avg_pool2d(
             self.n,
             self.c_in,
             self.h_in,

--- a/src/tileops/kernels/pool/avg_pool2d.py
+++ b/src/tileops/kernels/pool/avg_pool2d.py
@@ -7,7 +7,7 @@ import tilelang.language as T
 import torch
 
 from tileops.kernels.kernel_base import Kernel
-from tileops.kernels.pool.common import pool_output_dim
+from tileops.kernels.pool.common import pool_output_dim, require_cuda
 
 __all__ = ["AvgPool2dKernel", "AvgPool2dSpatialKernel"]
 
@@ -345,6 +345,7 @@ class AvgPool2dSpatialKernel(Kernel):
         ]
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        require_cuda(self, x)
         return _avg_pool2d_spatial_wrapped_kernel(
             self.n,
             self.c_in,
@@ -438,6 +439,7 @@ class AvgPool2dKernel(Kernel):
         ]
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        require_cuda(self, x)
         return _avg_pool2d_wrapped_kernel(
             self.n,
             self.c_in,

--- a/src/tileops/kernels/pool/avg_pool3d.py
+++ b/src/tileops/kernels/pool/avg_pool3d.py
@@ -425,7 +425,7 @@ class AvgPool3dSpatialKernel(Kernel):
         ]
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        require_cuda(self, x)
+        require_cuda(self, x=x)
         return _avg_pool3d_spatial_wrapped_kernel(
             self.n,
             self.c_in,
@@ -536,7 +536,7 @@ class AvgPool3dKernel(Kernel):
         ]
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        require_cuda(self, x)
+        require_cuda(self, x=x)
         return _avg_pool3d_wrapped_kernel(
             self.n,
             self.c_in,

--- a/src/tileops/kernels/pool/avg_pool3d.py
+++ b/src/tileops/kernels/pool/avg_pool3d.py
@@ -191,8 +191,7 @@ def _avg_pool3d_spatial_kernel(
     return _avg_pool3d_spatial_func
 
 
-@torch.library.custom_op("top::avg_pool3d_spatial_wrapped_kernel", mutates_args=())
-def _avg_pool3d_spatial_wrapped_kernel(
+def _launch_avg_pool3d_spatial(
     n: int,
     c_in: int,
     d_in: int,
@@ -231,36 +230,7 @@ def _avg_pool3d_spatial_wrapped_kernel(
     )(block_m, threads)(x)
 
 
-@_avg_pool3d_spatial_wrapped_kernel.register_fake
-def _(
-    n: int,
-    c_in: int,
-    d_in: int,
-    h_in: int,
-    w_in: int,
-    kernel_d: int,
-    kernel_h: int,
-    kernel_w: int,
-    stride_d: int,
-    stride_h: int,
-    stride_w: int,
-    pad_d: int,
-    pad_h: int,
-    pad_w: int,
-    dtype: str,
-    block_m: int,
-    threads: int,
-    x: torch.Tensor,
-) -> torch.Tensor:
-    _ = (dtype, block_m, threads)
-    out_d = pool_output_dim(d_in, kernel_d, stride_d, pad_d, False)
-    out_h = pool_output_dim(h_in, kernel_h, stride_h, pad_h, False)
-    out_w = pool_output_dim(w_in, kernel_w, stride_w, pad_w, False)
-    return torch.empty((n, c_in, out_d, out_h, out_w), dtype=x.dtype, device=x.device)
-
-
-@torch.library.custom_op("top::avg_pool3d_wrapped_kernel", mutates_args=())
-def _avg_pool3d_wrapped_kernel(
+def _launch_avg_pool3d(
     n: int,
     c_in: int,
     d_in: int,
@@ -305,45 +275,6 @@ def _avg_pool3d_wrapped_kernel(
         divisor_override,
         dtype,
     )(block_m, threads)(x)
-
-
-@_avg_pool3d_wrapped_kernel.register_fake
-def _(
-    n: int,
-    c_in: int,
-    d_in: int,
-    h_in: int,
-    w_in: int,
-    kernel_d: int,
-    kernel_h: int,
-    kernel_w: int,
-    stride_d: int,
-    stride_h: int,
-    stride_w: int,
-    pad_d: int,
-    pad_h: int,
-    pad_w: int,
-    ceil_mode: bool,
-    count_include_pad: bool,
-    use_divisor_override: bool,
-    divisor_override: int,
-    dtype: str,
-    block_m: int,
-    threads: int,
-    x: torch.Tensor,
-) -> torch.Tensor:
-    _ = (
-        count_include_pad,
-        use_divisor_override,
-        divisor_override,
-        dtype,
-        block_m,
-        threads,
-    )
-    out_d = pool_output_dim(d_in, kernel_d, stride_d, pad_d, ceil_mode)
-    out_h = pool_output_dim(h_in, kernel_h, stride_h, pad_h, ceil_mode)
-    out_w = pool_output_dim(w_in, kernel_w, stride_w, pad_w, ceil_mode)
-    return torch.empty((n, c_in, out_d, out_h, out_w), dtype=x.dtype, device=x.device)
 
 
 class AvgPool3dSpatialKernel(Kernel):
@@ -426,7 +357,7 @@ class AvgPool3dSpatialKernel(Kernel):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         require_cuda(self, x=x)
-        return _avg_pool3d_spatial_wrapped_kernel(
+        return _launch_avg_pool3d_spatial(
             self.n,
             self.c_in,
             self.d_in,
@@ -537,7 +468,7 @@ class AvgPool3dKernel(Kernel):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         require_cuda(self, x=x)
-        return _avg_pool3d_wrapped_kernel(
+        return _launch_avg_pool3d(
             self.n,
             self.c_in,
             self.d_in,

--- a/src/tileops/kernels/pool/avg_pool3d.py
+++ b/src/tileops/kernels/pool/avg_pool3d.py
@@ -7,7 +7,7 @@ import tilelang.language as T
 import torch
 
 from tileops.kernels.kernel_base import Kernel
-from tileops.kernels.pool.common import pool_output_dim
+from tileops.kernels.pool.common import pool_output_dim, require_cuda
 
 __all__ = ["AvgPool3dKernel", "AvgPool3dSpatialKernel"]
 
@@ -425,6 +425,7 @@ class AvgPool3dSpatialKernel(Kernel):
         ]
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        require_cuda(self, x)
         return _avg_pool3d_spatial_wrapped_kernel(
             self.n,
             self.c_in,
@@ -535,6 +536,7 @@ class AvgPool3dKernel(Kernel):
         ]
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        require_cuda(self, x)
         return _avg_pool3d_wrapped_kernel(
             self.n,
             self.c_in,

--- a/src/tileops/kernels/pool/common.py
+++ b/src/tileops/kernels/pool/common.py
@@ -6,6 +6,19 @@ import torch
 from tileops.kernels.kernel_base import Kernel
 
 
+def require_cuda(kernel: Kernel, x: torch.Tensor) -> None:
+    """Raise unless *x* is on a CUDA device.
+
+    The in-tree pool kernels are CUDA kernels, so the device requirement is theirs to
+    state; another target's backend serves other devices.
+    """
+    if not x.is_cuda:
+        raise ValueError(
+            f"{type(kernel).__name__} is a CUDA kernel; got input on {x.device}. "
+            "Another target's backend serves other devices."
+        )
+
+
 def pool_output_dim(
     input_size: int,
     kernel_size: int,
@@ -103,6 +116,7 @@ class AdaptivePool2dKernelBase(Kernel):
         ]
 
     def forward(self, x: torch.Tensor):
+        require_cuda(self, x)
         return type(self)._dispatch(
             self.n,
             self.c_in,

--- a/src/tileops/kernels/pool/common.py
+++ b/src/tileops/kernels/pool/common.py
@@ -6,17 +6,18 @@ import torch
 from tileops.kernels.kernel_base import Kernel
 
 
-def require_cuda(kernel: Kernel, x: torch.Tensor) -> None:
-    """Raise unless *x* is on a CUDA device.
+def require_cuda(kernel: Kernel, **tensors: torch.Tensor) -> None:
+    """Raise unless every named tensor is on a CUDA device.
 
     The in-tree pool kernels are CUDA kernels, so the device requirement is theirs to
     state; another target's backend serves other devices.
     """
-    if not x.is_cuda:
-        raise ValueError(
-            f"{type(kernel).__name__} is a CUDA kernel; got input on {x.device}. "
-            "Another target's backend serves other devices."
-        )
+    for name, tensor in tensors.items():
+        if not tensor.is_cuda:
+            raise ValueError(
+                f"{type(kernel).__name__} is a CUDA kernel; got {name} on {tensor.device}. "
+                "Another target's backend serves other devices."
+            )
 
 
 def pool_output_dim(
@@ -116,7 +117,7 @@ class AdaptivePool2dKernelBase(Kernel):
         ]
 
     def forward(self, x: torch.Tensor):
-        require_cuda(self, x)
+        require_cuda(self, x=x)
         return type(self)._dispatch(
             self.n,
             self.c_in,

--- a/src/tileops/kernels/pool/common.py
+++ b/src/tileops/kernels/pool/common.py
@@ -70,10 +70,7 @@ class AdaptivePool2dKernelBase(Kernel):
     declares nothing else:
 
     - ``_build`` the cached builder that traces the prim_func.
-    - ``_dispatch`` the registered custom op the forward call goes through.
-
-    Each variant keeps its own ``torch.library`` registration; those need
-    distinct names and are what ``torch.compile`` resolves against.
+    - ``_dispatch`` the launch the forward call goes through.
     """
 
     supported_archs: ClassVar[list[int]] = [80, 86, 89, 90]

--- a/src/tileops/kernels/pool/max_pool1d.py
+++ b/src/tileops/kernels/pool/max_pool1d.py
@@ -7,7 +7,7 @@ import tilelang.language as T
 import torch
 
 from tileops.kernels.kernel_base import Kernel
-from tileops.kernels.pool.common import pool_output_dim
+from tileops.kernels.pool.common import pool_output_dim, require_cuda
 
 __all__ = ["MaxPool1dKernel", "MaxPool1dWithIndicesKernel"]
 
@@ -186,6 +186,7 @@ class _MaxPool1dKernelBase(Kernel):
         ]
 
     def forward(self, x: torch.Tensor) -> Any:
+        require_cuda(self, x)
         return type(self)._dispatch(
             self.n,
             self.c_in,

--- a/src/tileops/kernels/pool/max_pool1d.py
+++ b/src/tileops/kernels/pool/max_pool1d.py
@@ -68,8 +68,7 @@ def _max_pool1d_kernel(
     return _max_pool1d_func
 
 
-@torch.library.custom_op("top::max_pool1d_wrapped_kernel", mutates_args=())
-def _max_pool1d_wrapped_kernel(
+def _launch_max_pool1d(
     n: int,
     c_in: int,
     l_in: int,
@@ -94,26 +93,6 @@ def _max_pool1d_wrapped_kernel(
         ceil_mode,
         dtype,
     )(block_m, threads)(x)
-
-
-@_max_pool1d_wrapped_kernel.register_fake
-def _(
-    n: int,
-    c_in: int,
-    l_in: int,
-    kernel_w: int,
-    stride_w: int,
-    pad_w: int,
-    dilation_w: int,
-    ceil_mode: bool,
-    dtype: str,
-    block_m: int,
-    threads: int,
-    x: torch.Tensor,
-) -> torch.Tensor:
-    _ = (dtype, block_m, threads)
-    out_l = pool_output_dim(l_in, kernel_w, stride_w, pad_w, ceil_mode, dilation_w)
-    return torch.empty((n, c_in, out_l), dtype=x.dtype, device=x.device)
 
 
 class _MaxPool1dKernelBase(Kernel):
@@ -207,7 +186,7 @@ class MaxPool1dKernel(_MaxPool1dKernelBase):
     """Max pooling forward kernel (return_indices=False)."""
 
     _build = staticmethod(_max_pool1d_kernel)
-    _dispatch = staticmethod(_max_pool1d_wrapped_kernel)
+    _dispatch = staticmethod(_launch_max_pool1d)
 
 
 @functools.lru_cache(maxsize=32)
@@ -289,8 +268,7 @@ def _max_pool1d_with_indices_kernel(
     return _max_pool1d_with_indices_func
 
 
-@torch.library.custom_op("top::max_pool1d_with_indices_wrapped_kernel", mutates_args=())
-def _max_pool1d_with_indices_wrapped_kernel(
+def _launch_max_pool1d_with_indices(
     n: int,
     c_in: int,
     l_in: int,
@@ -317,31 +295,8 @@ def _max_pool1d_with_indices_wrapped_kernel(
     )(block_m, threads)(x)
 
 
-@_max_pool1d_with_indices_wrapped_kernel.register_fake
-def _(
-    n: int,
-    c_in: int,
-    l_in: int,
-    kernel_w: int,
-    stride_w: int,
-    pad_w: int,
-    dilation_w: int,
-    ceil_mode: bool,
-    dtype: str,
-    block_m: int,
-    threads: int,
-    x: torch.Tensor,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    _ = (dtype, block_m, threads)
-    out_l = pool_output_dim(l_in, kernel_w, stride_w, pad_w, ceil_mode, dilation_w)
-    return (
-        torch.empty((n, c_in, out_l), dtype=x.dtype, device=x.device),
-        torch.empty((n, c_in, out_l), dtype=torch.int64, device=x.device),
-    )
-
-
 class MaxPool1dWithIndicesKernel(_MaxPool1dKernelBase):
     """Max pooling forward-with-indices kernel."""
 
     _build = staticmethod(_max_pool1d_with_indices_kernel)
-    _dispatch = staticmethod(_max_pool1d_with_indices_wrapped_kernel)
+    _dispatch = staticmethod(_launch_max_pool1d_with_indices)

--- a/src/tileops/kernels/pool/max_pool1d.py
+++ b/src/tileops/kernels/pool/max_pool1d.py
@@ -186,7 +186,7 @@ class _MaxPool1dKernelBase(Kernel):
         ]
 
     def forward(self, x: torch.Tensor) -> Any:
-        require_cuda(self, x)
+        require_cuda(self, x=x)
         return type(self)._dispatch(
             self.n,
             self.c_in,

--- a/src/tileops/kernels/pool/max_pool2d.py
+++ b/src/tileops/kernels/pool/max_pool2d.py
@@ -77,8 +77,7 @@ def _max_pool2d_kernel(
     return _max_pool2d_func
 
 
-@torch.library.custom_op("top::max_pool2d_wrapped_kernel", mutates_args=())
-def _max_pool2d_wrapped_kernel(
+def _launch_max_pool2d(
     n: int,
     c_in: int,
     h_in: int,
@@ -113,32 +112,6 @@ def _max_pool2d_wrapped_kernel(
         ceil_mode,
         dtype,
     )(block_m, threads)(x)
-
-
-@_max_pool2d_wrapped_kernel.register_fake
-def _(
-    n: int,
-    c_in: int,
-    h_in: int,
-    w_in: int,
-    kernel_h: int,
-    kernel_w: int,
-    stride_h: int,
-    stride_w: int,
-    pad_h: int,
-    pad_w: int,
-    dilation_h: int,
-    dilation_w: int,
-    ceil_mode: bool,
-    dtype: str,
-    block_m: int,
-    threads: int,
-    x: torch.Tensor,
-) -> torch.Tensor:
-    _ = (dtype, block_m, threads)
-    out_h = pool_output_dim(h_in, kernel_h, stride_h, pad_h, ceil_mode, dilation_h)
-    out_w = pool_output_dim(w_in, kernel_w, stride_w, pad_w, ceil_mode, dilation_w)
-    return torch.empty((n, c_in, out_h, out_w), dtype=x.dtype, device=x.device)
 
 
 class _MaxPool2dKernelBase(Kernel):
@@ -253,7 +226,7 @@ class MaxPool2dKernel(_MaxPool2dKernelBase):
     """Max pooling forward kernel (return_indices=False)."""
 
     _build = staticmethod(_max_pool2d_kernel)
-    _dispatch = staticmethod(_max_pool2d_wrapped_kernel)
+    _dispatch = staticmethod(_launch_max_pool2d)
 
 
 @functools.lru_cache(maxsize=32)
@@ -345,8 +318,7 @@ def _max_pool2d_with_indices_kernel(
     return _max_pool2d_with_indices_func
 
 
-@torch.library.custom_op("top::max_pool2d_with_indices_wrapped_kernel", mutates_args=())
-def _max_pool2d_with_indices_wrapped_kernel(
+def _launch_max_pool2d_with_indices(
     n: int,
     c_in: int,
     h_in: int,
@@ -383,37 +355,8 @@ def _max_pool2d_with_indices_wrapped_kernel(
     )(block_m, threads)(x)
 
 
-@_max_pool2d_with_indices_wrapped_kernel.register_fake
-def _(
-    n: int,
-    c_in: int,
-    h_in: int,
-    w_in: int,
-    kernel_h: int,
-    kernel_w: int,
-    stride_h: int,
-    stride_w: int,
-    pad_h: int,
-    pad_w: int,
-    dilation_h: int,
-    dilation_w: int,
-    ceil_mode: bool,
-    dtype: str,
-    block_m: int,
-    threads: int,
-    x: torch.Tensor,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    _ = (dtype, block_m, threads)
-    out_h = pool_output_dim(h_in, kernel_h, stride_h, pad_h, ceil_mode, dilation_h)
-    out_w = pool_output_dim(w_in, kernel_w, stride_w, pad_w, ceil_mode, dilation_w)
-    return (
-        torch.empty((n, c_in, out_h, out_w), dtype=x.dtype, device=x.device),
-        torch.empty((n, c_in, out_h, out_w), dtype=torch.int64, device=x.device),
-    )
-
-
 class MaxPool2dWithIndicesKernel(_MaxPool2dKernelBase):
     """Max pooling forward-with-indices kernel."""
 
     _build = staticmethod(_max_pool2d_with_indices_kernel)
-    _dispatch = staticmethod(_max_pool2d_with_indices_wrapped_kernel)
+    _dispatch = staticmethod(_launch_max_pool2d_with_indices)

--- a/src/tileops/kernels/pool/max_pool2d.py
+++ b/src/tileops/kernels/pool/max_pool2d.py
@@ -7,7 +7,7 @@ import tilelang.language as T
 import torch
 
 from tileops.kernels.kernel_base import Kernel
-from tileops.kernels.pool.common import pool_output_dim
+from tileops.kernels.pool.common import pool_output_dim, require_cuda
 
 __all__ = ["MaxPool2dKernel", "MaxPool2dWithIndicesKernel"]
 
@@ -227,6 +227,7 @@ class _MaxPool2dKernelBase(Kernel):
         ]
 
     def forward(self, x: torch.Tensor) -> Any:
+        require_cuda(self, x)
         return type(self)._dispatch(
             self.n,
             self.c_in,

--- a/src/tileops/kernels/pool/max_pool2d.py
+++ b/src/tileops/kernels/pool/max_pool2d.py
@@ -227,7 +227,7 @@ class _MaxPool2dKernelBase(Kernel):
         ]
 
     def forward(self, x: torch.Tensor) -> Any:
-        require_cuda(self, x)
+        require_cuda(self, x=x)
         return type(self)._dispatch(
             self.n,
             self.c_in,

--- a/src/tileops/kernels/pool/max_pool3d.py
+++ b/src/tileops/kernels/pool/max_pool3d.py
@@ -95,8 +95,7 @@ def _max_pool3d_kernel(
     return _max_pool3d_func
 
 
-@torch.library.custom_op("top::max_pool3d_wrapped_kernel", mutates_args=())
-def _max_pool3d_wrapped_kernel(
+def _launch_max_pool3d(
     n: int,
     c_in: int,
     d_in: int,
@@ -141,38 +140,6 @@ def _max_pool3d_wrapped_kernel(
         ceil_mode,
         dtype,
     )(block_m, threads)(x)
-
-
-@_max_pool3d_wrapped_kernel.register_fake
-def _(
-    n: int,
-    c_in: int,
-    d_in: int,
-    h_in: int,
-    w_in: int,
-    kernel_d: int,
-    kernel_h: int,
-    kernel_w: int,
-    stride_d: int,
-    stride_h: int,
-    stride_w: int,
-    pad_d: int,
-    pad_h: int,
-    pad_w: int,
-    dilation_d: int,
-    dilation_h: int,
-    dilation_w: int,
-    ceil_mode: bool,
-    dtype: str,
-    block_m: int,
-    threads: int,
-    x: torch.Tensor,
-) -> torch.Tensor:
-    _ = (dtype, block_m, threads)
-    out_d = pool_output_dim(d_in, kernel_d, stride_d, pad_d, ceil_mode, dilation_d)
-    out_h = pool_output_dim(h_in, kernel_h, stride_h, pad_h, ceil_mode, dilation_h)
-    out_w = pool_output_dim(w_in, kernel_w, stride_w, pad_w, ceil_mode, dilation_w)
-    return torch.empty((n, c_in, out_d, out_h, out_w), dtype=x.dtype, device=x.device)
 
 
 class _MaxPool3dKernelBase(Kernel):
@@ -308,7 +275,7 @@ class MaxPool3dKernel(_MaxPool3dKernelBase):
     """Max pooling forward kernel (return_indices=False)."""
 
     _build = staticmethod(_max_pool3d_kernel)
-    _dispatch = staticmethod(_max_pool3d_wrapped_kernel)
+    _dispatch = staticmethod(_launch_max_pool3d)
 
 
 @functools.lru_cache(maxsize=32)
@@ -417,8 +384,7 @@ def _max_pool3d_with_indices_kernel(
     return _max_pool3d_with_indices_func
 
 
-@torch.library.custom_op("top::max_pool3d_with_indices_wrapped_kernel", mutates_args=())
-def _max_pool3d_with_indices_wrapped_kernel(
+def _launch_max_pool3d_with_indices(
     n: int,
     c_in: int,
     d_in: int,
@@ -465,43 +431,8 @@ def _max_pool3d_with_indices_wrapped_kernel(
     )(block_m, threads)(x)
 
 
-@_max_pool3d_with_indices_wrapped_kernel.register_fake
-def _(
-    n: int,
-    c_in: int,
-    d_in: int,
-    h_in: int,
-    w_in: int,
-    kernel_d: int,
-    kernel_h: int,
-    kernel_w: int,
-    stride_d: int,
-    stride_h: int,
-    stride_w: int,
-    pad_d: int,
-    pad_h: int,
-    pad_w: int,
-    dilation_d: int,
-    dilation_h: int,
-    dilation_w: int,
-    ceil_mode: bool,
-    dtype: str,
-    block_m: int,
-    threads: int,
-    x: torch.Tensor,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    _ = (dtype, block_m, threads)
-    out_d = pool_output_dim(d_in, kernel_d, stride_d, pad_d, ceil_mode, dilation_d)
-    out_h = pool_output_dim(h_in, kernel_h, stride_h, pad_h, ceil_mode, dilation_h)
-    out_w = pool_output_dim(w_in, kernel_w, stride_w, pad_w, ceil_mode, dilation_w)
-    return (
-        torch.empty((n, c_in, out_d, out_h, out_w), dtype=x.dtype, device=x.device),
-        torch.empty((n, c_in, out_d, out_h, out_w), dtype=torch.int64, device=x.device),
-    )
-
-
 class MaxPool3dWithIndicesKernel(_MaxPool3dKernelBase):
     """Max pooling forward-with-indices kernel."""
 
     _build = staticmethod(_max_pool3d_with_indices_kernel)
-    _dispatch = staticmethod(_max_pool3d_with_indices_wrapped_kernel)
+    _dispatch = staticmethod(_launch_max_pool3d_with_indices)

--- a/src/tileops/kernels/pool/max_pool3d.py
+++ b/src/tileops/kernels/pool/max_pool3d.py
@@ -7,7 +7,7 @@ import tilelang.language as T
 import torch
 
 from tileops.kernels.kernel_base import Kernel
-from tileops.kernels.pool.common import pool_output_dim
+from tileops.kernels.pool.common import pool_output_dim, require_cuda
 
 __all__ = ["MaxPool3dKernel", "MaxPool3dWithIndicesKernel"]
 
@@ -277,6 +277,7 @@ class _MaxPool3dKernelBase(Kernel):
         ]
 
     def forward(self, x: torch.Tensor) -> Any:
+        require_cuda(self, x)
         return type(self)._dispatch(
             self.n,
             self.c_in,

--- a/src/tileops/kernels/pool/max_pool3d.py
+++ b/src/tileops/kernels/pool/max_pool3d.py
@@ -277,7 +277,7 @@ class _MaxPool3dKernelBase(Kernel):
         ]
 
     def forward(self, x: torch.Tensor) -> Any:
-        require_cuda(self, x)
+        require_cuda(self, x=x)
         return type(self)._dispatch(
             self.n,
             self.c_in,

--- a/src/tileops/kernels/pool/mean_pooling.py
+++ b/src/tileops/kernels/pool/mean_pooling.py
@@ -7,6 +7,8 @@ import torch
 
 from tileops.kernels.kernel_base import Kernel
 
+from .common import require_cuda
+
 __all__ = ["MeanPoolingFwdKernel"]
 
 
@@ -199,6 +201,7 @@ class MeanPoolingFwdKernel(Kernel):
     def forward(
         self, x: torch.Tensor, offsets: torch.Tensor, indices: torch.Tensor
     ) -> torch.Tensor:
+        require_cuda(self, x)
         return _mean_pooling_wrapped_kernel(
             self.batch_size,
             self.seq_len,

--- a/src/tileops/kernels/pool/mean_pooling.py
+++ b/src/tileops/kernels/pool/mean_pooling.py
@@ -201,7 +201,7 @@ class MeanPoolingFwdKernel(Kernel):
     def forward(
         self, x: torch.Tensor, offsets: torch.Tensor, indices: torch.Tensor
     ) -> torch.Tensor:
-        require_cuda(self, x)
+        require_cuda(self, x=x, offsets=offsets, indices=indices)
         return _mean_pooling_wrapped_kernel(
             self.batch_size,
             self.seq_len,

--- a/src/tileops/manifest/convolution.yaml
+++ b/src/tileops/manifest/convolution.yaml
@@ -9,6 +9,7 @@ Conv1dFwdOp:
   # Equivalent to torch.nn.functional.conv1d; bias is optional.
   family: convolution
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -80,6 +81,7 @@ Conv2dFwdOp:
   # Equivalent to torch.nn.functional.conv2d; bias is optional.
   family: convolution
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -187,6 +189,7 @@ Conv3dFwdOp:
   # Equivalent to torch.nn.functional.conv3d; bias is optional.
   family: convolution
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:

--- a/src/tileops/ops/convolution.py
+++ b/src/tileops/ops/convolution.py
@@ -1,7 +1,8 @@
-from typing import Dict, Optional, Tuple
+from typing import ClassVar, Dict, Optional, Tuple
 
 import torch
 
+from tileops.backend import Target
 from tileops.kernels.convolution import (
     Conv1dKernel,
     Conv1dPointwiseKernel,
@@ -15,6 +16,7 @@ from tileops.kernels.convolution import (
 )
 from tileops.kernels.kernel_base import Kernel
 
+from .compile_boundary import get_instance
 from .op_base import Op
 
 __all__ = [
@@ -199,12 +201,17 @@ def _conv1d_l_out(
 
 
 class Conv1dFwdOp(Op):
+    #: The operator this op registers; a test asserts the graph holds nothing else.
+    compile_op_names: ClassVar[Tuple[str, ...]] = ("top::conv_conv1d_fwd",)
+
     def __init__(
         self,
         stride: int | Tuple[int] = 1,
         padding: int | Tuple[int] | str = 0,
         dilation: int | Tuple[int] = 1,
         groups: int = 1,
+        *,
+        target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
@@ -219,6 +226,7 @@ class Conv1dFwdOp(Op):
         self.padding = padding
         self.groups = groups
         self.dtype = None
+        self.target = target
         self.tune = tune
 
         self.dispatch_kernel(kernel_map)
@@ -280,6 +288,7 @@ class Conv1dFwdOp(Op):
         dtype: torch.dtype,
         device_index: int | None,
         has_bias: bool,
+        inputs: tuple[torch.Tensor, ...],
     ) -> Kernel:
         use_pointwise = (
             self.groups == 1
@@ -348,7 +357,7 @@ class Conv1dFwdOp(Op):
                     dilation_l=self.dilation,
                 )
 
-        return self.get_or_build_kernel("conv1d_kernel", key=key, build=build)
+        return self.get_or_build_kernel("conv1d_kernel", inputs, key=key, build=build)
 
     def forward(
         self,
@@ -356,6 +365,33 @@ class Conv1dFwdOp(Op):
         weight: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
+        """Apply the convolution. One call to this op's operator, nothing else.
+
+        Args:
+            input: Input tensor in the manifest's layout.
+            weight: Convolution weight.
+            bias: Per-output-channel bias, or ``None``.
+
+        Returns:
+            The convolution result.
+
+        Raises:
+            ValueError: Dtypes or shapes disagree with the manifest. Raised from inside the
+                operator, by :meth:`_eager_forward`.
+        """
+        return _conv1d_fwd(input, weight, bias, self._instance_key)
+
+    def _eager_forward(
+        self,
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        bias: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Validate, normalize, resolve the kernel and launch, inside the operator.
+
+        Never traced: kernel construction enters a TileLang builder, which dynamo cannot
+        follow.
+        """
         self._validate_dtypes(input, weight, bias)
         (
             n,
@@ -371,6 +407,16 @@ class Conv1dFwdOp(Op):
         ) = self._resolve_spec_1d(input, weight)
         if bias is not None and tuple(bias.shape) != (c_out,):
             raise ValueError(f"Conv1d expects bias shape ({c_out},), got {tuple(bias.shape)}")
+
+        # Normalization is the op layer's job for every target: a kernel is handed
+        # contiguous tensors, in the manifest's ``signature.inputs`` order.
+        input = input.contiguous()
+        weight = weight.contiguous()
+        if bias is not None:
+            bias = bias.contiguous()
+        # Only the tensors this call carries: a missing optional input is absent from the
+        # hand-over, not a placeholder.
+        inputs = (input, weight) if bias is None else (input, weight, bias)
         kernel = self._get_kernel_1d(
             n,
             c_in,
@@ -384,6 +430,7 @@ class Conv1dFwdOp(Op):
             dtype,
             _device_index(input),
             bias is not None,
+            inputs,
         )
         self.kernel = kernel
         self.n = n
@@ -481,12 +528,17 @@ def _conv_out_dim(
 
 
 class Conv2dFwdOp(Op):
+    #: The operator this op registers; a test asserts the graph holds nothing else.
+    compile_op_names: ClassVar[Tuple[str, ...]] = ("top::conv_conv2d_fwd",)
+
     def __init__(
         self,
         stride: int | Tuple[int, int] = 1,
         padding: int | Tuple[int, int] | str = 0,
         dilation: int | Tuple[int, int] = 1,
         groups: int = 1,
+        *,
+        target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
@@ -502,6 +554,7 @@ class Conv2dFwdOp(Op):
         self.padding = padding
         self.groups = groups
         self.dtype = None
+        self.target = target
         self.tune = tune
 
         self.dispatch_kernel(kernel_map)
@@ -593,6 +646,7 @@ class Conv2dFwdOp(Op):
         dtype: torch.dtype,
         device_index: int | None,
         has_bias: bool,
+        inputs: tuple[torch.Tensor, ...],
     ) -> Kernel:
         is_symmetric = (
             kernel_h == kernel_w
@@ -697,7 +751,7 @@ class Conv2dFwdOp(Op):
                     dilation_w=self.dilation[1],
                 )
 
-        return self.get_or_build_kernel("conv2d_kernel", key=key, build=build)
+        return self.get_or_build_kernel("conv2d_kernel", inputs, key=key, build=build)
 
     def forward(
         self,
@@ -705,6 +759,33 @@ class Conv2dFwdOp(Op):
         weight: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
+        """Apply the convolution. One call to this op's operator, nothing else.
+
+        Args:
+            input: Input tensor in the manifest's layout.
+            weight: Convolution weight.
+            bias: Per-output-channel bias, or ``None``.
+
+        Returns:
+            The convolution result.
+
+        Raises:
+            ValueError: Dtypes or shapes disagree with the manifest. Raised from inside the
+                operator, by :meth:`_eager_forward`.
+        """
+        return _conv2d_fwd(input, weight, bias, self._instance_key)
+
+    def _eager_forward(
+        self,
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        bias: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Validate, normalize, resolve the kernel and launch, inside the operator.
+
+        Never traced: kernel construction enters a TileLang builder, which dynamo cannot
+        follow.
+        """
         self._validate_dtypes(input, weight, bias)
         (
             n,
@@ -723,6 +804,16 @@ class Conv2dFwdOp(Op):
         ) = self._resolve_spec_2d(input, weight)
         if bias is not None and tuple(bias.shape) != (c_out,):
             raise ValueError(f"Conv2d expects bias shape ({c_out},), got {tuple(bias.shape)}")
+
+        # Normalization is the op layer's job for every target: a kernel is handed
+        # contiguous tensors, in the manifest's ``signature.inputs`` order.
+        input = input.contiguous()
+        weight = weight.contiguous()
+        if bias is not None:
+            bias = bias.contiguous()
+        # Only the tensors this call carries: a missing optional input is absent from the
+        # hand-over, not a placeholder.
+        inputs = (input, weight) if bias is None else (input, weight, bias)
         kernel = self._get_kernel_2d(
             n,
             c_in,
@@ -739,6 +830,7 @@ class Conv2dFwdOp(Op):
             dtype,
             _device_index(input),
             bias is not None,
+            inputs,
         )
         self.kernel = kernel
         self.n = n
@@ -838,12 +930,17 @@ def _triple(value: int | Tuple[int, int, int]) -> Tuple[int, int, int]:
 
 
 class Conv3dFwdOp(Op):
+    #: The operator this op registers; a test asserts the graph holds nothing else.
+    compile_op_names: ClassVar[Tuple[str, ...]] = ("top::conv_conv3d_fwd",)
+
     def __init__(
         self,
         stride: int | Tuple[int, int, int] = 1,
         padding: int | Tuple[int, int, int] | str = 0,
         dilation: int | Tuple[int, int, int] = 1,
         groups: int = 1,
+        *,
+        target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
@@ -860,6 +957,7 @@ class Conv3dFwdOp(Op):
         self.padding = padding
         self.groups = groups
         self.dtype = None
+        self.target = target
         self.tune = tune
 
         self.dispatch_kernel(kernel_map)
@@ -964,6 +1062,7 @@ class Conv3dFwdOp(Op):
         dtype: torch.dtype,
         device_index: int | None,
         has_bias: bool,
+        inputs: tuple[torch.Tensor, ...],
     ) -> Kernel:
         use_group = self.groups > 1 and "group_conv3d_kernel" in self.kernel_map
         variant = "group" if use_group else "general"
@@ -1023,7 +1122,7 @@ class Conv3dFwdOp(Op):
             else:
                 return self.kernel_map["conv3d_kernel"](**kernel_kwargs)
 
-        return self.get_or_build_kernel("conv3d_kernel", key=key, build=build)
+        return self.get_or_build_kernel("conv3d_kernel", inputs, key=key, build=build)
 
     def forward(
         self,
@@ -1031,6 +1130,33 @@ class Conv3dFwdOp(Op):
         weight: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
+        """Apply the convolution. One call to this op's operator, nothing else.
+
+        Args:
+            input: Input tensor in the manifest's layout.
+            weight: Convolution weight.
+            bias: Per-output-channel bias, or ``None``.
+
+        Returns:
+            The convolution result.
+
+        Raises:
+            ValueError: Dtypes or shapes disagree with the manifest. Raised from inside the
+                operator, by :meth:`_eager_forward`.
+        """
+        return _conv3d_fwd(input, weight, bias, self._instance_key)
+
+    def _eager_forward(
+        self,
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        bias: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Validate, normalize, resolve the kernel and launch, inside the operator.
+
+        Never traced: kernel construction enters a TileLang builder, which dynamo cannot
+        follow.
+        """
         self._validate_dtypes(input, weight, bias)
         (
             n,
@@ -1053,6 +1179,16 @@ class Conv3dFwdOp(Op):
         ) = self._resolve_spec_3d(input, weight)
         if bias is not None and tuple(bias.shape) != (c_out,):
             raise ValueError(f"Conv3d expects bias shape ({c_out},), got {tuple(bias.shape)}")
+
+        # Normalization is the op layer's job for every target: a kernel is handed
+        # contiguous tensors, in the manifest's ``signature.inputs`` order.
+        input = input.contiguous()
+        weight = weight.contiguous()
+        if bias is not None:
+            bias = bias.contiguous()
+        # Only the tensors this call carries: a missing optional input is absent from the
+        # hand-over, not a placeholder.
+        inputs = (input, weight) if bias is None else (input, weight, bias)
         kernel = self._get_kernel_3d(
             n,
             c_in,
@@ -1073,6 +1209,7 @@ class Conv3dFwdOp(Op):
             dtype,
             _device_index(input),
             bias is not None,
+            inputs,
         )
         self.kernel = kernel
         self.n = n
@@ -1176,3 +1313,96 @@ class Conv3dFwdOp(Op):
             + (c_out if has_bias else 0)
         ) * elem_bytes
         return int(flops), int(bytes_)
+
+
+# The compile boundary, one operator per op. Module-level because registration happens once
+# per qualified name at import time and the schema is read off the annotations, so ``self``
+# cannot appear; the instance comes back from the string key. See
+# src/tileops/ops/compile_boundary.py.
+
+
+@torch.library.custom_op("top::conv_conv1d_fwd", mutates_args=())
+def _conv1d_fwd(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: Optional[torch.Tensor],
+    instance_key: str,
+) -> torch.Tensor:
+    return get_instance(instance_key)._eager_forward(input, weight, bias)
+
+
+@_conv1d_fwd.register_fake
+def _conv1d_fwd_fake(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: Optional[torch.Tensor],
+    instance_key: str,
+) -> torch.Tensor:
+    op = get_instance(instance_key)
+    shapes = op._infer_output_shapes(
+        tuple(input.shape),
+        tuple(weight.shape),
+        None if bias is None else tuple(bias.shape),
+    )
+    # ``new_empty``, not ``empty_like``: ``_eager_forward`` normalizes contiguity, so a
+    # non-contiguous public input's strides must not survive into the fake. Dtype is the
+    # manifest's ``same_as(input)``.
+    return input.new_empty(shapes["output"])
+
+
+@torch.library.custom_op("top::conv_conv2d_fwd", mutates_args=())
+def _conv2d_fwd(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: Optional[torch.Tensor],
+    instance_key: str,
+) -> torch.Tensor:
+    return get_instance(instance_key)._eager_forward(input, weight, bias)
+
+
+@_conv2d_fwd.register_fake
+def _conv2d_fwd_fake(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: Optional[torch.Tensor],
+    instance_key: str,
+) -> torch.Tensor:
+    op = get_instance(instance_key)
+    shapes = op._infer_output_shapes(
+        tuple(input.shape),
+        tuple(weight.shape),
+        None if bias is None else tuple(bias.shape),
+    )
+    # ``new_empty``, not ``empty_like``: ``_eager_forward`` normalizes contiguity, so a
+    # non-contiguous public input's strides must not survive into the fake. Dtype is the
+    # manifest's ``same_as(input)``.
+    return input.new_empty(shapes["output"])
+
+
+@torch.library.custom_op("top::conv_conv3d_fwd", mutates_args=())
+def _conv3d_fwd(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: Optional[torch.Tensor],
+    instance_key: str,
+) -> torch.Tensor:
+    return get_instance(instance_key)._eager_forward(input, weight, bias)
+
+
+@_conv3d_fwd.register_fake
+def _conv3d_fwd_fake(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: Optional[torch.Tensor],
+    instance_key: str,
+) -> torch.Tensor:
+    op = get_instance(instance_key)
+    shapes = op._infer_output_shapes(
+        tuple(input.shape),
+        tuple(weight.shape),
+        None if bias is None else tuple(bias.shape),
+    )
+    # ``new_empty``, not ``empty_like``: ``_eager_forward`` normalizes contiguity, so a
+    # non-contiguous public input's strides must not survive into the fake. Dtype is the
+    # manifest's ``same_as(input)``.
+    return input.new_empty(shapes["output"])

--- a/src/tileops/ops/convolution.py
+++ b/src/tileops/ops/convolution.py
@@ -442,9 +442,10 @@ class Conv1dFwdOp(Op):
         weight = weight.contiguous()
         if bias is not None:
             bias = bias.contiguous()
-        # Only the tensors this call carries: a missing optional input is absent from the
-        # hand-over, not a placeholder.
-        inputs = (input, weight) if bias is None else (input, weight, bias)
+        # One argument per ``signature.inputs`` entry, in that order; a bias this call did
+        # not pass is ``None`` there rather than absent, so a builder and the memory key
+        # read presence off the argument rather than off how many arguments there are.
+        inputs = (input, weight, bias)
         kernel = self._get_kernel_1d(
             n,
             c_in,
@@ -838,7 +839,7 @@ class Conv2dFwdOp(Op):
         weight = weight.contiguous()
         if bias is not None:
             bias = bias.contiguous()
-        inputs = (input, weight) if bias is None else (input, weight, bias)
+        inputs = (input, weight, bias)
         kernel = self._get_kernel_2d(
             n,
             c_in,
@@ -1210,7 +1211,7 @@ class Conv3dFwdOp(Op):
         weight = weight.contiguous()
         if bias is not None:
             bias = bias.contiguous()
-        inputs = (input, weight) if bias is None else (input, weight, bias)
+        inputs = (input, weight, bias)
         kernel = self._get_kernel_3d(
             n,
             c_in,

--- a/src/tileops/ops/convolution.py
+++ b/src/tileops/ops/convolution.py
@@ -154,6 +154,33 @@ def _validate_conv_params(
         raise ValueError(f"{op_name} output spatial dimensions must be greater than zero")
 
 
+def _validate_same_device(
+    op_name: str,
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: Optional[torch.Tensor],
+) -> None:
+    """Reject a call whose tensors are not all on one device.
+
+    The kernel memo keys on the first input's device and lets it speak for the rest, so
+    disagreement has to be an error here rather than a wrong lookup there.
+
+    Args:
+        op_name: Name used in the message.
+        input: The call's input tensor, whose device the others must match.
+        weight: The call's weight.
+        bias: The call's bias, or ``None``.
+
+    Raises:
+        ValueError: Some input is on another device.
+    """
+    for name, tensor in (("weight", weight), ("bias", bias)):
+        if tensor is not None and tensor.device != input.device:
+            raise ValueError(
+                f"{op_name} expects every input on {input.device}, got {name} on {tensor.device}"
+            )
+
+
 def _device_index(tensor: torch.Tensor) -> int | None:
     return tensor.device.index
 
@@ -393,6 +420,7 @@ class Conv1dFwdOp(Op):
         follow.
         """
         self._validate_dtypes(input, weight, bias)
+        _validate_same_device("Conv1d", input, weight, bias)
         (
             n,
             c_in,
@@ -787,6 +815,7 @@ class Conv2dFwdOp(Op):
         follow.
         """
         self._validate_dtypes(input, weight, bias)
+        _validate_same_device("Conv2d", input, weight, bias)
         (
             n,
             c_in,
@@ -805,14 +834,10 @@ class Conv2dFwdOp(Op):
         if bias is not None and tuple(bias.shape) != (c_out,):
             raise ValueError(f"Conv2d expects bias shape ({c_out},), got {tuple(bias.shape)}")
 
-        # Normalization is the op layer's job for every target: a kernel is handed
-        # contiguous tensors, in the manifest's ``signature.inputs`` order.
         input = input.contiguous()
         weight = weight.contiguous()
         if bias is not None:
             bias = bias.contiguous()
-        # Only the tensors this call carries: a missing optional input is absent from the
-        # hand-over, not a placeholder.
         inputs = (input, weight) if bias is None else (input, weight, bias)
         kernel = self._get_kernel_2d(
             n,
@@ -1158,6 +1183,7 @@ class Conv3dFwdOp(Op):
         follow.
         """
         self._validate_dtypes(input, weight, bias)
+        _validate_same_device("Conv3d", input, weight, bias)
         (
             n,
             c_in,
@@ -1180,14 +1206,10 @@ class Conv3dFwdOp(Op):
         if bias is not None and tuple(bias.shape) != (c_out,):
             raise ValueError(f"Conv3d expects bias shape ({c_out},), got {tuple(bias.shape)}")
 
-        # Normalization is the op layer's job for every target: a kernel is handed
-        # contiguous tensors, in the manifest's ``signature.inputs`` order.
         input = input.contiguous()
         weight = weight.contiguous()
         if bias is not None:
             bias = bias.contiguous()
-        # Only the tensors this call carries: a missing optional input is absent from the
-        # hand-over, not a placeholder.
         inputs = (input, weight) if bias is None else (input, weight, bias)
         kernel = self._get_kernel_3d(
             n,
@@ -1319,6 +1341,10 @@ class Conv3dFwdOp(Op):
 # per qualified name at import time and the schema is read off the annotations, so ``self``
 # cannot appear; the instance comes back from the string key. See
 # src/tileops/ops/compile_boundary.py.
+#
+# Each fake returns ``new_empty``, not ``empty_like``: ``_eager_forward`` normalizes
+# contiguity, so a non-contiguous public input's strides must not survive into the fake.
+# The dtype is the manifest's ``same_as(input)``.
 
 
 @torch.library.custom_op("top::conv_conv1d_fwd", mutates_args=())
@@ -1344,9 +1370,6 @@ def _conv1d_fwd_fake(
         tuple(weight.shape),
         None if bias is None else tuple(bias.shape),
     )
-    # ``new_empty``, not ``empty_like``: ``_eager_forward`` normalizes contiguity, so a
-    # non-contiguous public input's strides must not survive into the fake. Dtype is the
-    # manifest's ``same_as(input)``.
     return input.new_empty(shapes["output"])
 
 
@@ -1373,9 +1396,6 @@ def _conv2d_fwd_fake(
         tuple(weight.shape),
         None if bias is None else tuple(bias.shape),
     )
-    # ``new_empty``, not ``empty_like``: ``_eager_forward`` normalizes contiguity, so a
-    # non-contiguous public input's strides must not survive into the fake. Dtype is the
-    # manifest's ``same_as(input)``.
     return input.new_empty(shapes["output"])
 
 
@@ -1402,7 +1422,4 @@ def _conv3d_fwd_fake(
         tuple(weight.shape),
         None if bias is None else tuple(bias.shape),
     )
-    # ``new_empty``, not ``empty_like``: ``_eager_forward`` normalizes contiguity, so a
-    # non-contiguous public input's strides must not survive into the fake. Dtype is the
-    # manifest's ``same_as(input)``.
     return input.new_empty(shapes["output"])

--- a/src/tileops/ops/convolution.py
+++ b/src/tileops/ops/convolution.py
@@ -461,6 +461,9 @@ class Conv1dFwdOp(Op):
             bias is not None,
             inputs,
         )
+        out = kernel(input, weight, bias)
+        # Recorded after the launch: eval_roofline and profiling read these, and a call
+        # that raised described nothing.
         self.kernel = kernel
         self.n = n
         self.c_in = c_in
@@ -484,7 +487,7 @@ class Conv1dFwdOp(Op):
             dtype,
             bias is not None,
         )
-        return kernel(input, weight, bias)
+        return out
 
     def _infer_output_shapes(
         self,
@@ -858,6 +861,9 @@ class Conv2dFwdOp(Op):
             bias is not None,
             inputs,
         )
+        out = kernel(input, weight, bias)
+        # Recorded after the launch: eval_roofline and profiling read these, and a call
+        # that raised described nothing.
         self.kernel = kernel
         self.n = n
         self.c_in = c_in
@@ -885,7 +891,7 @@ class Conv2dFwdOp(Op):
             dtype,
             bias is not None,
         )
-        return kernel(input, weight, bias)
+        return out
 
     def _infer_output_shapes(
         self,
@@ -1234,6 +1240,9 @@ class Conv3dFwdOp(Op):
             bias is not None,
             inputs,
         )
+        out = kernel(input, weight, bias)
+        # Recorded after the launch: eval_roofline and profiling read these, and a call
+        # that raised described nothing.
         self.kernel = kernel
         self.n = n
         self.c_in = c_in
@@ -1266,7 +1275,7 @@ class Conv3dFwdOp(Op):
             dtype,
             bias is not None,
         )
-        return kernel(input, weight, bias)
+        return out
 
     def _infer_output_shapes(
         self,

--- a/src/tileops/ops/pool.py
+++ b/src/tileops/ops/pool.py
@@ -3,6 +3,7 @@ from typing import Any, ClassVar, Dict, Optional, Tuple
 
 import torch
 
+from tileops.backend import Target
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.pool import (
     AdaptiveAvgPool2dKernel,
@@ -140,19 +141,15 @@ class MeanPoolingForwardOp(Op):
         self._kernel_params = params
         self.dispatch_kernel(kernel_map)
 
-    def _get_kernel(
-        self,
-        x: torch.Tensor,
-        offsets: torch.Tensor,
-        indices: torch.Tensor,
-    ) -> Kernel:
+    def _get_kernel(self, dtype: torch.dtype) -> Kernel:
+        # Hands over no tensors and takes no ``target=``: this op has no manifest entry, so a
+        # target's builder could not be told what to build. In-tree only until it has one.
         return self.get_or_build_kernel(
             "mean_pooling_fwd_kernel",
-            (x, offsets, indices),
-            key=x.dtype,
+            key=dtype,
             build=lambda: self.kernel_map["mean_pooling_fwd_kernel"](
                 **self._kernel_params,
-                dtype=x.dtype,
+                dtype=dtype,
             ),
         )
 
@@ -166,7 +163,7 @@ class MeanPoolingForwardOp(Op):
         offsets: torch.Tensor,
         indices: torch.Tensor,
     ) -> torch.Tensor:
-        kernel = self._get_kernel(x, offsets, indices)
+        kernel = self._get_kernel(x.dtype)
         out = kernel(x, offsets, indices=indices)
         self.dtype = x.dtype
         return out
@@ -220,6 +217,8 @@ class _AvgPoolFwdOpBase(Op):
         ceil_mode: bool = False,
         count_include_pad: bool = True,
         divisor_override: Optional[int] = None,
+        *,
+        target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
@@ -237,6 +236,7 @@ class _AvgPoolFwdOpBase(Op):
         self.count_include_pad = count_include_pad
         self.divisor_override = divisor_override
         self.dtype = None
+        self.target = target
         self.tune = tune
         validate_pool_params(
             ndim=nd,
@@ -408,6 +408,8 @@ class AvgPool1dFwdOp(_AvgPoolFwdOpBase):
         padding: int | Tuple[int] = 0,
         ceil_mode: bool = False,
         count_include_pad: bool = True,
+        *,
+        target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
@@ -418,6 +420,7 @@ class AvgPool1dFwdOp(_AvgPoolFwdOpBase):
             padding=padding,
             ceil_mode=ceil_mode,
             count_include_pad=count_include_pad,
+            target=target,
             kernel_map=kernel_map,
             tune=tune,
         )
@@ -460,6 +463,8 @@ class AvgPool2dFwdOp(_AvgPoolFwdOpBase):
         ceil_mode: bool = False,
         count_include_pad: bool = True,
         divisor_override: Optional[int] = None,
+        *,
+        target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
@@ -470,6 +475,7 @@ class AvgPool2dFwdOp(_AvgPoolFwdOpBase):
             ceil_mode=ceil_mode,
             count_include_pad=count_include_pad,
             divisor_override=divisor_override,
+            target=target,
             kernel_map=kernel_map,
             tune=tune,
         )
@@ -558,6 +564,8 @@ class _MaxPoolFwdOpBase(Op):
         padding: int | Tuple[int, ...] = 0,
         dilation: int | Tuple[int, ...] = 1,
         ceil_mode: bool = False,
+        *,
+        target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
@@ -576,6 +584,7 @@ class _MaxPoolFwdOpBase(Op):
             raise TypeError("ceil_mode must be a bool")
         self.ceil_mode = ceil_mode
         self.dtype = None
+        self.target = target
         self.tune = tune
         validate_pool_params(
             ndim=nd,
@@ -727,6 +736,8 @@ class MaxPool1dFwdOp(_MaxPoolFwdOpBase):
         padding: int | Tuple[int] = 0,
         dilation: int | Tuple[int] = 1,
         ceil_mode: bool = False,
+        *,
+        target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
@@ -736,6 +747,7 @@ class MaxPool1dFwdOp(_MaxPoolFwdOpBase):
             padding=padding,
             dilation=dilation,
             ceil_mode=ceil_mode,
+            target=target,
             kernel_map=kernel_map,
             tune=tune,
         )
@@ -765,6 +777,8 @@ class MaxPool1dIndicesFwdOp(_MaxPoolFwdOpBase):
         padding: int | Tuple[int] = 0,
         dilation: int | Tuple[int] = 1,
         ceil_mode: bool = False,
+        *,
+        target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
@@ -774,6 +788,7 @@ class MaxPool1dIndicesFwdOp(_MaxPoolFwdOpBase):
             padding=padding,
             dilation=dilation,
             ceil_mode=ceil_mode,
+            target=target,
             kernel_map=kernel_map,
             tune=tune,
         )
@@ -805,6 +820,8 @@ class MaxPool2dFwdOp(_MaxPoolFwdOpBase):
         padding: int | Tuple[int, int] = 0,
         dilation: int | Tuple[int, int] = 1,
         ceil_mode: bool = False,
+        *,
+        target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
@@ -814,6 +831,7 @@ class MaxPool2dFwdOp(_MaxPoolFwdOpBase):
             padding=padding,
             dilation=dilation,
             ceil_mode=ceil_mode,
+            target=target,
             kernel_map=kernel_map,
             tune=tune,
         )
@@ -843,6 +861,8 @@ class MaxPool2dIndicesFwdOp(_MaxPoolFwdOpBase):
         padding: int | Tuple[int, int] = 0,
         dilation: int | Tuple[int, int] = 1,
         ceil_mode: bool = False,
+        *,
+        target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
@@ -852,6 +872,7 @@ class MaxPool2dIndicesFwdOp(_MaxPoolFwdOpBase):
             padding=padding,
             dilation=dilation,
             ceil_mode=ceil_mode,
+            target=target,
             kernel_map=kernel_map,
             tune=tune,
         )
@@ -883,6 +904,8 @@ class MaxPool3dFwdOp(_MaxPoolFwdOpBase):
         padding: int | Tuple[int, int, int] = 0,
         dilation: int | Tuple[int, int, int] = 1,
         ceil_mode: bool = False,
+        *,
+        target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
@@ -892,6 +915,7 @@ class MaxPool3dFwdOp(_MaxPoolFwdOpBase):
             padding=padding,
             dilation=dilation,
             ceil_mode=ceil_mode,
+            target=target,
             kernel_map=kernel_map,
             tune=tune,
         )
@@ -921,6 +945,8 @@ class MaxPool3dIndicesFwdOp(_MaxPoolFwdOpBase):
         padding: int | Tuple[int, int, int] = 0,
         dilation: int | Tuple[int, int, int] = 1,
         ceil_mode: bool = False,
+        *,
+        target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
@@ -930,6 +956,7 @@ class MaxPool3dIndicesFwdOp(_MaxPoolFwdOpBase):
             padding=padding,
             dilation=dilation,
             ceil_mode=ceil_mode,
+            target=target,
             kernel_map=kernel_map,
             tune=tune,
         )
@@ -961,6 +988,8 @@ class AvgPool3dFwdOp(_AvgPoolFwdOpBase):
         ceil_mode: bool = False,
         count_include_pad: bool = True,
         divisor_override: Optional[int] = None,
+        *,
+        target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
@@ -971,6 +1000,7 @@ class AvgPool3dFwdOp(_AvgPoolFwdOpBase):
             ceil_mode=ceil_mode,
             count_include_pad=count_include_pad,
             divisor_override=divisor_override,
+            target=target,
             kernel_map=kernel_map,
             tune=tune,
         )
@@ -1078,6 +1108,8 @@ class _AdaptivePool2dFwdOpBase(Op):
     def __init__(
         self,
         output_size: int | None | Tuple[Optional[int], Optional[int]],
+        *,
+        target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
@@ -1087,6 +1119,7 @@ class _AdaptivePool2dFwdOpBase(Op):
         self.w_in = None
         self.output_size = _normalize_output_size(output_size)
         self.dtype = None
+        self.target = target
         self.tune = tune
         self.dispatch_kernel(kernel_map)
         if self._kernel_slot not in self.kernel_map:
@@ -1185,10 +1218,17 @@ class AdaptiveAvgPool2dFwdOp(_AdaptivePool2dFwdOpBase):
     def __init__(
         self,
         output_size: int | None | Tuple[Optional[int], Optional[int]],
+        *,
+        target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
-        super().__init__(output_size=output_size, kernel_map=kernel_map, tune=tune)
+        super().__init__(
+            output_size=output_size,
+            target=target,
+            kernel_map=kernel_map,
+            tune=tune,
+        )
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
@@ -1209,10 +1249,17 @@ class AdaptiveMaxPool2dFwdOp(_AdaptivePool2dFwdOpBase):
     def __init__(
         self,
         output_size: int | None | Tuple[Optional[int], Optional[int]],
+        *,
+        target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
-        super().__init__(output_size=output_size, kernel_map=kernel_map, tune=tune)
+        super().__init__(
+            output_size=output_size,
+            target=target,
+            kernel_map=kernel_map,
+            tune=tune,
+        )
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
@@ -1234,10 +1281,17 @@ class AdaptiveMaxPool2dIndicesFwdOp(_AdaptivePool2dFwdOpBase):
     def __init__(
         self,
         output_size: int | None | Tuple[Optional[int], Optional[int]],
+        *,
+        target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
-        super().__init__(output_size=output_size, kernel_map=kernel_map, tune=tune)
+        super().__init__(
+            output_size=output_size,
+            target=target,
+            kernel_map=kernel_map,
+            tune=tune,
+        )
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:

--- a/src/tileops/ops/pool.py
+++ b/src/tileops/ops/pool.py
@@ -1156,6 +1156,10 @@ class _AdaptivePool2dFwdOpBase(Op):
         return type(self)._wrapped(input, self._instance_key)
 
     def _eager_forward(self, input: torch.Tensor):
+        # A 3D CHW call is the torch-parity convenience; the manifest declares NCHW only. The
+        # rank is normalized here, like contiguity, so what crosses to a kernel is the shape
+        # the manifest describes, and the batch axis is dropped again on the way out. A CHW
+        # call therefore shares its kernel with the batch-1 NCHW call, which computes it.
         if input.ndim == 3:
             squeezed = True
             x = input.unsqueeze(0)

--- a/src/tileops/ops/pool.py
+++ b/src/tileops/ops/pool.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import ClassVar, Dict, Optional, Tuple
+from typing import Any, ClassVar, Dict, Optional, Tuple
 
 import torch
 
@@ -140,13 +140,19 @@ class MeanPoolingForwardOp(Op):
         self._kernel_params = params
         self.dispatch_kernel(kernel_map)
 
-    def _get_kernel(self, dtype: torch.dtype) -> Kernel:
+    def _get_kernel(
+        self,
+        x: torch.Tensor,
+        offsets: torch.Tensor,
+        indices: torch.Tensor,
+    ) -> Kernel:
         return self.get_or_build_kernel(
             "mean_pooling_fwd_kernel",
-            key=dtype,
+            (x, offsets, indices),
+            key=x.dtype,
             build=lambda: self.kernel_map["mean_pooling_fwd_kernel"](
                 **self._kernel_params,
-                dtype=dtype,
+                dtype=x.dtype,
             ),
         )
 
@@ -160,8 +166,10 @@ class MeanPoolingForwardOp(Op):
         offsets: torch.Tensor,
         indices: torch.Tensor,
     ) -> torch.Tensor:
+        kernel = self._get_kernel(x, offsets, indices)
+        out = kernel(x, offsets, indices=indices)
         self.dtype = x.dtype
-        return self._get_kernel(x.dtype)(x, offsets, indices=indices)
+        return out
 
 
 def _device_index(tensor: torch.Tensor) -> int | None:
@@ -196,6 +204,13 @@ class _AvgPoolFwdOpBase(Op):
     """
 
     ndim: ClassVar[int]
+    #: Average pooling has one output; the registration below reads this.
+    _returns_indices: ClassVar[bool] = False
+
+    #: This op's operator, and its name; both set by the registrations at the bottom of
+    #: this module, one per concrete op class.
+    _wrapped: ClassVar[Any]
+    compile_op_names: ClassVar[Tuple[str, ...]] = ()
 
     def __init__(
         self,
@@ -275,8 +290,6 @@ class _AvgPoolFwdOpBase(Op):
                 f"{type(self).__name__} expects input to be a {nd + 2}D {_POOL_LAYOUTS[nd]} tensor"
             )
         n, c_in, *in_dims = input.shape
-        if not input.is_cuda:
-            raise ValueError("input must be a CUDA tensor")
         self._validate_dtypes(input)
         ks, st, pd = self._param_tuples()
         out_dims = tuple(
@@ -292,6 +305,7 @@ class _AvgPoolFwdOpBase(Op):
 
     def _get_kernel(
         self,
+        input: torch.Tensor,
         n: int,
         c_in: int,
         in_dims: Tuple[int, ...],
@@ -333,7 +347,7 @@ class _AvgPoolFwdOpBase(Op):
                     kernel_kwargs["divisor_override"] = self.divisor_override
             return self.kernel_map[kernel_name](**kernel_kwargs)
 
-        return self.get_or_build_kernel(kernel_name, key=key, build=build)
+        return self.get_or_build_kernel(kernel_name, (input,), key=key, build=build)
 
     def _infer_output_shapes(self, input_shape: tuple[int, ...]) -> Dict[str, tuple[int, ...]]:
         nd = self.ndim
@@ -355,7 +369,7 @@ class _AvgPoolFwdOpBase(Op):
         return {"output": (n, c_in, *out_dims)}
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
-        return _pool_fwd(input, self._instance_key)
+        return type(self)._wrapped(input, self._instance_key)
 
     def _eager_forward(self, input: torch.Tensor) -> torch.Tensor:
         resolved = self._resolve_input(input)
@@ -365,7 +379,10 @@ class _AvgPoolFwdOpBase(Op):
         in_dims = resolved[2 : 2 + nd]
         out_dims = resolved[2 + nd : 2 + 2 * nd]
         dtype = resolved[-1]
-        kernel = self._get_kernel(n, c_in, in_dims, dtype, _device_index(input))
+        kernel = self._get_kernel(input, n, c_in, in_dims, dtype, _device_index(input))
+        out = kernel(input)
+        # Recorded after the launch: eval_roofline and profiling read these, and a call that
+        # raised described nothing.
         self.kernel = kernel
         self.n = n
         self.c_in = c_in
@@ -375,7 +392,7 @@ class _AvgPoolFwdOpBase(Op):
             setattr(self, f"out_{name}", size)
         self.dtype = dtype
         self._last_roofline_spec = resolved
-        return kernel(input)
+        return out
 
 
 class AvgPool1dFwdOp(_AvgPoolFwdOpBase):
@@ -529,6 +546,11 @@ class _MaxPoolFwdOpBase(Op):
     _kernel_slot: ClassVar[str] = ""
     _returns_indices: ClassVar[bool] = False
 
+    #: This op's operator, and its name; both set by the registrations at the bottom of
+    #: this module, one per concrete op class.
+    _wrapped: ClassVar[Any]
+    compile_op_names: ClassVar[Tuple[str, ...]] = ()
+
     def __init__(
         self,
         kernel_size: int | Tuple[int, ...],
@@ -577,8 +599,6 @@ class _MaxPoolFwdOpBase(Op):
                 f"{nd + 2}D {_POOL_LAYOUTS[nd]} tensor"
             )
         n, c_in, *in_dims = input.shape
-        if not input.is_cuda:
-            raise ValueError("input must be a CUDA tensor")
         self._validate_dtypes(input)
         out_dims = tuple(
             pool_output_dim(
@@ -600,6 +620,7 @@ class _MaxPoolFwdOpBase(Op):
 
     def _get_kernel(
         self,
+        input: torch.Tensor,
         n: int,
         c_in: int,
         in_dims: Tuple[int, ...],
@@ -637,7 +658,7 @@ class _MaxPoolFwdOpBase(Op):
                 kernel_kwargs[f"dilation_{name}"] = self.dilation[k]
             return self.kernel_map[self._kernel_slot](**kernel_kwargs)
 
-        return self.get_or_build_kernel(self._kernel_slot, key=key, build=build)
+        return self.get_or_build_kernel(self._kernel_slot, (input,), key=key, build=build)
 
     def _infer_output_shapes(self, input_shape: tuple[int, ...]) -> Dict[str, tuple[int, ...]]:
         nd = self.ndim
@@ -666,7 +687,7 @@ class _MaxPoolFwdOpBase(Op):
         return {"output": full}
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
-        return _pool_fwd(input, self._instance_key)
+        return type(self)._wrapped(input, self._instance_key)
 
     def _eager_forward(self, input: torch.Tensor):
         resolved = self._resolve_input(input)
@@ -676,7 +697,10 @@ class _MaxPoolFwdOpBase(Op):
         in_dims = resolved[2 : 2 + nd]
         out_dims = resolved[2 + nd : 2 + 2 * nd]
         dtype = resolved[-1]
-        kernel = self._get_kernel(n, c_in, in_dims, dtype, _device_index(input))
+        kernel = self._get_kernel(input, n, c_in, in_dims, dtype, _device_index(input))
+        out = kernel(input)
+        # Recorded after the launch: eval_roofline and profiling read these, and a call that
+        # raised described nothing.
         self.kernel = kernel
         self.n = n
         self.c_in = c_in
@@ -686,7 +710,7 @@ class _MaxPoolFwdOpBase(Op):
             setattr(self, f"out_{name}", size)
         self.dtype = dtype
         self._last_roofline_spec = resolved
-        return kernel(input)
+        return out
 
 
 class MaxPool1dFwdOp(_MaxPoolFwdOpBase):
@@ -761,7 +785,7 @@ class MaxPool1dIndicesFwdOp(_MaxPoolFwdOpBase):
         }
 
     def forward(self, input: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-        return _pool_fwd_with_indices(input, self._instance_key)
+        return type(self)._wrapped(input, self._instance_key)
 
     def eval_roofline(self) -> tuple[int, int]:
         return _max_pool_roofline(self, indices=True)
@@ -839,7 +863,7 @@ class MaxPool2dIndicesFwdOp(_MaxPoolFwdOpBase):
         }
 
     def forward(self, input: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-        return _pool_fwd_with_indices(input, self._instance_key)
+        return type(self)._wrapped(input, self._instance_key)
 
     def eval_roofline(self) -> tuple[int, int]:
         return _max_pool_roofline(self, indices=True)
@@ -917,7 +941,7 @@ class MaxPool3dIndicesFwdOp(_MaxPoolFwdOpBase):
         }
 
     def forward(self, input: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-        return _pool_fwd_with_indices(input, self._instance_key)
+        return type(self)._wrapped(input, self._instance_key)
 
     def eval_roofline(self) -> tuple[int, int]:
         return _max_pool_roofline(self, indices=True)
@@ -1046,6 +1070,11 @@ class _AdaptivePool2dFwdOpBase(Op):
     _kernel_slot: ClassVar[str] = ""
     _returns_indices: ClassVar[bool] = False
 
+    #: This op's operator, and its name; both set by the registrations at the bottom of
+    #: this module, one per concrete op class.
+    _wrapped: ClassVar[Any]
+    compile_op_names: ClassVar[Tuple[str, ...]] = ()
+
     def __init__(
         self,
         output_size: int | None | Tuple[Optional[int], Optional[int]],
@@ -1091,7 +1120,7 @@ class _AdaptivePool2dFwdOpBase(Op):
         return {"output": full}
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
-        return _pool_fwd(input, self._instance_key)
+        return type(self)._wrapped(input, self._instance_key)
 
     def _eager_forward(self, input: torch.Tensor):
         if input.ndim == 3:
@@ -1104,8 +1133,6 @@ class _AdaptivePool2dFwdOpBase(Op):
             raise ValueError(
                 f"{type(self).__name__} expects input to be a 3D CHW or 4D NCHW tensor"
             )
-        if not x.is_cuda:
-            raise ValueError("input must be a CUDA tensor")
         self._validate_dtypes(x)
         n, c_in, h_in, w_in = x.shape
         out_h, out_w = self._resolve_out_dims(h_in, w_in)
@@ -1114,6 +1141,7 @@ class _AdaptivePool2dFwdOpBase(Op):
         key = (n, c_in, h_in, w_in, out_h, out_w, dtype, _device_index(x), self.tune)
         kernel = self.get_or_build_kernel(
             self._kernel_slot,
+            (x,),
             key=key,
             build=lambda: self.kernel_map[self._kernel_slot](
                 n=n,
@@ -1126,6 +1154,9 @@ class _AdaptivePool2dFwdOpBase(Op):
                 tune=self.tune,
             ),
         )
+        result = kernel(x)
+        # Recorded after the launch: eval_roofline and profiling read these, and a call that
+        # raised described nothing.
         self.kernel = kernel
         self.n = n
         self.c_in = c_in
@@ -1136,14 +1167,13 @@ class _AdaptivePool2dFwdOpBase(Op):
         self.dtype = dtype
         self._last_roofline_spec = (n, c_in, h_in, w_in, out_h, out_w, dtype)
         if self._returns_indices:
-            out, indices = kernel(x)
+            out, indices = result
             if squeezed:
                 return out.squeeze(0), indices.squeeze(0)
             return out, indices
-        out = kernel(x)
         if squeezed:
-            return out.squeeze(0)
-        return out
+            return result.squeeze(0)
+        return result
 
 
 class AdaptiveAvgPool2dFwdOp(_AdaptivePool2dFwdOpBase):
@@ -1216,43 +1246,67 @@ class AdaptiveMaxPool2dIndicesFwdOp(_AdaptivePool2dFwdOpBase):
         }
 
     def forward(self, input: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-        return _pool_fwd_with_indices(input, self._instance_key)
+        return type(self)._wrapped(input, self._instance_key)
 
     def eval_roofline(self) -> tuple[int, int]:
         return _adaptive_pool2d_roofline(self, indices=True)
 
 
-# torch.compile dispatch boundary (see src/tileops/ops/compile_boundary.py)
+# The compile boundary: one operator per concrete op class, registered at import time.
+# The op's key crosses it, and the body trades the key back for the instance — see
+# src/tileops/ops/compile_boundary.py. Per class rather than per family, so the name a
+# traced graph carries identifies the op that produced it, and a target that replaces one
+# pool op leaves what the others' graphs hold alone.
 
 
-@torch.library.custom_op("top::pool_fwd", mutates_args=())
-def _pool_fwd(input: torch.Tensor, instance_key: str) -> torch.Tensor:
-    return get_instance(instance_key)._eager_forward(input)
+def _register_pool_operator(op_cls: type, name: str) -> None:
+    """Register *name* as *op_cls*'s operator and record it on the class."""
+    if op_cls._returns_indices:
+
+        @torch.library.custom_op(name, mutates_args=())
+        def _fwd(input: torch.Tensor, instance_key: str) -> Tuple[torch.Tensor, torch.Tensor]:
+            return get_instance(instance_key)._eager_forward(input)
+
+        @_fwd.register_fake
+        def _fwd_fake(
+            input: torch.Tensor,
+            instance_key: str,
+        ) -> Tuple[torch.Tensor, torch.Tensor]:
+            shapes = get_instance(instance_key)._infer_output_shapes(tuple(input.shape))
+            # ``new_empty``, not ``empty_like``: ``_eager_forward`` normalizes contiguity, so
+            # a non-contiguous input's strides must not survive into the fake.
+            return (
+                input.new_empty(shapes["output"]),
+                input.new_empty(shapes["indices"], dtype=torch.int64),
+            )
+
+    else:
+
+        @torch.library.custom_op(name, mutates_args=())
+        def _fwd(input: torch.Tensor, instance_key: str) -> torch.Tensor:  # noqa: F811
+            return get_instance(instance_key)._eager_forward(input)
+
+        @_fwd.register_fake
+        def _fwd_fake(input: torch.Tensor, instance_key: str) -> torch.Tensor:  # noqa: F811
+            shapes = get_instance(instance_key)._infer_output_shapes(tuple(input.shape))
+            return input.new_empty(shapes["output"])
+
+    op_cls._wrapped = _fwd
+    op_cls.compile_op_names = (name,)
 
 
-@_pool_fwd.register_fake
-def _pool_fwd_fake(input: torch.Tensor, instance_key: str) -> torch.Tensor:
-    op = get_instance(instance_key)
-    shapes = op._infer_output_shapes(tuple(input.shape))
-    return input.new_empty(shapes["output"])
-
-
-@torch.library.custom_op("top::pool_fwd_with_indices", mutates_args=())
-def _pool_fwd_with_indices(
-    input: torch.Tensor,
-    instance_key: str,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    return get_instance(instance_key)._eager_forward(input)
-
-
-@_pool_fwd_with_indices.register_fake
-def _pool_fwd_with_indices_fake(
-    input: torch.Tensor,
-    instance_key: str,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    op = get_instance(instance_key)
-    shapes = op._infer_output_shapes(tuple(input.shape))
-    return (
-        input.new_empty(shapes["output"]),
-        input.new_empty(shapes["indices"], dtype=torch.int64),
-    )
+for _op_cls, _op_name in (
+    (AvgPool1dFwdOp, "top::pool_avg_pool1d_fwd"),
+    (AvgPool2dFwdOp, "top::pool_avg_pool2d_fwd"),
+    (AvgPool3dFwdOp, "top::pool_avg_pool3d_fwd"),
+    (MaxPool1dFwdOp, "top::pool_max_pool1d_fwd"),
+    (MaxPool2dFwdOp, "top::pool_max_pool2d_fwd"),
+    (MaxPool3dFwdOp, "top::pool_max_pool3d_fwd"),
+    (MaxPool1dIndicesFwdOp, "top::pool_max_pool1d_indices_fwd"),
+    (MaxPool2dIndicesFwdOp, "top::pool_max_pool2d_indices_fwd"),
+    (MaxPool3dIndicesFwdOp, "top::pool_max_pool3d_indices_fwd"),
+    (AdaptiveAvgPool2dFwdOp, "top::pool_adaptive_avg_pool2d_fwd"),
+    (AdaptiveMaxPool2dFwdOp, "top::pool_adaptive_max_pool2d_fwd"),
+    (AdaptiveMaxPool2dIndicesFwdOp, "top::pool_adaptive_max_pool2d_indices_fwd"),
+):
+    _register_pool_operator(_op_cls, _op_name)

--- a/tests/compile_contract.py
+++ b/tests/compile_contract.py
@@ -19,6 +19,7 @@ import torch
 # Modules whose import populates the registry. Add a module here when it
 # gains contract-backing compile tests.
 _EVIDENCE_MODULES = (
+    "tests.ops.test_convolution",
     "tests.ops.test_elementwise_compile",
     "tests.ops.test_moe_compile",
     "tests.ops.test_pool",

--- a/tests/ops/test_convolution.py
+++ b/tests/ops/test_convolution.py
@@ -667,6 +667,25 @@ def test_conv2d_no_bias_grouped_matches_torch() -> None:
 
 
 @pytest.mark.smoke
+@pytest.mark.parametrize("use_bias", [False, True], ids=["no-bias", "bias"])
+def test_conv2d_depthwise_dispatches_the_direct_kernel(use_bias: bool) -> None:
+    """One channel per group is a GEMM with M=1, so it gets a direct kernel instead."""
+    channels = 32
+    op = Conv2dFwdOp(padding=1, groups=channels)
+    x = torch.randn(1, channels, 28, 28, device="cuda", dtype=torch.float16).contiguous()
+    weight = torch.randn(channels, 1, 3, 3, device="cuda", dtype=torch.float16).contiguous()
+    bias = (
+        torch.randn(channels, device="cuda", dtype=torch.float16).contiguous() if use_bias else None
+    )
+
+    out = op(x, weight, bias)
+
+    assert isinstance(op.kernel, GroupConv2dKernel) and op.kernel.use_direct
+    ref = F.conv2d(x, weight, bias=bias, padding=1, groups=channels).contiguous()
+    torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
+
+
+@pytest.mark.smoke
 def test_conv2d_dispatches_1x1_kernel() -> None:
     op = Conv2dFwdOp()
     x = torch.randn(1, 32, 32, 32, device="cuda", dtype=torch.float16).contiguous()
@@ -1025,6 +1044,17 @@ def test_a_kernel_built_without_a_bias_refuses_one() -> None:
 
     with pytest.raises(ValueError, match="built without a bias"):
         kernel(x, weight, bias)
+
+
+@pytest.mark.smoke
+def test_inputs_on_different_devices_are_rejected() -> None:
+    """The kernel memo lets the first input's device speak for the rest, so they agree."""
+    op = Conv2dFwdOp(padding=1)
+    x = torch.randn(1, 8, 8, 8, device="cuda", dtype=torch.float16).contiguous()
+    weight = torch.randn(4, 8, 3, 3, dtype=torch.float16).contiguous()
+
+    with pytest.raises(ValueError, match="every input on cuda"):
+        op(x, weight)
 
 
 # --------------------------------------------------------------------------------------

--- a/tests/ops/test_convolution.py
+++ b/tests/ops/test_convolution.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
+from tests.compile_contract import assert_op_owns_graph_nodes, register_compile_contract
 from tests.test_base import FixtureBase, TestBase
 from tileops.kernels.convolution import (
     Conv1dKernel,
@@ -19,6 +20,9 @@ from tileops.ops import (
     Conv3dFwdOp,
 )
 from workloads.convolution import Conv1dWorkload, Conv2dWorkload, Conv3dWorkload
+
+for _op_cls in (Conv1dFwdOp, Conv2dFwdOp, Conv3dFwdOp):
+    register_compile_contract(_op_cls)
 
 
 class Conv1dFixture(FixtureBase):
@@ -351,8 +355,10 @@ def test_conv1d_dispatches_kernel(
     )
     x = torch.randn(1, 32, 256, device="cuda", dtype=torch.float16).contiguous()
     weight = torch.randn(64, 32, kernel_size, device="cuda", dtype=torch.float16).contiguous()
-    op(x, weight)
+    out = op(x, weight)
     assert isinstance(op.kernel, expected_kernel)
+    ref = F.conv1d(x, weight, bias=None, stride=stride, padding=padding, dilation=dilation)
+    torch.testing.assert_close(out, ref.contiguous(), atol=1e-3, rtol=1e-3)
 
 
 class Conv2dFixture(FixtureBase):
@@ -665,8 +671,10 @@ def test_conv2d_dispatches_1x1_kernel() -> None:
     op = Conv2dFwdOp()
     x = torch.randn(1, 32, 32, 32, device="cuda", dtype=torch.float16).contiguous()
     weight = torch.randn(64, 32, 1, 1, device="cuda", dtype=torch.float16).contiguous()
-    op(x, weight)
+    out = op(x, weight)
     assert isinstance(op.kernel, Conv2d1x1Kernel)
+    ref = F.conv2d(x, weight, bias=None, padding=0)
+    torch.testing.assert_close(out, ref.contiguous(), atol=1e-3, rtol=1e-3)
 
 
 @pytest.mark.smoke
@@ -686,8 +694,10 @@ def test_conv2d_dispatches_3x3_kernel() -> None:
     op = Conv2dFwdOp(padding=1)
     x = torch.randn(1, 32, 32, 32, device="cuda", dtype=torch.float16).contiguous()
     weight = torch.randn(64, 32, 3, 3, device="cuda", dtype=torch.float16).contiguous()
-    op(x, weight)
+    out = op(x, weight)
     assert isinstance(op.kernel, Conv2dSymmetricKernel)
+    ref = F.conv2d(x, weight, bias=None, padding=1)
+    torch.testing.assert_close(out, ref.contiguous(), atol=1e-3, rtol=1e-3)
 
 
 @pytest.mark.smoke
@@ -695,8 +705,10 @@ def test_conv2d_dispatches_5x5_kernel() -> None:
     op = Conv2dFwdOp(padding=2)
     x = torch.randn(1, 32, 32, 32, device="cuda", dtype=torch.float16).contiguous()
     weight = torch.randn(64, 32, 5, 5, device="cuda", dtype=torch.float16).contiguous()
-    op(x, weight)
+    out = op(x, weight)
     assert isinstance(op.kernel, Conv2dSymmetricKernel)
+    ref = F.conv2d(x, weight, bias=None, padding=2)
+    torch.testing.assert_close(out, ref.contiguous(), atol=1e-3, rtol=1e-3)
 
 
 class Conv3dFixture(FixtureBase):
@@ -971,6 +983,106 @@ def test_conv2d_dynamic_shape_kernel_cache_and_roofline() -> None:
 
     op(x2, w2)
     assert len(list(op.iter_kernels())) == 2
+
+
+@pytest.mark.smoke
+def test_conv1d_depthwise_no_bias_matches_torch() -> None:
+    """The depthwise-direct path is the one Conv1d variant no other no-bias case reaches."""
+    groups = 32
+    op = Conv1dFwdOp(padding=1, groups=groups)
+    x = torch.randn(1, groups, 128, device="cuda", dtype=torch.float16).contiguous()
+    weight = torch.randn(groups, 1, 3, device="cuda", dtype=torch.float16).contiguous()
+
+    out = op(x, weight)
+
+    assert isinstance(op.kernel, GroupConv1dKernel) and op.kernel.use_direct
+    ref = F.conv1d(x, weight, bias=None, padding=1, groups=groups).contiguous()
+    torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
+
+
+@pytest.mark.smoke
+def test_a_kernel_built_without_a_bias_refuses_one() -> None:
+    """Bias presence is compiled in, so the two sides are different programs.
+
+    Built directly: through the op the two always agree, so this guard has no op-level
+    entry point.
+    """
+    kernel = Conv2d1x1Kernel(
+        n=1,
+        c_in=32,
+        h=8,
+        w=8,
+        c_out=32,
+        stride_h=1,
+        stride_w=1,
+        pad_h=0,
+        pad_w=0,
+        dtype=torch.float16,
+    )
+    x = torch.randn(1, 32, 8, 8, device="cuda", dtype=torch.float16).contiguous()
+    weight = torch.randn(32, 32, 1, 1, device="cuda", dtype=torch.float16).contiguous()
+    bias = torch.randn(32, device="cuda", dtype=torch.float16).contiguous()
+
+    with pytest.raises(ValueError, match="built without a bias"):
+        kernel(x, weight, bias)
+
+
+# --------------------------------------------------------------------------------------
+# The compile boundary: the node in the graph is the op's, whichever target serves it
+# --------------------------------------------------------------------------------------
+
+
+@pytest.mark.smoke
+@pytest.mark.usefixtures("isolated_dynamo")
+@pytest.mark.parametrize("use_bias", [False, True], ids=["no-bias", "bias"])
+def test_conv2d_cold_traces_fullgraph_and_owns_its_graph_nodes(use_bias: bool) -> None:
+    """Cold is the whole contract: a warm op has nothing left for dynamo to trace into."""
+    op = Conv2dFwdOp(padding=1)
+    x = torch.randn(1, 32, 16, 16, device="cuda", dtype=torch.float16).contiguous()
+    weight = torch.randn(64, 32, 3, 3, device="cuda", dtype=torch.float16).contiguous()
+    bias = torch.randn(64, device="cuda", dtype=torch.float16).contiguous() if use_bias else None
+
+    assert_op_owns_graph_nodes(op, x, weight, bias)
+    torch.testing.assert_close(
+        torch.compile(op, fullgraph=True)(x, weight, bias), op(x, weight, bias)
+    )
+
+
+@pytest.mark.smoke
+@pytest.mark.usefixtures("isolated_dynamo")
+def test_conv1d_cold_traces_fullgraph_and_owns_its_graph_nodes() -> None:
+    op = Conv1dFwdOp(padding=1)
+    x = torch.randn(1, 32, 128, device="cuda", dtype=torch.float16).contiguous()
+    weight = torch.randn(64, 32, 3, device="cuda", dtype=torch.float16).contiguous()
+
+    assert_op_owns_graph_nodes(op, x, weight, None)
+    torch.testing.assert_close(torch.compile(op, fullgraph=True)(x, weight), op(x, weight))
+
+
+@pytest.mark.smoke
+@pytest.mark.usefixtures("isolated_dynamo")
+def test_conv3d_cold_traces_fullgraph_and_owns_its_graph_nodes() -> None:
+    op = Conv3dFwdOp(padding=1)
+    x = torch.randn(1, 16, 8, 8, 8, device="cuda", dtype=torch.float16).contiguous()
+    weight = torch.randn(32, 16, 3, 3, 3, device="cuda", dtype=torch.float16).contiguous()
+
+    assert_op_owns_graph_nodes(op, x, weight, None)
+    torch.testing.assert_close(torch.compile(op, fullgraph=True)(x, weight), op(x, weight))
+
+
+@pytest.mark.smoke
+@pytest.mark.usefixtures("isolated_dynamo")
+def test_a_non_contiguous_input_compiles_to_the_shape_the_fake_promised() -> None:
+    """The fake speaks before the body normalizes contiguity, so it promises contiguous."""
+    op = Conv2dFwdOp(padding=1)
+    x = torch.randn(1, 32, 16, 32, device="cuda", dtype=torch.float16)[:, :, :, ::2]
+    weight = torch.randn(64, 32, 3, 3, device="cuda", dtype=torch.float16).contiguous()
+    assert not x.is_contiguous()
+
+    output = torch.compile(op, fullgraph=True)(x, weight)
+
+    assert output.is_contiguous()
+    torch.testing.assert_close(output, op(x, weight))
 
 
 if __name__ == "__main__":

--- a/tests/ops/test_pool.py
+++ b/tests/ops/test_pool.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from tests.compile_contract import register_compile_contract
+from tests.compile_contract import assert_op_owns_graph_nodes, register_compile_contract
 from tests.test_base import FixtureBase, TestBase
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.pool import (
@@ -1809,7 +1809,7 @@ _MAX_POOL_INVALID_INPUT_CASES = [
         1,
         {"kernel_size": 3},
         ((1, 1, 8), None),
-        "input must be a CUDA tensor",
+        "is a CUDA kernel",
         False,
         id="1d-cpu-input",
         marks=pytest.mark.full,
@@ -1837,7 +1837,7 @@ _MAX_POOL_INVALID_INPUT_CASES = [
         2,
         {"kernel_size": (3, 3)},
         ((1, 1, 8, 8), None),
-        "input must be a CUDA tensor",
+        "is a CUDA kernel",
         False,
         id="2d-cpu-input",
         marks=pytest.mark.full,
@@ -1865,7 +1865,7 @@ _MAX_POOL_INVALID_INPUT_CASES = [
         3,
         {"kernel_size": 3},
         ((1, 1, 4, 8, 8), None),
-        "input must be a CUDA tensor",
+        "is a CUDA kernel",
         False,
         id="3d-cpu-input",
         marks=pytest.mark.full,
@@ -2002,6 +2002,7 @@ def test_max_pool_compile_fullgraph(
         torch.testing.assert_close(out[1], ref[1], atol=0, rtol=0)
     else:
         torch.testing.assert_close(out, ref, atol=0, rtol=0)
+    assert_op_owns_graph_nodes(op, x)
 
 
 # ---------------------------------------------------------------------------
@@ -2116,6 +2117,7 @@ def test_avg_pool_compile_fullgraph(op_cls: type, x_shape: tuple) -> None:
     out = compiled(x)
     ref = getattr(F, f"avg_pool{dims}d")(x, 2, 2, 0)
     torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
+    assert_op_owns_graph_nodes(op, x)
 
 
 # ---------------------------------------------------------------------------
@@ -2674,6 +2676,7 @@ def test_adaptive_pool_compile_fullgraph(
     else:
         ref = F.adaptive_max_pool2d(x, (4, 4))
         torch.testing.assert_close(out, ref, atol=0, rtol=0)
+    assert_op_owns_graph_nodes(op, x)
 
 
 @pytest.mark.smoke

--- a/tests/ops/test_pool.py
+++ b/tests/ops/test_pool.py
@@ -2132,6 +2132,7 @@ _AVG_POOL_CTOR_PARAMS_1D = (
     ("padding", 0),
     ("ceil_mode", False),
     ("count_include_pad", True),
+    ("target", None),
     ("kernel_map", None),
     ("tune", False),
 )
@@ -2143,6 +2144,7 @@ _AVG_POOL_CTOR_PARAMS_ND = (
     ("ceil_mode", False),
     ("count_include_pad", True),
     ("divisor_override", None),
+    ("target", None),
     ("kernel_map", None),
     ("tune", False),
 )
@@ -2153,6 +2155,7 @@ _MAX_POOL_CTOR_PARAMS = (
     ("padding", 0),
     ("dilation", 1),
     ("ceil_mode", False),
+    ("target", None),
     ("kernel_map", None),
     ("tune", False),
 )

--- a/tests/test_op_backend_seam.py
+++ b/tests/test_op_backend_seam.py
@@ -10,6 +10,7 @@ import pytest
 import torch
 
 from tileops.backend import BUILTIN, OpNotAvailableError, TensorSpec, registry
+from tileops.ops.convolution import Conv2dFwdOp
 from tileops.ops.norm.rms_norm import RMSNormFwdOp
 
 pytestmark = pytest.mark.smoke
@@ -449,3 +450,78 @@ def test_an_elementwise_op_without_a_builder_for_this_target_raises():
 
     with pytest.raises(OpNotAvailableError, match="registers no kernel builder"):
         SiluFwdOp()(torch.randn(4, 8, dtype=DTYPE))
+
+
+# --------------------------------------------------------------------------------------
+# An optional input at the seam: Conv2dFwdOp's bias
+# --------------------------------------------------------------------------------------
+
+
+class _ConvRecorder:
+    """A target for Conv2dFwdOp; its kernel takes whatever the op hands over."""
+
+    def __init__(self):
+        self.calls = []
+
+    def build_kernel(self, *inputs, **params):
+        self.calls.append((inputs, params))
+
+        def kernel(x, weight, bias=None):
+            assert x.is_contiguous() and weight.is_contiguous()
+            return torch.zeros(x.shape[0], weight.shape[0], x.shape[2], x.shape[3], dtype=x.dtype)
+
+        return kernel
+
+
+def _conv_inputs(bias=False):
+    x = torch.randn(1, 8, 8, 8, dtype=DTYPE)
+    weight = torch.randn(4, 8, 3, 3, dtype=DTYPE)
+    return x, weight, (torch.randn(4, dtype=DTYPE) if bias else None)
+
+
+def test_a_missing_optional_input_is_absent_from_the_hand_over():
+    """Presence is what the backend reads; an absent bias is not a placeholder tensor."""
+    recorder = _ConvRecorder()
+    _register(recorder, op="Conv2dFwdOp")
+    x, weight, _ = _conv_inputs()
+
+    Conv2dFwdOp(padding=1)(x, weight)
+
+    ((inputs, params),) = recorder.calls
+    assert inputs == (TensorSpec.of(x), TensorSpec.of(weight)), "signature.inputs order"
+    assert params == {"stride": (1, 1), "padding": 1, "dilation": (1, 1), "groups": 1}
+
+
+def test_a_bias_that_is_passed_reaches_the_backend_as_a_third_spec():
+    recorder = _ConvRecorder()
+    _register(recorder, op="Conv2dFwdOp")
+    x, weight, bias = _conv_inputs(bias=True)
+
+    Conv2dFwdOp(padding=1)(x, weight, bias)
+
+    ((inputs, _),) = recorder.calls
+    assert inputs == (TensorSpec.of(x), TensorSpec.of(weight), TensorSpec.of(bias))
+
+
+def test_the_two_sides_of_an_optional_input_are_two_kernels():
+    """Bias presence changes what a kernel is built for, so it is part of the signature."""
+    recorder = _ConvRecorder()
+    _register(recorder, op="Conv2dFwdOp")
+    op = Conv2dFwdOp(padding=1)
+    x, weight, bias = _conv_inputs(bias=True)
+
+    op(x, weight)
+    op(x, weight, bias)
+    op(x, weight)
+
+    assert len(recorder.calls) == 2
+
+
+def test_a_rejected_conv_call_never_reaches_the_backend():
+    recorder = _ConvRecorder()
+    _register(recorder, op="Conv2dFwdOp")
+    x, weight, _ = _conv_inputs()
+
+    with pytest.raises(ValueError, match="bias shape"):
+        Conv2dFwdOp(padding=1)(x, weight, torch.randn(999, dtype=DTYPE))
+    assert recorder.calls == [], "the op layer's checks run for every target"

--- a/tests/test_op_backend_seam.py
+++ b/tests/test_op_backend_seam.py
@@ -12,6 +12,7 @@ import torch
 from tileops.backend import BUILTIN, OpNotAvailableError, TensorSpec, registry
 from tileops.ops.convolution import Conv2dFwdOp
 from tileops.ops.norm.rms_norm import RMSNormFwdOp
+from tileops.ops.pool import MaxPool2dFwdOp
 
 pytestmark = pytest.mark.smoke
 
@@ -530,3 +531,44 @@ def test_a_rejected_conv_call_never_reaches_the_backend():
     with pytest.raises(ValueError, match="bias shape"):
         Conv2dFwdOp(padding=1)(x, weight, torch.randn(999, dtype=DTYPE))
     assert recorder.calls == [], "the op layer's checks run for every target"
+
+
+# --------------------------------------------------------------------------------------
+# An explicit target: MaxPool2dFwdOp
+# --------------------------------------------------------------------------------------
+
+
+class _PoolRecorder:
+    """A target for MaxPool2dFwdOp; its kernel takes the one input the op hands over."""
+
+    def __init__(self):
+        self.calls = []
+
+    def build_kernel(self, *inputs, **params):
+        self.calls.append((inputs, params))
+
+        def kernel(x):
+            assert x.is_contiguous()
+            return torch.full((x.shape[0], x.shape[1], 4, 4), 7, dtype=x.dtype)
+
+        return kernel
+
+
+def test_an_explicit_target_serves_a_pool_op_no_detector_claims_the_device():
+    """``target=`` is the override, so it routes with nothing claiming the device."""
+    recorder = _PoolRecorder()
+    _register(recorder, op="MaxPool2dFwdOp", claims=False)
+    x = torch.randn(1, 4, 8, 8, dtype=DTYPE)
+
+    out = MaxPool2dFwdOp(kernel_size=2, target="acme")(x)
+
+    ((inputs, params),) = recorder.calls
+    assert inputs == (TensorSpec.of(x),), "signature.inputs order"
+    assert params == {
+        "kernel_size": (2, 2),
+        "stride": (2, 2),
+        "padding": (0, 0),
+        "dilation": (1, 1),
+        "ceil_mode": False,
+    }
+    assert torch.equal(out, torch.full_like(out, 7)), "the target's kernel produced the result"

--- a/tests/test_op_backend_seam.py
+++ b/tests/test_op_backend_seam.py
@@ -479,8 +479,13 @@ def _conv_inputs(bias=False):
     return x, weight, (torch.randn(4, dtype=DTYPE) if bias else None)
 
 
-def test_a_missing_optional_input_is_absent_from_the_hand_over():
-    """Presence is what the backend reads; an absent bias is not a placeholder tensor."""
+def test_a_missing_optional_input_keeps_its_place_in_the_hand_over():
+    """Presence is what the backend reads, and it reads it off the argument.
+
+    One argument per ``signature.inputs`` entry: a bias this call did not pass is ``None``
+    there. Dropping the argument would leave the count to say what is missing, which it
+    cannot do for an op with two optional inputs.
+    """
     recorder = _ConvRecorder()
     _register(recorder, op="Conv2dFwdOp")
     x, weight, _ = _conv_inputs()
@@ -488,7 +493,7 @@ def test_a_missing_optional_input_is_absent_from_the_hand_over():
     Conv2dFwdOp(padding=1)(x, weight)
 
     ((inputs, params),) = recorder.calls
-    assert inputs == (TensorSpec.of(x), TensorSpec.of(weight)), "signature.inputs order"
+    assert inputs == (TensorSpec.of(x), TensorSpec.of(weight), None), "signature.inputs order"
     assert params == {"stride": (1, 1), "padding": 1, "dilation": (1, 1), "groups": 1}
 
 


### PR DESCRIPTION
Supersedes #1938. Closes #1937.

## Problems

- The conv and pool ops handed over no tensors and took no `target=`, so no target could serve them, and the node a traced graph carried belonged to a kernel (conv) or to a whole family (pool).
- `bias` was a mandatory prim_func parameter: every no-bias call allocated `torch.zeros(C_out)` and paid a launch to add zeros.
- Depthwise Conv2d ran the grouped GEMM with `M = 1` against a 64-row tile, and the grouped kernels staged their weight tile element by element.

## Changes

- Conv1d/2d/3d and the twelve pool ops each register one operator with a manifest-driven fake, hand over `signature.inputs` in order, normalize contiguity, and take a keyword-only `target=`. The kernel-level `custom_op`s — ten conv, fifteen pool — and the two shared pool operators are deleted: one compile boundary per family, and it belongs to the op.
- Bias is optional end to end: two prim_func signatures over one `@T.macro` body selected by `has_bias` at trace time, presence in the kernel cache key, and a kernel that refuses a call built for the other side. An absent `bias` crosses to a builder as `None` in its own argument, not as a shorter argument list — with two optional inputs the count cannot say which one is missing.
- Depthwise Conv2d gets a direct multiply-accumulate kernel, and the grouped kernels lay `k` out in the weight's own order, which makes the weight staging a tile copy.
- Inputs on different devices are rejected before kernel selection, the CUDA requirement moves into the pool kernels, and call state is recorded after the launch returns rather than before.
- `torch_compile_fullgraph: true` on the conv entries, backed by a cold fullgraph test per dimension; those and the three pool fullgraph tests assert the graph holds nothing but the op's own node.
- `MeanPoolingForwardOp` stays in-tree: it has no manifest entry, so a target's builder could not be told what to build.
- Test nodes: `tests/ops/test_convolution.py` +9, `tests/test_op_backend_seam.py` +5.

## Performance

H200, dev runner image, autotune on, all 57 conv workloads, `device_busy_ms`, baseline `main` at 50e3fe58. Every no-bias row drops one launch — the zero-bias fill, present in 31 of the 57 rows. No row regresses. Pool is measured too, since it loses its kernel-level operators: 96 rows against `main`, none slower.

| workload | dtype | bias | before (ms) | after (ms) | delta |
|---|---|---|---|---|---|
| Conv2d (1,32,56,56) depthwise | float16 | no | 0.00760 | 0.00230 | -69.7% |
| Conv2d (1,128,28,28) grouped | float16 | no | 0.00500 | 0.00340 | -32.0% |
| Conv1d (1,1,24000) | float16 | no | 0.00440 | 0.00300 | -31.8% |
| Conv3d (1,3,16,112,112) | float16 | no | 0.02380 | 0.01890 | -20.6% |
| Conv3d (1,32,32,64,64) | bfloat16 | yes | 0.35500 | 0.28920 | -18.5% |

Conv1d keeps its original k order: laying it over `(c_in, kernel_l)` to make the weight staging a tile copy cost 49% on `(1,128,600)`.

## Not in this PR

- Route the general Conv2d/Conv3d staging through `T.im2col` the way the symmetric path does — needs the NHWC transform on those paths.
- Decide what float32 conv should do about TF32; it changes numerics, so it needs a tolerance decision first.
- Kernel constructors still take launch-time sizes, so a decode-shaped sweep rebuilds a kernel per size.
