### PR TITLE
[Maintain][CI] Install the FlagGems pooling baselines in the runner image

### DIFF
--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -84,6 +84,10 @@ RUN for pkg in \
         uv pip install --no-build-isolation "$pkg" \
             || echo "WARNING: bench baseline '$pkg' install failed (non-fatal)"; \
     done
+# --no-deps, so not in the loop: flag_gems pins numpy==1.26.4 and this stack is on 2.2.6.
+RUN uv pip install sqlalchemy \
+    && uv pip install --no-deps flag_gems \
+    || echo "WARNING: bench baseline 'flag_gems' install failed (non-fatal)"
 # --no-deps so mamba_ssm cannot pull its own newer tilelang pin. The CUDA extension must still
 # build: importing the package loads selective_scan_cuda even for the Triton path the bench uses.
 RUN MAMBA_FORCE_BUILD=TRUE \

--- a/.github/runner/requirements.in
+++ b/.github/runner/requirements.in
@@ -1,5 +1,6 @@
 # Direct requirements of the runner image. The source-built packages (tilelang, FA2, FA3,
 # mamba-ssm, DeepGEMM) are absent: no wheel to resolve, and they go in with --no-deps.
+# flag_gems is absent too: its numpy pin does not resolve here, so it also goes in with --no-deps.
 # Compile with the command in constraints-runner-lock.txt's header.
 --index-url https://download.pytorch.org/whl/cu132
 --extra-index-url https://pypi.org/simple
@@ -38,3 +39,5 @@ py-spy
 flash-linear-attention
 vllm
 cupti-python
+# For flag_gems, which cannot be listed here.
+sqlalchemy

--- a/constraints-runner-lock.txt
+++ b/constraints-runner-lock.txt
@@ -51,6 +51,7 @@ flashinfer-python==0.6.16.post3
 frozenlist==1.8.0
 fsspec==2026.7.0
 googleapis-common-protos==1.75.1
+greenlet==3.5.5
 grpcio==1.83.0
 h11==0.16.0
 hf-xet==1.6.0
@@ -183,6 +184,7 @@ setuptools==80.10.2
 shellingham==1.5.4
 six==1.17.0
 sniffio==1.3.1
+sqlalchemy==2.0.52
 sse-starlette==3.4.8
 starlette==1.6.0
 supervisor==4.3.0

--- a/constraints.txt
+++ b/constraints.txt
@@ -36,6 +36,10 @@ coverage==7.15.4
 # `.[bench]` install both read the version from here.
 flash-linear-attention==0.5.2
 vllm==0.27.1
+# The 2D pooling baseline. Installed --no-deps: it pins numpy==1.26.4, this stack is on 2.2.6.
+flag_gems==5.0.2
+# flag_gems imports it at module load.
+sqlalchemy==2.0.52
 # Tracks the image CUDA version; bump with it.
 cupti-python==13.2.0
 # Stack dump of a hung benchmark child before the runner kills it.


### PR DESCRIPTION
## Problems

- The `bench` extra in `pyproject.toml` is not what CI installs: every job installs the checkout with `--no-deps`, so a baseline library reaches the benchmarks only through the runner image. Without `flag_gems` there, the pool benchmark falls back to its torch reference and reports that, whatever the extra lists.
- `flag_gems` cannot simply be added to `requirements.in`: its metadata pins `numpy==1.26.4` against this stack's 2.2.6, so the lock compile has no solution.

## Changes

- `flag_gems` installs with the other bench baselines, with `--no-deps` because of that numpy pin — the pooling kernels the bench calls never read numpy. `sqlalchemy`, the one import it needs, resolves normally and is in `requirements.in` and the lock.
- `constraints.txt` holds both versions, next to the other bench baselines, so the image install and a `.[bench]` install read the same numbers.
- libcudnn needs nothing: `nvidia-cudnn-cu13` is already in the image.