### PR TITLE
[Bench][Manifest] Say each workload's shape once in its label

### DIFF
--- a/src/tileops/manifest/attention_indexing.yaml
+++ b/src/tileops/manifest/attention_indexing.yaml
@@ -33,7 +33,7 @@ FP8LightningIndexerFwdOp:
   workloads:
   - {batch: 1, seq_len: 8192, heads: 32, index_dim: 64, seq_len_kv: 8192, kv_group: 1, clean_logits: true, dtypes: [bfloat16], label: "lightning-indexer-bf16-s8k-h32-d64"}
   - {batch: 1, seq_len: 8192, heads: 32, index_dim: 64, seq_len_kv: 8192, kv_group: 1, clean_logits: true, dtypes: [float8_e4m3fn], label: "lightning-indexer-fp8-s8k-h32-d64"}
-  - {batch: 1, seq_len: 8192, heads: 32, index_dim: 64, seq_len_kv: 8192, kv_group: 1, clean_logits: true, dtypes: [float8_e4m3fn], index_k_scale_shape: [1, 8192, 1], label: "lightning-indexer-fp8-s8k-h32-d64-kscale"}
+  - {batch: 1, seq_len: 8192, heads: 32, index_dim: 64, seq_len_kv: 8192, kv_group: 1, clean_logits: true, dtypes: [float8_e4m3fn], index_k_scale_shape: [1, 8192, 1], label: "lightning-indexer-s8k-h32-d64-kscale"}
 
   roofline:
     func: "tileops.perf.formulas.fp8_lightning_indexer_roofline"

--- a/src/tileops/manifest/convolution.yaml
+++ b/src/tileops/manifest/convolution.yaml
@@ -113,19 +113,18 @@ Conv2dFwdOp:
       - "out_W == W if _p_w == 'same' else (W + 2 * (0 if _p_w == 'valid' else _p_w) - _d_w * (kW - 1) - 1) // _s_w + 1"
 
   workloads:
-    - {input_shape: [2, 64, 56, 56], C_out: 64, kH: 3, kW: 3, stride: [1, 1], padding: [1, 1], dtypes: [float16, bfloat16], label: "resnet-3x3-fp16"}
-    - {input_shape: [1, 3, 112, 112], C_out: 64, kH: 3, kW: 3, stride: [2, 2], padding: [1, 1], dtypes: [float16], label: "stem-3x3-s2-fp16"}
-    - {input_shape: [1, 128, 56, 56], C_out: 256, kH: 3, kW: 3, stride: [2, 2], padding: [1, 1], dtypes: [float16], label: "stage-transition-3x3-s2-fp16"}
-    - {input_shape: [1, 256, 112, 112], C_out: 512, kH: 3, kW: 3, stride: [1, 1], padding: [1, 1], dtypes: [float16], label: "highres-3x3-s1-fp16"}
-    - {input_shape: [1, 64, 56, 56], C_out: 128, kH: 5, kW: 5, stride: [1, 1], padding: [2, 2], dtypes: [float16], label: "midres-5x5-s1-fp16"}
-    - {input_shape: [1, 128, 56, 56], C_out: 256, kH: 5, kW: 5, stride: [2, 2], padding: [2, 2], dtypes: [float16], label: "stage-transition-5x5-s2-fp16"}
-    - {input_shape: [1, 128, 28, 28], C_out: 128, kH: 3, kW: 3, stride: [2, 2], padding: [1, 1], dtypes: [bfloat16], label: "stride2-bf16"}
-    - {input_shape: [2, 64, 56, 56], C_out: 256, kH: 1, kW: 1, stride: [1, 1], padding: [0, 0], dtypes: [float16, bfloat16], label: "resnet-1x1-fp16"}
-    - {input_shape: [2, 128, 28, 28], C_out: 512, kH: 1, kW: 1, stride: [1, 1], padding: [0, 0], dtypes: [float16], label: "bottleneck-expand-1x1-fp16"}
-    - {input_shape: [2, 512, 28, 28], C_out: 128, kH: 1, kW: 1, stride: [1, 1], padding: [0, 0], dtypes: [float16], label: "bottleneck-reduce-1x1-fp16"}
-    - {input_shape: [1, 256, 14, 14], C_out: 1024, kH: 1, kW: 1, stride: [1, 1], padding: [0, 0], dtypes: [float16], label: "late-stage-1x1-fp16"}
-    - {input_shape: [1, 512, 7, 7], C_out: 2048, kH: 1, kW: 1, stride: [1, 1], padding: [0, 0], dtypes: [float16], label: "classifier-1x1-fp16"}
-    - {input_shape: [2, 64, 56, 56], C_out: 256, kH: 1, kW: 1, stride: [1, 1], padding: [0, 0], dtypes: [bfloat16], label: "resnet-1x1-bf16"}
+    - {input_shape: [2, 64, 56, 56], C_out: 64, kH: 3, kW: 3, stride: [1, 1], padding: [1, 1], dtypes: [float16, bfloat16], label: "resnet-3x3"}
+    - {input_shape: [1, 3, 112, 112], C_out: 64, kH: 3, kW: 3, stride: [2, 2], padding: [1, 1], dtypes: [float16], label: "stem-3x3-s2"}
+    - {input_shape: [1, 128, 56, 56], C_out: 256, kH: 3, kW: 3, stride: [2, 2], padding: [1, 1], dtypes: [float16], label: "stage-transition-3x3-s2"}
+    - {input_shape: [1, 256, 112, 112], C_out: 512, kH: 3, kW: 3, stride: [1, 1], padding: [1, 1], dtypes: [float16], label: "highres-3x3-s1"}
+    - {input_shape: [1, 64, 56, 56], C_out: 128, kH: 5, kW: 5, stride: [1, 1], padding: [2, 2], dtypes: [float16], label: "midres-5x5-s1"}
+    - {input_shape: [1, 128, 56, 56], C_out: 256, kH: 5, kW: 5, stride: [2, 2], padding: [2, 2], dtypes: [float16], label: "stage-transition-5x5-s2"}
+    - {input_shape: [1, 128, 28, 28], C_out: 128, kH: 3, kW: 3, stride: [2, 2], padding: [1, 1], dtypes: [bfloat16], label: "stride2"}
+    - {input_shape: [2, 64, 56, 56], C_out: 256, kH: 1, kW: 1, stride: [1, 1], padding: [0, 0], dtypes: [float16, bfloat16], label: "resnet-1x1"}
+    - {input_shape: [2, 128, 28, 28], C_out: 512, kH: 1, kW: 1, stride: [1, 1], padding: [0, 0], dtypes: [float16], label: "bottleneck-expand-1x1"}
+    - {input_shape: [2, 512, 28, 28], C_out: 128, kH: 1, kW: 1, stride: [1, 1], padding: [0, 0], dtypes: [float16], label: "bottleneck-reduce-1x1"}
+    - {input_shape: [1, 256, 14, 14], C_out: 1024, kH: 1, kW: 1, stride: [1, 1], padding: [0, 0], dtypes: [float16], label: "late-stage-1x1"}
+    - {input_shape: [1, 512, 7, 7], C_out: 2048, kH: 1, kW: 1, stride: [1, 1], padding: [0, 0], dtypes: [float16], label: "classifier-1x1"}
     - input_shape: [1, 2048, 32, 32]
       C_out: 256
       kH: 3
@@ -153,19 +152,18 @@ Conv2dFwdOp:
       groups: 32
       dtypes: [float16]
       label: resnext-grouped-3x3
-    - {input_shape: [2, 64, 56, 56], C_out: 64, kH: 3, kW: 3, stride: [1, 1], padding: [1, 1], dtypes: [float16, bfloat16], bias_shape: [64], label: "resnet-3x3-fp16-bias"}
-    - {input_shape: [1, 3, 112, 112], C_out: 64, kH: 3, kW: 3, stride: [2, 2], padding: [1, 1], dtypes: [float16], bias_shape: [64], label: "stem-3x3-s2-fp16-bias"}
-    - {input_shape: [1, 128, 56, 56], C_out: 256, kH: 3, kW: 3, stride: [2, 2], padding: [1, 1], dtypes: [float16], bias_shape: [256], label: "stage-transition-3x3-s2-fp16-bias"}
-    - {input_shape: [1, 256, 112, 112], C_out: 512, kH: 3, kW: 3, stride: [1, 1], padding: [1, 1], dtypes: [float16], bias_shape: [512], label: "highres-3x3-s1-fp16-bias"}
-    - {input_shape: [1, 64, 56, 56], C_out: 128, kH: 5, kW: 5, stride: [1, 1], padding: [2, 2], dtypes: [float16], bias_shape: [128], label: "midres-5x5-s1-fp16-bias"}
-    - {input_shape: [1, 128, 56, 56], C_out: 256, kH: 5, kW: 5, stride: [2, 2], padding: [2, 2], dtypes: [float16], bias_shape: [256], label: "stage-transition-5x5-s2-fp16-bias"}
-    - {input_shape: [1, 128, 28, 28], C_out: 128, kH: 3, kW: 3, stride: [2, 2], padding: [1, 1], dtypes: [bfloat16], bias_shape: [128], label: "stride2-bf16-bias"}
-    - {input_shape: [2, 64, 56, 56], C_out: 256, kH: 1, kW: 1, stride: [1, 1], padding: [0, 0], dtypes: [float16, bfloat16], bias_shape: [256], label: "resnet-1x1-fp16-bias"}
-    - {input_shape: [2, 128, 28, 28], C_out: 512, kH: 1, kW: 1, stride: [1, 1], padding: [0, 0], dtypes: [float16], bias_shape: [512], label: "bottleneck-expand-1x1-fp16-bias"}
-    - {input_shape: [2, 512, 28, 28], C_out: 128, kH: 1, kW: 1, stride: [1, 1], padding: [0, 0], dtypes: [float16], bias_shape: [128], label: "bottleneck-reduce-1x1-fp16-bias"}
-    - {input_shape: [1, 256, 14, 14], C_out: 1024, kH: 1, kW: 1, stride: [1, 1], padding: [0, 0], dtypes: [float16], bias_shape: [1024], label: "late-stage-1x1-fp16-bias"}
-    - {input_shape: [1, 512, 7, 7], C_out: 2048, kH: 1, kW: 1, stride: [1, 1], padding: [0, 0], dtypes: [float16], bias_shape: [2048], label: "classifier-1x1-fp16-bias"}
-    - {input_shape: [2, 64, 56, 56], C_out: 256, kH: 1, kW: 1, stride: [1, 1], padding: [0, 0], dtypes: [bfloat16], bias_shape: [256], label: "resnet-1x1-bf16-bias"}
+    - {input_shape: [2, 64, 56, 56], C_out: 64, kH: 3, kW: 3, stride: [1, 1], padding: [1, 1], dtypes: [float16, bfloat16], bias_shape: [64], label: "resnet-3x3-bias"}
+    - {input_shape: [1, 3, 112, 112], C_out: 64, kH: 3, kW: 3, stride: [2, 2], padding: [1, 1], dtypes: [float16], bias_shape: [64], label: "stem-3x3-s2-bias"}
+    - {input_shape: [1, 128, 56, 56], C_out: 256, kH: 3, kW: 3, stride: [2, 2], padding: [1, 1], dtypes: [float16], bias_shape: [256], label: "stage-transition-3x3-s2-bias"}
+    - {input_shape: [1, 256, 112, 112], C_out: 512, kH: 3, kW: 3, stride: [1, 1], padding: [1, 1], dtypes: [float16], bias_shape: [512], label: "highres-3x3-s1-bias"}
+    - {input_shape: [1, 64, 56, 56], C_out: 128, kH: 5, kW: 5, stride: [1, 1], padding: [2, 2], dtypes: [float16], bias_shape: [128], label: "midres-5x5-s1-bias"}
+    - {input_shape: [1, 128, 56, 56], C_out: 256, kH: 5, kW: 5, stride: [2, 2], padding: [2, 2], dtypes: [float16], bias_shape: [256], label: "stage-transition-5x5-s2-bias"}
+    - {input_shape: [1, 128, 28, 28], C_out: 128, kH: 3, kW: 3, stride: [2, 2], padding: [1, 1], dtypes: [bfloat16], bias_shape: [128], label: "stride2-bias"}
+    - {input_shape: [2, 64, 56, 56], C_out: 256, kH: 1, kW: 1, stride: [1, 1], padding: [0, 0], dtypes: [float16, bfloat16], bias_shape: [256], label: "resnet-1x1-bias"}
+    - {input_shape: [2, 128, 28, 28], C_out: 512, kH: 1, kW: 1, stride: [1, 1], padding: [0, 0], dtypes: [float16], bias_shape: [512], label: "bottleneck-expand-1x1-bias"}
+    - {input_shape: [2, 512, 28, 28], C_out: 128, kH: 1, kW: 1, stride: [1, 1], padding: [0, 0], dtypes: [float16], bias_shape: [128], label: "bottleneck-reduce-1x1-bias"}
+    - {input_shape: [1, 256, 14, 14], C_out: 1024, kH: 1, kW: 1, stride: [1, 1], padding: [0, 0], dtypes: [float16], bias_shape: [1024], label: "late-stage-1x1-bias"}
+    - {input_shape: [1, 512, 7, 7], C_out: 2048, kH: 1, kW: 1, stride: [1, 1], padding: [0, 0], dtypes: [float16], bias_shape: [2048], label: "classifier-1x1-bias"}
 
   roofline:
     vars:
@@ -227,9 +225,9 @@ Conv3dFwdOp:
       - "out_W == W if _p_w == 'same' else (W + 2 * (0 if _p_w == 'valid' else _p_w) - _d_w * (kW - 1) - 1) // _s_w + 1"
 
   workloads:
-    - {input_shape: [1, 3, 16, 112, 112], C_out: 64, kD: 3, kH: 3, kW: 3, stride: [1, 1, 1], padding: [1, 1, 1], dtypes: [float16], label: "r3d-stem-k3-s1-fp16"}
-    - {input_shape: [1, 64, 8, 56, 56], C_out: 128, kD: 3, kH: 3, kW: 3, stride: [2, 2, 2], padding: [1, 1, 1], dtypes: [float16], label: "video-stage-downsample-k3-s2-fp16"}
-    - {input_shape: [1, 32, 32, 64, 64], C_out: 64, kD: 3, kH: 3, kW: 3, stride: [1, 1, 1], padding: [1, 1, 1], dtypes: [bfloat16], label: "unet-encoder-k3-s1-bf16"}
+    - {input_shape: [1, 3, 16, 112, 112], C_out: 64, kD: 3, kH: 3, kW: 3, stride: [1, 1, 1], padding: [1, 1, 1], dtypes: [float16], label: "r3d-stem-k3-s1"}
+    - {input_shape: [1, 64, 8, 56, 56], C_out: 128, kD: 3, kH: 3, kW: 3, stride: [2, 2, 2], padding: [1, 1, 1], dtypes: [float16], label: "video-stage-downsample-k3-s2"}
+    - {input_shape: [1, 32, 32, 64, 64], C_out: 64, kD: 3, kH: 3, kW: 3, stride: [1, 1, 1], padding: [1, 1, 1], dtypes: [bfloat16], label: "unet-encoder-k3-s1"}
     - input_shape: [1, 256, 8, 16, 16]
       C_out: 256
       kD: 3
@@ -250,9 +248,9 @@ Conv3dFwdOp:
       groups: 32
       dtypes: [float16]
       label: 3d-resnext-grouped-k3
-    - {input_shape: [1, 3, 16, 112, 112], C_out: 64, kD: 3, kH: 3, kW: 3, stride: [1, 1, 1], padding: [1, 1, 1], dtypes: [float16], bias_shape: [64], label: "r3d-stem-k3-s1-fp16-bias"}
-    - {input_shape: [1, 64, 8, 56, 56], C_out: 128, kD: 3, kH: 3, kW: 3, stride: [2, 2, 2], padding: [1, 1, 1], dtypes: [float16], bias_shape: [128], label: "video-stage-downsample-k3-s2-fp16-bias"}
-    - {input_shape: [1, 32, 32, 64, 64], C_out: 64, kD: 3, kH: 3, kW: 3, stride: [1, 1, 1], padding: [1, 1, 1], dtypes: [bfloat16], bias_shape: [64], label: "unet-encoder-k3-s1-bf16-bias"}
+    - {input_shape: [1, 3, 16, 112, 112], C_out: 64, kD: 3, kH: 3, kW: 3, stride: [1, 1, 1], padding: [1, 1, 1], dtypes: [float16], bias_shape: [64], label: "r3d-stem-k3-s1-bias"}
+    - {input_shape: [1, 64, 8, 56, 56], C_out: 128, kD: 3, kH: 3, kW: 3, stride: [2, 2, 2], padding: [1, 1, 1], dtypes: [float16], bias_shape: [128], label: "video-stage-downsample-k3-s2-bias"}
+    - {input_shape: [1, 32, 32, 64, 64], C_out: 64, kD: 3, kH: 3, kW: 3, stride: [1, 1, 1], padding: [1, 1, 1], dtypes: [bfloat16], bias_shape: [64], label: "unet-encoder-k3-s1-bias"}
 
   roofline:
     vars:

--- a/src/tileops/manifest/gemm.yaml
+++ b/src/tileops/manifest/gemm.yaml
@@ -189,8 +189,8 @@ GroupedGemmFwdOp:
   workloads:
   - {batch_sum: 4096, batch_count: 16, n: 4096, k: 4096, dtype: float16, transpose_a: false, transpose_b: true, dtypes: [float16], label: "nt-batch16-m4096-n4096-k4096-fp16"}
   - {batch_sum: 4096, batch_count: 16, n: 4096, k: 4096, dtype: bfloat16, transpose_a: false, transpose_b: true, dtypes: [bfloat16], label: "nt-batch16-m4096-n4096-k4096-bf16"}
-  - {batch_sum: 4096, batch_count: 16, n: 4096, k: 4096, dtype: float16, transpose_a: false, transpose_b: false, dtypes: [float16], label: "nn-batch16-m4096-n4096-k4096-fp16"}
-  - {batch_sum: 4096, batch_count: 16, n: 4096, k: 4096, dtype: float16, transpose_a: true, transpose_b: false, dtypes: [float16], label: "tn-batch16-m4096-n4096-k4096-fp16"}
+  - {batch_sum: 4096, batch_count: 16, n: 4096, k: 4096, dtype: float16, transpose_a: false, transpose_b: false, dtypes: [float16], label: "nn-batch16-m4096-n4096-k4096"}
+  - {batch_sum: 4096, batch_count: 16, n: 4096, k: 4096, dtype: float16, transpose_a: true, transpose_b: false, dtypes: [float16], label: "tn-batch16-m4096-n4096-k4096"}
 
   roofline:
     func: "tileops.perf.formulas.grouped_gemm_roofline"

--- a/src/tileops/manifest/normalization.yaml
+++ b/src/tileops/manifest/normalization.yaml
@@ -27,14 +27,14 @@ RMSNormFwdOp:
 
   workloads:
     # Llama-3.1-8B (hidden_dim=4096)
-    - {x_shape: [2048, 4096], normalized_shape: [4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill"}
-    - {x_shape: [1, 4096], normalized_shape: [4096], dtypes: [bfloat16], label: "llama-3.1-8b-decode"}
+    - {x_shape: [2048, 4096], normalized_shape: [4096], dtypes: [float16, bfloat16], label: "8b-prefill"}
+    - {x_shape: [1, 4096], normalized_shape: [4096], dtypes: [bfloat16], label: "8b-decode"}
     # Llama-3.1-70B (hidden_dim=8192)
-    - {x_shape: [2048, 8192], normalized_shape: [8192], dtypes: [float16, bfloat16], label: "llama-3.1-70b-prefill"}
-    - {x_shape: [1, 8192], normalized_shape: [8192], dtypes: [bfloat16], label: "llama-3.1-70b-decode"}
+    - {x_shape: [2048, 8192], normalized_shape: [8192], dtypes: [float16, bfloat16], label: "70b-prefill"}
+    - {x_shape: [1, 8192], normalized_shape: [8192], dtypes: [bfloat16], label: "70b-decode"}
     # Llama-3.1-405B (hidden_dim=16384)
-    - {x_shape: [2048, 16384], normalized_shape: [16384], dtypes: [float16, bfloat16], label: "llama-3.1-405b-prefill"}
-    - {x_shape: [1, 16384], normalized_shape: [16384], dtypes: [bfloat16], label: "llama-3.1-405b-decode"}
+    - {x_shape: [2048, 16384], normalized_shape: [16384], dtypes: [float16, bfloat16], label: "405b-prefill"}
+    - {x_shape: [1, 16384], normalized_shape: [16384], dtypes: [bfloat16], label: "405b-decode"}
 
   roofline:
     vars:
@@ -78,14 +78,14 @@ LayerNormFwdOp:
 
   workloads:
     # Llama-3.1-8B (hidden_dim=4096)
-    - {x_shape: [2048, 4096], normalized_shape: [4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill"}
-    - {x_shape: [1, 4096], normalized_shape: [4096], dtypes: [bfloat16], label: "llama-3.1-8b-decode"}
+    - {x_shape: [2048, 4096], normalized_shape: [4096], dtypes: [float16, bfloat16], label: "8b-prefill"}
+    - {x_shape: [1, 4096], normalized_shape: [4096], dtypes: [bfloat16], label: "8b-decode"}
     # Llama-3.1-70B (hidden_dim=8192)
-    - {x_shape: [2048, 8192], normalized_shape: [8192], dtypes: [float16, bfloat16], label: "llama-3.1-70b-prefill"}
-    - {x_shape: [1, 8192], normalized_shape: [8192], dtypes: [bfloat16], label: "llama-3.1-70b-decode"}
+    - {x_shape: [2048, 8192], normalized_shape: [8192], dtypes: [float16, bfloat16], label: "70b-prefill"}
+    - {x_shape: [1, 8192], normalized_shape: [8192], dtypes: [bfloat16], label: "70b-decode"}
     # Llama-3.1-405B (hidden_dim=16384)
-    - {x_shape: [2048, 16384], normalized_shape: [16384], dtypes: [float16, bfloat16], label: "llama-3.1-405b-prefill"}
-    - {x_shape: [1, 16384], normalized_shape: [16384], dtypes: [bfloat16], label: "llama-3.1-405b-decode"}
+    - {x_shape: [2048, 16384], normalized_shape: [16384], dtypes: [float16, bfloat16], label: "405b-prefill"}
+    - {x_shape: [1, 16384], normalized_shape: [16384], dtypes: [bfloat16], label: "405b-decode"}
 
   roofline:
     vars:
@@ -220,11 +220,11 @@ FusedAddLayerNormFwdOp:
 
   workloads:
     # Llama-3.1-8B (hidden_dim=4096)
-    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill"}
-    - {x_shape: [1, 4096], dtypes: [bfloat16], label: "llama-3.1-8b-decode"}
+    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "8b-prefill"}
+    - {x_shape: [1, 4096], dtypes: [bfloat16], label: "8b-decode"}
     # Llama-3.1-70B (hidden_dim=8192)
-    - {x_shape: [2048, 8192], dtypes: [float16, bfloat16], label: "llama-3.1-70b-prefill"}
-    - {x_shape: [1, 8192], dtypes: [bfloat16], label: "llama-3.1-70b-decode"}
+    - {x_shape: [2048, 8192], dtypes: [float16, bfloat16], label: "70b-prefill"}
+    - {x_shape: [1, 8192], dtypes: [bfloat16], label: "70b-decode"}
 
   roofline:
     vars:
@@ -267,14 +267,14 @@ FusedAddRMSNormFwdOp:
 
   workloads:
     # Llama-3.1-8B (hidden_dim=4096)
-    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill"}
-    - {x_shape: [1, 4096], dtypes: [bfloat16], label: "llama-3.1-8b-decode"}
+    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "8b-prefill"}
+    - {x_shape: [1, 4096], dtypes: [bfloat16], label: "8b-decode"}
     # Llama-3.1-70B (hidden_dim=8192)
-    - {x_shape: [2048, 8192], dtypes: [float16, bfloat16], label: "llama-3.1-70b-prefill"}
-    - {x_shape: [1, 8192], dtypes: [bfloat16], label: "llama-3.1-70b-decode"}
+    - {x_shape: [2048, 8192], dtypes: [float16, bfloat16], label: "70b-prefill"}
+    - {x_shape: [1, 8192], dtypes: [bfloat16], label: "70b-decode"}
     # Llama-3.1-405B (hidden_dim=16384)
-    - {x_shape: [2048, 16384], dtypes: [float16, bfloat16], label: "llama-3.1-405b-prefill"}
-    - {x_shape: [1, 16384], dtypes: [bfloat16], label: "llama-3.1-405b-decode"}
+    - {x_shape: [2048, 16384], dtypes: [float16, bfloat16], label: "405b-prefill"}
+    - {x_shape: [1, 16384], dtypes: [bfloat16], label: "405b-decode"}
 
   roofline:
     vars:

--- a/src/tileops/manifest/normalization.yaml
+++ b/src/tileops/manifest/normalization.yaml
@@ -27,14 +27,14 @@ RMSNormFwdOp:
 
   workloads:
     # Llama-3.1-8B (hidden_dim=4096)
-    - {x_shape: [2048, 4096], normalized_shape: [4096], dtypes: [float16, bfloat16], label: "8b-prefill"}
-    - {x_shape: [1, 4096], normalized_shape: [4096], dtypes: [bfloat16], label: "8b-decode"}
+    - {x_shape: [2048, 4096], normalized_shape: [4096], dtypes: [float16, bfloat16], label: "llama-8b-prefill"}
+    - {x_shape: [1, 4096], normalized_shape: [4096], dtypes: [bfloat16], label: "llama-8b-decode"}
     # Llama-3.1-70B (hidden_dim=8192)
-    - {x_shape: [2048, 8192], normalized_shape: [8192], dtypes: [float16, bfloat16], label: "70b-prefill"}
-    - {x_shape: [1, 8192], normalized_shape: [8192], dtypes: [bfloat16], label: "70b-decode"}
+    - {x_shape: [2048, 8192], normalized_shape: [8192], dtypes: [float16, bfloat16], label: "llama-70b-prefill"}
+    - {x_shape: [1, 8192], normalized_shape: [8192], dtypes: [bfloat16], label: "llama-70b-decode"}
     # Llama-3.1-405B (hidden_dim=16384)
-    - {x_shape: [2048, 16384], normalized_shape: [16384], dtypes: [float16, bfloat16], label: "405b-prefill"}
-    - {x_shape: [1, 16384], normalized_shape: [16384], dtypes: [bfloat16], label: "405b-decode"}
+    - {x_shape: [2048, 16384], normalized_shape: [16384], dtypes: [float16, bfloat16], label: "llama-405b-prefill"}
+    - {x_shape: [1, 16384], normalized_shape: [16384], dtypes: [bfloat16], label: "llama-405b-decode"}
 
   roofline:
     vars:
@@ -78,14 +78,14 @@ LayerNormFwdOp:
 
   workloads:
     # Llama-3.1-8B (hidden_dim=4096)
-    - {x_shape: [2048, 4096], normalized_shape: [4096], dtypes: [float16, bfloat16], label: "8b-prefill"}
-    - {x_shape: [1, 4096], normalized_shape: [4096], dtypes: [bfloat16], label: "8b-decode"}
+    - {x_shape: [2048, 4096], normalized_shape: [4096], dtypes: [float16, bfloat16], label: "llama-8b-prefill"}
+    - {x_shape: [1, 4096], normalized_shape: [4096], dtypes: [bfloat16], label: "llama-8b-decode"}
     # Llama-3.1-70B (hidden_dim=8192)
-    - {x_shape: [2048, 8192], normalized_shape: [8192], dtypes: [float16, bfloat16], label: "70b-prefill"}
-    - {x_shape: [1, 8192], normalized_shape: [8192], dtypes: [bfloat16], label: "70b-decode"}
+    - {x_shape: [2048, 8192], normalized_shape: [8192], dtypes: [float16, bfloat16], label: "llama-70b-prefill"}
+    - {x_shape: [1, 8192], normalized_shape: [8192], dtypes: [bfloat16], label: "llama-70b-decode"}
     # Llama-3.1-405B (hidden_dim=16384)
-    - {x_shape: [2048, 16384], normalized_shape: [16384], dtypes: [float16, bfloat16], label: "405b-prefill"}
-    - {x_shape: [1, 16384], normalized_shape: [16384], dtypes: [bfloat16], label: "405b-decode"}
+    - {x_shape: [2048, 16384], normalized_shape: [16384], dtypes: [float16, bfloat16], label: "llama-405b-prefill"}
+    - {x_shape: [1, 16384], normalized_shape: [16384], dtypes: [bfloat16], label: "llama-405b-decode"}
 
   roofline:
     vars:
@@ -128,8 +128,8 @@ AdaLayerNormFwdOp:
     # DiT-XL/2 (hidden_dim=1152)
     - {x_shape: [1024, 1152], dtypes: [float16, bfloat16], label: "dit-xl-2"}
     # Llama-3.1-8B (hidden_dim=4096)
-    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill"}
-    - {x_shape: [1, 4096], dtypes: [bfloat16], label: "llama-3.1-8b-decode"}
+    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "llama-8b-prefill"}
+    - {x_shape: [1, 4096], dtypes: [bfloat16], label: "llama-8b-decode"}
 
   roofline:
     vars:
@@ -174,8 +174,8 @@ AdaLayerNormZeroFwdOp:
     # DiT-XL/2 (hidden_dim=1152)
     - {x_shape: [1024, 1152], dtypes: [float16, bfloat16], label: "dit-xl-2"}
     # Llama-3.1-8B (hidden_dim=4096)
-    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill"}
-    - {x_shape: [1, 4096], dtypes: [bfloat16], label: "llama-3.1-8b-decode"}
+    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "llama-8b-prefill"}
+    - {x_shape: [1, 4096], dtypes: [bfloat16], label: "llama-8b-decode"}
 
   roofline:
     vars:
@@ -220,11 +220,11 @@ FusedAddLayerNormFwdOp:
 
   workloads:
     # Llama-3.1-8B (hidden_dim=4096)
-    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "8b-prefill"}
-    - {x_shape: [1, 4096], dtypes: [bfloat16], label: "8b-decode"}
+    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "llama-8b-prefill"}
+    - {x_shape: [1, 4096], dtypes: [bfloat16], label: "llama-8b-decode"}
     # Llama-3.1-70B (hidden_dim=8192)
-    - {x_shape: [2048, 8192], dtypes: [float16, bfloat16], label: "70b-prefill"}
-    - {x_shape: [1, 8192], dtypes: [bfloat16], label: "70b-decode"}
+    - {x_shape: [2048, 8192], dtypes: [float16, bfloat16], label: "llama-70b-prefill"}
+    - {x_shape: [1, 8192], dtypes: [bfloat16], label: "llama-70b-decode"}
 
   roofline:
     vars:
@@ -267,14 +267,14 @@ FusedAddRMSNormFwdOp:
 
   workloads:
     # Llama-3.1-8B (hidden_dim=4096)
-    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "8b-prefill"}
-    - {x_shape: [1, 4096], dtypes: [bfloat16], label: "8b-decode"}
+    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "llama-8b-prefill"}
+    - {x_shape: [1, 4096], dtypes: [bfloat16], label: "llama-8b-decode"}
     # Llama-3.1-70B (hidden_dim=8192)
-    - {x_shape: [2048, 8192], dtypes: [float16, bfloat16], label: "70b-prefill"}
-    - {x_shape: [1, 8192], dtypes: [bfloat16], label: "70b-decode"}
+    - {x_shape: [2048, 8192], dtypes: [float16, bfloat16], label: "llama-70b-prefill"}
+    - {x_shape: [1, 8192], dtypes: [bfloat16], label: "llama-70b-decode"}
     # Llama-3.1-405B (hidden_dim=16384)
-    - {x_shape: [2048, 16384], dtypes: [float16, bfloat16], label: "405b-prefill"}
-    - {x_shape: [1, 16384], dtypes: [bfloat16], label: "405b-decode"}
+    - {x_shape: [2048, 16384], dtypes: [float16, bfloat16], label: "llama-405b-prefill"}
+    - {x_shape: [1, 16384], dtypes: [bfloat16], label: "llama-405b-decode"}
 
   roofline:
     vars:

--- a/src/tileops/manifest/pool.yaml
+++ b/src/tileops/manifest/pool.yaml
@@ -32,9 +32,9 @@ AvgPool1dFwdOp:
 
   workloads:
     # Temporal/audio downsampling cases, expressed in PyTorch NCL layout.
-    - {input_shape: [4, 128, 4096], kernel_size: 3, stride: 2, padding: 1, dtypes: [float16], label: "audio-downsample-fp16"}
-    - {input_shape: [2, 256, 32000], kernel_size: 5, stride: 4, padding: 2, dtypes: [float16], label: "long-temporal-fp16"}
-    - {input_shape: [2, 128, 2048], kernel_size: 4, stride: 2, padding: 1, ceil_mode: true, count_include_pad: false, dtypes: [bfloat16], label: "ceil-bf16"}
+    - {input_shape: [4, 128, 4096], kernel_size: 3, stride: 2, padding: 1, dtypes: [float16], label: "audio-downsample"}
+    - {input_shape: [2, 256, 32000], kernel_size: 5, stride: 4, padding: 2, dtypes: [float16], label: "long-temporal"}
+    - {input_shape: [2, 128, 2048], kernel_size: 4, stride: 2, padding: 1, ceil_mode: true, count_include_pad: false, dtypes: [bfloat16], label: "ceil"}
 
   roofline:
     vars:
@@ -94,7 +94,7 @@ AvgPool2dFwdOp:
     # PyTorch avg_pool2d semantics, not a separate model family.
     - {input_shape: [2, 64, 112, 112], kernel_size: [3, 3], stride: [2, 2], padding: [1, 1], dtypes: [float16], label: "vision-3x3-s2"}
     - {input_shape: [2, 128, 56, 56], kernel_size: [5, 5], stride: [2, 2], padding: [2, 2], dtypes: [float16], label: "vision-5x5-s2"}
-    - {input_shape: [3, 96, 55, 57], kernel_size: [3, 5], stride: [2, 2], padding: [1, 2], ceil_mode: true, count_include_pad: false, divisor_override: 7, dtypes: [bfloat16], label: "ceil-divisor-bf16"}
+    - {input_shape: [3, 96, 55, 57], kernel_size: [3, 5], stride: [2, 2], padding: [1, 2], ceil_mode: true, count_include_pad: false, divisor_override: 7, dtypes: [bfloat16], label: "ceil-divisor"}
 
   roofline:
     vars:
@@ -160,7 +160,7 @@ AvgPool3dFwdOp:
     # PyTorch avg_pool3d semantics on video-like feature volumes.
     - {input_shape: [1, 32, 16, 56, 56], kernel_size: [2, 2, 2], stride: [2, 2, 2], padding: [0, 0, 0], dtypes: [float16], label: "video-2x2x2"}
     - {input_shape: [2, 64, 8, 28, 28], kernel_size: [2, 3, 3], stride: [2, 2, 2], padding: [1, 1, 1], ceil_mode: true, count_include_pad: false, dtypes: [float16], label: "ceil-video"}
-    - {input_shape: [2, 24, 10, 20, 22], kernel_size: [2, 2, 3], stride: [2, 2, 2], padding: [0, 1, 1], divisor_override: 7, dtypes: [bfloat16], label: "divisor-bf16"}
+    - {input_shape: [2, 24, 10, 20, 22], kernel_size: [2, 2, 3], stride: [2, 2, 2], padding: [0, 1, 1], divisor_override: 7, dtypes: [bfloat16], label: "divisor"}
 
   roofline:
     vars:

--- a/src/tileops/manifest/position_encoding.yaml
+++ b/src/tileops/manifest/position_encoding.yaml
@@ -23,9 +23,9 @@ RopeNeoxFwdOp:
     - "x.shape[-1] % 2 == 0"
 
   workloads:
-  - {seq_len: 2048, head_dim: 64, dtype: float16, layout: "1d", dtypes: [float16], label: "neox-1d-2k-d64-fp16"}
-  - {seq_len: 4096, head_dim: 128, dtype: bfloat16, layout: "1d", dtypes: [bfloat16], label: "neox-1d-4k-d128-bf16"}
-  - {batch: 2, seq_len: 2048, num_heads: 32, head_dim: 128, dtype: float16, layout: "2d", dtypes: [float16], label: "neox-2d-b2-s2k-h32-d128-fp16"}
+  - {seq_len: 2048, head_dim: 64, dtype: float16, layout: "1d", dtypes: [float16], label: "neox-1d-2k-d64"}
+  - {seq_len: 4096, head_dim: 128, dtype: bfloat16, layout: "1d", dtypes: [bfloat16], label: "neox-1d-4k-d128"}
+  - {batch: 2, seq_len: 2048, num_heads: 32, head_dim: 128, dtype: float16, layout: "2d", dtypes: [float16], label: "neox-2d-b2-s2k-h32-d128"}
 
   roofline:
     func: "tileops.perf.formulas.rope_roofline"
@@ -58,8 +58,8 @@ RopeNonNeoxFwdOp:
     - "x.shape[-1] % 2 == 0"
 
   workloads:
-  - {seq_len: 2048, head_dim: 64, dtype: float16, layout: "1d", dtypes: [float16], label: "non-neox-1d-2k-d64-fp16"}
-  - {batch: 2, seq_len: 2048, num_heads: 32, head_dim: 128, dtype: bfloat16, layout: "2d", dtypes: [bfloat16], label: "non-neox-2d-b2-s2k-h32-d128-bf16"}
+  - {seq_len: 2048, head_dim: 64, dtype: float16, layout: "1d", dtypes: [float16], label: "non-neox-1d-2k-d64"}
+  - {batch: 2, seq_len: 2048, num_heads: 32, head_dim: 128, dtype: bfloat16, layout: "2d", dtypes: [bfloat16], label: "non-neox-2d-b2-s2k-h32-d128"}
 
   roofline:
     func: "tileops.perf.formulas.rope_roofline"
@@ -96,8 +96,8 @@ RopeLlama31FwdOp:
     - "x.shape[-1] % 2 == 0"
 
   workloads:
-  - {seq_len: 8192, head_dim: 128, dtype: bfloat16, layout: "1d", dtypes: [bfloat16], label: "llama31-1d-8k-d128-bf16"}
-  - {batch: 1, seq_len: 8192, num_heads: 32, head_dim: 128, dtype: float16, layout: "2d", dtypes: [float16], label: "llama31-2d-b1-s8k-h32-d128-fp16"}
+  - {seq_len: 8192, head_dim: 128, dtype: bfloat16, layout: "1d", dtypes: [bfloat16], label: "llama31-1d-8k-d128"}
+  - {batch: 1, seq_len: 8192, num_heads: 32, head_dim: 128, dtype: float16, layout: "2d", dtypes: [float16], label: "llama31-2d-b1-s8k-h32-d128"}
 
   roofline:
     func: "tileops.perf.formulas.rope_roofline"
@@ -135,8 +135,8 @@ RopeYarnFwdOp:
     - "x.shape[-1] % 2 == 0"
 
   workloads:
-  - {seq_len: 8192, head_dim: 128, dtype: bfloat16, layout: "1d", dtypes: [bfloat16], label: "yarn-1d-8k-d128-bf16"}
-  - {batch: 1, seq_len: 8192, num_heads: 32, head_dim: 128, dtype: float16, layout: "2d", dtypes: [float16], label: "yarn-2d-b1-s8k-h32-d128-fp16"}
+  - {seq_len: 8192, head_dim: 128, dtype: bfloat16, layout: "1d", dtypes: [bfloat16], label: "yarn-1d-8k-d128"}
+  - {batch: 1, seq_len: 8192, num_heads: 32, head_dim: 128, dtype: float16, layout: "2d", dtypes: [float16], label: "yarn-2d-b1-s8k-h32-d128"}
 
   roofline:
     func: "tileops.perf.formulas.rope_roofline"
@@ -172,8 +172,8 @@ RopeLongRopeFwdOp:
     - "x.shape[-1] % 2 == 0"
 
   workloads:
-  - {seq_len: 8192, head_dim: 128, dtype: bfloat16, layout: "1d", dtypes: [bfloat16], label: "longrope-1d-8k-d128-bf16"}
-  - {batch: 1, seq_len: 8192, num_heads: 32, head_dim: 128, dtype: float16, layout: "2d", dtypes: [float16], label: "longrope-2d-b1-s8k-h32-d128-fp16"}
+  - {seq_len: 8192, head_dim: 128, dtype: bfloat16, layout: "1d", dtypes: [bfloat16], label: "longrope-1d-8k-d128"}
+  - {batch: 1, seq_len: 8192, num_heads: 32, head_dim: 128, dtype: float16, layout: "2d", dtypes: [float16], label: "longrope-2d-b1-s8k-h32-d128"}
 
   roofline:
     func: "tileops.perf.formulas.rope_roofline"
@@ -209,8 +209,8 @@ RopeNeoxPositionIdsFwdOp:
     - "rotary_dim is None or (rotary_dim > 0 and rotary_dim % 2 == 0 and rotary_dim <= x.shape[-1])"
 
   workloads:
-  - {num_tokens: 2048, num_heads: 32, head_dim: 128, max_position: 4096, dtype: float16, dtypes: [float16], label: "position-ids-s2k-h32-d128-fp16"}
-  - {num_tokens: 4096, num_heads: 32, head_dim: 128, max_position: 8192, dtype: bfloat16, dtypes: [bfloat16], label: "position-ids-s4k-h32-d128-bf16"}
+  - {num_tokens: 2048, num_heads: 32, head_dim: 128, max_position: 4096, dtype: float16, dtypes: [float16], label: "position-ids-s2k-h32-d128"}
+  - {num_tokens: 4096, num_heads: 32, head_dim: 128, max_position: 8192, dtype: bfloat16, dtypes: [bfloat16], label: "position-ids-s4k-h32-d128"}
 
   roofline:
     func: "tileops.perf.formulas.rope_position_ids_roofline"

--- a/src/tileops/manifest/quantization.yaml
+++ b/src/tileops/manifest/quantization.yaml
@@ -21,7 +21,7 @@ FP8QuantFwdOp:
   workloads:
   - {batch: 1, seq_len_kv: 8192, kv_group: 1, index_dim: 64, in_dtype: float16, dtypes: [float16], label: "kv-index-8k-d64-fp16"}
   - {batch: 1, seq_len_kv: 8192, kv_group: 1, index_dim: 64, in_dtype: bfloat16, dtypes: [bfloat16], label: "kv-index-8k-d64-bf16"}
-  - {batch: 1, seq_len_kv: 4096, kv_group: 1, index_dim: 128, in_dtype: float32, dtypes: [float32], label: "kv-index-4k-d128-fp32"}
+  - {batch: 1, seq_len_kv: 4096, kv_group: 1, index_dim: 128, in_dtype: float32, dtypes: [float32], label: "kv-index-4k-d128"}
 
   roofline:
     func: "tileops.perf.formulas.fp8_quant_roofline"

--- a/src/tileops/manifest/regularization.yaml
+++ b/src/tileops/manifest/regularization.yaml
@@ -22,7 +22,7 @@ DropoutFwdOp:
   # Normal kernel path. p=0, p=1, and training=false are short-circuit paths
   # and should be tested separately from release-facing roofline workloads.
   - {input_shape: [1024, 4096], p: 0.5, training: true, dtypes: [float16], label: "tokens-1k-hidden-4k-fp16"}
-  - {input_shape: [1024, 10240], p: 0.5, training: true, dtypes: [bfloat16], label: "tokens-1k-hidden-10k-bf16"}
+  - {input_shape: [1024, 10240], p: 0.5, training: true, dtypes: [bfloat16], label: "tokens-1k-hidden-10k"}
   - {input_shape: [1024, 4096], p: 0.5, training: true, dtypes: [float32], label: "tokens-1k-hidden-4k-fp32"}
 
   roofline:

--- a/src/tileops/manifest/sequence_modeling.yaml
+++ b/src/tileops/manifest/sequence_modeling.yaml
@@ -36,9 +36,9 @@ EngramGateConvFwdOp:
 
   workloads:
   # d is kept 256-aligned so runtime padding does not distort roofline.
-  - {M: 1, seq_len: 32, d: 256, dtype: float16, dtypes: [float16], label: "fwd-b1-s32-d256-fp16"}
-  - {M: 2, seq_len: 64, d: 512, dtype: float16, dtypes: [float16], label: "fwd-b2-s64-d512-fp16"}
-  - {M: 1, seq_len: 128, d: 256, dtype: bfloat16, dtypes: [bfloat16], label: "fwd-b1-s128-d256-bf16"}
+  - {M: 1, seq_len: 32, d: 256, dtype: float16, dtypes: [float16], label: "fwd-b1-s32-d256"}
+  - {M: 2, seq_len: 64, d: 512, dtype: float16, dtypes: [float16], label: "fwd-b2-s64-d512"}
+  - {M: 1, seq_len: 128, d: 256, dtype: bfloat16, dtypes: [bfloat16], label: "fwd-b1-s128-d256"}
 
   roofline:
     func: "tileops.perf.formulas.engram_gate_conv_fwd_roofline"
@@ -96,9 +96,9 @@ EngramGateConvBwdOp:
     - "conv_w.shape == (4, d)"
 
   workloads:
-  - {M: 1, seq_len: 32, d: 256, dtype: float16, dtypes: [float16], label: "bwd-b1-s32-d256-fp16"}
-  - {M: 2, seq_len: 64, d: 512, dtype: float16, dtypes: [float16], label: "bwd-b2-s64-d512-fp16"}
-  - {M: 1, seq_len: 128, d: 256, dtype: bfloat16, dtypes: [bfloat16], label: "bwd-b1-s128-d256-bf16"}
+  - {M: 1, seq_len: 32, d: 256, dtype: float16, dtypes: [float16], label: "bwd-b1-s32-d256"}
+  - {M: 2, seq_len: 64, d: 512, dtype: float16, dtypes: [float16], label: "bwd-b2-s64-d512"}
+  - {M: 1, seq_len: 128, d: 256, dtype: bfloat16, dtypes: [bfloat16], label: "bwd-b1-s128-d256"}
 
   roofline:
     func: "tileops.perf.formulas.engram_gate_conv_bwd_roofline"
@@ -148,9 +148,9 @@ EngramDecodeFwdOp:
     - "d % 256 == 0"
 
   workloads:
-  - {batch: 1, d_mem: 512, d: 256, max_conv_len: 12, conv_kernel_size: 4, dilation: 3, dtype: float16, dtypes: [float16], label: "decode-b1-dmem512-d256-fp16"}
-  - {batch: 4, d_mem: 1024, d: 512, max_conv_len: 20, conv_kernel_size: 4, dilation: 5, dtype: float16, dtypes: [float16], label: "decode-b4-dmem1024-d512-fp16"}
-  - {batch: 8, d_mem: 512, d: 256, max_conv_len: 18, conv_kernel_size: 4, dilation: 3, dtype: bfloat16, dtypes: [bfloat16], label: "decode-b8-dmem512-d256-bf16"}
+  - {batch: 1, d_mem: 512, d: 256, max_conv_len: 12, conv_kernel_size: 4, dilation: 3, dtype: float16, dtypes: [float16], label: "decode-b1-dmem512-d256"}
+  - {batch: 4, d_mem: 1024, d: 512, max_conv_len: 20, conv_kernel_size: 4, dilation: 5, dtype: float16, dtypes: [float16], label: "decode-b4-dmem1024-d512"}
+  - {batch: 8, d_mem: 512, d: 256, max_conv_len: 18, conv_kernel_size: 4, dilation: 3, dtype: bfloat16, dtypes: [bfloat16], label: "decode-b8-dmem512-d256"}
 
   roofline:
     func: "tileops.perf.formulas.engram_decode_roofline"


### PR DESCRIPTION
## Problems

The benchmark pages render one column from `workloads[].label`, which the bench files suffix with the dtype. Two things in the labels carry nothing a reader can use:

- 62 labels across ten families name the dtype the suffix already appends, in the other spelling: `stage-transition-3x3-s2-fp16` renders as `stage-transition-3x3-s2-fp16-bias-float16`.
- The norm labels carry `llama-3.1-`, where the point release does not separate anything: every Llama 3.1 size shares its hidden dim with the 3.3 of the same size, so the shape a row measures is the same either way.

`resnet-1x1-bf16` also repeats `resnet-1x1-fp16` exactly — same shape, and that row's `dtypes` already covers bfloat16 — so one case was measured twice, as was its `-bias` pair.

## Changes

- Dropped the dtype from those labels, and the point release from the norm ones. A label keeps its dtype where it is the only thing separating two rows of one op — `nt-batch16-m4096-n4096-k4096-fp16` from its `-bf16` twin — and where it names something else, as `fp8-cache` names the cache dtype rather than the row's. The model stays: `llama-8b-prefill` reads on its own, which a row lifted into a regression alert has to.
- Dropped the two duplicate conv workloads.

Rendered ids go from 5-46 characters to 13-41, none repeating a dtype. Benchmark cases: 1131 collected, two fewer than before.

The nightly keys its 14-day best on the case name, so the renamed cases skip regression detection for one run rather than reading the gap as a regression.
