### PR TITLE
[Refactor][GroupedGemm] One tile-to-group mapping, and the NT/NN tiling it fixes

### DIFF
--- a/src/tileops/kernels/grouped_gemm/call.py
+++ b/src/tileops/kernels/grouped_gemm/call.py
@@ -25,3 +25,5 @@ class GroupedGemmCall(CallSpec):
     dtype: Optional[torch.dtype] = None
     #: Gated activation the caller wants applied, "" when the role has none.
     activation: str = ""
+    transpose_a: bool = False
+    transpose_b: bool = True

--- a/src/tileops/kernels/grouped_gemm/grouped_gemm.py
+++ b/src/tileops/kernels/grouped_gemm/grouped_gemm.py
@@ -7,11 +7,7 @@ import tilelang
 import tilelang.language as T
 import torch
 
-from tileops.kernels.grouped_tiling import (
-    make_group_tile_cumsum,
-    make_group_tile_decode,
-    tile_upper_bound,
-)
+from tileops.kernels.grouped_tiling import GroupTiling
 from tileops.kernels.kernel_base import Kernel
 
 __all__ = [
@@ -58,10 +54,9 @@ def _grouped_gemm_kernel(batch_sum, batch_count, N, K, transpose_a, transpose_b,
                 B_shared_shape = (block_k, block_n)
 
             # Tiles enumerated per group; CTAs past the real count exit.
-            _num_pid_m = tile_upper_bound(batch_sum, batch_count, block_m)
+            _tiling = GroupTiling(batch_count, block_m)
+            _num_pid_m = _tiling.tile_upper_bound(batch_sum)
             _num_pid_n = math.ceil(N / block_n)
-            _group_tile_cumsum = make_group_tile_cumsum(batch_count, block_m)
-            _group_tile_decode = make_group_tile_decode(batch_count, block_m)
 
             @T.prim_func
             def _grouped_gemm_main(
@@ -82,14 +77,14 @@ def _grouped_gemm_kernel(batch_sum, batch_count, N, K, transpose_a, transpose_b,
                     row = T.alloc_local([1], "int32")
                     cur_batch_idx = T.alloc_local([1], "int32")
 
-                    _group_tile_cumsum(batch_sizes, s_cum)
+                    _tiling.cumsum(batch_sizes, s_cum)
 
                     # M-major ordering: each M-tile processes all N-tiles
                     m_tile = pid // _num_pid_n
                     n_start = (pid % _num_pid_n) * block_n
 
                     if m_tile < s_cum[batch_count]:
-                        _group_tile_decode(m_tile, s_cum, lo, hi, cur_batch_idx, row)
+                        _tiling.decode(m_tile, s_cum, lo, hi, cur_batch_idx, row)
                         m_start = batch_offsets[cur_batch_idx[0]] + row[0]
                         actual_rows = T.min(block_m, batch_sizes[cur_batch_idx[0]] - row[0])
                         actual_cols = T.min(block_n, N - n_start)

--- a/src/tileops/kernels/grouped_gemm/grouped_gemm.py
+++ b/src/tileops/kernels/grouped_gemm/grouped_gemm.py
@@ -7,6 +7,11 @@ import tilelang
 import tilelang.language as T
 import torch
 
+from tileops.kernels.grouped_tiling import (
+    make_group_tile_cumsum,
+    make_group_tile_decode,
+    tile_upper_bound,
+)
 from tileops.kernels.kernel_base import Kernel
 
 __all__ = [
@@ -52,9 +57,13 @@ def _grouped_gemm_kernel(batch_sum, batch_count, N, K, transpose_a, transpose_b,
                 B_shape = (batch_count, K, N)
                 B_shared_shape = (block_k, block_n)
 
-            # 1D grid with M-major ordering for A-tile reuse
-            _num_pid_m = math.ceil(batch_sum / block_m)
+            # One M tile per group-local tile, so a tile never straddles a group
+            # boundary. Sizes arrive on the device, so the grid takes the bound
+            # and CTAs past the real count exit.
+            _num_pid_m = tile_upper_bound(batch_sum, batch_count, block_m)
             _num_pid_n = math.ceil(N / block_n)
+            _group_tile_cumsum = make_group_tile_cumsum(batch_count, block_m)
+            _group_tile_decode = make_group_tile_decode(batch_count, block_m)
 
             @T.prim_func
             def _grouped_gemm_main(
@@ -69,34 +78,22 @@ def _grouped_gemm_kernel(batch_sum, batch_count, N, K, transpose_a, transpose_b,
                     A_shared = T.alloc_shared(A_shared_shape, dtype)
                     B_shared = T.alloc_shared(B_shared_shape, dtype)
                     C_local = T.alloc_fragment([block_m, block_n], accum_dtype)
+                    s_cum = T.alloc_shared([batch_count + 1], "int32")
+                    lo = T.alloc_local([1], "int32")
+                    hi = T.alloc_local([1], "int32")
+                    row = T.alloc_local([1], "int32")
                     cur_batch_idx = T.alloc_local([1], "int32")
 
-                    # M-major ordering: each M-tile processes all N-tiles
-                    bx = pid // _num_pid_n
-                    by = pid % _num_pid_n
-                    m_start = bx * block_m
-                    n_start = by * block_n
+                    _group_tile_cumsum(batch_sizes, s_cum)
 
-                    # Guard: skip CTAs that fall beyond the actual padded data.
-                    # batch_padded_offsets[E-1] + batch_sizes[E-1] gives the true
-                    # end of the last expert's padded block.  When batch_sum is a
-                    # conservative upper bound (e.g. T*K + E*block_m in MoE), the
-                    # keeps extra CTAs off the K-loop, which for them reads all-zero
-                    # inputs, wasting SM cycles and B-tensor bandwidth.
-                    total_valid_rows = (
-                        batch_padded_offsets[batch_count - 1] + batch_sizes[batch_count - 1]
-                    )
-                    if m_start < total_valid_rows:
-                        cur_batch_idx[0] = 0
-                        for i in range(batch_count):
-                            batch_start = batch_offsets[i]
-                            batch_end = batch_start + batch_sizes[i]
-                            in_batch = (m_start >= batch_start) & (m_start < batch_end)
-                            cur_batch_idx[0] = T.if_then_else(in_batch, i, cur_batch_idx[0])
-                        batch_start = batch_offsets[cur_batch_idx[0]]
-                        batch_size = batch_sizes[cur_batch_idx[0]]
-                        batch_end = batch_start + batch_size
-                        actual_rows = T.min(block_m, batch_end - m_start)
+                    # M-major ordering: each M-tile processes all N-tiles
+                    m_tile = pid // _num_pid_n
+                    n_start = (pid % _num_pid_n) * block_n
+
+                    if m_tile < s_cum[batch_count]:
+                        _group_tile_decode(m_tile, s_cum, lo, hi, cur_batch_idx, row)
+                        m_start = batch_offsets[cur_batch_idx[0]] + row[0]
+                        actual_rows = T.min(block_m, batch_sizes[cur_batch_idx[0]] - row[0])
                         actual_cols = T.min(block_n, N - n_start)
                         T.clear(C_local)
 

--- a/src/tileops/kernels/grouped_gemm/grouped_gemm.py
+++ b/src/tileops/kernels/grouped_gemm/grouped_gemm.py
@@ -57,9 +57,7 @@ def _grouped_gemm_kernel(batch_sum, batch_count, N, K, transpose_a, transpose_b,
                 B_shape = (batch_count, K, N)
                 B_shared_shape = (block_k, block_n)
 
-            # One M tile per group-local tile, so a tile never straddles a group
-            # boundary. Sizes arrive on the device, so the grid takes the bound
-            # and CTAs past the real count exit.
+            # Tiles enumerated per group; CTAs past the real count exit.
             _num_pid_m = tile_upper_bound(batch_sum, batch_count, block_m)
             _num_pid_n = math.ceil(N / block_n)
             _group_tile_cumsum = make_group_tile_cumsum(batch_count, block_m)

--- a/src/tileops/kernels/grouped_gemm/grouped_gemm.py
+++ b/src/tileops/kernels/grouped_gemm/grouped_gemm.py
@@ -202,6 +202,7 @@ def _grouped_gemm_kernel(batch_sum, batch_count, N, K, transpose_a, transpose_b,
 
 class GroupedGemmKernel(Kernel):
     supported_archs: list[int] = [80, 86, 89, 90]
+    general: bool = True
 
     def __init__(
         self,

--- a/src/tileops/kernels/grouped_gemm/grouped_gemm_persistent_3wg.py
+++ b/src/tileops/kernels/grouped_gemm/grouped_gemm_persistent_3wg.py
@@ -37,6 +37,10 @@ import tilelang.language as T
 import torch
 
 from tileops.kernels.buffer_utils import tensors_overlap
+from tileops.kernels.grouped_tiling import (
+    make_group_tile_cumsum,
+    make_group_tile_decode,
+)
 from tileops.kernels.kernel_base import Kernel
 from tileops.utils import get_sm_count
 
@@ -330,7 +334,8 @@ def _make_pingpong_kernel(
     per-WG ring buffer (num_stages slots).
     """
     accum_dtype = "float"
-    log2_up = max(1, math.ceil(math.log2(num_experts + 1)))
+    _group_tile_cumsum = make_group_tile_cumsum(num_experts, block_m)
+    _group_tile_decode = make_group_tile_decode(num_experts, block_m)
 
     # V2 pingpong layout: 1 producer + 2 consumers, each WG = 128 threads.
     assert threads == 384, (
@@ -377,6 +382,9 @@ def _make_pingpong_kernel(
             s_total = T.alloc_shared((1,), "int32")
             lo = T.alloc_local((1,), "int32")
             hi = T.alloc_local((1,), "int32")
+            _row = T.alloc_local((1,), "int32")
+            _ex = T.alloc_local((1,), "int32")
+            _ms = T.alloc_local((1,), "int32")
             # Per-tile metadata hoisted to alloc_local so the interleaved
             # K-loop body can read m_start/n_start/expert_id across
             # IfFrame boundaries (TileLang ir_builder forbids cross-frame
@@ -425,9 +433,7 @@ def _make_pingpong_kernel(
                 T.dec_max_nreg(24)
 
                 if tx == 0:
-                    s_cum[0] = T.int32(0)
-                    for e in T.serial(num_experts):
-                        s_cum[e + 1] = s_cum[e] + (true_sizes[e] + (block_m - 1)) // block_m
+                    _group_tile_cumsum(true_sizes, s_cum)
                     s_total[0] = s_cum[num_experts] * T.int32(_num_pid_n)
                 # CTA-wide sync: publishes s_cum/s_total to consumers
                 # (this pairs with the corresponding sync_threads in
@@ -444,18 +450,8 @@ def _make_pingpong_kernel(
                         m_tile_0 = flat_id_0 // T.int32(_num_pid_n)
                         n_tile_0 = flat_id_0 % T.int32(_num_pid_n)
 
-                        lo[0] = T.int32(0)
-                        hi[0] = T.int32(num_experts - 1)
-                        for _bs in T.serial(log2_up):
-                            mid = (lo[0] + hi[0]) >> T.int32(1)
-                            if s_cum[mid + 1] <= m_tile_0:
-                                lo[0] = mid + T.int32(1)
-                            else:
-                                hi[0] = mid
-                        ex0[0] = lo[0]
-                        ms0[0] = true_offsets[ex0[0]] + (m_tile_0 - s_cum[ex0[0]]) * T.int32(
-                            block_m
-                        )
+                        _group_tile_decode(m_tile_0, s_cum, lo, hi, ex0, _row)
+                        ms0[0] = true_offsets[ex0[0]] + _row[0]
                         ns0[0] = n_tile_0 * T.int32(block_n)
                         v0[0] = T.int32(1)
                     else:
@@ -467,18 +463,8 @@ def _make_pingpong_kernel(
                         m_tile_1 = flat_id_1 // T.int32(_num_pid_n)
                         n_tile_1 = flat_id_1 % T.int32(_num_pid_n)
 
-                        lo[0] = T.int32(0)
-                        hi[0] = T.int32(num_experts - 1)
-                        for _bs in T.serial(log2_up):
-                            mid = (lo[0] + hi[0]) >> T.int32(1)
-                            if s_cum[mid + 1] <= m_tile_1:
-                                lo[0] = mid + T.int32(1)
-                            else:
-                                hi[0] = mid
-                        ex1[0] = lo[0]
-                        ms1[0] = true_offsets[ex1[0]] + (m_tile_1 - s_cum[ex1[0]]) * T.int32(
-                            block_m
-                        )
+                        _group_tile_decode(m_tile_1, s_cum, lo, hi, ex1, _row)
+                        ms1[0] = true_offsets[ex1[0]] + _row[0]
                         ns1[0] = n_tile_1 * T.int32(block_n)
                         v1[0] = T.int32(1)
                     else:
@@ -539,17 +525,11 @@ def _make_pingpong_kernel(
                         m_tile_0 = flat_id_0 // T.int32(_num_pid_n)
                         n_tile_0 = flat_id_0 % T.int32(_num_pid_n)
 
-                        lo[0] = T.int32(0)
-                        hi[0] = T.int32(num_experts - 1)
-                        for _bs in T.serial(log2_up):
-                            mid = (lo[0] + hi[0]) >> T.int32(1)
-                            if s_cum[mid + 1] <= m_tile_0:
-                                lo[0] = mid + T.int32(1)
-                            else:
-                                hi[0] = mid
-                        expert_id_0 = lo[0]
-                        row_0 = (m_tile_0 - s_cum[expert_id_0]) * T.int32(block_m)
-                        m_start_0 = true_offsets[expert_id_0] + row_0
+                        _group_tile_decode(m_tile_0, s_cum, lo, hi, _ex, _row)
+                        _ms[0] = true_offsets[_ex[0]] + _row[0]
+                        expert_id_0 = _ex[0]
+                        row_0 = _row[0]
+                        m_start_0 = _ms[0]
                         n_start_0 = n_tile_0 * T.int32(block_n)
                         arows_0 = T.min(T.int32(block_m), true_sizes[expert_id_0] - row_0)
                         acols_0 = T.min(T.int32(block_n), T.int32(N) - n_start_0)
@@ -617,17 +597,11 @@ def _make_pingpong_kernel(
                         m_tile_1 = flat_id_1 // T.int32(_num_pid_n)
                         n_tile_1 = flat_id_1 % T.int32(_num_pid_n)
 
-                        lo[0] = T.int32(0)
-                        hi[0] = T.int32(num_experts - 1)
-                        for _bs in T.serial(log2_up):
-                            mid = (lo[0] + hi[0]) >> T.int32(1)
-                            if s_cum[mid + 1] <= m_tile_1:
-                                lo[0] = mid + T.int32(1)
-                            else:
-                                hi[0] = mid
-                        expert_id_1 = lo[0]
-                        row_1 = (m_tile_1 - s_cum[expert_id_1]) * T.int32(block_m)
-                        m_start_1 = true_offsets[expert_id_1] + row_1
+                        _group_tile_decode(m_tile_1, s_cum, lo, hi, _ex, _row)
+                        _ms[0] = true_offsets[_ex[0]] + _row[0]
+                        expert_id_1 = _ex[0]
+                        row_1 = _row[0]
+                        m_start_1 = _ms[0]
                         n_start_1 = n_tile_1 * T.int32(block_n)
                         arows_1 = T.min(T.int32(block_m), true_sizes[expert_id_1] - row_1)
                         acols_1 = T.min(T.int32(block_n), T.int32(N) - n_start_1)
@@ -708,7 +682,8 @@ def _make_cooperative_kernel(
     ``ns≥3`` fit within H100's 228 KB cap when bm=128.
     """
     accum_dtype = "float"
-    log2_up = max(1, math.ceil(math.log2(num_experts + 1)))
+    _group_tile_cumsum = make_group_tile_cumsum(num_experts, block_m)
+    _group_tile_decode = make_group_tile_decode(num_experts, block_m)
 
     assert threads == 384, (
         f"V2 cooperative persistent grouped GEMM requires threads=384 "
@@ -787,6 +762,9 @@ def _make_cooperative_kernel(
             s_total = T.alloc_shared((1,), "int32")
             lo = T.alloc_local((1,), "int32")
             hi = T.alloc_local((1,), "int32")
+            _row = T.alloc_local((1,), "int32")
+            _ex = T.alloc_local((1,), "int32")
+            _ms = T.alloc_local((1,), "int32")
             # Per-tile metadata in alloc_local (same pattern as pingpong).
             ms = T.alloc_local((1,), "int32")
             ns_ = T.alloc_local((1,), "int32")
@@ -832,9 +810,7 @@ def _make_cooperative_kernel(
                 T.dec_max_nreg(24)
 
                 if tx == 0:
-                    s_cum[0] = T.int32(0)
-                    for e in T.serial(num_experts):
-                        s_cum[e + 1] = s_cum[e] + (true_sizes[e] + (block_m - 1)) // block_m
+                    _group_tile_cumsum(true_sizes, s_cum)
                     s_total[0] = s_cum[num_experts] * T.int32(_num_pid_n)
                 T.sync_threads()
 
@@ -850,16 +826,8 @@ def _make_cooperative_kernel(
                         m_tile = swz_m[0]
                         n_tile = swz_n[0]
 
-                        lo[0] = T.int32(0)
-                        hi[0] = T.int32(num_experts - 1)
-                        for _bs in T.serial(log2_up):
-                            mid = (lo[0] + hi[0]) >> T.int32(1)
-                            if s_cum[mid + 1] <= m_tile:
-                                lo[0] = mid + T.int32(1)
-                            else:
-                                hi[0] = mid
-                        ex[0] = lo[0]
-                        ms[0] = true_offsets[ex[0]] + (m_tile - s_cum[ex[0]]) * T.int32(block_m)
+                        _group_tile_decode(m_tile, s_cum, lo, hi, ex, _row)
+                        ms[0] = true_offsets[ex[0]] + _row[0]
                         ns_[0] = n_tile * T.int32(block_n)
                         v[0] = T.int32(1)
                     else:
@@ -911,17 +879,11 @@ def _make_cooperative_kernel(
                         m_tile = swz_m[0]
                         n_tile = swz_n[0]
 
-                        lo[0] = T.int32(0)
-                        hi[0] = T.int32(num_experts - 1)
-                        for _bs in T.serial(log2_up):
-                            mid = (lo[0] + hi[0]) >> T.int32(1)
-                            if s_cum[mid + 1] <= m_tile:
-                                lo[0] = mid + T.int32(1)
-                            else:
-                                hi[0] = mid
-                        expert_id = lo[0]
-                        row = (m_tile - s_cum[expert_id]) * T.int32(block_m)
-                        m_start = true_offsets[expert_id] + row
+                        _group_tile_decode(m_tile, s_cum, lo, hi, _ex, _row)
+                        _ms[0] = true_offsets[_ex[0]] + _row[0]
+                        expert_id = _ex[0]
+                        row = _row[0]
+                        m_start = _ms[0]
                         n_start = n_tile * T.int32(block_n)
                         # Top-half row count: clamp(true_arows, 0, half_m).
                         true_arows = true_sizes[expert_id] - row
@@ -993,17 +955,11 @@ def _make_cooperative_kernel(
                         m_tile = swz_m[0]
                         n_tile = swz_n[0]
 
-                        lo[0] = T.int32(0)
-                        hi[0] = T.int32(num_experts - 1)
-                        for _bs in T.serial(log2_up):
-                            mid = (lo[0] + hi[0]) >> T.int32(1)
-                            if s_cum[mid + 1] <= m_tile:
-                                lo[0] = mid + T.int32(1)
-                            else:
-                                hi[0] = mid
-                        expert_id = lo[0]
-                        row = (m_tile - s_cum[expert_id]) * T.int32(block_m)
-                        m_start = true_offsets[expert_id] + row
+                        _group_tile_decode(m_tile, s_cum, lo, hi, _ex, _row)
+                        _ms[0] = true_offsets[_ex[0]] + _row[0]
+                        expert_id = _ex[0]
+                        row = _row[0]
+                        m_start = _ms[0]
                         n_start = n_tile * T.int32(block_n)
                         # Bottom-half row count: clamp(true_arows-half_m, 0, half_m).
                         true_arows = true_sizes[expert_id] - row

--- a/src/tileops/kernels/grouped_gemm/grouped_gemm_persistent_3wg.py
+++ b/src/tileops/kernels/grouped_gemm/grouped_gemm_persistent_3wg.py
@@ -37,10 +37,7 @@ import tilelang.language as T
 import torch
 
 from tileops.kernels.buffer_utils import tensors_overlap
-from tileops.kernels.grouped_tiling import (
-    make_group_tile_cumsum,
-    make_group_tile_decode,
-)
+from tileops.kernels.grouped_tiling import GroupTiling
 from tileops.kernels.kernel_base import Kernel
 from tileops.utils import get_sm_count
 
@@ -334,8 +331,7 @@ def _make_pingpong_kernel(
     per-WG ring buffer (num_stages slots).
     """
     accum_dtype = "float"
-    _group_tile_cumsum = make_group_tile_cumsum(num_experts, block_m)
-    _group_tile_decode = make_group_tile_decode(num_experts, block_m)
+    _tiling = GroupTiling(num_experts, block_m)
 
     # V2 pingpong layout: 1 producer + 2 consumers, each WG = 128 threads.
     assert threads == 384, (
@@ -433,7 +429,7 @@ def _make_pingpong_kernel(
                 T.dec_max_nreg(24)
 
                 if tx == 0:
-                    _group_tile_cumsum(true_sizes, s_cum)
+                    _tiling.cumsum(true_sizes, s_cum)
                     s_total[0] = s_cum[num_experts] * T.int32(_num_pid_n)
                 # CTA-wide sync: publishes s_cum/s_total to consumers
                 # (this pairs with the corresponding sync_threads in
@@ -450,7 +446,7 @@ def _make_pingpong_kernel(
                         m_tile_0 = flat_id_0 // T.int32(_num_pid_n)
                         n_tile_0 = flat_id_0 % T.int32(_num_pid_n)
 
-                        _group_tile_decode(m_tile_0, s_cum, lo, hi, ex0, _row)
+                        _tiling.decode(m_tile_0, s_cum, lo, hi, ex0, _row)
                         ms0[0] = true_offsets[ex0[0]] + _row[0]
                         ns0[0] = n_tile_0 * T.int32(block_n)
                         v0[0] = T.int32(1)
@@ -463,7 +459,7 @@ def _make_pingpong_kernel(
                         m_tile_1 = flat_id_1 // T.int32(_num_pid_n)
                         n_tile_1 = flat_id_1 % T.int32(_num_pid_n)
 
-                        _group_tile_decode(m_tile_1, s_cum, lo, hi, ex1, _row)
+                        _tiling.decode(m_tile_1, s_cum, lo, hi, ex1, _row)
                         ms1[0] = true_offsets[ex1[0]] + _row[0]
                         ns1[0] = n_tile_1 * T.int32(block_n)
                         v1[0] = T.int32(1)
@@ -525,7 +521,7 @@ def _make_pingpong_kernel(
                         m_tile_0 = flat_id_0 // T.int32(_num_pid_n)
                         n_tile_0 = flat_id_0 % T.int32(_num_pid_n)
 
-                        _group_tile_decode(m_tile_0, s_cum, lo, hi, _ex, _row)
+                        _tiling.decode(m_tile_0, s_cum, lo, hi, _ex, _row)
                         _ms[0] = true_offsets[_ex[0]] + _row[0]
                         expert_id_0 = _ex[0]
                         row_0 = _row[0]
@@ -597,7 +593,7 @@ def _make_pingpong_kernel(
                         m_tile_1 = flat_id_1 // T.int32(_num_pid_n)
                         n_tile_1 = flat_id_1 % T.int32(_num_pid_n)
 
-                        _group_tile_decode(m_tile_1, s_cum, lo, hi, _ex, _row)
+                        _tiling.decode(m_tile_1, s_cum, lo, hi, _ex, _row)
                         _ms[0] = true_offsets[_ex[0]] + _row[0]
                         expert_id_1 = _ex[0]
                         row_1 = _row[0]
@@ -682,8 +678,7 @@ def _make_cooperative_kernel(
     ``ns≥3`` fit within H100's 228 KB cap when bm=128.
     """
     accum_dtype = "float"
-    _group_tile_cumsum = make_group_tile_cumsum(num_experts, block_m)
-    _group_tile_decode = make_group_tile_decode(num_experts, block_m)
+    _tiling = GroupTiling(num_experts, block_m)
 
     assert threads == 384, (
         f"V2 cooperative persistent grouped GEMM requires threads=384 "
@@ -810,7 +805,7 @@ def _make_cooperative_kernel(
                 T.dec_max_nreg(24)
 
                 if tx == 0:
-                    _group_tile_cumsum(true_sizes, s_cum)
+                    _tiling.cumsum(true_sizes, s_cum)
                     s_total[0] = s_cum[num_experts] * T.int32(_num_pid_n)
                 T.sync_threads()
 
@@ -826,7 +821,7 @@ def _make_cooperative_kernel(
                         m_tile = swz_m[0]
                         n_tile = swz_n[0]
 
-                        _group_tile_decode(m_tile, s_cum, lo, hi, ex, _row)
+                        _tiling.decode(m_tile, s_cum, lo, hi, ex, _row)
                         ms[0] = true_offsets[ex[0]] + _row[0]
                         ns_[0] = n_tile * T.int32(block_n)
                         v[0] = T.int32(1)
@@ -879,7 +874,7 @@ def _make_cooperative_kernel(
                         m_tile = swz_m[0]
                         n_tile = swz_n[0]
 
-                        _group_tile_decode(m_tile, s_cum, lo, hi, _ex, _row)
+                        _tiling.decode(m_tile, s_cum, lo, hi, _ex, _row)
                         _ms[0] = true_offsets[_ex[0]] + _row[0]
                         expert_id = _ex[0]
                         row = _row[0]
@@ -955,7 +950,7 @@ def _make_cooperative_kernel(
                         m_tile = swz_m[0]
                         n_tile = swz_n[0]
 
-                        _group_tile_decode(m_tile, s_cum, lo, hi, _ex, _row)
+                        _tiling.decode(m_tile, s_cum, lo, hi, _ex, _row)
                         _ms[0] = true_offsets[_ex[0]] + _row[0]
                         expert_id = _ex[0]
                         row = _row[0]

--- a/src/tileops/kernels/grouped_gemm/grouped_gemm_persistent_3wg.py
+++ b/src/tileops/kernels/grouped_gemm/grouped_gemm_persistent_3wg.py
@@ -114,8 +114,8 @@ class GroupedGemmPersistent3WGKernel(Kernel):
 
     @classmethod
     def applies(cls, call) -> bool:
-        """Shapes this kernel's tiling divides."""
-        return _tiling_divides(call.n, call.k)
+        """NT shapes this kernel's tiling divides; it computes ``A @ B^T`` only."""
+        return not call.transpose_a and call.transpose_b and _tiling_divides(call.n, call.k)
 
     def autotune(self, warmup: int = 10, rep: int = 10) -> None:
         """Override base autotune: the JIT factory already accepts config
@@ -131,9 +131,9 @@ class GroupedGemmPersistent3WGKernel(Kernel):
         B_dummy = (
             torch.randn(self.num_experts, self.N, self.K, dtype=self.dtype, device="cuda") * 0.02
         )
-        per = max(1, self.numel // self.num_experts)
-        sizes = torch.full((self.num_experts,), per, dtype=torch.int32, device="cuda")
-        sizes[-1] = self.numel - per * (self.num_experts - 1)
+        base, extra = divmod(self.numel, self.num_experts)
+        sizes = torch.full((self.num_experts,), base, dtype=torch.int32, device="cuda")
+        sizes[:extra] += 1
         offsets = torch.zeros(self.num_experts, dtype=torch.int32, device="cuda")
         offsets[1:] = torch.cumsum(sizes[:-1], dim=0)
 

--- a/src/tileops/kernels/grouped_tiling.py
+++ b/src/tileops/kernels/grouped_tiling.py
@@ -5,20 +5,23 @@ are enumerated per group. Enumerated over the whole row range instead, a tile ca
 straddle a boundary, and one that resolves a single group computes only the first
 of the ones it covers.
 
-The primitives run inside a kernel and take the caller's buffers, so each caller
-keeps its own scheduler.
+A CTA builds the prefix sum once and searches it for the group owning a tile.
 """
 
 import tilelang.language as T
 
-__all__ = ["make_group_tile_cumsum", "make_group_tile_decode", "tile_upper_bound"]
+__all__ = [
+    "make_group_tile_cumsum",
+    "make_group_tile_decode",
+    "tile_upper_bound",
+]
 
 
 def tile_upper_bound(numel: int, num_groups: int, block_m: int) -> int:
     """Tiles ``numel`` rows can need, at most one partial tile per group.
 
-    Sizes arrive on the device, so a grid takes this bound and reads the exact
-    count off ``s_cum[num_groups]``.
+    Sizes arrive on the device, so a grid takes this bound and drops the tiles
+    past the count the kernel finds at run time.
     """
     return numel // block_m + num_groups
 
@@ -40,11 +43,11 @@ def make_group_tile_cumsum(num_groups: int, block_m: int):
 
 
 def make_group_tile_decode(num_groups: int, block_m: int):
-    """Build the macro resolving one M tile id into its group and first row.
+    """Build the macro searching ``s_cum`` for the group owning one M tile id.
 
-    ``row`` is the tile's first row within its group: the caller reads the packed
-    start as ``offsets[group] + row`` and clamps the tile with
-    ``sizes[group] - row``.
+    For a CTA that resolves several tiles, so the prefix sum it searches is built
+    once. ``row`` is the tile's first row within its group: the caller reads the
+    packed start as ``offsets[group] + row``.
     """
     log2_up = max(1, (num_groups - 1).bit_length())
 

--- a/src/tileops/kernels/grouped_tiling.py
+++ b/src/tileops/kernels/grouped_tiling.py
@@ -1,13 +1,12 @@
 """Mapping a flat tile id onto the group that owns it.
 
-A grouped GEMM lays its rows out per group, so an M tile belongs to one group
-only if the tiles are enumerated per group rather than over the whole row range.
-Enumerating them globally lets a tile straddle a group boundary, and a tile that
-resolves a single group computes only the first of the ones it covers.
+Rows are laid out per group, so an M tile belongs to one group only if the tiles
+are enumerated per group. Enumerated over the whole row range instead, a tile can
+straddle a boundary, and one that resolves a single group computes only the first
+of the ones it covers.
 
-Both primitives here run inside a kernel and take the caller's buffers, so the
-caller keeps its own scheduler: a static wave, a plain grid, or a separate
-scheduling launch all decode a tile id the same way.
+The primitives run inside a kernel and take the caller's buffers, so each caller
+keeps its own scheduler.
 """
 
 import tilelang.language as T
@@ -16,25 +15,19 @@ __all__ = ["make_group_tile_cumsum", "make_group_tile_decode", "tile_upper_bound
 
 
 def tile_upper_bound(numel: int, num_groups: int, block_m: int) -> int:
-    """Tiles ``numel`` rows can need once every group starts a fresh tile.
+    """Tiles ``numel`` rows can need, at most one partial tile per group.
 
-    Each group rounds up to a whole tile, so the worst case adds one partial tile
-    per group. Sizes arrive on the device, which is why this is a bound and the
-    exact count is read from the prefix sum at run time.
+    Sizes arrive on the device, so a grid takes this bound and reads the exact
+    count off ``s_cum[num_groups]``.
     """
     return numel // block_m + num_groups
 
 
 def make_group_tile_cumsum(num_groups: int, block_m: int):
-    """Build the macro that writes the per-group tile-count prefix sum.
+    """Build the macro writing the per-group tile-count prefix sum into ``s_cum``.
 
-    ``s_cum[g + 1] - s_cum[g]`` is the tiles group *g* needs, so ``s_cum`` maps a
-    tile id to its group by search, and ``s_cum[num_groups]`` is how many tiles
-    the call actually has.
-
-    Args:
-        num_groups: Groups the rows are spread over.
-        block_m: Rows one tile covers.
+    ``s_cum[g + 1] - s_cum[g]`` is the tiles group *g* needs, and
+    ``s_cum[num_groups]`` is how many the call has.
     """
 
     @T.macro
@@ -47,15 +40,11 @@ def make_group_tile_cumsum(num_groups: int, block_m: int):
 
 
 def make_group_tile_decode(num_groups: int, block_m: int):
-    """Build the macro that resolves one M tile id into its group and first row.
+    """Build the macro resolving one M tile id into its group and first row.
 
-    ``row`` is the tile's first row within its group, so the caller reads its
-    start in the packed layout as ``offsets[group] + row`` and clamps the tile
-    with ``sizes[group] - row``.
-
-    Args:
-        num_groups: Groups the rows are spread over.
-        block_m: Rows one tile covers.
+    ``row`` is the tile's first row within its group: the caller reads the packed
+    start as ``offsets[group] + row`` and clamps the tile with
+    ``sizes[group] - row``.
     """
     log2_up = max(1, (num_groups - 1).bit_length())
 

--- a/src/tileops/kernels/grouped_tiling.py
+++ b/src/tileops/kernels/grouped_tiling.py
@@ -5,63 +5,75 @@ are enumerated per group. Enumerated over the whole row range instead, a tile ca
 straddle a boundary, and one that resolves a single group computes only the first
 of the ones it covers.
 
-A CTA builds the prefix sum once and searches it for the group owning a tile.
+The prefix sum and the search read the same tile counts, so one object holds the
+group count and tile height both of them are built from, and the macros take the
+caller's buffers so each kernel keeps its own scheduler.
 """
 
 import tilelang.language as T
 
-__all__ = [
-    "make_group_tile_cumsum",
-    "make_group_tile_decode",
-    "tile_upper_bound",
-]
+__all__ = ["GroupTiling"]
 
 
-def tile_upper_bound(numel: int, num_groups: int, block_m: int) -> int:
-    """Tiles ``numel`` rows can need, at most one partial tile per group.
+class GroupTiling:
+    """Tiles enumerated per group, for ``num_groups`` groups of ``block_m`` rows.
 
-    Sizes arrive on the device, so a grid takes this bound and drops the tiles
-    past the count the kernel finds at run time.
-    """
-    return numel // block_m + num_groups
-
-
-def make_group_tile_cumsum(num_groups: int, block_m: int):
-    """Build the macro writing the per-group tile-count prefix sum into ``s_cum``.
-
-    ``s_cum[g + 1] - s_cum[g]`` is the tiles group *g* needs, and
-    ``s_cum[num_groups]`` is how many the call has.
+    Example:
+        >>> tiling = GroupTiling(num_groups=16, block_m=64)
+        >>> tiling.tile_upper_bound(4096)
+        80
     """
 
-    @T.macro
-    def group_tile_cumsum(sizes, s_cum):
-        s_cum[0] = T.int32(0)
-        for g in T.serial(num_groups):
-            s_cum[g + 1] = s_cum[g] + (sizes[g] + T.int32(block_m - 1)) // T.int32(block_m)
+    def __init__(self, num_groups: int, block_m: int) -> None:
+        self.num_groups = num_groups
+        self.block_m = block_m
+        self._search_steps = max(1, (num_groups - 1).bit_length())
 
-    return group_tile_cumsum
+    def tile_upper_bound(self, numel: int) -> int:
+        """Tiles ``numel`` rows can need, at most one partial tile per group.
 
+        Sizes arrive on the device, so a grid takes this bound and drops the
+        tiles past the count the kernel finds at run time.
+        """
+        return numel // self.block_m + self.num_groups
 
-def make_group_tile_decode(num_groups: int, block_m: int):
-    """Build the macro searching ``s_cum`` for the group owning one M tile id.
+    @property
+    def cumsum(self):
+        """Macro writing the per-group tile-count prefix sum into ``s_cum``.
 
-    For a CTA that resolves several tiles, so the prefix sum it searches is built
-    once. ``row`` is the tile's first row within its group: the caller reads the
-    packed start as ``offsets[group] + row``.
-    """
-    log2_up = max(1, (num_groups - 1).bit_length())
+        ``s_cum[g + 1] - s_cum[g]`` is the tiles group *g* needs, and
+        ``s_cum[num_groups]`` is how many the call has.
+        """
+        num_groups, block_m = self.num_groups, self.block_m
 
-    @T.macro
-    def group_tile_decode(m_tile, s_cum, lo, hi, group, row):
-        lo[0] = T.int32(0)
-        hi[0] = T.int32(num_groups - 1)
-        for _ in T.serial(log2_up):
-            mid = (lo[0] + hi[0]) >> T.int32(1)
-            if s_cum[mid + 1] <= m_tile:
-                lo[0] = mid + T.int32(1)
-            else:
-                hi[0] = mid
-        group[0] = lo[0]
-        row[0] = (m_tile - s_cum[lo[0]]) * T.int32(block_m)
+        @T.macro
+        def group_tile_cumsum(sizes, s_cum):
+            s_cum[0] = T.int32(0)
+            for g in T.serial(num_groups):
+                s_cum[g + 1] = s_cum[g] + (sizes[g] + T.int32(block_m - 1)) // T.int32(block_m)
 
-    return group_tile_decode
+        return group_tile_cumsum
+
+    @property
+    def decode(self):
+        """Macro searching ``s_cum`` for the group owning one M tile id.
+
+        ``row`` is the tile's first row within its group: the caller reads the
+        packed start as ``offsets[group] + row``.
+        """
+        num_groups, block_m, steps = self.num_groups, self.block_m, self._search_steps
+
+        @T.macro
+        def group_tile_decode(m_tile, s_cum, lo, hi, group, row):
+            lo[0] = T.int32(0)
+            hi[0] = T.int32(num_groups - 1)
+            for _ in T.serial(steps):
+                mid = (lo[0] + hi[0]) >> T.int32(1)
+                if s_cum[mid + 1] <= m_tile:
+                    lo[0] = mid + T.int32(1)
+                else:
+                    hi[0] = mid
+            group[0] = lo[0]
+            row[0] = (m_tile - s_cum[lo[0]]) * T.int32(block_m)
+
+        return group_tile_decode

--- a/src/tileops/kernels/grouped_tiling.py
+++ b/src/tileops/kernels/grouped_tiling.py
@@ -1,0 +1,75 @@
+"""Mapping a flat tile id onto the group that owns it.
+
+A grouped GEMM lays its rows out per group, so an M tile belongs to one group
+only if the tiles are enumerated per group rather than over the whole row range.
+Enumerating them globally lets a tile straddle a group boundary, and a tile that
+resolves a single group computes only the first of the ones it covers.
+
+Both primitives here run inside a kernel and take the caller's buffers, so the
+caller keeps its own scheduler: a static wave, a plain grid, or a separate
+scheduling launch all decode a tile id the same way.
+"""
+
+import tilelang.language as T
+
+__all__ = ["make_group_tile_cumsum", "make_group_tile_decode", "tile_upper_bound"]
+
+
+def tile_upper_bound(numel: int, num_groups: int, block_m: int) -> int:
+    """Tiles ``numel`` rows can need once every group starts a fresh tile.
+
+    Each group rounds up to a whole tile, so the worst case adds one partial tile
+    per group. Sizes arrive on the device, which is why this is a bound and the
+    exact count is read from the prefix sum at run time.
+    """
+    return numel // block_m + num_groups
+
+
+def make_group_tile_cumsum(num_groups: int, block_m: int):
+    """Build the macro that writes the per-group tile-count prefix sum.
+
+    ``s_cum[g + 1] - s_cum[g]`` is the tiles group *g* needs, so ``s_cum`` maps a
+    tile id to its group by search, and ``s_cum[num_groups]`` is how many tiles
+    the call actually has.
+
+    Args:
+        num_groups: Groups the rows are spread over.
+        block_m: Rows one tile covers.
+    """
+
+    @T.macro
+    def group_tile_cumsum(sizes, s_cum):
+        s_cum[0] = T.int32(0)
+        for g in T.serial(num_groups):
+            s_cum[g + 1] = s_cum[g] + (sizes[g] + T.int32(block_m - 1)) // T.int32(block_m)
+
+    return group_tile_cumsum
+
+
+def make_group_tile_decode(num_groups: int, block_m: int):
+    """Build the macro that resolves one M tile id into its group and first row.
+
+    ``row`` is the tile's first row within its group, so the caller reads its
+    start in the packed layout as ``offsets[group] + row`` and clamps the tile
+    with ``sizes[group] - row``.
+
+    Args:
+        num_groups: Groups the rows are spread over.
+        block_m: Rows one tile covers.
+    """
+    log2_up = max(1, (num_groups - 1).bit_length())
+
+    @T.macro
+    def group_tile_decode(m_tile, s_cum, lo, hi, group, row):
+        lo[0] = T.int32(0)
+        hi[0] = T.int32(num_groups - 1)
+        for _ in T.serial(log2_up):
+            mid = (lo[0] + hi[0]) >> T.int32(1)
+            if s_cum[mid + 1] <= m_tile:
+                lo[0] = mid + T.int32(1)
+            else:
+                hi[0] = mid
+        group[0] = lo[0]
+        row[0] = (m_tile - s_cum[lo[0]]) * T.int32(block_m)
+
+    return group_tile_decode

--- a/src/tileops/kernels/moe/moe_grouped_gemm_nopad.py
+++ b/src/tileops/kernels/moe/moe_grouped_gemm_nopad.py
@@ -43,10 +43,7 @@ import tilelang
 import tilelang.language as T
 import torch
 
-from tileops.kernels.grouped_tiling import (
-    make_group_tile_cumsum,
-    make_group_tile_decode,
-)
+from tileops.kernels.grouped_tiling import GroupTiling
 from tileops.kernels.kernel_base import Kernel
 
 __all__ = ["MoeGroupedGemmNopadKernel"]
@@ -78,8 +75,7 @@ def _tile_scheduler_kernel(num_experts: int, max_tiles: int, block_m: int):
         max_tiles:   Conservative tile upper bound (numel // block_m + E).
         block_m:     Tile height in M dimension (compile-time constant).
     """
-    _group_tile_cumsum = make_group_tile_cumsum(num_experts, block_m)
-    _group_tile_decode = make_group_tile_decode(num_experts, block_m)
+    _tiling = GroupTiling(num_experts, block_m)
 
     @tilelang.jit(out_idx=[1, 2, 3])
     def _func(threads: int):
@@ -102,7 +98,7 @@ def _tile_scheduler_kernel(num_experts: int, max_tiles: int, block_m: int):
                 # Sub-phase (a): thread 0 computes exclusive prefix sum of
                 # ceildiv(true_sizes[e], block_m) into SMEM.
                 if tx == 0:
-                    _group_tile_cumsum(true_sizes, s_cum)
+                    _tiling.cumsum(true_sizes, s_cum)
                     if bx == 0:
                         total_tiles[0] = s_cum[num_experts]
                 T.sync_threads()
@@ -111,7 +107,7 @@ def _tile_scheduler_kernel(num_experts: int, max_tiles: int, block_m: int):
                 tile_id = bx * threads + tx
                 if tile_id < max_tiles:
                     if tile_id < s_cum[num_experts]:
-                        _group_tile_decode(tile_id, s_cum, lo, hi, _ex, _row)
+                        _tiling.decode(tile_id, s_cum, lo, hi, _ex, _row)
                         tile_expert_ids[tile_id] = _ex[0]
                         tile_row_offsets[tile_id] = _row[0]
                     else:

--- a/src/tileops/kernels/moe/moe_grouped_gemm_nopad.py
+++ b/src/tileops/kernels/moe/moe_grouped_gemm_nopad.py
@@ -43,6 +43,10 @@ import tilelang
 import tilelang.language as T
 import torch
 
+from tileops.kernels.grouped_tiling import (
+    make_group_tile_cumsum,
+    make_group_tile_decode,
+)
 from tileops.kernels.kernel_base import Kernel
 
 __all__ = ["MoeGroupedGemmNopadKernel"]
@@ -74,8 +78,8 @@ def _tile_scheduler_kernel(num_experts: int, max_tiles: int, block_m: int):
         max_tiles:   Conservative tile upper bound (numel // block_m + E).
         block_m:     Tile height in M dimension (compile-time constant).
     """
-    # Static binary search depth: ceil(log2(E+1)) iterations suffice for E experts.
-    log2_up = max(1, math.ceil(math.log2(num_experts + 1)))
+    _group_tile_cumsum = make_group_tile_cumsum(num_experts, block_m)
+    _group_tile_decode = make_group_tile_decode(num_experts, block_m)
 
     @tilelang.jit(out_idx=[1, 2, 3])
     def _func(threads: int):
@@ -90,15 +94,15 @@ def _tile_scheduler_kernel(num_experts: int, max_tiles: int, block_m: int):
                 s_cum = T.alloc_shared([num_experts + 1], "int32")
                 lo = T.alloc_local([1], "int32")
                 hi = T.alloc_local([1], "int32")
+                _ex = T.alloc_local([1], "int32")
+                _row = T.alloc_local([1], "int32")
 
                 tx = T.get_thread_binding()
 
                 # Sub-phase (a): thread 0 computes exclusive prefix sum of
                 # ceildiv(true_sizes[e], block_m) into SMEM.
                 if tx == 0:
-                    s_cum[0] = T.int32(0)
-                    for e in T.serial(num_experts):
-                        s_cum[e + 1] = s_cum[e] + (true_sizes[e] + (block_m - 1)) // block_m
+                    _group_tile_cumsum(true_sizes, s_cum)
                     if bx == 0:
                         total_tiles[0] = s_cum[num_experts]
                 T.sync_threads()
@@ -107,16 +111,9 @@ def _tile_scheduler_kernel(num_experts: int, max_tiles: int, block_m: int):
                 tile_id = bx * threads + tx
                 if tile_id < max_tiles:
                     if tile_id < s_cum[num_experts]:
-                        lo[0] = T.int32(0)
-                        hi[0] = T.int32(num_experts - 1)
-                        for _bs in T.serial(log2_up):
-                            mid = (lo[0] + hi[0]) >> T.int32(1)
-                            if s_cum[mid + 1] <= tile_id:
-                                lo[0] = mid + T.int32(1)
-                            else:
-                                hi[0] = mid
-                        tile_expert_ids[tile_id] = lo[0]
-                        tile_row_offsets[tile_id] = (tile_id - s_cum[lo[0]]) * T.int32(block_m)
+                        _group_tile_decode(tile_id, s_cum, lo, hi, _ex, _row)
+                        tile_expert_ids[tile_id] = _ex[0]
+                        tile_row_offsets[tile_id] = _row[0]
                     else:
                         tile_expert_ids[tile_id] = T.int32(-1)
                         tile_row_offsets[tile_id] = T.int32(0)

--- a/src/tileops/kernels/moe/moe_grouped_gemm_persistent_3wg_fused_act.py
+++ b/src/tileops/kernels/moe/moe_grouped_gemm_persistent_3wg_fused_act.py
@@ -17,6 +17,10 @@ import tilelang.language as T
 import torch
 
 from tileops.kernels.grouped_gemm import rows_per_group_regime
+from tileops.kernels.grouped_tiling import (
+    make_group_tile_cumsum,
+    make_group_tile_decode,
+)
 from tileops.kernels.kernel_base import Kernel
 from tileops.utils import get_sm_count
 
@@ -298,9 +302,8 @@ def _make_pingpong_fused_act_kernel(
     the [numel, 2*ffn] gate_up tensor never reaches global memory.
     """
     accum_dtype = "float"
-    # Binary search over [0, num_experts-1] (num_experts elements) needs
-    # ceil(log2(num_experts)) iterations to converge to one element.
-    log2_up = max(1, math.ceil(math.log2(num_experts)))
+    _group_tile_cumsum = make_group_tile_cumsum(num_experts, block_m)
+    _group_tile_decode = make_group_tile_decode(num_experts, block_m)
 
     assert threads == 384, (
         f"fused-act pingpong persistent grouped GEMM requires threads=384 "
@@ -350,6 +353,9 @@ def _make_pingpong_fused_act_kernel(
             s_total = T.alloc_shared((1,), "int32")
             lo = T.alloc_local((1,), "int32")
             hi = T.alloc_local((1,), "int32")
+            _row = T.alloc_local((1,), "int32")
+            _ex = T.alloc_local((1,), "int32")
+            _ms = T.alloc_local((1,), "int32")
             # Per-tile metadata hoisted to alloc_local so the interleaved
             # K-loop body can read m_start/n_start/expert_id across IfFrame
             # boundaries.
@@ -396,9 +402,7 @@ def _make_pingpong_fused_act_kernel(
                 T.dec_max_nreg(24)
 
                 if tx == 0:
-                    s_cum[0] = T.int32(0)
-                    for e in T.serial(num_experts):
-                        s_cum[e + 1] = s_cum[e] + (true_sizes[e] + (block_m - 1)) // block_m
+                    _group_tile_cumsum(true_sizes, s_cum)
                     s_total[0] = s_cum[num_experts] * T.int32(_num_pid_n)
                 # CTA-wide sync: publishes s_cum/s_total to consumers.
                 T.sync_threads()
@@ -413,18 +417,8 @@ def _make_pingpong_fused_act_kernel(
                         m_tile_0 = flat_id_0 // T.int32(_num_pid_n)
                         n_tile_0 = flat_id_0 % T.int32(_num_pid_n)
 
-                        lo[0] = T.int32(0)
-                        hi[0] = T.int32(num_experts - 1)
-                        for _bs in T.serial(log2_up):
-                            mid = (lo[0] + hi[0]) >> T.int32(1)
-                            if s_cum[mid + 1] <= m_tile_0:
-                                lo[0] = mid + T.int32(1)
-                            else:
-                                hi[0] = mid
-                        ex0[0] = lo[0]
-                        ms0[0] = true_offsets[ex0[0]] + (m_tile_0 - s_cum[ex0[0]]) * T.int32(
-                            block_m
-                        )
+                        _group_tile_decode(m_tile_0, s_cum, lo, hi, ex0, _row)
+                        ms0[0] = true_offsets[ex0[0]] + _row[0]
                         ns0[0] = n_tile_0 * T.int32(block_n)
                         v0[0] = T.int32(1)
                     else:
@@ -436,18 +430,8 @@ def _make_pingpong_fused_act_kernel(
                         m_tile_1 = flat_id_1 // T.int32(_num_pid_n)
                         n_tile_1 = flat_id_1 % T.int32(_num_pid_n)
 
-                        lo[0] = T.int32(0)
-                        hi[0] = T.int32(num_experts - 1)
-                        for _bs in T.serial(log2_up):
-                            mid = (lo[0] + hi[0]) >> T.int32(1)
-                            if s_cum[mid + 1] <= m_tile_1:
-                                lo[0] = mid + T.int32(1)
-                            else:
-                                hi[0] = mid
-                        ex1[0] = lo[0]
-                        ms1[0] = true_offsets[ex1[0]] + (m_tile_1 - s_cum[ex1[0]]) * T.int32(
-                            block_m
-                        )
+                        _group_tile_decode(m_tile_1, s_cum, lo, hi, ex1, _row)
+                        ms1[0] = true_offsets[ex1[0]] + _row[0]
                         ns1[0] = n_tile_1 * T.int32(block_n)
                         v1[0] = T.int32(1)
                     else:
@@ -526,17 +510,11 @@ def _make_pingpong_fused_act_kernel(
                         m_tile_0 = flat_id_0 // T.int32(_num_pid_n)
                         n_tile_0 = flat_id_0 % T.int32(_num_pid_n)
 
-                        lo[0] = T.int32(0)
-                        hi[0] = T.int32(num_experts - 1)
-                        for _bs in T.serial(log2_up):
-                            mid = (lo[0] + hi[0]) >> T.int32(1)
-                            if s_cum[mid + 1] <= m_tile_0:
-                                lo[0] = mid + T.int32(1)
-                            else:
-                                hi[0] = mid
-                        expert_id_0 = lo[0]
-                        row_0 = (m_tile_0 - s_cum[expert_id_0]) * T.int32(block_m)
-                        m_start_0 = true_offsets[expert_id_0] + row_0
+                        _group_tile_decode(m_tile_0, s_cum, lo, hi, _ex, _row)
+                        _ms[0] = true_offsets[_ex[0]] + _row[0]
+                        expert_id_0 = _ex[0]
+                        row_0 = _row[0]
+                        m_start_0 = _ms[0]
                         n_start_0 = n_tile_0 * T.int32(block_n)
                         arows_0 = T.min(T.int32(block_m), true_sizes[expert_id_0] - row_0)
 
@@ -610,17 +588,11 @@ def _make_pingpong_fused_act_kernel(
                         m_tile_1 = flat_id_1 // T.int32(_num_pid_n)
                         n_tile_1 = flat_id_1 % T.int32(_num_pid_n)
 
-                        lo[0] = T.int32(0)
-                        hi[0] = T.int32(num_experts - 1)
-                        for _bs in T.serial(log2_up):
-                            mid = (lo[0] + hi[0]) >> T.int32(1)
-                            if s_cum[mid + 1] <= m_tile_1:
-                                lo[0] = mid + T.int32(1)
-                            else:
-                                hi[0] = mid
-                        expert_id_1 = lo[0]
-                        row_1 = (m_tile_1 - s_cum[expert_id_1]) * T.int32(block_m)
-                        m_start_1 = true_offsets[expert_id_1] + row_1
+                        _group_tile_decode(m_tile_1, s_cum, lo, hi, _ex, _row)
+                        _ms[0] = true_offsets[_ex[0]] + _row[0]
+                        expert_id_1 = _ex[0]
+                        row_1 = _row[0]
+                        m_start_1 = _ms[0]
                         n_start_1 = n_tile_1 * T.int32(block_n)
                         arows_1 = T.min(T.int32(block_m), true_sizes[expert_id_1] - row_1)
 
@@ -700,9 +672,8 @@ def _make_cooperative_fused_act_kernel(
     never reaches global memory.
     """
     accum_dtype = "float"
-    # Binary search over [0, num_experts-1] (num_experts elements) needs
-    # ceil(log2(num_experts)) iterations to converge to one element.
-    log2_up = max(1, math.ceil(math.log2(num_experts)))
+    _group_tile_cumsum = make_group_tile_cumsum(num_experts, block_m)
+    _group_tile_decode = make_group_tile_decode(num_experts, block_m)
 
     assert threads == 384, (
         f"fused-act cooperative persistent grouped GEMM requires threads=384 "
@@ -760,6 +731,9 @@ def _make_cooperative_fused_act_kernel(
             s_total = T.alloc_shared((1,), "int32")
             lo = T.alloc_local((1,), "int32")
             hi = T.alloc_local((1,), "int32")
+            _row = T.alloc_local((1,), "int32")
+            _ex = T.alloc_local((1,), "int32")
+            _ms = T.alloc_local((1,), "int32")
             # Per-tile metadata in alloc_local (same pattern as pingpong).
             ms = T.alloc_local((1,), "int32")
             ns_ = T.alloc_local((1,), "int32")
@@ -798,9 +772,7 @@ def _make_cooperative_fused_act_kernel(
                 T.dec_max_nreg(24)
 
                 if tx == 0:
-                    s_cum[0] = T.int32(0)
-                    for e in T.serial(num_experts):
-                        s_cum[e + 1] = s_cum[e] + (true_sizes[e] + (block_m - 1)) // block_m
+                    _group_tile_cumsum(true_sizes, s_cum)
                     s_total[0] = s_cum[num_experts] * T.int32(_num_pid_n)
                 # CTA-wide sync: publishes s_cum/s_total to consumers
                 T.sync_threads()
@@ -813,16 +785,8 @@ def _make_cooperative_fused_act_kernel(
                         m_tile = flat_id // T.int32(_num_pid_n)
                         n_tile = flat_id % T.int32(_num_pid_n)
 
-                        lo[0] = T.int32(0)
-                        hi[0] = T.int32(num_experts - 1)
-                        for _bs in T.serial(log2_up):
-                            mid = (lo[0] + hi[0]) >> T.int32(1)
-                            if s_cum[mid + 1] <= m_tile:
-                                lo[0] = mid + T.int32(1)
-                            else:
-                                hi[0] = mid
-                        ex[0] = lo[0]
-                        ms[0] = true_offsets[ex[0]] + (m_tile - s_cum[ex[0]]) * T.int32(block_m)
+                        _group_tile_decode(m_tile, s_cum, lo, hi, ex, _row)
+                        ms[0] = true_offsets[ex[0]] + _row[0]
                         ns_[0] = n_tile * T.int32(block_n)
                         rows[0] = true_sizes[ex[0]] - (m_tile - s_cum[ex[0]]) * T.int32(block_m)
                         v[0] = T.int32(1)
@@ -889,17 +853,11 @@ def _make_cooperative_fused_act_kernel(
                         m_tile = flat_id // T.int32(_num_pid_n)
                         n_tile = flat_id % T.int32(_num_pid_n)
 
-                        lo[0] = T.int32(0)
-                        hi[0] = T.int32(num_experts - 1)
-                        for _bs in T.serial(log2_up):
-                            mid = (lo[0] + hi[0]) >> T.int32(1)
-                            if s_cum[mid + 1] <= m_tile:
-                                lo[0] = mid + T.int32(1)
-                            else:
-                                hi[0] = mid
-                        expert_id = lo[0]
-                        row = (m_tile - s_cum[expert_id]) * T.int32(block_m)
-                        m_start = true_offsets[expert_id] + row
+                        _group_tile_decode(m_tile, s_cum, lo, hi, _ex, _row)
+                        _ms[0] = true_offsets[_ex[0]] + _row[0]
+                        expert_id = _ex[0]
+                        row = _row[0]
+                        m_start = _ms[0]
                         n_start = n_tile * T.int32(block_n)
                         # Top-half row count: clamp(true_arows, 0, half_m).
                         true_arows = true_sizes[expert_id] - row
@@ -974,17 +932,11 @@ def _make_cooperative_fused_act_kernel(
                         m_tile = flat_id // T.int32(_num_pid_n)
                         n_tile = flat_id % T.int32(_num_pid_n)
 
-                        lo[0] = T.int32(0)
-                        hi[0] = T.int32(num_experts - 1)
-                        for _bs in T.serial(log2_up):
-                            mid = (lo[0] + hi[0]) >> T.int32(1)
-                            if s_cum[mid + 1] <= m_tile:
-                                lo[0] = mid + T.int32(1)
-                            else:
-                                hi[0] = mid
-                        expert_id = lo[0]
-                        row = (m_tile - s_cum[expert_id]) * T.int32(block_m)
-                        m_start = true_offsets[expert_id] + row
+                        _group_tile_decode(m_tile, s_cum, lo, hi, _ex, _row)
+                        _ms[0] = true_offsets[_ex[0]] + _row[0]
+                        expert_id = _ex[0]
+                        row = _row[0]
+                        m_start = _ms[0]
                         n_start = n_tile * T.int32(block_n)
                         # Bottom-half row count: clamp(true_arows-half_m, 0, half_m).
                         true_arows = true_sizes[expert_id] - row

--- a/src/tileops/kernels/moe/moe_grouped_gemm_persistent_3wg_fused_act.py
+++ b/src/tileops/kernels/moe/moe_grouped_gemm_persistent_3wg_fused_act.py
@@ -788,7 +788,7 @@ def _make_cooperative_fused_act_kernel(
                         _group_tile_decode(m_tile, s_cum, lo, hi, ex, _row)
                         ms[0] = true_offsets[ex[0]] + _row[0]
                         ns_[0] = n_tile * T.int32(block_n)
-                        rows[0] = true_sizes[ex[0]] - (m_tile - s_cum[ex[0]]) * T.int32(block_m)
+                        rows[0] = true_sizes[ex[0]] - _row[0]
                         v[0] = T.int32(1)
                     else:
                         v[0] = T.int32(0)

--- a/src/tileops/kernels/moe/moe_grouped_gemm_persistent_3wg_fused_act.py
+++ b/src/tileops/kernels/moe/moe_grouped_gemm_persistent_3wg_fused_act.py
@@ -17,10 +17,7 @@ import tilelang.language as T
 import torch
 
 from tileops.kernels.grouped_gemm import rows_per_group_regime
-from tileops.kernels.grouped_tiling import (
-    make_group_tile_cumsum,
-    make_group_tile_decode,
-)
+from tileops.kernels.grouped_tiling import GroupTiling
 from tileops.kernels.kernel_base import Kernel
 from tileops.utils import get_sm_count
 
@@ -302,8 +299,7 @@ def _make_pingpong_fused_act_kernel(
     the [numel, 2*ffn] gate_up tensor never reaches global memory.
     """
     accum_dtype = "float"
-    _group_tile_cumsum = make_group_tile_cumsum(num_experts, block_m)
-    _group_tile_decode = make_group_tile_decode(num_experts, block_m)
+    _tiling = GroupTiling(num_experts, block_m)
 
     assert threads == 384, (
         f"fused-act pingpong persistent grouped GEMM requires threads=384 "
@@ -402,7 +398,7 @@ def _make_pingpong_fused_act_kernel(
                 T.dec_max_nreg(24)
 
                 if tx == 0:
-                    _group_tile_cumsum(true_sizes, s_cum)
+                    _tiling.cumsum(true_sizes, s_cum)
                     s_total[0] = s_cum[num_experts] * T.int32(_num_pid_n)
                 # CTA-wide sync: publishes s_cum/s_total to consumers.
                 T.sync_threads()
@@ -417,7 +413,7 @@ def _make_pingpong_fused_act_kernel(
                         m_tile_0 = flat_id_0 // T.int32(_num_pid_n)
                         n_tile_0 = flat_id_0 % T.int32(_num_pid_n)
 
-                        _group_tile_decode(m_tile_0, s_cum, lo, hi, ex0, _row)
+                        _tiling.decode(m_tile_0, s_cum, lo, hi, ex0, _row)
                         ms0[0] = true_offsets[ex0[0]] + _row[0]
                         ns0[0] = n_tile_0 * T.int32(block_n)
                         v0[0] = T.int32(1)
@@ -430,7 +426,7 @@ def _make_pingpong_fused_act_kernel(
                         m_tile_1 = flat_id_1 // T.int32(_num_pid_n)
                         n_tile_1 = flat_id_1 % T.int32(_num_pid_n)
 
-                        _group_tile_decode(m_tile_1, s_cum, lo, hi, ex1, _row)
+                        _tiling.decode(m_tile_1, s_cum, lo, hi, ex1, _row)
                         ms1[0] = true_offsets[ex1[0]] + _row[0]
                         ns1[0] = n_tile_1 * T.int32(block_n)
                         v1[0] = T.int32(1)
@@ -510,7 +506,7 @@ def _make_pingpong_fused_act_kernel(
                         m_tile_0 = flat_id_0 // T.int32(_num_pid_n)
                         n_tile_0 = flat_id_0 % T.int32(_num_pid_n)
 
-                        _group_tile_decode(m_tile_0, s_cum, lo, hi, _ex, _row)
+                        _tiling.decode(m_tile_0, s_cum, lo, hi, _ex, _row)
                         _ms[0] = true_offsets[_ex[0]] + _row[0]
                         expert_id_0 = _ex[0]
                         row_0 = _row[0]
@@ -588,7 +584,7 @@ def _make_pingpong_fused_act_kernel(
                         m_tile_1 = flat_id_1 // T.int32(_num_pid_n)
                         n_tile_1 = flat_id_1 % T.int32(_num_pid_n)
 
-                        _group_tile_decode(m_tile_1, s_cum, lo, hi, _ex, _row)
+                        _tiling.decode(m_tile_1, s_cum, lo, hi, _ex, _row)
                         _ms[0] = true_offsets[_ex[0]] + _row[0]
                         expert_id_1 = _ex[0]
                         row_1 = _row[0]
@@ -672,8 +668,7 @@ def _make_cooperative_fused_act_kernel(
     never reaches global memory.
     """
     accum_dtype = "float"
-    _group_tile_cumsum = make_group_tile_cumsum(num_experts, block_m)
-    _group_tile_decode = make_group_tile_decode(num_experts, block_m)
+    _tiling = GroupTiling(num_experts, block_m)
 
     assert threads == 384, (
         f"fused-act cooperative persistent grouped GEMM requires threads=384 "
@@ -772,7 +767,7 @@ def _make_cooperative_fused_act_kernel(
                 T.dec_max_nreg(24)
 
                 if tx == 0:
-                    _group_tile_cumsum(true_sizes, s_cum)
+                    _tiling.cumsum(true_sizes, s_cum)
                     s_total[0] = s_cum[num_experts] * T.int32(_num_pid_n)
                 # CTA-wide sync: publishes s_cum/s_total to consumers
                 T.sync_threads()
@@ -785,7 +780,7 @@ def _make_cooperative_fused_act_kernel(
                         m_tile = flat_id // T.int32(_num_pid_n)
                         n_tile = flat_id % T.int32(_num_pid_n)
 
-                        _group_tile_decode(m_tile, s_cum, lo, hi, ex, _row)
+                        _tiling.decode(m_tile, s_cum, lo, hi, ex, _row)
                         ms[0] = true_offsets[ex[0]] + _row[0]
                         ns_[0] = n_tile * T.int32(block_n)
                         rows[0] = true_sizes[ex[0]] - _row[0]
@@ -853,7 +848,7 @@ def _make_cooperative_fused_act_kernel(
                         m_tile = flat_id // T.int32(_num_pid_n)
                         n_tile = flat_id % T.int32(_num_pid_n)
 
-                        _group_tile_decode(m_tile, s_cum, lo, hi, _ex, _row)
+                        _tiling.decode(m_tile, s_cum, lo, hi, _ex, _row)
                         _ms[0] = true_offsets[_ex[0]] + _row[0]
                         expert_id = _ex[0]
                         row = _row[0]
@@ -932,7 +927,7 @@ def _make_cooperative_fused_act_kernel(
                         m_tile = flat_id // T.int32(_num_pid_n)
                         n_tile = flat_id % T.int32(_num_pid_n)
 
-                        _group_tile_decode(m_tile, s_cum, lo, hi, _ex, _row)
+                        _tiling.decode(m_tile, s_cum, lo, hi, _ex, _row)
                         _ms[0] = true_offsets[_ex[0]] + _row[0]
                         expert_id = _ex[0]
                         row = _row[0]

--- a/src/tileops/manifest/gemm.yaml
+++ b/src/tileops/manifest/gemm.yaml
@@ -199,6 +199,7 @@ GroupedGemmFwdOp:
     kernel: tileops/kernels/grouped_gemm/grouped_gemm.py
     kernel_map:
       grouped_gemm_kernel: GroupedGemmKernel
+      grouped_gemm_persistent_3wg_kernel: GroupedGemmPersistent3WGKernel
     op: tileops/ops/grouped_gemm.py
     test: tests/ops/test_grouped_gemm.py
     bench: benchmarks/ops/bench_grouped_gemm.py

--- a/src/tileops/ops/grouped_gemm.py
+++ b/src/tileops/ops/grouped_gemm.py
@@ -44,7 +44,6 @@ class GroupedGemmFwdOp(Op):
         self.dispatch_kernel(kernel_map)
         self.kernel = None
 
-    #: Selection asks both, and takes the specialised one where it applies.
     _KERNEL_KEYS = ("grouped_gemm_persistent_3wg_kernel", "grouped_gemm_kernel")
 
     @property

--- a/src/tileops/ops/grouped_gemm.py
+++ b/src/tileops/ops/grouped_gemm.py
@@ -2,8 +2,13 @@ from typing import Dict, Optional
 
 import torch
 
-from tileops.kernels.grouped_gemm import GroupedGemmKernel
+from tileops.kernels.grouped_gemm import (
+    GroupedGemmCall,
+    GroupedGemmKernel,
+    GroupedGemmPersistent3WGKernel,
+)
 from tileops.kernels.kernel_base import Kernel
+from tileops.utils import get_sm_version
 
 from .op_base import Op
 
@@ -39,9 +44,15 @@ class GroupedGemmFwdOp(Op):
         self.dispatch_kernel(kernel_map)
         self.kernel = None
 
+    #: Selection asks both, and takes the specialised one where it applies.
+    _KERNEL_KEYS = ("grouped_gemm_persistent_3wg_kernel", "grouped_gemm_kernel")
+
     @property
     def default_kernel_map(self) -> Dict:
-        return {"grouped_gemm_kernel": GroupedGemmKernel}
+        return {
+            "grouped_gemm_kernel": GroupedGemmKernel,
+            "grouped_gemm_persistent_3wg_kernel": GroupedGemmPersistent3WGKernel,
+        }
 
     def _resolve_spec(
         self,
@@ -105,7 +116,23 @@ class GroupedGemmFwdOp(Op):
         k: int,
         dtype: torch.dtype,
         device_index: int | None,
-    ) -> Kernel:
+    ) -> tuple[str, Kernel]:
+        call = GroupedGemmCall(
+            arch=get_sm_version(device_index),
+            numel=batch_sum,
+            num_experts=batch_count,
+            n=n,
+            k=k,
+            dtype=dtype,
+            transpose_a=self.transpose_a,
+            transpose_b=self.transpose_b,
+        )
+        key_name = self.select_kernel_key(self._KERNEL_KEYS, call)
+        kernel_cls = self.kernel_map[key_name]
+        kwargs: Dict[str, object] = {"dtype": dtype, "tune": self.tune}
+        if key_name == "grouped_gemm_kernel":
+            kwargs["transpose_a"] = self.transpose_a
+            kwargs["transpose_b"] = self.transpose_b
         key = (
             batch_sum,
             batch_count,
@@ -116,20 +143,13 @@ class GroupedGemmFwdOp(Op):
             self.transpose_a,
             self.transpose_b,
             self.tune,
+            key_name,
         )
-        return self.get_or_build_kernel(
-            "grouped_gemm_kernel",
+
+        return key_name, self.get_or_build_kernel(
+            key_name,
             key=key,
-            build=lambda: self.kernel_map["grouped_gemm_kernel"](
-                batch_sum,
-                batch_count,
-                n,
-                k,
-                dtype=dtype,
-                transpose_a=self.transpose_a,
-                transpose_b=self.transpose_b,
-                tune=self.tune,
-            ),
+            build=lambda: kernel_cls(batch_sum, batch_count, n, k, **kwargs),
         )
 
     def forward(
@@ -152,5 +172,9 @@ class GroupedGemmFwdOp(Op):
         self.N = n
         self.K = k
         self.dtype = dtype
-        self.kernel = self._get_kernel(batch_sum, batch_count, n, k, dtype, device_index)
+        key_name, self.kernel = self._get_kernel(batch_sum, batch_count, n, k, dtype, device_index)
+        if key_name == "grouped_gemm_persistent_3wg_kernel":
+            # It reads the tight layout straight off batch_sizes / batch_offsets
+            # and has no use for the padded ones.
+            return self.kernel(a, b, batch_sizes, batch_offsets)
         return self.kernel(a, b, batch_sizes, batch_offsets, batch_padded_offsets)

--- a/tests/ops/test_grouped_gemm.py
+++ b/tests/ops/test_grouped_gemm.py
@@ -147,33 +147,24 @@ def test_supply_prog_keeps_every_row_in_the_k_loop():
 
 
 @pytest.mark.parametrize(
-    "numel, num_experts, n, k, transpose_a, transpose_b, expected",
+    "n, k, transpose_a, transpose_b, expected",
     [
-        (4096, 16, 4096, 4096, False, True, "grouped_gemm_persistent_3wg_kernel"),
-        # Groups shorter than the general kernel's block_m: only the persistent
-        # kernel computes every expert in a tile that spans several of them.
-        (128, 128, 4096, 4096, False, True, "grouped_gemm_persistent_3wg_kernel"),
-        (4096, 16, 4000, 4096, False, True, "grouped_gemm_kernel"),  # N the tiling misses
-        (4096, 16, 4096, 4096, False, False, "grouped_gemm_kernel"),  # NN
-        (4096, 16, 4096, 4096, True, False, "grouped_gemm_kernel"),  # TN
+        (4096, 4096, False, True, "grouped_gemm_persistent_3wg_kernel"),
+        (4000, 4096, False, True, "grouped_gemm_kernel"),  # N the tiling misses
+        (4096, 4096, False, False, "grouped_gemm_kernel"),  # NN
+        (4096, 4096, True, False, "grouped_gemm_kernel"),  # TN
     ],
 )
 @pytest.mark.smoke
 def test_selection_prefers_the_persistent_kernel_where_it_applies(
-    numel: int,
-    num_experts: int,
-    n: int,
-    k: int,
-    transpose_a: bool,
-    transpose_b: bool,
-    expected: str,
+    n: int, k: int, transpose_a: bool, transpose_b: bool, expected: str
 ):
     """The persistent kernel serves aligned NT; the general one serves the rest."""
     op = GroupedGemmFwdOp(transpose_a=transpose_a, transpose_b=transpose_b)
     call = GroupedGemmCall(
         arch=get_sm_version(),
-        numel=numel,
-        num_experts=num_experts,
+        numel=4096,
+        num_experts=16,
         n=n,
         k=k,
         dtype=torch.float16,

--- a/tests/ops/test_grouped_gemm.py
+++ b/tests/ops/test_grouped_gemm.py
@@ -37,7 +37,7 @@ class GroupedGemmFixture(FixtureBase):
                     marks=pytest.mark.smoke,
                 ),
                 pytest.param(
-                    4098,
+                    4099,
                     6,
                     4000,
                     4096,
@@ -46,10 +46,10 @@ class GroupedGemmFixture(FixtureBase):
                     True,
                     False,
                     marks=pytest.mark.smoke,
-                    id="groups-unaligned-to-block-m",
+                    id="uneven-unaligned",
                 ),
                 pytest.param(
-                    4098,
+                    4099,
                     6,
                     4000,
                     4096,
@@ -58,7 +58,7 @@ class GroupedGemmFixture(FixtureBase):
                     False,
                     False,
                     marks=pytest.mark.smoke,
-                    id="nn-groups-unaligned-to-block-m",
+                    id="nn-uneven-unaligned",
                 ),
                 pytest.param(
                     16384,

--- a/tests/ops/test_grouped_gemm.py
+++ b/tests/ops/test_grouped_gemm.py
@@ -49,6 +49,18 @@ class GroupedGemmFixture(FixtureBase):
                     id="groups-unaligned-to-block-m",
                 ),
                 pytest.param(
+                    4098,
+                    6,
+                    4000,
+                    4096,
+                    torch.float16,
+                    False,
+                    False,
+                    False,
+                    marks=pytest.mark.smoke,
+                    id="nn-groups-unaligned-to-block-m",
+                ),
+                pytest.param(
                     16384,
                     4,
                     4864,

--- a/tests/ops/test_grouped_gemm.py
+++ b/tests/ops/test_grouped_gemm.py
@@ -2,8 +2,9 @@ import pytest
 import torch
 
 from tests.test_base import FixtureBase, TestBase
-from tileops.kernels.grouped_gemm import GroupedGemmKernel
+from tileops.kernels.grouped_gemm import GroupedGemmCall, GroupedGemmKernel
 from tileops.ops.grouped_gemm import GroupedGemmFwdOp
+from tileops.utils import get_sm_version
 from workloads.grouped_gemm import (
     GroupedGemmWorkload,
 )
@@ -128,3 +129,43 @@ def test_supply_prog_keeps_every_row_in_the_k_loop():
     # A fourth such parameter must fail rather than silently receive the offsets.
     with pytest.raises(RuntimeError, match="expects 3 int32"):
         kernel.autotune_supply_prog(params + [_FakeKernelParam("int32", [batch_count])])
+
+
+# Which kernel serves which call
+
+
+@pytest.mark.parametrize(
+    "numel, num_experts, n, k, transpose_a, transpose_b, expected",
+    [
+        (4096, 16, 4096, 4096, False, True, "grouped_gemm_persistent_3wg_kernel"),
+        # Groups shorter than the general kernel's block_m: only the persistent
+        # kernel computes every expert in a tile that spans several of them.
+        (128, 128, 4096, 4096, False, True, "grouped_gemm_persistent_3wg_kernel"),
+        (4096, 16, 4000, 4096, False, True, "grouped_gemm_kernel"),  # N the tiling misses
+        (4096, 16, 4096, 4096, False, False, "grouped_gemm_kernel"),  # NN
+        (4096, 16, 4096, 4096, True, False, "grouped_gemm_kernel"),  # TN
+    ],
+)
+@pytest.mark.smoke
+def test_selection_prefers_the_persistent_kernel_where_it_applies(
+    numel: int,
+    num_experts: int,
+    n: int,
+    k: int,
+    transpose_a: bool,
+    transpose_b: bool,
+    expected: str,
+):
+    """The persistent kernel serves aligned NT; the general one serves the rest."""
+    op = GroupedGemmFwdOp(transpose_a=transpose_a, transpose_b=transpose_b)
+    call = GroupedGemmCall(
+        arch=get_sm_version(),
+        numel=numel,
+        num_experts=num_experts,
+        n=n,
+        k=k,
+        dtype=torch.float16,
+        transpose_a=transpose_a,
+        transpose_b=transpose_b,
+    )
+    assert op.select_kernel_key(op._KERNEL_KEYS, call) == expected

--- a/tests/ops/test_grouped_gemm.py
+++ b/tests/ops/test_grouped_gemm.py
@@ -37,6 +37,18 @@ class GroupedGemmFixture(FixtureBase):
                     marks=pytest.mark.smoke,
                 ),
                 pytest.param(
+                    4098,
+                    6,
+                    4000,
+                    4096,
+                    torch.float16,
+                    False,
+                    True,
+                    False,
+                    marks=pytest.mark.smoke,
+                    id="groups-unaligned-to-block-m",
+                ),
+                pytest.param(
                     16384,
                     4,
                     4864,


### PR DESCRIPTION
## Problems

- Four grouped-GEMM kernels each carried their own tile-to-group mapping: 15 hand-written binary searches, 5 prefix sums, 5 definitions of `log2_up` under three formulas.
- The fifth variant, a linear scan in `GroupedGemmKernel`'s NT/NN branch, was wrong: it enumerated M tiles over the whole row range and resolved one group per tile, so a tile straddling a boundary computed only the first group it covered. Wrong at 60 of 78 measured points, whenever `rows/group % block_m != 0`. Every test and the manifest workload used multiples of the default `block_m`, so none caught it.
- `GroupedGemmPersistent3WGKernel` served no call this op could make, so aligned NT ran the general kernel.

## Changes

- `GroupTiling` holds the group count and tile height that the prefix sum and the search must agree on, and hands out both as macros over the caller's buffers. Each kernel keeps its own scheduler. The search runs `(num_groups - 1).bit_length()` steps, one fewer than any of the three formulas it replaces.
- NT/NN enumerates tiles per group, so a tile can no longer span two. All 78 points exact; TN/TT launch group-major and were never affected.
- `GroupedGemmFwdOp` picks between the two kernels through `select_kernel_key`. `signature` is unchanged — which kernel serves a call is second-layer selection, so only `source.kernel_map` records the new one.
- Two regression cases, NT and NN, over groups that are neither equal nor a multiple of any `block_m` the sweep tries. Both fail before this change and pass after. Every case the suite had ran 4096 rows per group, equal and aligned.
- `applies` now requires NT, and the persistent kernel's tuning metadata no longer gives the last group a negative row count.

`bench_kernel`, idle H200, warmed cache, interleaved two rounds, ms:

| case | before | after |
| --- | --- | --- |
| aligned NT fp16 / bf16, through the op | 0.346 / 0.345 | **0.217 / 0.217** |
| persistent, 262144 rows over 256 groups | 19.25, 19.15 | 19.12, 18.83 |
| general NT | 0.3396, 0.3394 | 0.3472, 0.3538 |
| general NN | 0.4285, 0.4315 | 0.4401, 0.4385 |

The general kernel gives up 2-4%: per-group enumeration needs a prefix sum in shared memory and a search where the old scan read the offsets directly. The shapes it slows were correct before; the ones it makes correct were not.

## Follow-up

Small groups have no fast correct path: the persistent kernel is 34x slower than the general one at one row per group, and selection does not narrow by speed because the general kernel was the wrong one there.
