### PR TITLE
[Perf][Autotune] Refuse to tune integer inputs TileLang would randomise

### DIFF
--- a/.claude/domain-rules/ops-design.md
+++ b/.claude/domain-rules/ops-design.md
@@ -25,3 +25,5 @@
 - Inline roofline state contract: for every `signature.inputs` / `signature.params` name **referenced** by the op's manifest `roofline` expressions, the op exposes it on `self`. Inputs: `self.<input>` with `.shape` and `.ndim`, OR `self.<input>_shape` as a shape tuple/list. Params: `self.<param>`. Unreferenced names need not be exposed. See [docs/design/roofline.md §4.4.3](../../docs/design/roofline.md).
 
 - Dynamo-traced `forward` MUST NOT construct a `Kernel` or enter a TileLang builder; call-time kernel resolution goes through the compile dispatch boundary. See [ops-design.md](../../docs/design/ops-design.md#compile-dispatch-boundary).
+
+- A kernel whose integer tensor inputs decide how much work it runs supplies them through `autotune_supply_prog`; one whose integer inputs are data or masks sets `autotune_accepts_random_int_inputs = True` with the reason. `tune_jit_kernel` refuses the unanswered case. **Why:** TileLang generates an unsupplied integer tensor from `randint(-2, 3)`, so every candidate times a collapsed kernel.

--- a/docs/design/ops-design-reference.md
+++ b/docs/design/ops-design-reference.md
@@ -53,13 +53,14 @@ Rationale and the role / entry vocabulary: [ops-design.md § Kernel caching and 
 
 Unlike `Op`, a `Kernel` **is** constructed for one element type — it compiles a dtype-specialized program, so `dtype` is a ctor argument here. The op supplies it from the tensors at `forward()`.
 
-| Attribute          | Type                    | Purpose                                        |
-| ------------------ | ----------------------- | ---------------------------------------------- |
-| `dtype`            | `Optional[torch.dtype]` | Element type this kernel is specialized for    |
-| `config`           | `Dict[str, Any]`        | Tile configuration (block sizes, stages, etc.) |
-| `autotune_configs` | `Optional[list[dict]]`  | Search space for autotuning                    |
-| `supported_archs`  | `Optional[list[int]]`   | GPU SM versions (e.g., `[80, 86, 89, 90]`)     |
-| `kernel`           | `Callable`              | Compiled TileLang kernel function              |
+| Attribute                            | Type                    | Purpose                                                             |
+| ------------------------------------ | ----------------------- | ------------------------------------------------------------------- |
+| `dtype`                              | `Optional[torch.dtype]` | Element type this kernel is specialized for                         |
+| `config`                             | `Dict[str, Any]`        | Tile configuration (block sizes, stages, etc.)                      |
+| `autotune_configs`                   | `Optional[list[dict]]`  | Search space for autotuning                                         |
+| `supported_archs`                    | `Optional[list[int]]`   | GPU SM versions (e.g., `[80, 86, 89, 90]`)                          |
+| `kernel`                             | `Callable`              | Compiled TileLang kernel function                                   |
+| `autotune_accepts_random_int_inputs` | `bool`                  | Whether autotuning may generate the integer tensor inputs at random |
 
 Abstract interface: `forward()`. Key methods: `init_config(config, tune)`, `autotune(warmup, rep)`.
 

--- a/src/tileops/kernels/elementwise.py
+++ b/src/tileops/kernels/elementwise.py
@@ -781,6 +781,12 @@ class UnaryKernel(Kernel):
             within the resolved strategy).
     """
 
+    #: Elementwise work is sized by the tensor shape, never by a value: an
+    #: integer operand is data and a ``uint8`` ``cond``/``mask`` selects a result
+    #: after the element is already visited. Random values change what a
+    #: candidate computes, not how much of it.
+    autotune_accepts_random_int_inputs: bool = True
+
     supported_archs: list[int] = [80, 86, 89, 90]
     STRATEGIES = ["direct", "explicit_parallel", "register_copy"]
     # Benchmark (H200): register_copy wins for fp16/bf16 across all tested shapes;
@@ -999,6 +1005,12 @@ class BinaryKernel(Kernel):
         out_shape: Broadcast output shape.
         N_total: Total output elements.
     """
+
+    #: Elementwise work is sized by the tensor shape, never by a value: an
+    #: integer operand is data and a ``uint8`` ``cond``/``mask`` selects a result
+    #: after the element is already visited. Random values change what a
+    #: candidate computes, not how much of it.
+    autotune_accepts_random_int_inputs: bool = True
 
     supported_archs: list[int] = [80, 86, 89, 90]
     STRATEGIES = ["direct", "explicit_parallel", "register_copy"]
@@ -1254,6 +1266,12 @@ class FusedGatedKernel(Kernel):
         tune: Whether to autotune (sweeps "threads" / "num_per_thread"
             within the resolved strategy).
     """
+
+    #: Elementwise work is sized by the tensor shape, never by a value: an
+    #: integer operand is data and a ``uint8`` ``cond``/``mask`` selects a result
+    #: after the element is already visited. Random values change what a
+    #: candidate computes, not how much of it.
+    autotune_accepts_random_int_inputs: bool = True
 
     supported_archs: list[int] = [80, 86, 89, 90]
     STRATEGIES = ["direct", "explicit_parallel"]

--- a/src/tileops/kernels/elementwise.py
+++ b/src/tileops/kernels/elementwise.py
@@ -781,10 +781,8 @@ class UnaryKernel(Kernel):
             within the resolved strategy).
     """
 
-    #: Elementwise work is sized by the tensor shape, never by a value: an
-    #: integer operand is data and a ``uint8`` ``cond``/``mask`` selects a result
-    #: after the element is already visited. Random values change what a
-    #: candidate computes, not how much of it.
+    #: Elementwise work is sized by the tensor shape: an integer operand is
+    #: data, and a ``uint8`` ``cond``/``mask`` only selects a result.
     autotune_accepts_random_int_inputs: bool = True
 
     supported_archs: list[int] = [80, 86, 89, 90]
@@ -1006,10 +1004,8 @@ class BinaryKernel(Kernel):
         N_total: Total output elements.
     """
 
-    #: Elementwise work is sized by the tensor shape, never by a value: an
-    #: integer operand is data and a ``uint8`` ``cond``/``mask`` selects a result
-    #: after the element is already visited. Random values change what a
-    #: candidate computes, not how much of it.
+    #: Elementwise work is sized by the tensor shape: an integer operand is
+    #: data, and a ``uint8`` ``cond``/``mask`` only selects a result.
     autotune_accepts_random_int_inputs: bool = True
 
     supported_archs: list[int] = [80, 86, 89, 90]
@@ -1267,10 +1263,8 @@ class FusedGatedKernel(Kernel):
             within the resolved strategy).
     """
 
-    #: Elementwise work is sized by the tensor shape, never by a value: an
-    #: integer operand is data and a ``uint8`` ``cond``/``mask`` selects a result
-    #: after the element is already visited. Random values change what a
-    #: candidate computes, not how much of it.
+    #: Elementwise work is sized by the tensor shape: an integer operand is
+    #: data, and a ``uint8`` ``cond``/``mask`` only selects a result.
     autotune_accepts_random_int_inputs: bool = True
 
     supported_archs: list[int] = [80, 86, 89, 90]

--- a/src/tileops/kernels/gemm_w4a16_decode.py
+++ b/src/tileops/kernels/gemm_w4a16_decode.py
@@ -134,9 +134,8 @@ def _gemm_w4a16_decode_kernel(n: int, k: int, dtype: str) -> Callable:
 class GemmW4A16DecodeKernel(Kernel):
     """Fuse nibble unpacking, affine dequantization, and the M=1 GEMV."""
 
-    #: ``packed_weight`` and ``weight_zero`` are uint8 payloads the kernel
-    #: unpacks; the K loop is ``k // block_k``, so no value decides how much work
-    #: a candidate runs.
+    #: ``packed_weight`` and ``weight_zero`` are uint8 payloads; the K loop is
+    #: ``k // block_k``.
     autotune_accepts_random_int_inputs: bool = True
 
     supported_archs: list[int] = [80, 86, 89, 90]

--- a/src/tileops/kernels/gemm_w4a16_decode.py
+++ b/src/tileops/kernels/gemm_w4a16_decode.py
@@ -134,6 +134,11 @@ def _gemm_w4a16_decode_kernel(n: int, k: int, dtype: str) -> Callable:
 class GemmW4A16DecodeKernel(Kernel):
     """Fuse nibble unpacking, affine dequantization, and the M=1 GEMV."""
 
+    #: ``packed_weight`` and ``weight_zero`` are uint8 payloads the kernel
+    #: unpacks; the K loop is ``k // block_k``, so no value decides how much work
+    #: a candidate runs.
+    autotune_accepts_random_int_inputs: bool = True
+
     supported_archs: list[int] = [80, 86, 89, 90]
 
     @classmethod

--- a/src/tileops/kernels/grouped_gemm/grouped_gemm.py
+++ b/src/tileops/kernels/grouped_gemm/grouped_gemm.py
@@ -237,6 +237,56 @@ class GroupedGemmKernel(Kernel):
         self.init_config(config, tune)
 
     @property
+    def autotune_supply_prog(self):
+        """Supply autotuning the batch metadata a real call carries.
+
+        TileLang fills an int32 parameter from ``randint(-2, 3)``, and both
+        templates read a group's row count out of that metadata, so candidates
+        would time an almost empty kernel and the winner would be noise. Both
+        offset vectors take the tight prefix sum, which puts
+        ``batch_padded_offsets[-1] + batch_sizes[-1]`` at ``batch_sum``.
+        """
+        from tilelang.utils.device import get_current_device
+        from tilelang.utils.tensor import get_tensor_supply
+
+        default_supply = get_tensor_supply(tilelang.TensorSupplyType.Auto)
+        batch_count = self.batch_count
+        base, extra = divmod(self.batch_sum, batch_count)
+
+        def supply_prog(params):
+            device = get_current_device()
+            sizes = torch.full((batch_count,), base, dtype=torch.int32, device=device)
+            sizes[:extra] += 1
+            offsets = torch.zeros(batch_count, dtype=torch.int32, device=device)
+            offsets[1:] = torch.cumsum(sizes[:-1], dim=0)
+
+            # Matched by position among themselves, because the prim_func takes
+            # batch_sizes, then batch_offsets, then batch_padded_offsets. A
+            # fourth such parameter would otherwise be handed offsets and tune
+            # against a plausible but wrong tensor, so the count is checked.
+            is_metadata = [
+                str(p.dtype) == "int32" and list(p.shape) == [batch_count] for p in params
+            ]
+            if sum(is_metadata) != 3:
+                raise RuntimeError(
+                    f"autotuning {type(self).__name__} expects 3 int32 [{batch_count}] "
+                    f"parameters (batch_sizes, batch_offsets, batch_padded_offsets), "
+                    f"got {sum(is_metadata)}"
+                )
+
+            seen = 0
+            inputs = []
+            for param, metadata in zip(params, is_metadata, strict=True):
+                if metadata:
+                    inputs.append(sizes if seen == 0 else offsets)
+                    seen += 1
+                else:
+                    inputs.append(default_supply(param))
+            return inputs
+
+        return supply_prog
+
+    @property
     def default_config(self) -> dict:
         return _DEFAULT_CONFIGS[(self.transpose_a, self.transpose_b)]
 

--- a/src/tileops/kernels/grouped_gemm/grouped_gemm.py
+++ b/src/tileops/kernels/grouped_gemm/grouped_gemm.py
@@ -240,11 +240,10 @@ class GroupedGemmKernel(Kernel):
     def autotune_supply_prog(self):
         """Supply autotuning the batch metadata a real call carries.
 
-        TileLang fills an int32 parameter from ``randint(-2, 3)``, and both
-        templates read a group's row count out of that metadata, so candidates
-        would time an almost empty kernel and the winner would be noise. Both
-        offset vectors take the tight prefix sum, which puts
-        ``batch_padded_offsets[-1] + batch_sizes[-1]`` at ``batch_sum``.
+        Both templates read a group's row count out of this metadata. Both offset
+        vectors take the tight prefix sum, which puts
+        ``batch_padded_offsets[-1] + batch_sizes[-1]`` at ``batch_sum`` and so
+        keeps every tile in the K-loop.
         """
         from tilelang.utils.device import get_current_device
         from tilelang.utils.tensor import get_tensor_supply
@@ -260,10 +259,8 @@ class GroupedGemmKernel(Kernel):
             offsets = torch.zeros(batch_count, dtype=torch.int32, device=device)
             offsets[1:] = torch.cumsum(sizes[:-1], dim=0)
 
-            # Matched by position among themselves, because the prim_func takes
-            # batch_sizes, then batch_offsets, then batch_padded_offsets. A
-            # fourth such parameter would otherwise be handed offsets and tune
-            # against a plausible but wrong tensor, so the count is checked.
+            # Matched by position among themselves: the prim_func takes
+            # batch_sizes, then batch_offsets, then batch_padded_offsets.
             is_metadata = [
                 str(p.dtype) == "int32" and list(p.shape) == [batch_count] for p in params
             ]

--- a/src/tileops/kernels/kernel_base.py
+++ b/src/tileops/kernels/kernel_base.py
@@ -12,13 +12,9 @@ _INHERIT_SUPPLY_PROG = object()
 def _int_tensor_input_names(jit_kernel: Any, seeds: Dict[str, Any]) -> list[str]:
     """Integer tensor parameters *jit_kernel* takes as inputs, outputs excluded.
 
-    Reads the TIR rather than compiling: ``get_tir`` elaborates the PrimFunc for
-    one config, which is what carries the parameter dtypes.
-
     Raises:
-        ValueError: When the parameters cannot be read. Unread parameters are
-            unproven, not proven safe, so the caller refuses rather than
-            assuming the generated inputs are harmless.
+        ValueError: When the parameters cannot be read, which the caller treats
+            as unproven rather than safe.
     """
     get_tir = getattr(jit_kernel, "get_tir", None)
     if not callable(get_tir):
@@ -62,14 +58,10 @@ class Kernel(ABC):
         self._check_arch()
         self.config = {}
 
-    #: Whether autotuning may generate this kernel's integer tensor inputs at
-    #: random. TileLang's supplier fills an integer tensor from
-    #: ``randint(-2, 3)``, which shrinks the work when a value is a row count, a
-    #: slice bound or a loop trip count: every candidate then times a collapsed
-    #: kernel and the winner is measurement noise. Left False, because answering
-    #: by omission is what makes that silent. A kernel whose integer inputs are
-    #: ordinary data, or a mask read after the work is already sized, says so
-    #: here; one whose values decide the work supplies them instead.
+    #: Set True when this kernel's integer tensor inputs are data or masks, so
+    #: autotuning may generate them from ``randint(-2, 3)``. A kernel whose
+    #: integer values decide how much work runs overrides
+    #: ``autotune_supply_prog`` instead; left False, autotuning refuses.
     autotune_accepts_random_int_inputs: bool = False
 
     #: Whether this implementation is the one behind the specialised ones.
@@ -267,11 +259,6 @@ class Kernel(ABC):
 
     def _refuse_random_int_inputs(self, jit_kernel: Callable, seeds: Dict[str, Any]) -> None:
         """Refuse to tune *jit_kernel* on integer inputs TileLang would randomise.
-
-        Only the kernel knows which of its integer inputs decide how much work
-        runs, so the base class asks for an answer rather than guessing one. What
-        it can establish is narrower: an integer tensor input exists, and nothing
-        supplies it.
 
         Raises:
             ValueError: When the kernel takes integer tensor inputs, supplies

--- a/src/tileops/kernels/kernel_base.py
+++ b/src/tileops/kernels/kernel_base.py
@@ -9,6 +9,43 @@ from tilelang.autotuner import autotune
 _INHERIT_SUPPLY_PROG = object()
 
 
+def _int_tensor_input_names(jit_kernel: Any, seeds: Dict[str, Any]) -> list[str]:
+    """Integer tensor parameters *jit_kernel* takes as inputs, outputs excluded.
+
+    Reads the TIR rather than compiling: ``get_tir`` elaborates the PrimFunc for
+    one config, which is what carries the parameter dtypes.
+
+    Raises:
+        ValueError: When the parameters cannot be read. Unread parameters are
+            unproven, not proven safe, so the caller refuses rather than
+            assuming the generated inputs are harmless.
+    """
+    get_tir = getattr(jit_kernel, "get_tir", None)
+    if not callable(get_tir):
+        raise ValueError(
+            f"{jit_kernel!r} does not expose get_tir, so its parameters cannot be read"
+        )
+    try:
+        prim_func = get_tir(**seeds)
+    except Exception as exc:
+        raise ValueError(f"the parameters of {jit_kernel!r} cannot be read: {exc}") from exc
+
+    out_idx = getattr(jit_kernel, "out_idx", None) or []
+    if isinstance(out_idx, int):
+        out_idx = [out_idx]
+    count = len(prim_func.params)
+    outputs = {i + count if i < 0 else i for i in out_idx}
+
+    names = []
+    for i, param in enumerate(prim_func.params):
+        if i in outputs:
+            continue
+        buffer = prim_func.buffer_map.get(param)
+        if buffer is not None and "int" in str(buffer.dtype):
+            names.append(str(param.name))
+    return names
+
+
 class Kernel(ABC):
     dtype: Optional[torch.dtype] = None
     config: Dict[str, Any]
@@ -24,6 +61,16 @@ class Kernel(ABC):
     def __init__(self, *args, **kwargs) -> None:
         self._check_arch()
         self.config = {}
+
+    #: Whether autotuning may generate this kernel's integer tensor inputs at
+    #: random. TileLang's supplier fills an integer tensor from
+    #: ``randint(-2, 3)``, which shrinks the work when a value is a row count, a
+    #: slice bound or a loop trip count: every candidate then times a collapsed
+    #: kernel and the winner is measurement noise. Left False, because answering
+    #: by omission is what makes that silent. A kernel whose integer inputs are
+    #: ordinary data, or a mask read after the work is already sized, says so
+    #: here; one whose values decide the work supplies them instead.
+    autotune_accepts_random_int_inputs: bool = False
 
     #: Whether this implementation is the one behind the specialised ones.
     #: A dispatch key may have at most one general implementation applying to a
@@ -218,6 +265,31 @@ class Kernel(ABC):
     ) -> Any:
         return autotuned_kernel_fn(**self._autotune_initial_kwargs(kernel=kernel, config=config))
 
+    def _refuse_random_int_inputs(self, jit_kernel: Callable, seeds: Dict[str, Any]) -> None:
+        """Refuse to tune *jit_kernel* on integer inputs TileLang would randomise.
+
+        Only the kernel knows which of its integer inputs decide how much work
+        runs, so the base class asks for an answer rather than guessing one. What
+        it can establish is narrower: an integer tensor input exists, and nothing
+        supplies it.
+
+        Raises:
+            ValueError: When the kernel takes integer tensor inputs, supplies
+                none of them, and has not declared random values safe.
+        """
+        if self.autotune_accepts_random_int_inputs:
+            return
+        names = _int_tensor_input_names(jit_kernel, seeds)
+        if not names:
+            return
+        raise ValueError(
+            f"{type(self).__name__} autotunes with integer tensor inputs "
+            f"{', '.join(names)} and no supply_prog, so TileLang would generate them "
+            f"from randint(-2, 3). Override autotune_supply_prog to build them, or set "
+            f"autotune_accepts_random_int_inputs = True where random values cannot "
+            f"change what the candidates measure."
+        )
+
     def tune_jit_kernel(
         self,
         jit_kernel: Callable,
@@ -261,6 +333,8 @@ class Kernel(ABC):
             supply_prog = self.autotune_supply_prog
         if supply_prog is not None:
             autotune_kwargs["supply_prog"] = supply_prog
+        else:
+            self._refuse_random_int_inputs(jit_kernel, seeds)
         autotuned_kernel_fn = autotune(**autotune_kwargs)(jit_kernel)
 
         return self._call_autotuned_kernel(autotuned_kernel_fn, jit_kernel, seed_config)

--- a/src/tileops/kernels/mamba/ssd_chunk_state.py
+++ b/src/tileops/kernels/mamba/ssd_chunk_state.py
@@ -357,6 +357,11 @@ class SSDChunkStateFwdKernel(Kernel):
 
     supported_archs: list[int] = [80, 86, 89, 90]
 
+    #: ``seq_idx`` masks contributions; it does not size them. The K-loop trip
+    #: count comes from the chunk length, so random values change which elements
+    #: are zeroed and not how much work a candidate runs.
+    autotune_accepts_random_int_inputs: bool = True
+
     def __init__(
         self,
         batch: int,

--- a/src/tileops/kernels/mamba/ssd_chunk_state.py
+++ b/src/tileops/kernels/mamba/ssd_chunk_state.py
@@ -357,9 +357,8 @@ class SSDChunkStateFwdKernel(Kernel):
 
     supported_archs: list[int] = [80, 86, 89, 90]
 
-    #: ``seq_idx`` masks contributions; it does not size them. The K-loop trip
-    #: count comes from the chunk length, so random values change which elements
-    #: are zeroed and not how much work a candidate runs.
+    #: ``seq_idx`` masks contributions; the trip count comes from the chunk
+    #: length.
     autotune_accepts_random_int_inputs: bool = True
 
     def __init__(

--- a/src/tileops/kernels/pool/mean_pooling.py
+++ b/src/tileops/kernels/pool/mean_pooling.py
@@ -189,11 +189,9 @@ class MeanPoolingFwdKernel(Kernel):
     def autotune_supply_prog(self):
         """Supply autotuning the chunk map a real call carries.
 
-        ``offsets`` and ``indices`` place every chunk: the kernel takes its token
-        range from ``offsets[seq_id]`` and ``offsets[seq_id + 1]`` and divides the
-        sum by that range's length. Values from TileLang's random supplier leave
-        the range empty or inverted, so candidates time a kernel that pools
-        nothing and the winner is measurement noise.
+        The kernel takes each chunk's token range from ``offsets[seq_id]`` and
+        ``offsets[seq_id + 1]`` and divides by that range's length, so random
+        values leave it empty or inverted.
         """
         from tilelang.utils.device import get_current_device
         from tilelang.utils.tensor import get_tensor_supply
@@ -204,9 +202,8 @@ class MeanPoolingFwdKernel(Kernel):
 
         def supply_prog(params):
             device = get_current_device()
-            # Sequences split the tokens evenly, and chunk slots run through each
-            # sequence in turn. A slot past the last sequence clamps onto it and
-            # repeats an earlier chunk, which measures the same amount of work.
+            # Sequences split the tokens evenly; a slot past the last sequence
+            # clamps onto it and repeats a chunk of the same size.
             bounds = torch.linspace(0, seq_len, seq_num + 1, device=device).to(torch.int32)
             per_seq = max(1, seq_len // seq_num)
             chunks_per_seq = max(1, (per_seq + chunk_size - 1) // chunk_size)

--- a/src/tileops/kernels/pool/mean_pooling.py
+++ b/src/tileops/kernels/pool/mean_pooling.py
@@ -186,6 +186,60 @@ class MeanPoolingFwdKernel(Kernel):
         self.init_config(config, tune)
 
     @property
+    def autotune_supply_prog(self):
+        """Supply autotuning the chunk map a real call carries.
+
+        ``offsets`` and ``indices`` place every chunk: the kernel takes its token
+        range from ``offsets[seq_id]`` and ``offsets[seq_id + 1]`` and divides the
+        sum by that range's length. Values from TileLang's random supplier leave
+        the range empty or inverted, so candidates time a kernel that pools
+        nothing and the winner is measurement noise.
+        """
+        from tilelang.utils.device import get_current_device
+        from tilelang.utils.tensor import get_tensor_supply
+
+        default_supply = get_tensor_supply(tilelang.TensorSupplyType.Auto)
+        seq_len, seq_num = self.seq_len, self.seq_num
+        chunk_size, chunks_per_batch = self.chunk_size, self.chunks_per_batch
+
+        def supply_prog(params):
+            device = get_current_device()
+            # Sequences split the tokens evenly, and chunk slots run through each
+            # sequence in turn. A slot past the last sequence clamps onto it and
+            # repeats an earlier chunk, which measures the same amount of work.
+            bounds = torch.linspace(0, seq_len, seq_num + 1, device=device).to(torch.int32)
+            per_seq = max(1, seq_len // seq_num)
+            chunks_per_seq = max(1, (per_seq + chunk_size - 1) // chunk_size)
+            slots = torch.arange(chunks_per_batch, device=device)
+            indices = torch.stack(
+                ((slots // chunks_per_seq).clamp(max=seq_num - 1), slots % chunks_per_seq),
+                dim=1,
+            ).to(torch.int32)
+
+            supplied = []
+            matched = 0
+            for param in params:
+                shape = list(param.shape)
+                if str(param.dtype) != "int32":
+                    supplied.append(default_supply(param))
+                elif shape == [seq_num + 1]:
+                    supplied.append(bounds)
+                    matched += 1
+                elif shape == [chunks_per_batch, 2]:
+                    supplied.append(indices)
+                    matched += 1
+                else:
+                    supplied.append(default_supply(param))
+            if matched != 2:
+                raise RuntimeError(
+                    f"autotuning {type(self).__name__} expects int32 offsets "
+                    f"[{seq_num + 1}] and indices [{chunks_per_batch}, 2], matched {matched}"
+                )
+            return supplied
+
+        return supply_prog
+
+    @property
     def default_config(self) -> dict:
         return {
             "bdim": 128,

--- a/tests/kernels/test_kernel_autotune_binding.py
+++ b/tests/kernels/test_kernel_autotune_binding.py
@@ -8,8 +8,20 @@ from tileops.kernels.kernel_base import Kernel
 pytestmark = pytest.mark.smoke
 
 
+class _FakePrimFunc:
+    """A PrimFunc taking no tensor parameters."""
+
+    params: tuple = ()
+    buffer_map: dict = {}
+
+
 class _FakeJit:
     signature = inspect.signature(lambda block_m, threads: None)
+    out_idx = None
+
+    @staticmethod
+    def get_tir(**config):
+        return _FakePrimFunc()
 
 
 class _FakeAliasedJit:

--- a/tests/kernels/test_kernel_autotune_binding.py
+++ b/tests/kernels/test_kernel_autotune_binding.py
@@ -8,11 +8,37 @@ from tileops.kernels.kernel_base import Kernel
 pytestmark = pytest.mark.smoke
 
 
+class _FakeVar:
+    """A PrimFunc parameter, which carries its name like a TIR ``Var``."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _FakeBuffer:
+    def __init__(self, dtype: str) -> None:
+        self.dtype = dtype
+
+
 class _FakePrimFunc:
     """A PrimFunc taking no tensor parameters."""
 
     params: tuple = ()
     buffer_map: dict = {}
+
+
+_X, _SIZES, _OUT = _FakeVar("x"), _FakeVar("sizes"), _FakeVar("out")
+
+
+class _FakeIntPrimFunc:
+    """A PrimFunc taking one float input, one int input, and a float output."""
+
+    params = (_X, _SIZES, _OUT)
+    buffer_map = {
+        _X: _FakeBuffer("float16"),
+        _SIZES: _FakeBuffer("int32"),
+        _OUT: _FakeBuffer("float16"),
+    }
 
 
 class _FakeJit:
@@ -102,3 +128,45 @@ def test_autotune_initial_kwargs_support_common_jit_param_aliases():
     )
 
     assert captured == {"threads_arg": 128, "npt_arg": 4}
+
+
+class _FakeIntJit(_FakeJit):
+    out_idx = [-1]
+
+    @staticmethod
+    def get_tir(**config):
+        return _FakeIntPrimFunc()
+
+
+class _KernelWithIntInputs(_KernelWithRequiredTunables):
+    """A kernel whose JIT builder takes an integer tensor input."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.kernel = _FakeIntJit()
+
+
+def test_autotune_refuses_integer_inputs_no_supplier_would_supply():
+    """Random integer metadata makes every candidate time a collapsed kernel."""
+    with pytest.raises(ValueError, match="integer tensor inputs sizes"):
+        _KernelWithIntInputs().autotune()
+
+
+def test_autotune_accepts_random_integer_inputs_when_declared(monkeypatch):
+    """A kernel whose integer inputs are data says so and tunes as before."""
+
+    def fake_autotune(**autotune_kwargs):
+        def decorate(kernel):
+            def wrapped(**kwargs):
+                return _TunedKernel()
+
+            return wrapped
+
+        return decorate
+
+    monkeypatch.setattr(kernel_base, "autotune", fake_autotune)
+    kernel = _KernelWithIntInputs()
+    kernel.autotune_accepts_random_int_inputs = True
+    kernel.autotune()
+
+    assert kernel.config == _TunedKernel.config

--- a/tests/kernels/test_linear_attn_autotune.py
+++ b/tests/kernels/test_linear_attn_autotune.py
@@ -412,7 +412,3 @@ def test_tune_true_reaches_the_sweep(monkeypatch, kernel_cls) -> None:
 
     assert calls == [kernel_cls.__name__]
     assert kernel.autotune_configs == la.delta_rule_fwd_autotune_configs(64)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/attention/test_deepseek_dsa_decode.py
+++ b/tests/ops/attention/test_deepseek_dsa_decode.py
@@ -99,7 +99,3 @@ def test_sparse_mla_decode(
         tune=tune,
     )
     test.check(op, *test.gen_inputs(), atol=3e-4, rtol=1e-5)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/attention/test_deepseek_mla_decode.py
+++ b/tests/ops/attention/test_deepseek_mla_decode.py
@@ -39,7 +39,3 @@ def test_mla_decode(
         batch, heads, heads_kv, seq_len_kv, dim, dim_pe, tune=tune
     )
     test.check(op, *test.gen_inputs(), atol=1e-3, rtol=1e-3)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/attention/test_deepseek_nsa.py
+++ b/tests/ops/attention/test_deepseek_nsa.py
@@ -113,7 +113,3 @@ def test_nsa_varlen_op(
     }
     op = NSAFwdVarlenOp(**params)
     test.check(op, *test.gen_inputs(), atol=5e-4, rtol=1e-5)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/attention/test_deepseek_nsa_cmp.py
+++ b/tests/ops/attention/test_deepseek_nsa_cmp.py
@@ -73,7 +73,3 @@ def test_nsa_cmp_fwd_varlen_op(
         chunk_num=test.chunk_num,
     )
     test.check(op, *inputs, atol=4e-3, rtol=1e-5)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/attention/test_deepseek_nsa_topk.py
+++ b/tests/ops/attention/test_deepseek_nsa_topk.py
@@ -114,7 +114,3 @@ def test_nsa_topk_varlen_op(
         chunk_num=test.chunk_num,
     )
     test.check_topk(op, *inputs)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/attention/test_gqa.py
+++ b/tests/ops/attention/test_gqa.py
@@ -1243,7 +1243,3 @@ def test_gqa_prefill_dense_build_threads_q_and_kv_lengths_apart() -> None:
 
     assert kernel.kwargs["max_seqlen_q"] == max_seqlen_q
     assert kernel.kwargs["max_seqlen_kv"] == max_seqlen_kv
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/attention/test_gqa_decode.py
+++ b/tests/ops/attention/test_gqa_decode.py
@@ -164,7 +164,3 @@ def test_gqa_decode_bs1_group4() -> None:
     assert op._get_kernel(torch.float16).__class__.__name__ == "GQADecodeBs1Kernel"
     test = GroupedQueryAttentionDecodeTest(1, 32, 8, 4096, 128, torch.float16)
     test.check(op, *test.gen_inputs(), atol=1e-2, rtol=1e-2)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/attention/test_gqa_decode_paged.py
+++ b/tests/ops/attention/test_gqa_decode_paged.py
@@ -270,7 +270,3 @@ def test_gqa_decode_paged_bs1_dispatch_fallbacks(
         batch, 32, 4, seqlen_kv, dim, page_size, softcap=softcap
     )
     assert op._get_kernel(dtype).__class__.__name__ == "GQADecodePagedKernel"
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/attention/test_gqa_sliding_window.py
+++ b/tests/ops/attention/test_gqa_sliding_window.py
@@ -243,7 +243,3 @@ class TestGroupedQueryAttentionSlidingWindowFwdOpValidation:
         v = torch.randn(1, 64, 2, 64, dtype=torch.float16)
         with pytest.raises(ValueError, match="cuda"):
             float16_op.forward(q, k, v)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/attention/test_gqa_sliding_window_varlen.py
+++ b/tests/ops/attention/test_gqa_sliding_window_varlen.py
@@ -330,10 +330,6 @@ def test_gqa_sliding_window_varlen_fwd_op(
     test.check(op, *test.gen_inputs(), atol=1e-2, rtol=1e-2)
 
 
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])
-
-
 # ----------------------------------------------------------------------
 # Visible-score accounting for the packed-varlen and sliding-window GQA rooflines.
 # ----------------------------------------------------------------------

--- a/tests/ops/attention/test_mha.py
+++ b/tests/ops/attention/test_mha.py
@@ -231,7 +231,3 @@ def test_mha_bwd(
     test = MhaBwdTest(batch, heads, seq_len, dim, causal, dtype)
     op = MultiHeadAttentionBwdOp(batch, heads, seq_len, dim, causal, tune=tune)
     test.check(op, *test.gen_inputs(), atol=5e-3, rtol=1e-5)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/attention/test_mha_decode.py
+++ b/tests/ops/attention/test_mha_decode.py
@@ -30,7 +30,3 @@ def test_mha_decode(
     test = MhaDecodeTest(b, h, s_q, s_kv, d, dtype)
     op = MultiHeadAttentionDecodeWithKVCacheFwdOp(b, h, s_q, s_kv, d, tune=tune)
     test.check(op, *test.gen_inputs(), atol=2e-3, rtol=1e-5)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/attention/test_mha_decode_paged.py
+++ b/tests/ops/attention/test_mha_decode_paged.py
@@ -177,7 +177,3 @@ def test_mha_decode_paged_dispatch_declines_multi_token_query() -> None:
     )
     key = op.select_kernel_key(MHA_PAGED_DECODE_KEYS, op._attention_call(torch.float16))
     assert key == "mha_decode_paged_kernel"
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_activation.py
+++ b/tests/ops/test_activation.py
@@ -372,7 +372,3 @@ def test_independent_activation_rejects_non_float_dtype() -> None:
 
     with pytest.raises(ValueError, match="only supports dtypes"):
         LeakyReluFwdKernel(N_total=16, dtype=torch.int32)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_ada_layer_norm.py
+++ b/tests/ops/test_ada_layer_norm.py
@@ -189,7 +189,3 @@ def test_ada_layer_norm_3d(batch: int, seq: int, hidden: int, dtype: torch.dtype
     assert torch.allclose(y, y_ref, atol=atol, rtol=rtol), (
         f"3D test failed, max err: {(y - y_ref).abs().max()}"
     )
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_ada_layer_norm_zero.py
+++ b/tests/ops/test_ada_layer_norm_zero.py
@@ -132,7 +132,3 @@ def test_ada_layer_norm_zero_3d(batch: int, seq: int, hidden: int, dtype: torch.
     assert torch.allclose(y, y_ref, atol=atol, rtol=rtol), (
         f"3D test failed, max err: {(y - y_ref).abs().max()}"
     )
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_argreduce.py
+++ b/tests/ops/test_argreduce.py
@@ -707,7 +707,3 @@ def test_argreduce_tuning_space_matches_its_kernel(
     assert kernel.default_config in kernel.autotune_configs, (
         "tuning cannot be worse than not tuning: the default must be a candidate"
     )
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_batch_norm.py
+++ b/tests/ops/test_batch_norm.py
@@ -172,7 +172,3 @@ def test_batch_norm_fwd_returns_single_tensor() -> None:
     y = op(x, rm, rv, weight, bias)
     assert isinstance(y, torch.Tensor)
     assert y.shape == x.shape
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_binary_arith.py
+++ b/tests/ops/test_binary_arith.py
@@ -1234,7 +1234,3 @@ def test_add_bool_broadcast() -> None:
     with torch.no_grad():
         out = op(a, b)
     _exact_compare(out, ref)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_bitwise.py
+++ b/tests/ops/test_bitwise.py
@@ -270,7 +270,3 @@ def test_bitwise_binary_rejects_float_dtype(op_cls, dtype: torch.dtype) -> None:
     x = torch.zeros(shape, device="cuda", dtype=dtype)
     with pytest.raises(ValueError, match="has dtype|does not support dtype"):
         op(x, x)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_bmm.py
+++ b/tests/ops/test_bmm.py
@@ -457,7 +457,3 @@ def test_bmm_fp8_persistent_default_tile_boundary() -> None:
     b_f = b_kn.float() * scale_b
     ref = torch.bmm(a_f, b_f).to(torch.bfloat16)
     torch.testing.assert_close(out, ref, atol=0.05, rtol=0.05)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_comparison.py
+++ b/tests/ops/test_comparison.py
@@ -392,7 +392,3 @@ def test_comparison_rejects_unsupported_dtype(
     x = torch.zeros(shape, device="cuda", dtype=dtype)
     with pytest.raises(ValueError, match="has dtype|does not support dtype"):
         op(x, x)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_convolution.py
+++ b/tests/ops/test_convolution.py
@@ -1113,7 +1113,3 @@ def test_a_non_contiguous_input_compiles_to_the_shape_the_fake_promised() -> Non
 
     assert output.is_contiguous()
     torch.testing.assert_close(output, op(x, weight))
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_cumulative.py
+++ b/tests/ops/test_cumulative.py
@@ -374,7 +374,3 @@ def test_cumsum_compile_fullgraph_warm_cache(M: int, N: int, dtype: torch.dtype)
     assert torch.allclose(y, ref, **_tol(dtype)), (
         f"Compiled output mismatch for shape ({M},{N}): max_diff={torch.abs(y - ref).max()}"
     )
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_deltanet_chunkwise_bwd.py
+++ b/tests/ops/test_deltanet_chunkwise_bwd.py
@@ -134,7 +134,3 @@ def test_deltanet_bwd(
             **tols,
             msg=lambda m, n=name: f"{n}: {m}",
         )
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_deltanet_fwd.py
+++ b/tests/ops/test_deltanet_fwd.py
@@ -77,7 +77,3 @@ def test_deltanet_fwd(
         # The forward above already proves the selected config builds and runs;
         # this pins it to the declared candidate set the sweep draws from.
         assert op.kernel.config in op.kernel.autotune_configs
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_deltanet_recurrence.py
+++ b/tests/ops/test_deltanet_recurrence.py
@@ -322,7 +322,3 @@ def test_deltanet_decode_raw_cuda_config_requires_two_lane_group() -> None:
                 "raw_maxrregcount": 146,
             },
         )
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_elementwise_caching_autotune.py
+++ b/tests/ops/test_elementwise_caching_autotune.py
@@ -243,7 +243,3 @@ class TestCachingCorrectness:
         out = k(x)
         ref = torch.nn.functional.leaky_relu(x.float(), 0.01).to(torch.float16)
         torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_elementwise_compile.py
+++ b/tests/ops/test_elementwise_compile.py
@@ -1293,7 +1293,3 @@ def _mask(*shape):
 def test_the_traced_graph_holds_only_this_ops_operators(build_case):
     op, inputs = build_case()
     assert_op_owns_graph_nodes(op, *inputs)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_elementwise_fp8.py
+++ b/tests/ops/test_elementwise_fp8.py
@@ -229,7 +229,3 @@ def test_division_family_kernel_rejects_bool_and_int():
             cls(**_binary_kwargs(torch.bool))
         with pytest.raises(ValueError, match="only supports dtypes"):
             cls(**_binary_kwargs(torch.int32))
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_elementwise_independent_fp8.py
+++ b/tests/ops/test_elementwise_independent_fp8.py
@@ -49,7 +49,3 @@ def test_where_accepts_manifest_dtypes(dtype: torch.dtype) -> None:
     out = op(cond, inp, other)
     ref = torch.where(cond, inp, other)
     torch.testing.assert_close(out, ref, atol=0, rtol=0)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_elementwise_unary_activation_alignment.py
+++ b/tests/ops/test_elementwise_unary_activation_alignment.py
@@ -189,7 +189,3 @@ def test_gelu_approximate_runs_through_forward(approximate: str) -> None:
 # refactor pulling shared ``__init__`` / ``forward`` / ``_eager_forward``
 # logic up into a base or mixin must keep these byte-identical, because
 # downstream code (tests, benches, codegen) relies on them.
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_engram.py
+++ b/tests/ops/test_engram.py
@@ -173,7 +173,3 @@ def test_engram_decode_multi_step():
 
         assert y_err < 0.1, f"Step {step}: y max_err={y_err:.6f}"
         assert s_err < 0.05, f"Step {step}: state max_err={s_err:.6f}"
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_fft.py
+++ b/tests/ops/test_fft.py
@@ -38,7 +38,3 @@ def test_fft_c2c(n: int, dtype: torch.dtype, tune: bool, batch_shape: tuple) -> 
     else:
         tolerances = {"atol": 1e-8, "rtol": 1e-8}
     test.check(op, *test.gen_inputs(), **tolerances)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_fp8_lightning_indexer.py
+++ b/tests/ops/test_fp8_lightning_indexer.py
@@ -89,7 +89,3 @@ def test_indexer_rejects_bf16_inputs_with_external_scale() -> None:
 
     with pytest.raises(ValueError, match="float8_e4m3fn"):
         op(index_q, index_k, weights, cu_seqlen_ks, cu_seqlen_ke, index_k_scale)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_fp8_quant.py
+++ b/tests/ops/test_fp8_quant.py
@@ -41,7 +41,3 @@ def test_fp8_quant_op(
     test = FP8QuantTest(batch, seq_len_kv, kv_group, index_dim, in_dtype)
     op = FP8QuantFwdOp(tune=tune)
     test.check(op, *test.gen_inputs(), compare=_cosine_compare)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_fused_add_layer_norm.py
+++ b/tests/ops/test_fused_add_layer_norm.py
@@ -129,7 +129,3 @@ def test_fused_add_layer_norm_3d(batch: int, seq: int, hidden: int, dtype: torch
     assert torch.allclose(residual_out, add_ref, atol=atol, rtol=rtol), (
         f"3D residual_out test failed, max err: {(residual_out - add_ref).abs().max()}"
     )
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_fused_add_rms_norm.py
+++ b/tests/ops/test_fused_add_rms_norm.py
@@ -119,7 +119,3 @@ def test_fused_add_rms_norm_3d(batch: int, seq: int, hidden: int, dtype: torch.d
     assert torch.allclose(residual_out, add_ref, atol=atol, rtol=rtol), (
         f"3D residual_out test failed, max err: {(residual_out - add_ref).abs().max()}"
     )
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_fused_gated.py
+++ b/tests/ops/test_fused_gated.py
@@ -253,7 +253,3 @@ def test_fused_gated_kernel_stores_strategy() -> None:
     k2 = SiluAndMulFwdKernel(M=16, N=16, dtype=torch.float16)
     assert k2.strategy == FusedGatedKernel.DEFAULT_STRATEGY
     assert k2.config["strategy"] == FusedGatedKernel.DEFAULT_STRATEGY
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_gated_deltanet_chunkwise_bwd.py
+++ b/tests/ops/test_gated_deltanet_chunkwise_bwd.py
@@ -263,7 +263,3 @@ def test_gated_deltanet_bwd_default_carry_dispatch(
     )
     assert kernel.default_config["recurrence_segmented_carry"] == expected_mode
     assert kernel.default_config["recurrence_block_v"] == expected_block_v
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_gated_deltanet_fwd.py
+++ b/tests/ops/test_gated_deltanet_fwd.py
@@ -150,7 +150,3 @@ def test_gated_deltanet_bthd_matches_the_head_major_op(
     torch.testing.assert_close(production[1], legacy[1], **tols)
     torch.testing.assert_close(production[2].permute(0, 2, 1, 3), legacy[2], **tols)
     torch.testing.assert_close(production[3].permute(0, 2, 1, 3), legacy[3], **tols)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_gated_deltanet_prefill.py
+++ b/tests/ops/test_gated_deltanet_prefill.py
@@ -367,10 +367,6 @@ def test_gated_deltanet_prefill_dense_transition_reference() -> None:
     torch.testing.assert_close(scan_final_state, serial_final_state, atol=5e-4, rtol=5e-4)
 
 
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])
-
-
 # ----------------------------------------------------------------------
 # Cross-layout contract for the Gated DeltaNet prefill roofline.
 # ----------------------------------------------------------------------

--- a/tests/ops/test_gated_deltanet_recurrence.py
+++ b/tests/ops/test_gated_deltanet_recurrence.py
@@ -176,7 +176,3 @@ def test_gated_deltanet_decode_rejects_manifest_shape_mismatch() -> None:
 
     with pytest.raises(ValueError, match="g must have shape"):
         op.forward(q, k, v, g, beta, state)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_gemm.py
+++ b/tests/ops/test_gemm.py
@@ -481,7 +481,3 @@ def test_gemv_boundary_rhs_col(n: int, k: int, dtype: torch.dtype, tune: bool) -
     op = GemmFwdOp(trans_a=False, trans_b=False, tune=tune)
     tolerances = {"atol": 1e-2, "rtol": 1e-2}
     test.check(op, *test.gen_inputs(), **tolerances)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_gla_chunkwise_bwd.py
+++ b/tests/ops/test_gla_chunkwise_bwd.py
@@ -149,7 +149,3 @@ def test_gla_bwd(
             cos = cosine_sim(fla_grads[name], op_grads[name])
             print(f"  TileOPs vs FLA {name}: cosine={cos:.6f}")
             assert cos > 0.99, f"TileOPs vs FLA {name} cosine too low: {cos:.6f}"
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_gla_chunkwise_fwd.py
+++ b/tests/ops/test_gla_chunkwise_fwd.py
@@ -89,7 +89,3 @@ def test_gla_fwd(
         cos = cosine_sim(fla_o, op_o)
         print(f"  TileOPs vs FLA o: cosine={cos:.6f}")
         assert cos > 0.99, f"TileOPs vs FLA o cosine too low: {cos:.6f}"
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_gla_recurrence.py
+++ b/tests/ops/test_gla_recurrence.py
@@ -166,7 +166,3 @@ def test_gla_decode_rejects_manifest_shape_mismatch() -> None:
 
     with pytest.raises(ValueError, match="gk must have shape"):
         op.forward(q, k, v, gk, state)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_group_norm.py
+++ b/tests/ops/test_group_norm.py
@@ -305,7 +305,3 @@ def test_group_norm_no_affine_tail_block(n: int, c: int, spatial: tuple, g: int)
     y_ref = F.group_norm(x.float(), g, weight=None, bias=None, eps=1e-5).to(dtype)
     atol, rtol = _get_tolerances(dtype)
     assert torch.allclose(y, y_ref, atol=atol, rtol=rtol), f"max err: {(y - y_ref).abs().max()}"
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_grouped_gemm.py
+++ b/tests/ops/test_grouped_gemm.py
@@ -128,7 +128,3 @@ def test_supply_prog_keeps_every_row_in_the_k_loop():
     # A fourth such parameter must fail rather than silently receive the offsets.
     with pytest.raises(RuntimeError, match="expects 3 int32"):
         kernel.autotune_supply_prog(params + [_FakeKernelParam("int32", [batch_count])])
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_grouped_gemm.py
+++ b/tests/ops/test_grouped_gemm.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 
 from tests.test_base import FixtureBase, TestBase
+from tileops.kernels.grouped_gemm import GroupedGemmKernel
 from tileops.ops.grouped_gemm import GroupedGemmFwdOp
 from workloads.grouped_gemm import (
     GroupedGemmWorkload,
@@ -86,6 +87,47 @@ def test_grouped_gemm(
     test = GroupedGemmTest(batch_sum, batch_count, N, K, dtype, transpose_a, transpose_b)
     op = GroupedGemmFwdOp(transpose_a=transpose_a, transpose_b=transpose_b, tune=tune)
     test.check(op, *test.gen_inputs())
+
+
+# What `tune=True` measures
+
+
+class _FakeKernelParam:
+    """The part of TileLang's ``KernelParam`` its tensor supplier reads."""
+
+    def __init__(self, dtype: str, shape: list[int]) -> None:
+        self.dtype = dtype
+        self.shape = shape
+
+    def torch_dtype(self):
+        return getattr(torch, self.dtype)
+
+    def __getattr__(self, name):  # is_unsigned / is_float8 / is_float4 / is_boolean
+        return lambda: False
+
+
+@pytest.mark.smoke
+def test_supply_prog_keeps_every_row_in_the_k_loop():
+    """Random int32 metadata drops the NT/NN guard sum to ~0 and every tile skips the K-loop."""
+    batch_sum, batch_count, n, k = 64, 8, 32, 32
+    kernel = GroupedGemmKernel(batch_sum, batch_count, n, k, torch.float16)
+    # TileLang supplies inputs only, so the ``out_idx=[2]`` output is absent.
+    params = [
+        _FakeKernelParam("float16", [batch_sum, k]),
+        _FakeKernelParam("float16", [batch_count, n, k]),
+        *(_FakeKernelParam("int32", [batch_count]) for _ in range(3)),
+    ]
+    supplied = kernel.autotune_supply_prog(params)
+
+    assert [list(t.shape) for t in supplied] == [p.shape for p in params]
+    sizes, offsets, padded_offsets = supplied[2:]
+    assert int(sizes.sum()) == batch_sum
+    assert int(offsets[0]) == 0 and int(offsets[-1]) == batch_sum - int(sizes[-1])
+    assert int(padded_offsets[-1]) + int(sizes[-1]) == batch_sum
+
+    # A fourth such parameter must fail rather than silently receive the offsets.
+    with pytest.raises(RuntimeError, match="expects 3 int32"):
+        kernel.autotune_supply_prog(params + [_FakeKernelParam("int32", [batch_count])])
 
 
 if __name__ == "__main__":

--- a/tests/ops/test_instance_norm.py
+++ b/tests/ops/test_instance_norm.py
@@ -396,7 +396,3 @@ def test_instance_norm_default_momentum_does_not_change_output() -> None:
     y2 = op_other(x, weight=weight, bias=bias)
     atol, rtol = _get_tolerances(dtype)
     assert torch.allclose(y1, y2, atol=atol, rtol=rtol)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_layer_norm.py
+++ b/tests/ops/test_layer_norm.py
@@ -249,7 +249,3 @@ def test_layer_norm_rebuilds_kernel_on_m_change() -> None:
     ).to(dtype)
     atol, rtol = _get_tolerances(dtype)
     assert torch.allclose(y2, y_ref, atol=atol, rtol=rtol)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_logical.py
+++ b/tests/ops/test_logical.py
@@ -249,7 +249,3 @@ def test_logical_int_bool_matrix(
     with torch.no_grad():
         out = op(a, b)
     _bool_compare(out, ref)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_logical_reduce.py
+++ b/tests/ops/test_logical_reduce.py
@@ -718,7 +718,3 @@ def test_logical_reduce_returns_bool(op_name: str) -> None:
     x = torch.randn(_M, _N, dtype=torch.float16, device="cuda")
     out = op(x)
     assert out.dtype == torch.bool
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_mamba.py
+++ b/tests/ops/test_mamba.py
@@ -451,10 +451,6 @@ def test_mamba2_fwd_e2e(batch, seqlen, n_heads, d_head, d_state, n_groups, chunk
     allclose_compare(y_op.float(), y_ref.float(), atol=atol, rtol=1e-3)
 
 
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])
-
-
 # ----------------------------------------------------------------------
 # Composite-vs-stage contract for the Mamba-2 / State-Space Dual (SSD) rooflines.
 # ----------------------------------------------------------------------

--- a/tests/ops/test_mean_pooling.py
+++ b/tests/ops/test_mean_pooling.py
@@ -163,7 +163,3 @@ def test_mean_pooling_op(
     op = MeanPoolingForwardOp(**params)
     inputs = test.gen_inputs()
     test.check(op, *inputs, atol=1e-3, rtol=1e-5)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_mhc.py
+++ b/tests/ops/test_mhc.py
@@ -61,7 +61,3 @@ def test_mhc_post_op(batch: int, n_expand: int, c_x: int, dtype: torch.dtype, tu
     test = MHCPostTest(batch, n_expand, c_x, dtype)
     op = MHCPostFwdOp(tune=tune)
     test.check(op, *test.gen_inputs(), compare=_cosine_compare)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_moe_compile.py
+++ b/tests/ops/test_moe_compile.py
@@ -215,7 +215,3 @@ for _op_cls in (
     MoeGroupedGemmNopadFwdOp,
 ):
     register_compile_contract(_op_cls)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_moe_gate_up.py
+++ b/tests/ops/test_moe_gate_up.py
@@ -93,7 +93,3 @@ def test_the_op_rejects_a_dtype_the_manifest_does_not_declare():
     op = MoeGateUpFwdOp(numel, num_experts, ffn, k)
     with pytest.raises((ValueError, TypeError)):
         op(a, b, sizes, offsets)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_moe_grouped_gemm_nopad.py
+++ b/tests/ops/test_moe_grouped_gemm_nopad.py
@@ -112,7 +112,3 @@ def test_moe_grouped_gemm_nopad_op(numel, num_experts, n, k, distribution, dtype
         atol=1e-2,
         rtol=1e-2,
     )
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_moe_permute_align.py
+++ b/tests/ops/test_moe_permute_align.py
@@ -191,7 +191,3 @@ def test_permute_align_skewed_distribution() -> None:
     outputs_ref = tuple(ref_permute_align(topk_ids, block_size, num_experts))
 
     _permute_align_compare(outputs, outputs_ref, block_size, num_experts, numel)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_moe_permute_nopad.py
+++ b/tests/ops/test_moe_permute_nopad.py
@@ -204,7 +204,3 @@ def test_moe_permute_nopad_invalid_dtype_raises() -> None:
     op = MoePermuteNopadFwdOp(num_experts=4, num_experts_local=4)
     with pytest.raises(ValueError, match="Expected hidden_states.dtype"):
         op(hidden_states, topk_ids)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_moe_unpermute.py
+++ b/tests/ops/test_moe_unpermute.py
@@ -204,7 +204,3 @@ def test_moe_unpermute_out_buffer_validation():
     mm2_ws.copy_(mm2_pad)
     got = op(mm2_ws, fwd_idx, topk_weights, out=out_ws)
     torch.testing.assert_close(got.float(), ref.float(), rtol=1e-2, atol=1e-2)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_multi_dtype_instance.py
+++ b/tests/ops/test_multi_dtype_instance.py
@@ -302,7 +302,3 @@ def test_enumeration_still_sees_the_family():
         "BitwiseNotFwdOp",
     ):
         assert expected in _SINGLE_TENSOR_OPS, f"{expected} dropped out of the sweep"
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_norm_ops.py
+++ b/tests/ops/test_norm_ops.py
@@ -87,7 +87,3 @@ class TestBatchNormCustomOp:
         compiled = torch.compile(op, fullgraph=False)
         gx, gw, gb = compiled(grad_out, x, weight, mean, rstd)
         assert gx.shape == x.shape
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_pool.py
+++ b/tests/ops/test_pool.py
@@ -2710,7 +2710,3 @@ def test_adaptive_max_pool2d_indices_nan_window() -> None:
     ref_val, ref_idx = F.adaptive_max_pool2d(x.float(), (1, 1), return_indices=True)
     assert torch.isnan(val.float()).all()
     torch.testing.assert_close(idx, ref_idx, atol=0, rtol=0)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_reduce.py
+++ b/tests/ops/test_reduce.py
@@ -732,7 +732,3 @@ def test_var_mean_spec_dim(shape: tuple, dim: int, keepdim: bool, dtype: torch.d
     assert torch.allclose(mean_out, ref_mean, **tol), (
         f"var_mean spec mean err: {(mean_out - ref_mean).abs().max()}"
     )
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_reduce_arithmetic_conformance.py
+++ b/tests/ops/test_reduce_arithmetic_conformance.py
@@ -144,7 +144,3 @@ def test_arithmetic_reduce_unaligned_innermost(
         f"{op_cls.__name__} dim={dim} unaligned: shape {y.shape} vs ref {ref.shape}"
     )
     torch.testing.assert_close(y, ref, **_tol(dtype))
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_reduce_boolean_conformance.py
+++ b/tests/ops/test_reduce_boolean_conformance.py
@@ -200,7 +200,3 @@ def test_count_nonzero_unaligned_innermost(dim) -> None:
         f"CountNonzeroFwdOp dim={dim} unaligned: shape {y.shape} vs ref {ref.shape}"
     )
     torch.testing.assert_close(y, ref, atol=0, rtol=0)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_reduce_dim_none.py
+++ b/tests/ops/test_reduce_dim_none.py
@@ -429,7 +429,3 @@ def test_inf_norm_dim_none(
     tol = _tol(dtype)
     assert y.shape == ref.shape, f"shape mismatch: {y.shape} vs {ref.shape}"
     assert torch.allclose(y, ref, **tol), f"max err: {(y - ref).abs().max()}"
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_reduce_multidim.py
+++ b/tests/ops/test_reduce_multidim.py
@@ -598,7 +598,3 @@ def test_duplicate_dims_raises() -> None:
     op = SumFwdOp(dim=[1, 1], keepdim=False)
     with pytest.raises(ValueError, match="Duplicate dims"):
         op(x)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_reduce_scalar_conformance.py
+++ b/tests/ops/test_reduce_scalar_conformance.py
@@ -188,7 +188,3 @@ def test_scalar_logical_and_count_reductions(
             f"{op_cls.__name__} scalar dim={dim} dtype={dtype}: shape {y.shape} vs ref {ref.shape}"
         )
         torch.testing.assert_close(y, ref, atol=0, rtol=0)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_reduce_variance_conformance.py
+++ b/tests/ops/test_reduce_variance_conformance.py
@@ -256,7 +256,3 @@ def test_std_unaligned_innermost(dim) -> None:
     ref = _ref_std(x, dim, False, 1)
     assert y.shape == ref.shape
     torch.testing.assert_close(y, ref, **_tol(dtype))
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_rms_norm.py
+++ b/tests/ops/test_rms_norm.py
@@ -214,7 +214,3 @@ def test_a_non_contiguous_input_compiles_to_the_shape_the_fake_promised() -> Non
 
     assert output.is_contiguous()
     torch.testing.assert_close(output, op(x, weight))
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_rope.py
+++ b/tests/ops/test_rope.py
@@ -687,7 +687,3 @@ def test_rope_rejects_non_float_dtype() -> None:
 
     with pytest.raises(ValueError, match="only supports dtypes"):
         RopeNeoxKernel(seq_len=16, head_dim=64, dtype=torch.int32)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_softmax.py
+++ b/tests/ops/test_softmax.py
@@ -679,7 +679,3 @@ def test_log_softmax_eval_roofline_flops_5mn() -> None:
     assert mem_bytes == 2 * M * N * elem_bytes, (
         f"LogSoftmax bytes {mem_bytes} != 2 * M * N * elem_bytes = {2 * M * N * elem_bytes}"
     )
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_special_elementwise.py
+++ b/tests/ops/test_special_elementwise.py
@@ -729,7 +729,3 @@ def test_softplus_rejects_non_numeric_beta() -> None:
     op = SoftplusFwdOp(beta="bad")
     with pytest.raises(TypeError, match="int/float"):
         op(torch.zeros(1024, device="cuda", dtype=torch.float16))
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_topk_selector.py
+++ b/tests/ops/test_topk_selector.py
@@ -76,7 +76,3 @@ def test_topk_selector_op(
     test = TopkSelectorTest(batch, seq_len, seq_len_kv, kv_group, topk, in_dtype, out_dtype)
     op = TopkSelectorFwdOp(topk=topk, tune=tune)
     test.check(op, *test.gen_inputs(), compare=_set_compare)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_unary_math.py
+++ b/tests/ops/test_unary_math.py
@@ -642,7 +642,3 @@ def test_reciprocal_int_input_validation() -> None:
     assert len(op.built_kernels(op._op_name)) == 2, "each semantic dtype keys its own entry"
     with pytest.raises(ValueError, match="dtype"):
         op(torch.ones(4, device="cuda", dtype=torch.float64))
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_vector_norm.py
+++ b/tests/ops/test_vector_norm.py
@@ -606,7 +606,3 @@ def test_vector_norm_tiled_autotune() -> None:
     kernel = op.built_kernels(op._kernel_key)[(m, n, dtype)]
     assert kernel._needs_tiling
     assert kernel.config in kernel.autotune_configs
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_welford_non_aligned.py
+++ b/tests/ops/test_welford_non_aligned.py
@@ -360,7 +360,3 @@ def test_var_mean_multidim_non_aligned(
     assert torch.allclose(mean_out, ref_mean, **tol), (
         f"var_mean multidim mean non-aligned max err: {(mean_out - ref_mean).abs().max()}"
     )
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -48,7 +48,3 @@ def test_mha_cold_fullgraph_trace_matches_eager():
 
     assert output.shape == q.shape
     torch.testing.assert_close(output, op(q, k, v))
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-vvs"])

--- a/tests/trace/test_payload.py
+++ b/tests/trace/test_payload.py
@@ -204,7 +204,3 @@ def test_dynamic_payload_runtime_expr(preserve_trace_state, tmp_path):
 
     payloads = sorted([s.payload for s in loop_slices[:4]])
     assert payloads == [0, 1, 2, 3], f"Expected payloads [0, 1, 2, 3], got {payloads}"
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problems

- `TensorSupplyType.Auto` fills an integer tensor parameter from `randint(-2, 3)`. Where those values decide how much work runs, every autotune candidate times a collapsed kernel and the winner is noise.
- `GroupedGemmKernel` supplied nothing. Its NT/NN guard `m_start < batch_padded_offsets[-1] + batch_sizes[-1]` then failed for nearly every CTA, and the autotuner reported `best_latency=0.00599 ms` for a GEMM whose floor is 0.31 ms.
- `Kernel.autotune` left `autotune_supply_prog` at `None` and handed that to TileLang, so any kernel with integer inputs and no supplier tuned on random values and reported a plausible number.
- TileLang keys its autotune disk cache on `inspect.getsource`, so 50e3fe58 (ruff-format whitespace, no functional change) invalidated the cached winners on `/ci-cache/tilelang` and the nightly re-tuned onto different ones — the 2026-08-19 step.

## Changes

- `Kernel.tune_jit_kernel` refuses when a kernel takes integer tensor inputs, supplies none, and has not set `autotune_accepts_random_int_inputs`. Placed after supply_prog resolution, so an explicit `supply_prog=None` from a sub-kernel is validated against that sub-kernel's parameters. `_int_tensor_input_names` reads them through `get_tir` without compiling and refuses when they cannot be read.
- `GroupedGemmKernel.autotune_supply_prog` supplies row counts and their tight prefix sum, which puts the guard sum at `batch_sum`. The int32 parameters are matched by position among themselves; a list not holding exactly three raises.
- `MeanPoolingFwdKernel.autotune_supply_prog` — the guard's one other catch.
- Declared value-independent with a reason: `SSDChunkStateFwdKernel`, `UnaryKernel`, `BinaryKernel`, `FusedGatedKernel`, `GemmW4A16DecodeKernel`.
- Dropped the `__main__` block from all 83 test files carrying it.
- `autotune_accepts_random_int_inputs` joins the `Kernel` attribute table in `ops-design-reference.md`, and the supplier requirement joins `.claude/domain-rules/ops-design.md`.
- Test node delta: `tests/ops/test_grouped_gemm.py` 4 → 5, `tests/kernels/test_kernel_autotune_binding.py` 3 → 5. The two new binding cases cover the guard's refusal and its declared exemption.

`benchmarks/timing.bench_kernel`, one H200, base and branch in sequence, `tune=True`, `maxerr=0`. Grouped GEMM `batch_sum=4096 batch_count=16 N=K=4096`:

| case | base | branch |
| --- | --- | --- |
| nt fp16 | 2.856 ms / 48.1 TF | 0.346 ms / 397.8 TF |
| nt bf16 | 2.879 ms / 47.7 TF | 0.345 ms / 398.3 TF |
| nn fp16 | 2.831 ms / 48.6 TF | 0.342 ms / 401.6 TF |
| tn fp16 | 1.744 ms / 78.8 TF | 0.781 ms / 176.0 TF |

The base column is not a fixed baseline — it is whatever the broken sweep picked; the nightly reported 21.6 TF for `nt fp16` on 2026-08-20.

Mean pooling: `varlen-long` 0.1386 → 0.1339 ms (`bdim` 128 → 64); the other three cases keep their config and their time. No case regressed. The 8 benchmarks that set `tune=True` pass 126 cases with no refusal.

## Follow-ups

- TN stays behind torch-ref: each CTA owns one `(expert, N-block, K-block)` tile and serially scans the group's M rows through guarded scalar copies.
- `GroupedGemmPersistent3WGKernel` reaches ~700 TF but serves neither this op's dispatch nor its `batch_padded_offsets` signature.
- `PagedPrefillKernel` subclasses, `GQAPrefillVarlenFwdKernel`, `NSAFwdVarlenKernel`, `NSACmpFwdVarlenKernel`, `NSATopkVarlenKernel`, `MoeGroupedGemmNopadKernel` declare `autotune_configs` but never set `self.kernel`, so `tune=True` raises before the guard. Their integer inputs do gate work.
