### PR TITLE
[Bench] Time every op family against its library kernels, not just eager torch

### DIFF
--- a/.claude/domain-rules/benchmark.md
+++ b/.claude/domain-rules/benchmark.md
@@ -1,10 +1,8 @@
-- **MUST NOT**: import from `tests/`. Reads of any other file are unrestricted.
-- **MUST NOT**: author `gen_inputs`. Import the op's workload from `workloads/`; if it has none, add it there instead of copying locally.
-- Time the workload's `ref_program` for the torch baseline. Override it in a subclass only when the baseline is deliberately not the reference, and say so in the subclass docstring.
-- A baseline that is a different implementation takes its own tag next to `ref_program` rather than overriding it, is asserted against the reference before the case is timed, and raises when unavailable instead of falling back.
-
-The two **MUST NOT**s are checked by `benchmarks/tests/test_benchmark_boundaries.py`,
-which matches names literally — it will not catch a draw helper under another name.
+- **MUST NOT**: import from `tests/`, or author `gen_inputs` — take the op's workload from `workloads/`, adding it there if the op has none. `benchmarks/tests/test_benchmark_boundaries.py` checks both by name, so a draw helper under another name slips through.
+- Time the workload's `ref_program` for the torch baseline. Override it in a subclass only when the baseline is deliberately not the reference, and say so in its docstring.
+- Another implementation of the same computation takes its own tag beside `ref_program` instead of overriding it, and is asserted against the reference before the case is timed. Time a library's kernel where it has one; where it cannot express the case, drop the tag and say why.
+- A library a row selects resolves through `benchmarks.baselines`, which raises when it is missing: the image installs every baseline non-fatally, so a degraded image must fail the row rather than report torch under a library's tag. One a row merely prefers (mamba-ssm, FA3) keeps its guarded import and drops the tag.
+- A baseline that overwrites its inputs gets private copies, through the `(callable, args)` form of `compare`. Sharing them silently feeds every later tag something the reference never read.
 
 → [trust-model.md §Benchmark](../../docs/design/trust-model.md#benchmark) | [testing.md §Benchmarks](../../docs/design/testing.md#benchmarks)
 
@@ -12,8 +10,6 @@ ______________________________________________________________________
 
 - Every benchmark records ≥1 non-`tileops` baseline.
 - A timed callable launches its own work. Gradients come from `backward_of`, never `Tensor.backward`: autograd's engine thread carries no iteration id, so the timer cannot attribute what it launches.
-- Every case is named: a manifest `label`, or `id=` on `pytest.param`. Name the scenario (`serving-130m-4k`), not the parameters. Enforced by the `workload-names-lint` pre-commit hook.
-- A workload `label` omits the dtype; the case id appends it.
-- Tag names: lowercase, hyphen-separated. Tags starting with `tileops` are TileOPs entries; everything else is a baseline.
-- `calculate_flops()` / `calculate_memory()` return `None` to omit the metric.
-- Benchmark shapes reflect real DNN workloads (LLaMA-family by default). Annotate shape constants with the model/scenario; never use arbitrary flat numbers (262K, 1M, 4M).
+- Name the scenario (`serving-130m-4k`), not the parameters; a `label` omits the dtype, the case id appends it. The `workload-names-lint` hook checks a name exists, not that it reads as one.
+- Tag names: lowercase, hyphen-separated. A `tileops` prefix marks a TileOPs entry; everything else is a baseline.
+- Benchmark shapes reflect real DNN workloads (LLaMA-family by default). Annotate shape constants with the model/scenario; never arbitrary flat numbers (262K, 1M, 4M).

--- a/benchmarks/baselines.py
+++ b/benchmarks/baselines.py
@@ -1,0 +1,260 @@
+"""Third-party baselines the bench files time next to their torch reference.
+
+A resolver raises when its library is absent rather than let a tag that names a
+library report torch: ``.github/runner/Dockerfile`` installs every one of them
+non-fatally, so a degraded image has to fail the row it degraded. A kernel that
+cannot express the case is the bench file's call: that row carries no tag for the
+library and says why.
+
+Importing this module also arms :class:`_FlagGemsImportOrder`.
+"""
+
+import contextlib
+import importlib
+import importlib.abc
+import sys
+from typing import Any, Callable, Optional
+
+import torch
+
+__all__ = [
+    "FLAGGEMS_TAG",
+    "FLASHINFER_TAG",
+    "TORCH_COMPILE_TAG",
+    "VLLM_TAG",
+    "assert_matches_reference",
+    "compiled_reference",
+    "flaggems_dims",
+    "flaggems_group_norm",
+    "flaggems_op",
+    "flashinfer_op",
+    "reference_tolerance",
+    "vllm_op",
+]
+
+# docs/design/testing.md's per-dtype tolerances. A baseline is checked at the same
+# strength a test checks an op: the question is the same one.
+_TOLERANCES = {
+    torch.float16: (1e-3, 1e-3),
+    torch.bfloat16: (1.6e-2, 1.6e-2),
+    torch.float32: (1e-5, 1e-5),
+    torch.float64: (1e-7, 1e-7),
+}
+
+TORCH_COMPILE_TAG = "torch-compile"
+FLAGGEMS_TAG = "flaggems"
+FLASHINFER_TAG = "flashinfer"
+VLLM_TAG = "vllm"
+
+
+def compiled_reference(fn: Callable, *, dynamic: bool = False) -> Callable:
+    """Return *fn* compiled by inductor, resetting dynamo first.
+
+    dynamo caches eight graphs per code object and every case of a bench file
+    shares one reference callable, so without the reset the later cases would
+    time eager under a tag that says compiled.
+    """
+    torch._dynamo.reset()
+    return torch.compile(fn, dynamic=dynamic)
+
+
+def _resolve(module: str, attr: str, library: str) -> Any:
+    """Return ``module.attr``, naming the library in both failure messages."""
+    try:
+        mod = importlib.import_module(module)
+    except ImportError as exc:
+        raise RuntimeError(
+            f"{library} is a selected baseline for this case; install it "
+            f"(see .github/runner/Dockerfile) or drop the tag from the bench file"
+        ) from exc
+    target = mod
+    for part in attr.split("."):
+        target = getattr(target, part, None)
+        if target is None:
+            raise RuntimeError(
+                f"{library} {getattr(mod, '__version__', '?')} does not expose "
+                f"{module}.{attr}; the adapter needs updating for this version"
+            )
+    return target
+
+
+def _claim_registry_before_flaggems() -> None:
+    """Import vllm's custom ops, if installed, before flag_gems registers any.
+
+    In the other order the process aborts: flag_gems claims schemas that vllm's
+    ``_moe_C`` then re-defines, and the failed ``aoti_torch_library_def`` throws
+    through a C++ static initializer, past any ``except``. Costs the vllm import
+    (5.9s, measured in the runner image) in every process that reaches flag_gems.
+    """
+    with contextlib.suppress(ImportError):
+        importlib.import_module("vllm._custom_ops")
+
+
+class _FlagGemsImportOrder(importlib.abc.MetaPathFinder):
+    """Hold that order for every importer, not just :func:`flaggems_op`.
+
+    Returns ``None`` always: it claims no module, it only runs first.
+    """
+
+    _importing = False
+
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname != "flag_gems" and not fullname.startswith("flag_gems."):
+            return None
+        if _FlagGemsImportOrder._importing:
+            return None
+        _FlagGemsImportOrder._importing = True
+        try:
+            _claim_registry_before_flaggems()
+        finally:
+            _FlagGemsImportOrder._importing = False
+        return None
+
+
+def _install_flaggems_import_order() -> None:
+    """Arm the guard once. ``benchmarks/conftest.py`` imports this module for it."""
+    if any(isinstance(finder, _FlagGemsImportOrder) for finder in sys.meta_path):
+        return
+    sys.meta_path.insert(0, _FlagGemsImportOrder())
+
+
+_install_flaggems_import_order()
+
+
+def _builds_pointwise_kernel(fn: Callable) -> bool:
+    """Is *fn* built by flag_gems' ``pointwise_dynamic``?
+
+    Structural rather than a list of names: the module defining such an op holds a
+    ``pointwise_dynamic`` kernel object, and no other flag_gems module does.
+    """
+    module = sys.modules.get(getattr(fn, "__module__", ""))
+    if module is None:
+        return False
+    return any(
+        type(value).__module__.startswith("flag_gems.utils.pointwise_dynamic")
+        for value in vars(module).values()
+    )
+
+
+def flaggems_op(name: str) -> Callable:
+    """Return the ``flag_gems.ops`` entry point *name*.
+
+    Its parameters follow the aten schema, not the ``torch.nn.functional``
+    signature: ``softmax(self, dim, half_to_float=False)``,
+    ``group_norm(input, weight, bias, N, C, HxW, group, eps)``.
+
+    Raises:
+        RuntimeError: When *name* is built by ``pointwise_dynamic``, whose second
+            launch aborts the process.
+    """
+    fn = _resolve("flag_gems.ops", name, "flag_gems")
+    if _builds_pointwise_kernel(fn):
+        raise RuntimeError(
+            f"flag_gems.ops.{name} goes through LibEntry, whose argument cache "
+            "misaligns under triton 3.7: it returns once, then aborts the process on "
+            "the second launch, which a timing loop reaches immediately. Reaching such "
+            "a kernel means launching it through triton's own Autotuner, the way "
+            "benchmarks/ops/bench_pool.py does for two named pooling kernels"
+        )
+    return fn
+
+
+def flaggems_dims(dim) -> list:
+    """Wrap a manifest row's ``dim`` into the list flag_gems' reductions take."""
+    return list(dim) if isinstance(dim, (list, tuple)) else [dim]
+
+
+def flaggems_group_norm(n: int, c: int, hxw: int, groups: int, eps: float) -> Callable:
+    """Return flag_gems' group_norm bound to this geometry, output only.
+
+    It takes the geometry rather than reading it off the input, and ``None`` for
+    an unaffine row.
+    """
+    fn = flaggems_op("group_norm")
+
+    def baseline_fn(x, weight=None, bias=None):
+        return fn(x, weight, bias, n, c, hxw, groups, eps)[0]
+
+    return baseline_fn
+
+
+def flashinfer_op(name: str) -> Callable:
+    """Return the ``flashinfer`` entry point *name*, dots allowed for submodules."""
+    return _resolve("flashinfer", name, "flashinfer")
+
+
+def vllm_op(name: str) -> Callable:
+    """Return the ``vllm._custom_ops`` entry point *name*.
+
+    Most of them write into a caller-allocated out tensor and return ``None``,
+    so an adapter has to allocate before the timed region, not inside it.
+
+    Raises:
+        RuntimeError: When flag_gems got to the registry first, which
+            :func:`_claim_registry_before_flaggems` explains. Importing vllm here
+            would abort the process, so this reports it instead.
+    """
+    if "flag_gems" in sys.modules and "vllm._custom_ops" not in sys.modules:
+        raise RuntimeError(
+            "flag_gems was imported before vllm, and importing vllm now would abort "
+            "the process inside a C++ static initializer. Import benchmarks.baselines "
+            "before anything that imports flag_gems (benchmarks/conftest.py does), or "
+            "resolve flag_gems through flaggems_op"
+        )
+    return _resolve("vllm._custom_ops", name, "vllm")
+
+
+def reference_tolerance(dtype: torch.dtype) -> dict[str, float]:
+    """Return ``rtol``/``atol`` for *dtype*, ready to splat into an assertion.
+
+    A dtype outside the table takes no tolerance override, leaving
+    ``assert_close`` on its own defaults.
+    """
+    rtol_atol = _TOLERANCES.get(dtype)
+    if rtol_atol is None:
+        return {}
+    return {"rtol": rtol_atol[0], "atol": rtol_atol[1]}
+
+
+def assert_matches_reference(
+    fn: Callable,
+    reference: Callable,
+    *inputs: Any,
+    rtol: Optional[float] = None,
+    atol: Optional[float] = None,
+) -> None:
+    """Check a baseline against the reference, output by output.
+
+    A baseline may return more than the reference does — saved statistics an aten
+    signature carries — and those extra outputs go unchecked.
+
+    Raises:
+        AssertionError: When an output disagrees, or the baseline returns fewer
+            outputs than the reference.
+    """
+    got, expected = fn(*inputs), reference(*inputs)
+    tolerances = {}
+    if rtol is not None:
+        tolerances["rtol"] = rtol
+    if atol is not None:
+        tolerances["atol"] = atol
+    if tolerances:
+        tolerances.setdefault("rtol", 0.0)
+        tolerances.setdefault("atol", 0.0)
+
+    if not isinstance(expected, (tuple, list)):
+        got = got[0] if isinstance(got, (tuple, list)) else got
+        torch.testing.assert_close(got, expected, **tolerances)
+        return
+    if not isinstance(got, (tuple, list)) or len(got) < len(expected):
+        raise AssertionError(
+            f"baseline returned {1 if not isinstance(got, (tuple, list)) else len(got)} "
+            f"output(s), the reference {len(expected)}"
+        )
+    for index, (got_i, expected_i) in enumerate(zip(got[: len(expected)], expected, strict=True)):
+        torch.testing.assert_close(
+            got_i,
+            expected_i,
+            msg=lambda message, index=index: f"output {index}: {message}",
+            **tolerances,
+        )

--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -84,10 +84,12 @@ class BenchmarkBase(Generic[W], ABC):
 
     @abstractmethod
     def calculate_flops(self) -> Optional[float]:
+        """Total FLOPs of one call, or ``None`` to leave TFLOPS out of the row."""
         raise NotImplementedError
 
     @abstractmethod
     def calculate_memory(self) -> Optional[float]:
+        """Bytes moved by one call, or ``None`` to leave bandwidth out of the row."""
         raise NotImplementedError
 
     def profile(self, functor: Any, *inputs: Any) -> dict:

--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -3,6 +3,9 @@ import gc
 import pytest
 import torch
 
+# Imported for its side effect: arming the guard that keeps flag_gems from
+# reaching torch's op registry before vllm. See benchmarks.baselines.
+import benchmarks.baselines  # noqa: F401
 from benchmarks.report import BenchmarkReport, _bench_results
 
 

--- a/benchmarks/ops/attention/bench_deepseek_dsa_decode.py
+++ b/benchmarks/ops/attention/bench_deepseek_dsa_decode.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 
+from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
 from benchmarks.benchmark_base import ManifestBenchmark
 from benchmarks.ops.attention.manifest_params import dsa_decode_args, manifest_params
 from tileops.manifest import load_workloads
@@ -69,5 +70,12 @@ def test_dsa_decode_bench(
     bm = ManifestBenchmark(_OP_NAME, op, test)
 
     bm.compare(
-        {"tileops": op, "torch-ref": test.ref_program}, *inputs, record_as=op, params=locals()
+        {
+            "tileops": op,
+            "torch-ref": test.ref_program,
+            TORCH_COMPILE_TAG: compiled_reference(test.ref_program),
+        },
+        *inputs,
+        record_as=op,
+        params=locals(),
     )

--- a/benchmarks/ops/attention/bench_deepseek_mla_decode.py
+++ b/benchmarks/ops/attention/bench_deepseek_mla_decode.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 
+from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
 from benchmarks.benchmark_base import ManifestBenchmark
 from benchmarks.ops.attention.manifest_params import manifest_params, mla_decode_args
 from tileops.manifest import load_workloads
@@ -36,5 +37,12 @@ def test_mla_decode_bench(
     bm = ManifestBenchmark(_OP_NAME, op, test)
 
     bm.compare(
-        {"tileops": op, "torch-ref": test.ref_program}, *inputs, record_as=op, params=locals()
+        {
+            "tileops": op,
+            "torch-ref": test.ref_program,
+            TORCH_COMPILE_TAG: compiled_reference(test.ref_program),
+        },
+        *inputs,
+        record_as=op,
+        params=locals(),
     )

--- a/benchmarks/ops/bench_ada_layer_norm.py
+++ b/benchmarks/ops/bench_ada_layer_norm.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
+from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
 from benchmarks.benchmark_base import ManifestBenchmark
 from tileops.manifest import load_workloads
 from tileops.ops.norm.ada_layer_norm import AdaLayerNormFwdOp
@@ -36,7 +37,16 @@ def test_ada_layer_norm_bench(m: int, n: int, dtype: torch.dtype) -> None:
         normed = F.layer_norm(x, (n,), weight=None, bias=None, eps=test.eps)
         return scale * normed + shift
 
-    bm.compare({"tileops": op, "torch-ref": baseline_fn}, *inputs, record_as=op, params=locals())
+    bm.compare(
+        {
+            "tileops": op,
+            "torch-ref": baseline_fn,
+            TORCH_COMPILE_TAG: compiled_reference(baseline_fn),
+        },
+        *inputs,
+        record_as=op,
+        params=locals(),
+    )
 
 
 @pytest.mark.parametrize("m, n, dtype", _to_params(load_workloads(_ADA_ZERO_OP_NAME)))
@@ -52,4 +62,13 @@ def test_ada_layer_norm_zero_bench(m: int, n: int, dtype: torch.dtype) -> None:
         normed = F.layer_norm(x, (n,), weight=None, bias=None, eps=test.eps)
         return gate * (scale * normed + shift)
 
-    bm.compare({"tileops": op, "torch-ref": baseline_fn}, *inputs, record_as=op, params=locals())
+    bm.compare(
+        {
+            "tileops": op,
+            "torch-ref": baseline_fn,
+            TORCH_COMPILE_TAG: compiled_reference(baseline_fn),
+        },
+        *inputs,
+        record_as=op,
+        params=locals(),
+    )

--- a/benchmarks/ops/bench_argreduce.py
+++ b/benchmarks/ops/bench_argreduce.py
@@ -4,17 +4,46 @@ Measures latency, TFLOPS, and DRAM bandwidth against PyTorch baselines.
 Workload shapes, dtypes, and op-call parameters (e.g. ``dim``) are loaded
 from the ops manifest (``src/tileops/manifest/``) — the benchmark must not
 hard-code op parameters that are declared on manifest workload entries.
+
+Each row is timed against flag_gems' Triton argreduce and against torch eager and
+inductor.
 """
 
 import pytest
 import torch
 
+from benchmarks.baselines import (
+    FLAGGEMS_TAG,
+    TORCH_COMPILE_TAG,
+    assert_matches_reference,
+    compiled_reference,
+    flaggems_op,
+)
 from benchmarks.benchmark_base import ManifestBenchmark, workloads_to_params
 from tileops.ops.reduction.argreduce import ArgmaxFwdOp, ArgminFwdOp
 from workloads.reduction import ArgmaxWorkload, ArgminWorkload
 
 _ARGMAX_OP = "ArgmaxFwdOp"
 _ARGMIN_OP = "ArgminFwdOp"
+
+
+def _functors(op, baseline_fn, flaggems_name: str, dim: int, inputs) -> dict:
+    """The op, flag_gems' argreduce, and torch eager and compiled.
+
+    Indices are exact or wrong, so the check takes no tolerance.
+    """
+    fn = flaggems_op(flaggems_name)
+
+    def flaggems_fn(x):
+        return fn(x, dim)
+
+    assert_matches_reference(flaggems_fn, baseline_fn, *inputs)
+    return {
+        "tileops": op,
+        FLAGGEMS_TAG: flaggems_fn,
+        "torch": baseline_fn,
+        TORCH_COMPILE_TAG: compiled_reference(baseline_fn),
+    }
 
 
 # Argmax benchmarks
@@ -34,7 +63,7 @@ def test_argmax_bench(shape: tuple, dtype: torch.dtype, extra: dict) -> None:
         return x.argmax(dim=dim)
 
     bm.compare(
-        {"tileops": op, "torch": baseline_fn},
+        _functors(op, baseline_fn, "argmax", dim, inputs),
         *inputs,
         record_as=op,
         params={"shape": shape, "dtype": dtype, "dim": dim},
@@ -58,7 +87,7 @@ def test_argmin_bench(shape: tuple, dtype: torch.dtype, extra: dict) -> None:
         return x.argmin(dim=dim)
 
     bm.compare(
-        {"tileops": op, "torch": baseline_fn},
+        _functors(op, baseline_fn, "argmin", dim, inputs),
         *inputs,
         record_as=op,
         params={"shape": shape, "dtype": dtype, "dim": dim},

--- a/benchmarks/ops/bench_batch_norm.py
+++ b/benchmarks/ops/bench_batch_norm.py
@@ -1,6 +1,9 @@
 """Benchmark for BatchNormFwdOp and BatchNormBwdOp.
 
-Compares TileOPs vs PyTorch cuDNN batch norm on common ResNet-style shapes.
+Compares TileOPs vs PyTorch cuDNN batch norm on common ResNet-style shapes. The
+forward row adds flag_gems' batch_norm and cuDNN through inductor; the backward row
+stays on the autograd reference alone, which is a node driven on this thread and not
+work either of those performs.
 """
 
 import math
@@ -8,6 +11,13 @@ import math
 import pytest
 import torch
 
+from benchmarks.baselines import (
+    FLAGGEMS_TAG,
+    TORCH_COMPILE_TAG,
+    assert_matches_reference,
+    compiled_reference,
+    flaggems_op,
+)
 from benchmarks.benchmark_base import ManifestBenchmark, backward_of
 from tileops.manifest import load_workloads
 from tileops.ops.norm.batch_norm import BatchNormBwdOp, BatchNormFwdOp
@@ -52,6 +62,21 @@ def _torch_bn_fwd(x, weight, bias, running_mean, running_var):
         bias.float(),
         training=True,
     )
+
+
+def _flaggems_bn_fwd(running_mean: torch.Tensor, running_var: torch.Tensor):
+    """flag_gems' batch_norm on its own running statistics, output only.
+
+    Training mode updates them in place, and the cuDNN reference clones before it
+    does, so this gets copies rather than the tensors the other tags read.
+    """
+    fn = flaggems_op("batch_norm")
+    private_mean, private_var = running_mean.clone(), running_var.clone()
+
+    def baseline_fn(x, _running_mean, _running_var, weight, bias):
+        return fn(x.float(), weight, bias, private_mean, private_var, True, 0.1, 1e-5)[0]
+
+    return baseline_fn
 
 
 def _torch_bn_bwd(grad_out, x, weight, mean, rstd):
@@ -111,10 +136,19 @@ def test_batch_norm_fwd_bench(N, C, spatial, dtype, training, tune):
 
     spatial = str(spatial)  # stringify tuple so it survives BenchmarkReport.record filtering
 
+    def torch_fn(x, rm, rv, w, b):
+        return _torch_bn_fwd(x, w, b, rm, rv)
+
+    flaggems_fn = _flaggems_bn_fwd(running_mean, running_var)
+    # cuDNN and Triton both reduce over N*H*W in fp32; agreement is at fp32 strength.
+    assert_matches_reference(flaggems_fn, torch_fn, *inputs, rtol=1e-4, atol=1e-4)
+
     bm.compare(
         {
             "tileops": lambda *a: op(*a),
-            "torch-cudnn": lambda x, rm, rv, w, b: _torch_bn_fwd(x, w, b, rm, rv),
+            FLAGGEMS_TAG: flaggems_fn,
+            "torch-cudnn": torch_fn,
+            TORCH_COMPILE_TAG: compiled_reference(torch_fn),
         },
         *inputs,
         record_as=op,

--- a/benchmarks/ops/bench_binary_elementwise.py
+++ b/benchmarks/ops/bench_binary_elementwise.py
@@ -2,6 +2,9 @@
 
 Profiles TileOPs vs PyTorch baselines for each new op category using
 DNN-realistic 2D shapes (tokens × hidden_dim) with the default op configuration.
+
+Every row adds the same reference through inductor. The three fused gated ops add
+flashinfer's kernel, which takes the concatenated input the reference splits.
 """
 
 from math import prod
@@ -11,6 +14,14 @@ import pytest
 import torch
 import torch.nn.functional as F
 
+from benchmarks.baselines import (
+    FLASHINFER_TAG,
+    TORCH_COMPILE_TAG,
+    assert_matches_reference,
+    compiled_reference,
+    flashinfer_op,
+    reference_tolerance,
+)
 from benchmarks.benchmark_base import (
     BenchmarkBase,
     ManifestBenchmark,
@@ -357,7 +368,16 @@ def test_binary_arith_bench(
 
     op = op_cls()
 
-    bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+    bm.compare(
+        {
+            "tileops": op,
+            "torch": baseline_fn,
+            TORCH_COMPILE_TAG: compiled_reference(baseline_fn),
+        },
+        *inputs,
+        record_as=op,
+        params=locals(),
+    )
 
 
 # Comparison ops (6)
@@ -403,7 +423,16 @@ def test_comparison_bench(
 
     op = _CMP_OPS[op_name]()
 
-    bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+    bm.compare(
+        {
+            "tileops": op,
+            "torch": baseline_fn,
+            TORCH_COMPILE_TAG: compiled_reference(baseline_fn),
+        },
+        *inputs,
+        record_as=op,
+        params=locals(),
+    )
 
 
 # Logical ops (2)
@@ -468,13 +497,8 @@ def test_logical_bench(
 
     # Baseline uses bool tensors
     a_bool, b_bool = inputs[0].bool(), inputs[1].bool()
-    functors["torch"] = (
-        baseline_fn,
-        (
-            a_bool,
-            b_bool,
-        ),
-    )
+    functors["torch"] = (baseline_fn, (a_bool, b_bool))
+    functors[TORCH_COMPILE_TAG] = (compiled_reference(baseline_fn), (a_bool, b_bool))
     bm.compare(functors, *inputs, record_as=op, params=locals())
 
 
@@ -533,7 +557,16 @@ def test_bitwise_bench(
 
     op = op_cls()
 
-    bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+    bm.compare(
+        {
+            "tileops": op,
+            "torch": baseline_fn,
+            TORCH_COMPILE_TAG: compiled_reference(baseline_fn),
+        },
+        *inputs,
+        record_as=op,
+        params=locals(),
+    )
 
 
 # Fused gated ops (2)
@@ -590,6 +623,8 @@ def _gelu_tanh_and_mul_baseline(x: torch.Tensor) -> torch.Tensor:
     return F.gelu(x[..., :half], approximate="tanh") * x[..., half:]
 
 
+# flashinfer names its fused gated kernels after the same three activations and
+# takes the same concatenated input, so a key here doubles as its entry-point name.
 _FUSED_BASELINES = {
     "silu_and_mul": _silu_and_mul_baseline,
     "gelu_and_mul": _gelu_and_mul_baseline,
@@ -599,8 +634,18 @@ _FUSED_BASELINES = {
 
 def _profile_fused_gated(bm: ManifestBenchmark, op, test, baseline_key: str, params: dict) -> None:
     inputs = test.gen_inputs()
+    baseline_fn = _FUSED_BASELINES[baseline_key]
+    flashinfer_fn = flashinfer_op(baseline_key)
+    assert_matches_reference(
+        flashinfer_fn, baseline_fn, *inputs, **reference_tolerance(params["dtype"])
+    )
     bm.compare(
-        {"tileops": op, "torch-ref": _FUSED_BASELINES[baseline_key]},
+        {
+            "tileops": op,
+            FLASHINFER_TAG: flashinfer_fn,
+            "torch-ref": baseline_fn,
+            TORCH_COMPILE_TAG: compiled_reference(baseline_fn),
+        },
         *inputs,
         record_as=op,
         params=params,
@@ -695,7 +740,11 @@ def test_fused_gated_strategy_bench(
     kernel = kernel_cls(M=M, N=N, dtype=dtype, config={"strategy": strategy})
     baseline_fn = _FUSED_BASELINES[op_name]
     bm.compare(
-        {f"tileops-{strategy}": kernel, "torch": baseline_fn},
+        {
+            f"tileops-{strategy}": kernel,
+            "torch": baseline_fn,
+            TORCH_COMPILE_TAG: compiled_reference(baseline_fn),
+        },
         *inputs,
         record_as=f"{op_name}_strategy",
         params=locals(),
@@ -838,7 +887,11 @@ def test_broadcast_bench(
     op = op_cls()
 
     bm.compare(
-        {"tileops": op, "torch": baseline_fn},
+        {
+            "tileops": op,
+            "torch": baseline_fn,
+            TORCH_COMPILE_TAG: compiled_reference(baseline_fn),
+        },
         *inputs,
         record_as=f"{op_name}_bcast",
         params=locals(),

--- a/benchmarks/ops/bench_bmm.py
+++ b/benchmarks/ops/bench_bmm.py
@@ -1,6 +1,12 @@
 import pytest
 import torch
 
+from benchmarks.baselines import (
+    FLAGGEMS_TAG,
+    assert_matches_reference,
+    flaggems_op,
+    reference_tolerance,
+)
 from benchmarks.benchmark_base import ManifestBenchmark
 from tileops.manifest import load_workloads
 from tileops.ops import BmmFp8KNFwdOp, BmmFp8NKFwdOp, BmmFwdOp
@@ -108,7 +114,20 @@ def test_bmm_bench(batch: int, m: int, n: int, k: int, dtype_str: str) -> None:
     # eval_roofline() is read lazily after profiling, by which point
     # forward() has bound the dims.
 
-    bm.compare({"tileops": op, "torch-cublas": torch.bmm}, a, b, record_as=op, params=locals())
+    flaggems_bmm = flaggems_op("bmm")
+    assert_matches_reference(flaggems_bmm, torch.bmm, a, b, **reference_tolerance(a.dtype))
+
+    bm.compare(
+        {
+            "tileops": op,
+            FLAGGEMS_TAG: flaggems_bmm,
+            "torch-cublas": torch.bmm,
+        },
+        a,
+        b,
+        record_as=op,
+        params=locals(),
+    )
 
 
 @pytest.mark.parametrize("batch, m, n, k, dtype_str", _fp8_params(load_workloads(_FP8_KN_OP_NAME)))

--- a/benchmarks/ops/bench_convolution.py
+++ b/benchmarks/ops/bench_convolution.py
@@ -8,6 +8,10 @@ FLOP/byte counts come from each op's ``eval_roofline()`` via
 One ``test_*_bench`` per op, so the validator's L4 AST check can tie each
 ``load_workloads("<OpName>")`` call to its manifest entry. A row passes bias
 when it declares ``bias_shape``.
+
+Every row is timed against flag_gems' Triton convolutions, ``F.convNd`` eager
+(which is cuDNN, so cuDNN takes no tag of its own), and that reference through
+inductor.
 """
 
 from dataclasses import asdict, dataclass
@@ -17,12 +21,28 @@ import pytest
 import torch
 import torch.nn.functional as F
 
+from benchmarks.baselines import (
+    FLAGGEMS_TAG,
+    TORCH_COMPILE_TAG,
+    assert_matches_reference,
+    compiled_reference,
+    flaggems_op,
+)
 from benchmarks.benchmark_base import ManifestBenchmark
 from tileops.manifest import load_workloads
 from tileops.ops import Conv1dFwdOp, Conv2dFwdOp, Conv3dFwdOp
 
 # Bench-local: autotuning is benchmark infrastructure, not a workload property.
 _TUNE = True
+
+# flag_gems' aten-level convolutions, by spatial rank.
+_FLAGGEMS_CONV = {1: "conv1d", 2: "conv2d", 3: "conv3d"}
+
+# Triton and cuDNN sum the same products in a different order, so agreement is
+# relative to the output scale: over the 13 manifest workloads on an H200, flag_gems
+# lands within 0.25 of cuDNN where |ref| reaches 564.
+_BASELINE_RTOL = 2e-2
+_BASELINE_ATOL = 2e-2
 
 
 class ConvWorkload:
@@ -157,16 +177,48 @@ def _torch_conv_baseline(
     return baseline_fn
 
 
+def _flaggems_conv_baseline(
+    rank: int,
+    stride: tuple[int, ...],
+    padding: tuple[int, ...],
+    dilation: tuple[int, ...],
+    groups: int,
+) -> Callable:
+    """Return flag_gems' convolution of this rank, bound to these params.
+
+    Same parameter names as ``F.convNd``, but the spatial extents go in as lists.
+    """
+    conv_fn = flaggems_op(_FLAGGEMS_CONV[rank])
+
+    def baseline_fn(
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        bias: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        return conv_fn(
+            x,
+            weight,
+            bias,
+            list(stride),
+            list(padding),
+            list(dilation),
+            groups,
+        )
+
+    return baseline_fn
+
+
 def _run_conv(
     op,
     bm: ManifestBenchmark,
     torch_fn: Callable,
     case: ConvCase,
     *,
+    rank: int,
     with_bias: bool,
     static_weight: bool = False,
 ) -> None:
-    """Profile op and its torch baseline on the same inputs, recording both.
+    """Profile op against flag_gems and torch on the same inputs, recording all.
 
     One caller per manifest op, so each keeps a literal
     ``ManifestBenchmark(<op name>, ...)`` the manifest validator matches
@@ -187,11 +239,29 @@ def _run_conv(
         case.dilation,
         case.groups,
     )
+    flaggems = _flaggems_conv_baseline(
+        rank,
+        case.stride,
+        case.padding,
+        case.dilation,
+        case.groups,
+    )
+    assert_matches_reference(
+        flaggems,
+        baseline,
+        *inputs,
+        rtol=_BASELINE_RTOL,
+        atol=_BASELINE_ATOL,
+    )
     _profile_conv(
         op,
         bm,
         inputs,
-        baseline,
+        {
+            FLAGGEMS_TAG: flaggems,
+            "torch": baseline,
+            TORCH_COMPILE_TAG: compiled_reference(baseline),
+        },
         case.as_record(),
         static_weight=static_weight,
     )
@@ -201,12 +271,12 @@ def _profile_conv(
     op,
     bm: ManifestBenchmark,
     inputs: tuple[torch.Tensor, ...],
-    baseline_fn: Callable,
+    baselines: dict[str, Callable],
     params: dict,
     *,
     static_weight: bool = False,
 ) -> None:
-    """Profile op and the torch baseline on the same inputs and record both."""
+    """Profile op and every baseline on the same inputs and record them all."""
     if static_weight:
         x, weight, *maybe_bias = inputs
         bias = maybe_bias[0] if maybe_bias else None
@@ -216,18 +286,24 @@ def _profile_conv(
                 return op(x_i, weight)
             return op(x_i, weight, bias)
 
-        def baseline_with_static_weight(x_i):
-            return baseline_fn(x_i, weight, bias)
+        def bind_static_weight(fn: Callable) -> Callable:
+            def run(x_i):
+                return fn(x_i, weight, bias)
+
+            return run
 
         bm.compare(
-            {"tileops": op_with_static_weight, "torch": baseline_with_static_weight},
+            {
+                "tileops": op_with_static_weight,
+                **{tag: bind_static_weight(fn) for tag, fn in baselines.items()},
+            },
             x,
             record_as=op,
             params=params,
         )
         return
 
-    bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=params)
+    bm.compare({"tileops": op, **baselines}, *inputs, record_as=op, params=params)
 
 
 # Conv1d
@@ -249,7 +325,7 @@ def test_conv1d_bench(case: ConvCase) -> None:
         tune=_TUNE,
     )
     bm = ManifestBenchmark(_CONV1D_OP, op, ConvWorkload(case.input_shape, case.dtype))
-    _run_conv(op, bm, F.conv1d, case, with_bias=case.with_bias, static_weight=True)
+    _run_conv(op, bm, F.conv1d, case, rank=1, with_bias=case.with_bias, static_weight=True)
 
 
 # Conv2d
@@ -271,7 +347,7 @@ def test_conv2d_bench(case: ConvCase) -> None:
         tune=_TUNE,
     )
     bm = ManifestBenchmark(_CONV2D_OP, op, ConvWorkload(case.input_shape, case.dtype))
-    _run_conv(op, bm, F.conv2d, case, with_bias=case.with_bias)
+    _run_conv(op, bm, F.conv2d, case, rank=2, with_bias=case.with_bias)
 
 
 # Conv3d
@@ -293,4 +369,4 @@ def test_conv3d_bench(case: ConvCase) -> None:
         tune=_TUNE,
     )
     bm = ManifestBenchmark(_CONV3D_OP, op, ConvWorkload(case.input_shape, case.dtype))
-    _run_conv(op, bm, F.conv3d, case, with_bias=case.with_bias)
+    _run_conv(op, bm, F.conv3d, case, rank=3, with_bias=case.with_bias)

--- a/benchmarks/ops/bench_cumulative.py
+++ b/benchmarks/ops/bench_cumulative.py
@@ -3,11 +3,22 @@
 Measures latency, TFLOPS, and DRAM bandwidth against PyTorch baselines.
 Workload shapes and roofline formulas are loaded from the ops manifest
 (src/tileops/manifest/).
+
+cumsum is timed against flag_gems' Triton scan as well as torch, eager and
+compiled. cumprod has no flag_gems entry point in 5.0.2.
 """
 
 import pytest
 import torch
 
+from benchmarks.baselines import (
+    FLAGGEMS_TAG,
+    TORCH_COMPILE_TAG,
+    assert_matches_reference,
+    compiled_reference,
+    flaggems_op,
+    reference_tolerance,
+)
 from benchmarks.benchmark_base import (
     ManifestBenchmark,
     workloads_to_params,
@@ -48,7 +59,24 @@ def test_cumsum_bench(shape: tuple, dtype: torch.dtype) -> None:
     op = _make_op(shape, dtype, "cumsum")
     bm = ManifestBenchmark(_CUMSUM_OP, op, test)
 
-    bm.compare({"tileops": op, "torch": test.ref_program}, *inputs, record_as=op, params=locals())
+    flaggems_cumsum = flaggems_op("cumsum")
+
+    def flaggems_fn(x):
+        return flaggems_cumsum(x, -1)
+
+    assert_matches_reference(flaggems_fn, test.ref_program, *inputs, **reference_tolerance(dtype))
+
+    bm.compare(
+        {
+            "tileops": op,
+            FLAGGEMS_TAG: flaggems_fn,
+            "torch": test.ref_program,
+            TORCH_COMPILE_TAG: compiled_reference(test.ref_program),
+        },
+        *inputs,
+        record_as=op,
+        params=locals(),
+    )
 
 
 @pytest.mark.parametrize("shape, dtype", workloads_to_params(_CUMPROD_OP))
@@ -59,4 +87,13 @@ def test_cumprod_bench(shape: tuple, dtype: torch.dtype) -> None:
     op = _make_op(shape, dtype, "cumprod")
     bm = ManifestBenchmark(_CUMPROD_OP, op, test)
 
-    bm.compare({"tileops": op, "torch": test.ref_program}, *inputs, record_as=op, params=locals())
+    bm.compare(
+        {
+            "tileops": op,
+            "torch": test.ref_program,
+            TORCH_COMPILE_TAG: compiled_reference(test.ref_program),
+        },
+        *inputs,
+        record_as=op,
+        params=locals(),
+    )

--- a/benchmarks/ops/bench_deltanet_recurrence.py
+++ b/benchmarks/ops/bench_deltanet_recurrence.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 import torch
 
+from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
 from benchmarks.benchmark_base import BenchmarkBase, ManifestBenchmark
 from benchmarks.ops.attention.manifest_params import manifest_params
 from tileops.manifest import load_workloads
@@ -84,4 +85,13 @@ def test_deltanet_decode_bench(
     op = DeltaNetDecodeFwdOp(tune=tune)
     bm = ManifestBenchmark(_OP_NAME, op, test)
 
-    bm.compare({"tileops": op, "torch": test.ref_program}, *inputs, record_as=op, params=locals())
+    bm.compare(
+        {
+            "tileops": op,
+            "torch": test.ref_program,
+            TORCH_COMPILE_TAG: compiled_reference(test.ref_program),
+        },
+        *inputs,
+        record_as=op,
+        params=locals(),
+    )

--- a/benchmarks/ops/bench_dropout.py
+++ b/benchmarks/ops/bench_dropout.py
@@ -2,12 +2,16 @@
 
 Profiles TileOPs dropout vs torch.nn.functional.dropout on DNN-realistic shapes.
 Uses p=0.5 (default) as representative drop rate.
+
+torch eager and inductor are the two competitors: flag_gems' ``dropout`` raises on
+this torch version.
 """
 
 import pytest
 import torch
 import torch.nn.functional as F
 
+from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
 from benchmarks.benchmark_base import ManifestBenchmark, workloads_to_params
 from tileops.ops.dropout import DropoutFwdOp
 from workloads.elementwise import ShapedRandnWorkload
@@ -32,4 +36,13 @@ def test_dropout_bench(shape: tuple, dtype: torch.dtype) -> None:
     op = DropoutFwdOp(p=test.p, seed=42)
     bm = ManifestBenchmark(_OP_NAME, op, test)
 
-    bm.compare({"tileops": op, "torch": test.ref_program}, x, record_as=op, params=locals())
+    bm.compare(
+        {
+            "tileops": op,
+            "torch": test.ref_program,
+            TORCH_COMPILE_TAG: compiled_reference(test.ref_program),
+        },
+        x,
+        record_as=op,
+        params=locals(),
+    )

--- a/benchmarks/ops/bench_elementwise_manifest.py
+++ b/benchmarks/ops/bench_elementwise_manifest.py
@@ -3,6 +3,8 @@
 These cases keep the legacy risk-matrix benchmarks intact while giving each
 implemented elementwise manifest entry a benchmark path that is sourced from
 ``workloads`` and reports roofline data through ``ManifestBenchmark``.
+
+Each row is timed against torch eager and the same reference through inductor.
 """
 
 from math import prod
@@ -12,6 +14,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
+from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
 from benchmarks.benchmark_base import ManifestBenchmark
 from tileops.manifest import load_workloads
 from tileops.ops.elementwise import (
@@ -234,7 +237,14 @@ def _record_unary(
     baseline_fn: Callable,
 ) -> None:
     bm.compare(
-        {"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=_manifest_params(bm)
+        {
+            "tileops": op,
+            "torch": baseline_fn,
+            TORCH_COMPILE_TAG: compiled_reference(baseline_fn),
+        },
+        *inputs,
+        record_as=op,
+        params=_manifest_params(bm),
     )
 
 
@@ -245,7 +255,14 @@ def _record_binary(
     baseline_fn: Callable,
 ) -> None:
     bm.compare(
-        {"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=_manifest_params(bm)
+        {
+            "tileops": op,
+            "torch": baseline_fn,
+            TORCH_COMPILE_TAG: compiled_reference(baseline_fn),
+        },
+        *inputs,
+        record_as=op,
+        params=_manifest_params(bm),
     )
 
 
@@ -417,7 +434,17 @@ def test_prelu_manifest_bench(
     x, weight = test.gen_inputs()
     op = PreluFwdOp()
     bm = ManifestBenchmark(_PRELU_OP, op, test)
-    bm.compare({"tileops": op, "torch": F.prelu}, x, weight, record_as=op, params=locals())
+    bm.compare(
+        {
+            "tileops": op,
+            "torch": F.prelu,
+            TORCH_COMPILE_TAG: compiled_reference(F.prelu),
+        },
+        x,
+        weight,
+        record_as=op,
+        params=locals(),
+    )
 
 
 _MASKED_FILL_OP = "MaskedFillFwdOp"
@@ -438,8 +465,16 @@ def test_masked_fill_tensor_manifest_bench(
     x, mask, value = test.gen_inputs()
     op = MaskedFillFwdOp()
     bm = ManifestBenchmark(_MASKED_FILL_OP, op, test)
+
+    def baseline_fn(a, m, v):
+        return a.masked_fill(m, v)
+
     bm.compare(
-        {"tileops": op, "torch": lambda a, m, v: a.masked_fill(m, v)},
+        {
+            "tileops": op,
+            "torch": baseline_fn,
+            TORCH_COMPILE_TAG: compiled_reference(baseline_fn),
+        },
         x,
         mask,
         value,
@@ -460,8 +495,16 @@ def test_masked_fill_scalar_manifest_bench(
     x, mask = test.gen_inputs()
     op = MaskedFillScalarFwdOp(value=-100.0)
     bm = ManifestBenchmark(_MASKED_FILL_SCALAR_OP, op, test)
+
+    def baseline_fn(a, m):
+        return a.masked_fill(m, -100.0)
+
     bm.compare(
-        {"tileops": op, "torch": lambda a, m: a.masked_fill(m, -100.0)},
+        {
+            "tileops": op,
+            "torch": baseline_fn,
+            TORCH_COMPILE_TAG: compiled_reference(baseline_fn),
+        },
         x,
         mask,
         record_as=op,
@@ -740,7 +783,18 @@ def test_where_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> Non
     cond, x, other = test.gen_inputs()
     op = WhereFwdOp()
     bm = ManifestBenchmark(_WHERE_OP, op, test)
-    bm.compare({"tileops": op, "torch": torch.where}, cond, x, other, record_as=op, params=locals())
+    bm.compare(
+        {
+            "tileops": op,
+            "torch": torch.where,
+            TORCH_COMPILE_TAG: compiled_reference(torch.where),
+        },
+        cond,
+        x,
+        other,
+        record_as=op,
+        params=locals(),
+    )
 
 
 @pytest.mark.parametrize("shape, dtype", _shape_dtype_params(load_workloads(_LERP_TENSOR_OP)))
@@ -749,4 +803,15 @@ def test_lerp_tensor_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) 
     x, end, weight = test.gen_inputs()
     op = LerpTensorFwdOp()
     bm = ManifestBenchmark(_LERP_TENSOR_OP, op, test)
-    bm.compare({"tileops": op, "torch": torch.lerp}, x, end, weight, record_as=op, params=locals())
+    bm.compare(
+        {
+            "tileops": op,
+            "torch": torch.lerp,
+            TORCH_COMPILE_TAG: compiled_reference(torch.lerp),
+        },
+        x,
+        end,
+        weight,
+        record_as=op,
+        params=locals(),
+    )

--- a/benchmarks/ops/bench_engram.py
+++ b/benchmarks/ops/bench_engram.py
@@ -11,6 +11,7 @@ One ``test_*_bench`` per op, so the validator's L4 AST check can tie each
 import pytest
 import torch
 
+from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
 from benchmarks.benchmark_base import (
     ManifestBenchmark,
     workload_field_params,
@@ -45,7 +46,14 @@ def test_engram_gate_conv_fwd_bench(M, seq_len, d, dtype):
     bm = ManifestBenchmark(_ENGRAM_GATE_CONV_FWD_OP, op, test)
 
     bm.compare(
-        {"tileops": op, "torch-ref": test.ref_program}, *inputs, record_as=op, params=locals()
+        {
+            "tileops": op,
+            "torch-ref": test.ref_program,
+            TORCH_COMPILE_TAG: compiled_reference(test.ref_program),
+        },
+        *inputs,
+        record_as=op,
+        params=locals(),
     )
 
 
@@ -68,7 +76,16 @@ def test_engram_gate_conv_bwd_bench(M, seq_len, d, dtype):
     def ref_with_grad(*args):
         return test.ref_program(*args)
 
-    bm.compare({"tileops": op, "torch": ref_with_grad}, *inputs, record_as=op, params=locals())
+    bm.compare(
+        {
+            "tileops": op,
+            "torch": ref_with_grad,
+            TORCH_COMPILE_TAG: compiled_reference(ref_with_grad),
+        },
+        *inputs,
+        record_as=op,
+        params=locals(),
+    )
 
 
 _ENGRAM_DECODE_OP = "EngramDecodeFwdOp"
@@ -98,5 +115,12 @@ def test_engram_decode_bench(batch, d_mem, d, max_conv_len, conv_kernel_size, di
     bm = ManifestBenchmark(_ENGRAM_DECODE_OP, op, test)
 
     bm.compare(
-        {"tileops": op, "torch-ref": test.ref_program}, *inputs, record_as=op, params=locals()
+        {
+            "tileops": op,
+            "torch-ref": test.ref_program,
+            TORCH_COMPILE_TAG: compiled_reference(test.ref_program),
+        },
+        *inputs,
+        record_as=op,
+        params=locals(),
     )

--- a/benchmarks/ops/bench_fft.py
+++ b/benchmarks/ops/bench_fft.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 
+from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
 from benchmarks.benchmark_base import (
     ManifestBenchmark,
     workloads_to_params,
@@ -27,5 +28,12 @@ def test_fft_bench(shape: tuple, dtype: torch.dtype) -> None:
     bm = ManifestBenchmark(_OP_NAME, op, test)
 
     bm.compare(
-        {"tileops": op, "torch-cufft": test.ref_program}, *inputs, record_as=op, params=locals()
+        {
+            "tileops": op,
+            "torch-cufft": test.ref_program,
+            TORCH_COMPILE_TAG: compiled_reference(test.ref_program),
+        },
+        *inputs,
+        record_as=op,
+        params=locals(),
     )

--- a/benchmarks/ops/bench_fp8_lightning_indexer.py
+++ b/benchmarks/ops/bench_fp8_lightning_indexer.py
@@ -6,6 +6,7 @@ come from the op's ``eval_roofline()`` via :class:`ManifestBenchmark`.
 
 import pytest
 
+from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
 from benchmarks.benchmark_base import ManifestBenchmark
 from tileops.manifest import load_workloads
 from tileops.ops import FP8LightningIndexerFwdOp
@@ -72,5 +73,12 @@ def test_fp8_lightning_indexer_bench(
     bm = ManifestBenchmark(_FP8_LIGHTNING_INDEXER_OP, op, test)
 
     bm.compare(
-        {"tileops": op, "torch-ref": test.ref_program}, *inputs, record_as=op, params=locals()
+        {
+            "tileops": op,
+            "torch-ref": test.ref_program,
+            TORCH_COMPILE_TAG: compiled_reference(test.ref_program),
+        },
+        *inputs,
+        record_as=op,
+        params=locals(),
     )

--- a/benchmarks/ops/bench_fp8_quant.py
+++ b/benchmarks/ops/bench_fp8_quant.py
@@ -8,6 +8,7 @@ byte counts come from the op's ``eval_roofline()`` via
 import pytest
 import torch
 
+from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
 from benchmarks.benchmark_base import (
     ManifestBenchmark,
     workload_field_params,
@@ -39,5 +40,12 @@ def test_fp8_quant_bench(
     bm = ManifestBenchmark(_FP8_QUANT_OP, op, test)
 
     bm.compare(
-        {"tileops": op, "torch-ref": test.ref_program}, *inputs, record_as=op, params=locals()
+        {
+            "tileops": op,
+            "torch-ref": test.ref_program,
+            TORCH_COMPILE_TAG: compiled_reference(test.ref_program),
+        },
+        *inputs,
+        record_as=op,
+        params=locals(),
     )

--- a/benchmarks/ops/bench_gated_deltanet_prefill.py
+++ b/benchmarks/ops/bench_gated_deltanet_prefill.py
@@ -128,7 +128,15 @@ def test_gated_deltanet_prefill_bhtd_bench(
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
-    """Head-major prefill. No FLA row: FLA takes token-major only."""
+    """Head-major prefill, timed alone."""
+    # FIXME(staged-rollout): this row records no baseline.
+    #
+    # Broken invariant: every benchmark records ≥1 non-tileops baseline.
+    # Why: FLA reads token-major only, and the workload's chunked reference is a
+    #   Python loop over chunks — at this op's 128k-token rows it costs more than
+    #   the rest of the family's benchmarks together.
+    # Cleanup: a reference that scales to 128k tokens, or an FLA entry point that
+    #   takes head-major input.
     test = GatedDeltaNetPrefillFwdWorkload(
         batch, heads, seq_len, dim_k, dim_v, chunk_size, dtype, layout=layout
     )

--- a/benchmarks/ops/bench_gemm.py
+++ b/benchmarks/ops/bench_gemm.py
@@ -3,6 +3,12 @@ from typing import Any, Callable, Optional
 import pytest
 import torch
 
+from benchmarks.baselines import (
+    FLAGGEMS_TAG,
+    assert_matches_reference,
+    flaggems_op,
+    reference_tolerance,
+)
 from benchmarks.benchmark_base import ManifestBenchmark
 from tileops.manifest import load_workloads
 from tileops.ops import GemmFp8FwdOp, GemmFwdOp, GemmW4A16FwdOp
@@ -292,9 +298,17 @@ def test_gemm_bench(
     # The benchmark framework warms up internally; eval_roofline() is read
     # lazily after profiling, by which point forward() has bound the dims.
 
-    bm.compare(
-        {"tileops": op, "torch-cublas": workload.torch_matmul}, a, b, record_as=op, params=locals()
-    )
+    # flag_gems' mm takes row-major operands; a transposed row is its own layout,
+    # which its kernel does not express, so those rows carry cuBLAS alone.
+    functors = {"tileops": op, "torch-cublas": workload.torch_matmul}
+    if not trans_a and not trans_b:
+        flaggems_mm = flaggems_op("mm")
+        assert_matches_reference(
+            flaggems_mm, workload.torch_matmul, a, b, **reference_tolerance(dtype)
+        )
+        functors[FLAGGEMS_TAG] = flaggems_mm
+
+    bm.compare(functors, a, b, record_as=op, params=locals())
 
 
 @pytest.mark.parametrize("m, n, k, scale_mode, dtype_str", _manifest_fp8_params())

--- a/benchmarks/ops/bench_gla_recurrence.py
+++ b/benchmarks/ops/bench_gla_recurrence.py
@@ -10,6 +10,7 @@ from typing import Optional
 
 import torch
 
+from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
 from benchmarks.benchmark_base import BenchmarkBase, ManifestBenchmark
 from benchmarks.ops.attention.manifest_params import manifest_params
 from tileops.manifest import load_workloads
@@ -125,8 +126,8 @@ def test_gla_decode_bench(
             )
 
         functors["fla"] = (fla_decode, ())
-    else:
-        # --- Torch reference baseline ---
-        functors["torch"] = test.ref_program
+
+    functors["torch"] = test.ref_program
+    functors[TORCH_COMPILE_TAG] = compiled_reference(test.ref_program)
 
     bm.compare(functors, *inputs, record_as=op, params=locals())

--- a/benchmarks/ops/bench_group_norm.py
+++ b/benchmarks/ops/bench_group_norm.py
@@ -1,7 +1,19 @@
+"""Benchmarks for GroupNormFwdOp, affine and not, against flag_gems and torch."""
+
+import math
+
 import pytest
 import torch
 import torch.nn.functional as F
 
+from benchmarks.baselines import (
+    FLAGGEMS_TAG,
+    TORCH_COMPILE_TAG,
+    assert_matches_reference,
+    compiled_reference,
+    flaggems_group_norm,
+    reference_tolerance,
+)
 from benchmarks.benchmark_base import ManifestBenchmark
 from tileops.manifest import load_workloads
 from tileops.ops.norm.group_norm import GroupNormFwdOp
@@ -46,8 +58,23 @@ def test_group_norm_bench(
     def baseline_fn(x, weight, bias):
         return F.group_norm(x, num_groups, weight=weight, bias=bias, eps=1e-5)
 
+    flaggems_fn = flaggems_group_norm(n, c, math.prod(spatial), num_groups, 1e-5)
+    assert_matches_reference(
+        flaggems_fn, baseline_fn, x, weight, bias, **reference_tolerance(dtype)
+    )
+
     bm.compare(
-        {"tileops": op, "torch": baseline_fn}, x, weight, bias, record_as=op, params=locals()
+        {
+            "tileops": op,
+            FLAGGEMS_TAG: flaggems_fn,
+            "torch": baseline_fn,
+            TORCH_COMPILE_TAG: compiled_reference(baseline_fn),
+        },
+        x,
+        weight,
+        bias,
+        record_as=op,
+        params=locals(),
     )
 
 
@@ -64,4 +91,17 @@ def test_group_norm_no_affine_bench(
     def baseline_no_affine(x):
         return F.group_norm(x, num_groups, weight=None, bias=None, eps=1e-5)
 
-    bm.compare({"tileops": op, "torch": baseline_no_affine}, x, record_as=op, params=locals())
+    flaggems_fn = flaggems_group_norm(n, c, math.prod(spatial), num_groups, 1e-5)
+    assert_matches_reference(flaggems_fn, baseline_no_affine, x, **reference_tolerance(dtype))
+
+    bm.compare(
+        {
+            "tileops": op,
+            FLAGGEMS_TAG: flaggems_fn,
+            "torch": baseline_no_affine,
+            TORCH_COMPILE_TAG: compiled_reference(baseline_no_affine),
+        },
+        x,
+        record_as=op,
+        params=locals(),
+    )

--- a/benchmarks/ops/bench_grouped_gemm.py
+++ b/benchmarks/ops/bench_grouped_gemm.py
@@ -10,6 +10,7 @@ GEMM launches, which no single manifest workload describes.
 import pytest
 import torch
 
+from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
 from benchmarks.benchmark_base import (
     ManifestBenchmark,
     workload_field_params,
@@ -57,5 +58,12 @@ def test_grouped_gemm_bench(
     bm = ManifestBenchmark(_GROUPED_GEMM_OP, op, test)
 
     bm.compare(
-        {"tileops": op, "torch-ref": test.ref_program}, *inputs, record_as=name, params=locals()
+        {
+            "tileops": op,
+            "torch-ref": test.ref_program,
+            TORCH_COMPILE_TAG: compiled_reference(test.ref_program),
+        },
+        *inputs,
+        record_as=name,
+        params=locals(),
     )

--- a/benchmarks/ops/bench_independent_elementwise.py
+++ b/benchmarks/ops/bench_independent_elementwise.py
@@ -2,6 +2,9 @@
 
 Profiles TileOPs vs PyTorch baselines using DNN-realistic 2-D shapes
 (tokens x hidden_dim) across all supported dtypes.
+
+Each row is timed against torch eager and the same reference through inductor,
+including the two generative ops (alibi, sinusoidal), which take no inputs.
 """
 
 from math import prod
@@ -11,6 +14,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
+from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
 from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, ManifestBenchmark
 from tileops.manifest import load_workloads
 from tileops.ops.elementwise import (
@@ -111,7 +115,11 @@ def test_clamp_tensor_bench(
         return torch.clamp(x, t_min, t_max)
 
     bm.compare(
-        {"tileops": op, "torch": baseline_fn},
+        {
+            "tileops": op,
+            "torch": baseline_fn,
+            TORCH_COMPILE_TAG: compiled_reference(baseline_fn),
+        },
         x,
         t_min,
         t_max,
@@ -183,8 +191,15 @@ def test_alibi_bench(seq_len: int, num_heads: int, dtype: torch.dtype) -> None:
     workload = _GenerativeWorkload((num_heads, seq_len, seq_len), dtype)
     bm = ManifestBenchmark(_ALIBI_OP, op, workload)
 
+    def baseline_fn():
+        return _alibi_reference(seq_len, num_heads, dtype)
+
     bm.compare(
-        {"tileops": op, "torch-ref": lambda: _alibi_reference(seq_len, num_heads, dtype)},
+        {
+            "tileops": op,
+            "torch-ref": baseline_fn,
+            TORCH_COMPILE_TAG: compiled_reference(baseline_fn),
+        },
         record_as=op,
         params=locals(),
     )
@@ -196,8 +211,15 @@ def test_sinusoidal_bench(seq_len: int, d_model: int, dtype: torch.dtype) -> Non
     workload = _GenerativeWorkload((seq_len, d_model), dtype)
     bm = ManifestBenchmark(_SINUSOIDAL_OP, op, workload)
 
+    def baseline_fn():
+        return _sinusoidal_reference(seq_len, d_model, dtype)
+
     bm.compare(
-        {"tileops": op, "torch-ref": lambda: _sinusoidal_reference(seq_len, d_model, dtype)},
+        {
+            "tileops": op,
+            "torch-ref": baseline_fn,
+            TORCH_COMPILE_TAG: compiled_reference(baseline_fn),
+        },
         record_as=op,
         params=locals(),
     )
@@ -273,7 +295,14 @@ def test_fp8_unary_independent_bench(op_name: str, shape: tuple, dtype: torch.dt
         return baseline_fn(x.to(torch.float16)).to(dtype)
 
     bm.compare(
-        {"tileops": op, "torch-ref": baseline}, *inputs, record_as=f"{op_name}_fp8", params=locals()
+        {
+            "tileops": op,
+            "torch-ref": baseline,
+            TORCH_COMPILE_TAG: compiled_reference(baseline),
+        },
+        *inputs,
+        record_as=f"{op_name}_fp8",
+        params=locals(),
     )
 
 
@@ -343,4 +372,14 @@ def test_fp8_selection_bench(op_name: str, shape: tuple, dtype: torch.dtype) -> 
         def baseline(x, mask):
             return x.to(torch.float16).masked_fill(mask, -100.0).to(dtype)
 
-        bm.compare({"tileops": op, "torch-ref": baseline}, x, mask, record_as=op, params=locals())
+        bm.compare(
+            {
+                "tileops": op,
+                "torch-ref": baseline,
+                TORCH_COMPILE_TAG: compiled_reference(baseline),
+            },
+            x,
+            mask,
+            record_as=op,
+            params=locals(),
+        )

--- a/benchmarks/ops/bench_instance_norm.py
+++ b/benchmarks/ops/bench_instance_norm.py
@@ -1,7 +1,24 @@
+"""Benchmarks for InstanceNormFwdOp.
+
+flag_gems ships no instance_norm, so the tag goes to its ``group_norm`` with one
+group per channel, which computes the same thing. torch eager and inductor complete
+the row.
+"""
+
+import math
+
 import pytest
 import torch
 import torch.nn.functional as F
 
+from benchmarks.baselines import (
+    FLAGGEMS_TAG,
+    TORCH_COMPILE_TAG,
+    assert_matches_reference,
+    compiled_reference,
+    flaggems_group_norm,
+    reference_tolerance,
+)
 from benchmarks.benchmark_base import ManifestBenchmark
 from tileops.manifest import load_workloads
 from tileops.ops.norm.instance_norm import InstanceNormFwdOp
@@ -47,8 +64,23 @@ def test_instance_norm_bench(
     def baseline_fn(x, running_mean, running_var, weight, bias):
         return F.instance_norm(x, weight=weight, bias=bias, eps=1e-5)
 
+    # One group per channel is instance norm.
+    group_norm_fn = flaggems_group_norm(n, c, math.prod(spatial), c, 1e-5)
+
+    def flaggems_fn(x, running_mean, running_var, weight, bias):
+        return group_norm_fn(x, weight, bias)
+
+    assert_matches_reference(
+        flaggems_fn, baseline_fn, x, None, None, weight, bias, **reference_tolerance(dtype)
+    )
+
     bm.compare(
-        {"tileops": op, "torch": baseline_fn},
+        {
+            "tileops": op,
+            FLAGGEMS_TAG: flaggems_fn,
+            "torch": baseline_fn,
+            TORCH_COMPILE_TAG: compiled_reference(baseline_fn),
+        },
         x,
         None,
         None,

--- a/benchmarks/ops/bench_logical_reduce.py
+++ b/benchmarks/ops/bench_logical_reduce.py
@@ -2,11 +2,22 @@
 
 Measures latency, TFLOPS, and DRAM bandwidth against PyTorch baselines.
 Workload shapes and roofline formulas are loaded from the ops manifest (src/tileops/manifest/).
+
+any and all are timed against flag_gems' Triton reductions as well as torch, eager
+and compiled. count_nonzero has none: its entry point raises on a list of dims.
 """
 
 import pytest
 import torch
 
+from benchmarks.baselines import (
+    FLAGGEMS_TAG,
+    TORCH_COMPILE_TAG,
+    assert_matches_reference,
+    compiled_reference,
+    flaggems_dims,
+    flaggems_op,
+)
 from benchmarks.benchmark_base import ManifestBenchmark, workloads_to_params
 from tileops.ops.reduction.logical_reduce import AllFwdOp, AnyFwdOp, CountNonzeroFwdOp
 from workloads.reduction import AllWorkload, AnyWorkload, CountNonzeroWorkload
@@ -16,6 +27,26 @@ from workloads.reduction import AllWorkload, AnyWorkload, CountNonzeroWorkload
 _ANY_OP = "AnyFwdOp"
 _ALL_OP = "AllFwdOp"
 _COUNT_NONZERO_OP = "CountNonzeroFwdOp"
+
+
+def _functors(op, baseline_fn, inputs, flaggems_name=None, dim=None, keepdim=False) -> dict:
+    """The op, flag_gems where it has a kernel, and torch eager and compiled.
+
+    A boolean reduction is exact or wrong, so the check takes no tolerance.
+    """
+    functors = {"tileops": op}
+    if flaggems_name is not None:
+        fn = flaggems_op(flaggems_name)
+        dims = flaggems_dims(dim)
+
+        def flaggems_fn(x):
+            return fn(x.bool(), dims, keepdim)
+
+        assert_matches_reference(flaggems_fn, baseline_fn, *inputs)
+        functors[FLAGGEMS_TAG] = flaggems_fn
+    functors["torch"] = baseline_fn
+    functors[TORCH_COMPILE_TAG] = compiled_reference(baseline_fn)
+    return functors
 
 
 # Any benchmarks
@@ -39,7 +70,12 @@ def test_any_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> None:
         return x.bool().any(dim=dim, keepdim=keepdim)
 
     try:
-        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+        bm.compare(
+            _functors(op, baseline_fn, inputs, "any_dims", dim, keepdim),
+            *inputs,
+            record_as=op,
+            params=locals(),
+        )
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
@@ -67,7 +103,12 @@ def test_all_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> None:
         return x.bool().all(dim=dim, keepdim=keepdim)
 
     try:
-        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+        bm.compare(
+            _functors(op, baseline_fn, inputs, "all_dims", dim, keepdim),
+            *inputs,
+            record_as=op,
+            params=locals(),
+        )
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
@@ -94,7 +135,12 @@ def test_count_nonzero_bench(shape: tuple, dtype: torch.dtype, op_params: dict) 
         return torch.count_nonzero(x, dim=dim).to(torch.int64)
 
     try:
-        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+        bm.compare(
+            _functors(op, baseline_fn, inputs),
+            *inputs,
+            record_as=op,
+            params=locals(),
+        )
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")

--- a/benchmarks/ops/bench_mamba.py
+++ b/benchmarks/ops/bench_mamba.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
+from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
 from benchmarks.benchmark_base import ManifestBenchmark
 from benchmarks.ops.attention.manifest_params import manifest_params
 from tileops.manifest import load_workloads
@@ -170,19 +171,19 @@ def test_da_cumsum_fwd_bench(
             )
 
         functors["mamba"] = (mamba_fwd, ())
-    else:
 
-        def baseline(dt_raw, A, dt_bias):
-            return da_cumsum_fwd_ref(
-                dt_raw,
-                A,
-                num_chunks,
-                chunk_len,
-                dt_bias=dt_bias if has_dt_bias else None,
-                dt_softplus=dt_softplus,
-            )
+    def baseline(dt_raw, A, dt_bias):
+        return da_cumsum_fwd_ref(
+            dt_raw,
+            A,
+            num_chunks,
+            chunk_len,
+            dt_bias=dt_bias if has_dt_bias else None,
+            dt_softplus=dt_softplus,
+        )
 
-        functors["torch-ref"] = baseline
+    functors["torch-ref"] = baseline
+    functors[TORCH_COMPILE_TAG] = compiled_reference(baseline)
 
     bm.compare(functors, *inputs, record_as=op, params=locals())
 
@@ -302,12 +303,12 @@ def test_ssd_chunk_scan_fwd_bench(
             return _mamba_chunk_scan_fwd(cb, x, dt, dA_cumsum, C, prev_states)
 
         functors["mamba"] = (mamba_fwd, ())
-    else:
 
-        def torch_ref(x, cb, dA_cumsum, C, prev_states, dt):
-            return ssd_chunk_scan_fwd_ref(x, cb, dA_cumsum, C, prev_states, dt, n_groups)
+    def torch_ref(x, cb, dA_cumsum, C, prev_states, dt):
+        return ssd_chunk_scan_fwd_ref(x, cb, dA_cumsum, C, prev_states, dt, n_groups)
 
-        functors["torch-ref"] = torch_ref
+    functors["torch-ref"] = torch_ref
+    functors[TORCH_COMPILE_TAG] = compiled_reference(torch_ref)
 
     bm.compare(functors, *inputs, record_as=op, params=locals())
 
@@ -397,14 +398,12 @@ def test_ssd_chunk_state_fwd_bench(
             )
 
         functors["mamba"] = (mamba_fwd, ())
-    else:
 
-        def baseline(x, Bmat, dt, dA_cumsum, seq_idx):
-            return ssd_chunk_state_fwd_ref(
-                x, Bmat, dt, dA_cumsum, n_groups=n_groups, seq_idx=seq_idx
-            )
+    def baseline(x, Bmat, dt, dA_cumsum, seq_idx):
+        return ssd_chunk_state_fwd_ref(x, Bmat, dt, dA_cumsum, n_groups=n_groups, seq_idx=seq_idx)
 
-        functors["torch-ref"] = baseline
+    functors["torch-ref"] = baseline
+    functors[TORCH_COMPILE_TAG] = compiled_reference(baseline)
 
     bm.compare(functors, *inputs, record_as=op, params=locals())
 
@@ -461,12 +460,12 @@ def test_ssd_state_passing_fwd_bench(
         torch.cuda.synchronize()
 
         functors["mamba"] = (mamba_fwd, ())
-    else:
 
-        def baseline(states, dA_chunk_cumsum, initial_states):
-            return ssd_state_passing_fwd_ref(states, dA_chunk_cumsum, initial_states)
+    def baseline(states, dA_chunk_cumsum, initial_states):
+        return ssd_state_passing_fwd_ref(states, dA_chunk_cumsum, initial_states)
 
-        functors["torch-ref"] = baseline
+    functors["torch-ref"] = baseline
+    functors[TORCH_COMPILE_TAG] = compiled_reference(baseline)
 
     bm.compare(functors, *inputs, record_as=op, params=locals())
 
@@ -540,15 +539,11 @@ def test_ssd_decode_bench(
     def baseline(A, dt, x, B_in, C_in, state):
         return ssd_decode_ref(A, dt, x, B_in, C_in, state)
 
-    functors["torch-ref"] = (
-        baseline,
-        (
-            A,
-            dt,
-            x,
-            B_in,
-            C_in,
-            state_bl,
-        ),
+    reference_args = (A, dt, x, B_in, C_in, state_bl)
+    functors["torch-ref"] = (baseline, reference_args)
+    # Its own state copy again: inductor's graph mutates it the same way eager does.
+    functors[TORCH_COMPILE_TAG] = (
+        compiled_reference(baseline),
+        (A, dt, x, B_in, C_in, state.clone()),
     )
     bm.compare(functors, A, dt, x, B_in, C_in, state_for_op, record_as=op, params=locals())

--- a/benchmarks/ops/bench_mamba2_e2e.py
+++ b/benchmarks/ops/bench_mamba2_e2e.py
@@ -13,6 +13,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
+from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
 from benchmarks.benchmark_base import ManifestBenchmark
 from benchmarks.ops.attention.manifest_params import manifest_params
 from tileops.manifest import load_workloads
@@ -235,20 +236,12 @@ def test_mamba2_fwd_bench(
                 C,
             ),
         )
-    else:
 
-        def _torch_wrapper(x, dt, A, B, C):
-            return mamba2_fwd_ref(x, dt, A, B, C, dt_bias, chunk_size, dt_softplus, initial_states)
+    def _torch_wrapper(x, dt, A, B, C):
+        return mamba2_fwd_ref(x, dt, A, B, C, dt_bias, chunk_size, dt_softplus, initial_states)
 
-        functors["torch-ref"] = (
-            _torch_wrapper,
-            (
-                x,
-                dt,
-                A,
-                B,
-                C,
-            ),
-        )
+    reference_args = (x, dt, A, B, C)
+    functors["torch-ref"] = (_torch_wrapper, reference_args)
+    functors[TORCH_COMPILE_TAG] = (compiled_reference(_torch_wrapper), reference_args)
 
     bm.compare(functors, x, dt, A, B, C, dt_bias, initial_states, record_as=op, params=locals())

--- a/benchmarks/ops/bench_mean_pooling.py
+++ b/benchmarks/ops/bench_mean_pooling.py
@@ -3,6 +3,7 @@ from typing import List, Optional
 import pytest
 import torch
 
+from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
 from benchmarks.benchmark_base import BenchmarkBase
 from tileops.ops import MeanPoolingForwardOp
 from workloads.nsa_utils import prepare_chunk_indices
@@ -128,5 +129,12 @@ def test_mean_pooling_bench(
     op = MeanPoolingForwardOp(**params)
 
     bm.compare(
-        {"tileops": op, "torch-ref": test.ref_program}, *inputs, record_as=op, params=locals()
+        {
+            "tileops": op,
+            "torch-ref": test.ref_program,
+            TORCH_COMPILE_TAG: compiled_reference(test.ref_program),
+        },
+        *inputs,
+        record_as=op,
+        params=locals(),
     )

--- a/benchmarks/ops/bench_mhc.py
+++ b/benchmarks/ops/bench_mhc.py
@@ -8,6 +8,7 @@ manifest; roofline FLOP and byte counts come from each op's
 import pytest
 import torch
 
+from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
 from benchmarks.benchmark_base import (
     ManifestBenchmark,
     workload_field_params,
@@ -65,7 +66,14 @@ def test_mhc_pre_bench(
     bm = ManifestBenchmark(_MHC_PRE_OP, op, test)
 
     bm.compare(
-        {"tileops": op, "torch-ref": test.ref_program}, *inputs, record_as=op, params=locals()
+        {
+            "tileops": op,
+            "torch-ref": test.ref_program,
+            TORCH_COMPILE_TAG: compiled_reference(test.ref_program),
+        },
+        *inputs,
+        record_as=op,
+        params=locals(),
     )
 
 
@@ -85,5 +93,12 @@ def test_mhc_post_bench(batch: int, n_expand: int, c_x: int, dtype: torch.dtype)
     bm = ManifestBenchmark(_MHC_POST_OP, op, test)
 
     bm.compare(
-        {"tileops": op, "torch-ref": test.ref_program}, *inputs, record_as=op, params=locals()
+        {
+            "tileops": op,
+            "torch-ref": test.ref_program,
+            TORCH_COMPILE_TAG: compiled_reference(test.ref_program),
+        },
+        *inputs,
+        record_as=op,
+        params=locals(),
     )

--- a/benchmarks/ops/bench_moe_gate_up.py
+++ b/benchmarks/ops/bench_moe_gate_up.py
@@ -15,6 +15,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
+from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
 from benchmarks.benchmark_base import ManifestBenchmark
 from tileops.kernels.moe import (
     MoeGroupedGemmPersistent3WGFusedActKernel,
@@ -106,7 +107,12 @@ def test_moe_gate_up_bench(
         forced[tag] = kernel
 
     bm.compare(
-        {"tileops": op, **forced, "torch-ref": _torch_fn},
+        {
+            "tileops": op,
+            **forced,
+            "torch-ref": _torch_fn,
+            TORCH_COMPILE_TAG: compiled_reference(_torch_fn),
+        },
         a,
         b,
         true_sizes,

--- a/benchmarks/ops/bench_moe_grouped_gemm_nopad.py
+++ b/benchmarks/ops/bench_moe_grouped_gemm_nopad.py
@@ -11,6 +11,7 @@ manifest-derived roofline (`op.eval_roofline()`).
 import pytest
 import torch
 
+from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
 from benchmarks.benchmark_base import ManifestBenchmark
 from tileops.manifest import load_workloads
 from tileops.ops.moe import MoeGroupedGemmNopadFwdOp
@@ -84,7 +85,11 @@ def test_moe_grouped_gemm_nopad_bench(
     torch.cuda.synchronize()
 
     bm.compare(
-        {"tileops": op, "torch-ref": _torch_fn},
+        {
+            "tileops": op,
+            "torch-ref": _torch_fn,
+            TORCH_COMPILE_TAG: compiled_reference(_torch_fn),
+        },
         a,
         b,
         true_sizes,

--- a/benchmarks/ops/bench_norm.py
+++ b/benchmarks/ops/bench_norm.py
@@ -1,9 +1,28 @@
-"""Benchmarks for RMSNorm / LayerNorm and their fused-add variants."""
+"""Benchmarks for RMSNorm / LayerNorm and their fused-add variants.
+
+Normalization is where the serving stacks ship hand-written kernels, so every row
+takes the ones that cover it, plus torch eager and inductor: RMSNorm all three of
+flag_gems, flashinfer and vllm; LayerNorm the two with a kernel for it, flag_gems
+and flashinfer; fused-add RMSNorm the two fused kernels, flashinfer's and vllm's;
+fused-add LayerNorm none, which nobody fuses.
+"""
 
 import pytest
 import torch
 import torch.nn.functional as F
 
+from benchmarks.baselines import (
+    FLAGGEMS_TAG,
+    FLASHINFER_TAG,
+    TORCH_COMPILE_TAG,
+    VLLM_TAG,
+    assert_matches_reference,
+    compiled_reference,
+    flaggems_op,
+    flashinfer_op,
+    reference_tolerance,
+    vllm_op,
+)
 from benchmarks.benchmark_base import ManifestBenchmark
 from tileops.manifest import load_workloads
 from tileops.ops.norm.fused_add_layer_norm import FusedAddLayerNormFwdOp
@@ -16,6 +35,72 @@ from workloads.normalization import (
     LayerNormWorkload,
     RMSNormWorkload,
 )
+
+
+def _flaggems_rms_norm(n: int, eps: float):
+    """flag_gems' aten-level ``rms_norm(x, normalized_shape, weight, eps)``."""
+    fn = flaggems_op("rms_norm")
+
+    def baseline_fn(x, weight):
+        return fn(x, [n], weight, eps)
+
+    return baseline_fn
+
+
+def _flashinfer_rms_norm(eps: float):
+    fn = flashinfer_op("rmsnorm")
+
+    def baseline_fn(x, weight):
+        return fn(x, weight, eps)
+
+    return baseline_fn
+
+
+def _vllm_rms_norm(x: torch.Tensor, eps: float):
+    """vllm's kernel writes into a caller-allocated tensor, so allocate it here.
+
+    Allocating inside the callable would charge the tag for an ``empty_like`` the
+    other tags never pay.
+    """
+    fn = vllm_op("rms_norm")
+    out = torch.empty_like(x)
+
+    def baseline_fn(x_i, weight):
+        fn(out, x_i, weight, eps)
+        return out
+
+    return baseline_fn
+
+
+def _in_place_fused_add(fn, args: tuple, eps: float):
+    """Bind an in-place fused-add norm to its own copies of ``(x, residual)``.
+
+    Both kernels overwrite input and residual, and sharing them would hand every
+    later tag a different tensor than the reference read.
+
+    The residual therefore grows across iterations, by at most ``max|weight|`` each
+    — under 10 for a standard-normal weight, against an fp16 range of 65504 over a
+    few hundred iterations. The kernel reads and writes the same bytes regardless,
+    which is what the row reports.
+    """
+    x, residual, weight = args
+    private = (x.clone(), residual.clone(), weight)
+
+    def baseline_fn(x_i, residual_i, weight_i):
+        fn(x_i, residual_i, weight_i, eps)
+        return x_i, residual_i
+
+    return baseline_fn, private
+
+
+def _assert_fused_add_matches(fn, reference, x, residual, weight, eps, **tolerance) -> None:
+    """Check an in-place fused-add kernel on throwaway copies of its inputs."""
+    x_copy, residual_copy = x.clone(), residual.clone()
+    fn(x_copy, residual_copy, weight, eps)
+    expected_y, expected_add = reference(x, residual, weight)
+    torch.testing.assert_close(x_copy, expected_y, **tolerance)
+    torch.testing.assert_close(residual_copy, expected_add, **tolerance)
+
 
 _RMS_OP_NAME = "RMSNormFwdOp"
 
@@ -40,8 +125,25 @@ def test_rms_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
     op = RMSNormFwdOp(normalized_shape=(n,), tune=tune)
     bm = ManifestBenchmark(_RMS_OP_NAME, op, test)
 
+    tolerance = reference_tolerance(dtype)
+    library = {
+        FLAGGEMS_TAG: _flaggems_rms_norm(n, test.eps),
+        FLASHINFER_TAG: _flashinfer_rms_norm(test.eps),
+        VLLM_TAG: _vllm_rms_norm(inputs[0], test.eps),
+    }
+    for baseline_fn in library.values():
+        assert_matches_reference(baseline_fn, test.ref_program, *inputs, **tolerance)
+
     bm.compare(
-        {"tileops": op, "torch-ref": test.ref_program}, *inputs, record_as=op, params=locals()
+        {
+            "tileops": op,
+            **library,
+            "torch-ref": test.ref_program,
+            TORCH_COMPILE_TAG: compiled_reference(test.ref_program),
+        },
+        *inputs,
+        record_as=op,
+        params=locals(),
     )
 
 
@@ -81,7 +183,19 @@ def test_fused_add_rms_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool
         y = ((add_result.float() / rms) * weight.float()).to(x.dtype)
         return y, add_result
 
-    bm.compare({"tileops": op, "torch-ref": baseline_fn}, *inputs, record_as=op, params=locals())
+    tolerance = reference_tolerance(dtype)
+    fused_kernels = {
+        FLASHINFER_TAG: flashinfer_op("fused_add_rmsnorm"),
+        VLLM_TAG: vllm_op("fused_add_rms_norm"),
+    }
+    functors = {"tileops": op}
+    for tag, fn in fused_kernels.items():
+        _assert_fused_add_matches(fn, baseline_fn, *inputs, eps=test.eps, **tolerance)
+        functors[tag] = _in_place_fused_add(fn, inputs, test.eps)
+    functors["torch-ref"] = baseline_fn
+    functors[TORCH_COMPILE_TAG] = compiled_reference(baseline_fn)
+
+    bm.compare(functors, *inputs, record_as=op, params=locals())
 
 
 _LN_OP_NAME = "LayerNormFwdOp"
@@ -110,7 +224,32 @@ def test_layer_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool) -> Non
     def baseline_fn(x, weight, bias):
         return F.layer_norm(x, (n,), weight=weight, bias=bias, eps=1e-5)
 
-    bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+    flaggems_layer_norm = flaggems_op("layer_norm")
+    flashinfer_layer_norm = flashinfer_op("layernorm")
+
+    def flaggems_fn(x, weight, bias):
+        # Returns (output, mean, rstd); the row reports the output.
+        return flaggems_layer_norm(x, [n], weight, bias, 1e-5)[0]
+
+    def flashinfer_fn(x, weight, bias):
+        return flashinfer_layer_norm(x, weight, bias, 1e-5)
+
+    tolerance = reference_tolerance(dtype)
+    for library_fn in (flaggems_fn, flashinfer_fn):
+        assert_matches_reference(library_fn, baseline_fn, *inputs, **tolerance)
+
+    bm.compare(
+        {
+            "tileops": op,
+            FLAGGEMS_TAG: flaggems_fn,
+            FLASHINFER_TAG: flashinfer_fn,
+            "torch": baseline_fn,
+            TORCH_COMPILE_TAG: compiled_reference(baseline_fn),
+        },
+        *inputs,
+        record_as=op,
+        params=locals(),
+    )
 
 
 _FUSED_LN_OP_NAME = "FusedAddLayerNormFwdOp"
@@ -140,4 +279,15 @@ def test_fused_add_layer_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bo
         add_result = (x.float() + residual.float()).to(x.dtype)
         return F.layer_norm(add_result, (n,), weight=weight, bias=bias, eps=test.eps), add_result
 
-    bm.compare({"tileops": op, "torch-ref": baseline_fn}, *inputs, record_as=op, params=locals())
+    # flashinfer's and vllm's fused-add kernels are RMSNorm only, so this row is
+    # torch against itself, eager and compiled.
+    bm.compare(
+        {
+            "tileops": op,
+            "torch-ref": baseline_fn,
+            TORCH_COMPILE_TAG: compiled_reference(baseline_fn),
+        },
+        *inputs,
+        record_as=op,
+        params=locals(),
+    )

--- a/benchmarks/ops/bench_reduce.py
+++ b/benchmarks/ops/bench_reduce.py
@@ -2,11 +2,27 @@
 
 Measures latency, TFLOPS, and DRAM bandwidth against PyTorch baselines.
 Workload shapes and roofline formulas are loaded from the ops manifest (src/tileops/manifest/).
+
+Every row is timed against torch eager, the same reference through inductor, and
+flag_gems' Triton reduction where one exists. amin has none: flag_gems 5.0.2
+exposes amax but no amin, and ``min_dim`` also produces indices.
+
+The flag_gems callables cast nothing — like aten, its reductions accumulate in fp32
+and return the storage dtype — so each tag is one kernel.
 """
 
 import pytest
 import torch
 
+from benchmarks.baselines import (
+    FLAGGEMS_TAG,
+    TORCH_COMPILE_TAG,
+    assert_matches_reference,
+    compiled_reference,
+    flaggems_dims,
+    flaggems_op,
+    reference_tolerance,
+)
 from benchmarks.benchmark_base import ManifestBenchmark, workloads_to_params
 from tileops.ops.reduction.reduce import (
     AmaxFwdOp,
@@ -41,6 +57,17 @@ _VAR_OP = "VarFwdOp"
 _VAR_MEAN_OP = "VarMeanFwdOp"
 
 
+def _functors(op, baseline_fn, inputs, dtype: torch.dtype, flaggems_fn=None) -> dict:
+    """The op, flag_gems where it has a kernel, and torch eager and compiled."""
+    functors = {"tileops": op}
+    if flaggems_fn is not None:
+        assert_matches_reference(flaggems_fn, baseline_fn, *inputs, **reference_tolerance(dtype))
+        functors[FLAGGEMS_TAG] = flaggems_fn
+    functors["torch"] = baseline_fn
+    functors[TORCH_COMPILE_TAG] = compiled_reference(baseline_fn)
+    return functors
+
+
 # Sum benchmarks
 
 
@@ -61,8 +88,18 @@ def test_sum_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> None:
     def baseline_fn(x):
         return x.float().sum(dim=dim, keepdim=keepdim).to(x.dtype)
 
+    flaggems_sum = flaggems_op("sum_dim")
+
+    def flaggems_fn(x):
+        return flaggems_sum(x, flaggems_dims(dim), keepdim)
+
     try:
-        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+        bm.compare(
+            _functors(op, baseline_fn, inputs, dtype, flaggems_fn),
+            *inputs,
+            record_as=op,
+            params=locals(),
+        )
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
@@ -89,8 +126,18 @@ def test_mean_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> None:
     def baseline_fn(x):
         return x.float().mean(dim=dim, keepdim=keepdim).to(x.dtype)
 
+    flaggems_mean = flaggems_op("mean_dim")
+
+    def flaggems_fn(x):
+        return flaggems_mean(x, flaggems_dims(dim), keepdim)
+
     try:
-        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+        bm.compare(
+            _functors(op, baseline_fn, inputs, dtype, flaggems_fn),
+            *inputs,
+            record_as=op,
+            params=locals(),
+        )
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
@@ -117,8 +164,18 @@ def test_amax_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> None:
     def baseline_fn(x):
         return x.amax(dim=dim, keepdim=keepdim)
 
+    flaggems_amax = flaggems_op("amax")
+
+    def flaggems_fn(x):
+        return flaggems_amax(x, flaggems_dims(dim), keepdim)
+
     try:
-        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+        bm.compare(
+            _functors(op, baseline_fn, inputs, dtype, flaggems_fn),
+            *inputs,
+            record_as=op,
+            params=locals(),
+        )
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
@@ -146,7 +203,12 @@ def test_amin_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> None:
         return x.amin(dim=dim, keepdim=keepdim)
 
     try:
-        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+        bm.compare(
+            _functors(op, baseline_fn, inputs, dtype),
+            *inputs,
+            record_as=op,
+            params=locals(),
+        )
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
@@ -167,8 +229,18 @@ def test_prod_bench(shape: tuple, dtype: torch.dtype) -> None:
     def baseline_fn(x):
         return x.float().prod(dim=-1).to(x.dtype)
 
+    flaggems_prod = flaggems_op("prod_dim")
+
+    def flaggems_fn(x):
+        return flaggems_prod(x, -1)
+
     try:
-        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+        bm.compare(
+            _functors(op, baseline_fn, inputs, dtype, flaggems_fn),
+            *inputs,
+            record_as=op,
+            params=locals(),
+        )
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
@@ -195,8 +267,18 @@ def test_std_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> None:
     def baseline_fn(x):
         return x.float().std(dim=dim, keepdim=keepdim, correction=1).to(x.dtype)
 
+    flaggems_std = flaggems_op("std")
+
+    def flaggems_fn(x):
+        return flaggems_std(x, flaggems_dims(dim), correction=1, keepdim=keepdim)
+
     try:
-        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+        bm.compare(
+            _functors(op, baseline_fn, inputs, dtype, flaggems_fn),
+            *inputs,
+            record_as=op,
+            params=locals(),
+        )
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
@@ -223,8 +305,18 @@ def test_var_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> None:
     def baseline_fn(x):
         return x.float().var(dim=dim, keepdim=keepdim, correction=1).to(x.dtype)
 
+    flaggems_var = flaggems_op("var_dim")
+
+    def flaggems_fn(x):
+        return flaggems_var(x, flaggems_dims(dim), correction=1, keepdim=keepdim)
+
     try:
-        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+        bm.compare(
+            _functors(op, baseline_fn, inputs, dtype, flaggems_fn),
+            *inputs,
+            record_as=op,
+            params=locals(),
+        )
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
@@ -253,8 +345,18 @@ def test_var_mean_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> No
         m = x.float().mean(dim=dim, keepdim=keepdim).to(x.dtype)
         return (v, m)
 
+    flaggems_var_mean = flaggems_op("var_mean")
+
+    def flaggems_fn(x):
+        return flaggems_var_mean(x, flaggems_dims(dim), correction=1, keepdim=keepdim)
+
     try:
-        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+        bm.compare(
+            _functors(op, baseline_fn, inputs, dtype, flaggems_fn),
+            *inputs,
+            record_as=op,
+            params=locals(),
+        )
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")

--- a/benchmarks/ops/bench_rope.py
+++ b/benchmarks/ops/bench_rope.py
@@ -14,6 +14,12 @@ rotation itself is measured.
 import pytest
 import torch
 
+from benchmarks.baselines import (
+    TORCH_COMPILE_TAG,
+    VLLM_TAG,
+    compiled_reference,
+    vllm_op,
+)
 from benchmarks.benchmark_base import ManifestBenchmark
 from tileops.manifest import load_workloads
 from tileops.ops.rope import (
@@ -115,6 +121,34 @@ def _rotate(x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tens
     return x * cos + torch.cat((-x2, x1), dim=-1) * sin
 
 
+def _vllm_rope(
+    x: torch.Tensor,
+    position_ids: torch.Tensor,
+    head_dim: int,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+):
+    """Return vllm's rotary_embedding and the arguments it rotates.
+
+    It rewrites its query in place and takes it flattened to
+    ``[num_tokens, num_heads * head_dim]``, so it gets its own copy; its cache is
+    the half-width cos and sin concatenated, not the doubled tables the reference
+    indexes; and ``is_neox=True`` is the same half-split rotation.
+    """
+    fn = vllm_op("rotary_embedding")
+    num_tokens = x.shape[0]
+    half = head_dim // 2
+    cache = torch.cat([cos[:, :half], sin[:, :half]], dim=-1).contiguous()
+    positions = position_ids.long()
+    query = x.reshape(num_tokens, -1).clone()
+
+    def baseline_fn(positions_i, query_i):
+        fn(positions_i, query_i, None, head_dim, cache, True)
+        return query_i
+
+    return baseline_fn, (positions, query)
+
+
 def _profile_rope(
     op, bm: ManifestBenchmark, shape: tuple[int, ...], dtype: torch.dtype, layout: str
 ) -> None:
@@ -126,8 +160,19 @@ def _profile_rope(
     cos, sin = _rope_tables(seq_len, shape[-1], dtype)
     if layout != "1d":
         cos, sin = (t.view(1, seq_len, 1, shape[-1]) for t in (cos, sin))
+
+    def baseline_fn(t):
+        return _rotate(t, cos, sin)
+
     bm.compare(
-        {"tileops": op, "torch-ref": lambda t: _rotate(t, cos, sin)}, x, record_as=op, params=params
+        {
+            "tileops": op,
+            "torch-ref": baseline_fn,
+            TORCH_COMPILE_TAG: compiled_reference(baseline_fn),
+        },
+        x,
+        record_as=op,
+        params=params,
     )
 
 
@@ -251,6 +296,27 @@ def test_rope_neox_position_ids_bench(
         idx = pos.long()
         return _rotate(t, cos[idx].unsqueeze(1), sin[idx].unsqueeze(1))
 
+    # vllm rotates in fp32 and rounds once, the reference in the storage dtype, so they
+    # agree to one rounding step: over the manifest's rows on an H200, max |Δ| 0.0039
+    # in fp16 and 0.0156 in bf16.
+    check_fn, check_args = _vllm_rope(x, position_ids, head_dim, cos, sin)
+    torch.testing.assert_close(
+        check_fn(*check_args).view(x.shape),
+        baseline_fn(x, position_ids),
+        rtol=1e-2,
+        atol=2e-2,
+    )
+    vllm_fn, vllm_args = _vllm_rope(x, position_ids, head_dim, cos, sin)
+
     bm.compare(
-        {"tileops": op, "torch-ref": baseline_fn}, x, position_ids, record_as=op, params=params
+        {
+            "tileops": op,
+            VLLM_TAG: (vllm_fn, vllm_args),
+            "torch-ref": baseline_fn,
+            TORCH_COMPILE_TAG: compiled_reference(baseline_fn),
+        },
+        x,
+        position_ids,
+        record_as=op,
+        params=params,
     )

--- a/benchmarks/ops/bench_softmax.py
+++ b/benchmarks/ops/bench_softmax.py
@@ -2,12 +2,23 @@
 
 Measures latency, TFLOPS, and DRAM bandwidth against PyTorch baselines.
 Workload shapes and roofline formulas are loaded from the ops manifest (src/tileops/manifest/).
+
+softmax and log_softmax are timed against flag_gems' Triton kernels as well as
+torch, eager and compiled. logsumexp has no flag_gems entry point.
 """
 
 import pytest
 import torch
 import torch.nn.functional as F
 
+from benchmarks.baselines import (
+    FLAGGEMS_TAG,
+    TORCH_COMPILE_TAG,
+    assert_matches_reference,
+    compiled_reference,
+    flaggems_op,
+    reference_tolerance,
+)
 from benchmarks.benchmark_base import ManifestBenchmark, workloads_to_params
 from tileops.ops.reduction.softmax import LogSoftmaxFwdOp, LogSumExpFwdOp, SoftmaxFwdOp
 from workloads.reduction import (
@@ -21,6 +32,16 @@ from workloads.reduction import (
 _SOFTMAX_OP = "SoftmaxFwdOp"
 _LOG_SOFTMAX_OP = "LogSoftmaxFwdOp"
 _LOGSUMEXP_OP = "LogSumExpFwdOp"
+
+
+def _flaggems_softmax(name: str, dim: int):
+    """Bind a flag_gems softmax entry point to *dim*."""
+    fn = flaggems_op(name)
+
+    def baseline_fn(x):
+        return fn(x, dim)
+
+    return baseline_fn
 
 
 # Softmax benchmarks
@@ -37,8 +58,21 @@ def test_softmax_bench(shape: tuple, dtype: torch.dtype) -> None:
     def baseline_fn(x):
         return F.softmax(x, dim=-1)
 
+    flaggems_fn = _flaggems_softmax("softmax", -1)
+    assert_matches_reference(flaggems_fn, baseline_fn, *inputs, **reference_tolerance(dtype))
+
     try:
-        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+        bm.compare(
+            {
+                "tileops": op,
+                FLAGGEMS_TAG: flaggems_fn,
+                "torch": baseline_fn,
+                TORCH_COMPILE_TAG: compiled_reference(baseline_fn),
+            },
+            *inputs,
+            record_as=op,
+            params=locals(),
+        )
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
@@ -59,8 +93,21 @@ def test_log_softmax_bench(shape: tuple, dtype: torch.dtype) -> None:
     def baseline_fn(x):
         return F.log_softmax(x, dim=-1)
 
+    flaggems_fn = _flaggems_softmax("log_softmax", -1)
+    assert_matches_reference(flaggems_fn, baseline_fn, *inputs, **reference_tolerance(dtype))
+
     try:
-        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+        bm.compare(
+            {
+                "tileops": op,
+                FLAGGEMS_TAG: flaggems_fn,
+                "torch": baseline_fn,
+                TORCH_COMPILE_TAG: compiled_reference(baseline_fn),
+            },
+            *inputs,
+            record_as=op,
+            params=locals(),
+        )
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
@@ -88,7 +135,16 @@ def test_logsumexp_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> N
         return torch.logsumexp(x, dim=dim, keepdim=keepdim)
 
     try:
-        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+        bm.compare(
+            {
+                "tileops": op,
+                "torch": baseline_fn,
+                TORCH_COMPILE_TAG: compiled_reference(baseline_fn),
+            },
+            *inputs,
+            record_as=op,
+            params=locals(),
+        )
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")

--- a/benchmarks/ops/bench_topk_selector.py
+++ b/benchmarks/ops/bench_topk_selector.py
@@ -3,11 +3,16 @@
 Workload shapes, dtypes, and ``topk`` come from the ops manifest; roofline
 FLOP and byte counts come from the op's ``eval_roofline()`` via
 :class:`ManifestBenchmark`.
+
+The row is timed against torch eager and the same reference through inductor.
+flag_gems' top-k selects over the last dimension only, and this op selects over
+``seq_len_kv``, dim 2 of 4.
 """
 
 import pytest
 import torch
 
+from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
 from benchmarks.benchmark_base import (
     ManifestBenchmark,
     workload_field_params,
@@ -47,4 +52,13 @@ def test_topk_selector_bench(
     op = TopkSelectorFwdOp(topk=topk, tune=_TUNE)
     bm = ManifestBenchmark(_TOPK_SELECTOR_OP, op, test)
 
-    bm.compare({"tileops": op, "torch": test.ref_program}, *inputs, record_as=op, params=locals())
+    bm.compare(
+        {
+            "tileops": op,
+            "torch": test.ref_program,
+            TORCH_COMPILE_TAG: compiled_reference(test.ref_program),
+        },
+        *inputs,
+        record_as=op,
+        params=locals(),
+    )

--- a/benchmarks/ops/bench_unary_elementwise.py
+++ b/benchmarks/ops/bench_unary_elementwise.py
@@ -8,6 +8,9 @@ One ``test_*_bench`` per op, so the validator's L4 AST check can tie each
 ``load_workloads("<OpName>")`` call to its manifest entry. A shared
 ``_profile_and_record`` helper handles the profile + record pair so the
 per-op functions stay tiny and intentional.
+
+Baselines: torch eager and the same reference through inductor. flag_gems covers
+most of these ops but cannot be timed on them; ``flaggems_op`` says why.
 """
 
 from typing import Callable
@@ -15,6 +18,7 @@ from typing import Callable
 import pytest
 import torch
 
+from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
 from benchmarks.benchmark_base import ManifestBenchmark, workloads_to_params
 from tileops.ops.elementwise import (
     AbsFwdOp,
@@ -84,8 +88,13 @@ def _profile_and_record(
     caller's scope; passing it explicitly keeps the report rows distinguishable
     instead of reflecting only this helper's locals.
     """
+    functors = {
+        "tileops": op,
+        "torch": baseline_fn,
+        TORCH_COMPILE_TAG: compiled_reference(baseline_fn),
+    }
     try:
-        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=params)
+        bm.compare(functors, *inputs, record_as=op, params=params)
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")

--- a/benchmarks/ops/bench_vector_norm.py
+++ b/benchmarks/ops/bench_vector_norm.py
@@ -2,11 +2,23 @@
 
 Measures latency, TFLOPS, and DRAM bandwidth against PyTorch baselines.
 Workload shapes and roofline formulas are loaded from the ops manifest (src/tileops/manifest/).
+
+Each order is timed against flag_gems' Triton ``vector_norm`` and against torch
+eager and inductor.
 """
 
 import pytest
 import torch
 
+from benchmarks.baselines import (
+    FLAGGEMS_TAG,
+    TORCH_COMPILE_TAG,
+    assert_matches_reference,
+    compiled_reference,
+    flaggems_dims,
+    flaggems_op,
+    reference_tolerance,
+)
 from benchmarks.benchmark_base import ManifestBenchmark, workloads_to_params
 from tileops.ops.reduction.vector_norm import InfNormFwdOp, L1NormFwdOp, L2NormFwdOp
 from workloads.reduction import InfNormWorkload, L1NormWorkload, L2NormWorkload
@@ -16,6 +28,27 @@ from workloads.reduction import InfNormWorkload, L1NormWorkload, L2NormWorkload
 _L1_NORM_OP = "L1NormFwdOp"
 _L2_NORM_OP = "L2NormFwdOp"
 _INF_NORM_OP = "InfNormFwdOp"
+
+
+def _flaggems_vector_norm(ord_value, dim, keepdim: bool):
+    """flag_gems' ``vector_norm``, which accumulates in fp32 as the reference does."""
+    fn = flaggems_op("vector_norm")
+    dims = flaggems_dims(dim)
+
+    def baseline_fn(x):
+        return fn(x, ord_value, dims, keepdim)
+
+    return baseline_fn
+
+
+def _functors(op, baseline_fn, flaggems_fn, inputs, dtype: torch.dtype) -> dict:
+    assert_matches_reference(flaggems_fn, baseline_fn, *inputs, **reference_tolerance(dtype))
+    return {
+        "tileops": op,
+        FLAGGEMS_TAG: flaggems_fn,
+        "torch": baseline_fn,
+        TORCH_COMPILE_TAG: compiled_reference(baseline_fn),
+    }
 
 
 # L1 Norm benchmarks
@@ -43,8 +76,15 @@ def test_l1_norm_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> Non
             keepdim=keepdim,
         ).to(x.dtype)
 
+    flaggems_fn = _flaggems_vector_norm(1, dim, keepdim)
+
     try:
-        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+        bm.compare(
+            _functors(op, baseline_fn, flaggems_fn, inputs, dtype),
+            *inputs,
+            record_as=op,
+            params=locals(),
+        )
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
@@ -76,8 +116,15 @@ def test_l2_norm_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> Non
             keepdim=keepdim,
         ).to(x.dtype)
 
+    flaggems_fn = _flaggems_vector_norm(2, dim, keepdim)
+
     try:
-        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+        bm.compare(
+            _functors(op, baseline_fn, flaggems_fn, inputs, dtype),
+            *inputs,
+            record_as=op,
+            params=locals(),
+        )
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
@@ -109,8 +156,15 @@ def test_inf_norm_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> No
             keepdim=keepdim,
         ).to(x.dtype)
 
+    flaggems_fn = _flaggems_vector_norm(float("inf"), dim, keepdim)
+
     try:
-        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+        bm.compare(
+            _functors(op, baseline_fn, flaggems_fn, inputs, dtype),
+            *inputs,
+            record_as=op,
+            params=locals(),
+        )
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")

--- a/benchmarks/tests/test_baselines.py
+++ b/benchmarks/tests/test_baselines.py
@@ -1,0 +1,128 @@
+"""Tests for :mod:`benchmarks.baselines`.
+
+The import-order tests run in subprocesses: the failure they pin down is a process
+abort that no ``except`` here would survive.
+"""
+
+import subprocess
+import sys
+from importlib.util import find_spec
+
+import pytest
+import torch
+
+from benchmarks.baselines import (
+    _FlagGemsImportOrder,
+    assert_matches_reference,
+    flaggems_op,
+    reference_tolerance,
+    vllm_op,
+)
+
+# flag_gems refuses to import without a device, so both tests below need one.
+_BOTH_LIBRARIES = (
+    find_spec("flag_gems") is not None
+    and find_spec("vllm") is not None
+    and torch.cuda.is_available()
+)
+_needs_both = pytest.mark.skipif(
+    not _BOTH_LIBRARIES, reason="needs both flag_gems and vllm installed, on a GPU"
+)
+
+
+def _run(source: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-c", source],
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+
+
+def test_guard_is_armed_on_import():
+    """Importing the module installs the finder, and installing twice is a no-op."""
+    finders = [f for f in sys.meta_path if isinstance(f, _FlagGemsImportOrder)]
+    assert len(finders) == 1
+
+
+@_needs_both
+def test_flag_gems_before_vllm_aborts_without_the_guard():
+    """The hazard the guard exists for. If this ever passes, drop the guard."""
+    result = _run("import flag_gems.ops; import vllm._custom_ops; print('survived')")
+    # A negative code is death by signal — the abort itself, not a Python error
+    # that happens to leave a traceback.
+    assert result.returncode < 0, (
+        f"flag_gems before vllm exited {result.returncode} rather than aborting; if it "
+        "no longer aborts, the import-order guard in benchmarks.baselines and the vllm "
+        f"import it costs are no longer needed. stderr: {result.stderr[-500:]}"
+    )
+    assert "survived" not in result.stdout
+
+
+@_needs_both
+def test_the_guard_makes_either_import_order_safe():
+    """With the guard armed, importing flag_gems first is no longer fatal."""
+    result = _run(
+        "import benchmarks.baselines; "
+        "import flag_gems.ops; "
+        "import vllm._custom_ops; "
+        "print('survived')"
+    )
+    assert result.returncode == 0, result.stderr[-2000:]
+    assert "survived" in result.stdout
+
+
+@pytest.mark.skipif(find_spec("vllm") is None, reason="needs vllm installed")
+def test_vllm_op_reports_the_order_instead_of_aborting(monkeypatch):
+    """A process that lost the race gets a message, not a segfault."""
+    monkeypatch.setitem(sys.modules, "flag_gems", object())
+    monkeypatch.delitem(sys.modules, "vllm._custom_ops", raising=False)
+    with pytest.raises(RuntimeError, match="imported before vllm"):
+        vllm_op("rms_norm")
+
+
+@pytest.mark.skipif(find_spec("flag_gems") is None, reason="needs flag_gems installed")
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="flag_gems needs a device")
+def test_flaggems_op_refuses_a_pointwise_entry_point():
+    """A pointwise kernel would abort the process on the timing loop's second call."""
+    with pytest.raises(RuntimeError, match="LibEntry"):
+        flaggems_op("exp")
+    # A reduction goes through a different launcher and resolves.
+    assert flaggems_op("sum_dim") is not None
+
+
+def test_reference_tolerance_follows_the_dtype():
+    import torch
+
+    assert reference_tolerance(torch.float16) == {"rtol": 1e-3, "atol": 1e-3}
+    assert reference_tolerance(torch.bfloat16) == {"rtol": 1.6e-2, "atol": 1.6e-2}
+    # An unlisted dtype leaves assert_close on its own defaults.
+    assert reference_tolerance(torch.int32) == {}
+
+
+def test_assert_matches_reference_compares_every_output_the_reference_returns():
+    import torch
+
+    value = torch.ones(4)
+    other = torch.zeros(4)
+
+    def one_output(x):
+        return x
+
+    def two_outputs(x):
+        return x, other
+
+    # A baseline that returns more than the reference names is fine.
+    assert_matches_reference(two_outputs, one_output, value)
+    with pytest.raises(AssertionError):
+        assert_matches_reference(lambda x: x + 1, one_output, value)
+
+    # The output the reference names second is checked too: comparing only the
+    # first would accept this baseline.
+    assert_matches_reference(two_outputs, two_outputs, value)
+    with pytest.raises(AssertionError, match="output 1"):
+        assert_matches_reference(lambda x: (x, other + 1), two_outputs, value)
+
+    # Returning fewer outputs than the reference is a mismatch, not a pass.
+    with pytest.raises(AssertionError, match="output"):
+        assert_matches_reference(one_output, two_outputs, value)

--- a/docs/design/testing.md
+++ b/docs/design/testing.md
@@ -135,6 +135,7 @@ fields its own benchmark reads.
 1. **Benchmark class** in `benchmarks/ops/bench_<op>.py` — subclass `BenchmarkBase`, implement `calculate_flops()` and `calculate_memory()` (return `None` if not applicable).
 1. **Benchmark function** — `@YourFixture` decorated, construct workload + benchmark, call `inputs = workload.gen_inputs()`, then `bm.profile(op, *inputs)` and `BenchmarkReport.record(op, locals(), result, tag="tileops")`.
 1. **Independent baseline** — record at least one non-`"tileops"` baseline (e.g., `"torch"`, `"fa3"`). Profile the workload's `ref_program` for the torch baseline. Another idiom for the same computation overrides `ref_program` and says why; a different implementation takes its own tag next to it, is asserted against the reference before the case is timed, and raises when unavailable. Never import a baseline from `tests/`.
+1. **Library baselines** — resolve them through [`benchmarks/baselines.py`](../../benchmarks/baselines.py): `flaggems_op`, `flashinfer_op` and `vllm_op` for the kernels the runner image must have, `compiled_reference` for the reference through inductor. Every row that has a library kernel for its op times it, so the nightly's ratio is against the strongest implementation available rather than against eager torch alone.
 
 ### Metrics
 


### PR DESCRIPTION
## problems

- The nightly report renders one row per baseline tag a case records, so a family that registers one tag shows one candidate: `convolution` showed torch alone, `gemm` showed four. The tags were missing, not the report.
- 30 of 50 bench files timed TileOPs against eager torch only, while the runner image already carries flag_gems, flashinfer, vllm and flash-linear-attention.
- Nothing kept flag_gems from reaching torch's op registry before vllm, which aborts the process inside a C++ static initializer, past any `except`.
- flag_gems' pointwise entry points return once and then abort in triton's launcher, and the only sign is a segfault with no traceback.
- `bench_mamba`, `bench_mamba2_e2e` and `bench_gla_recurrence` timed their torch reference only when the library kernel was missing, so no row ever carried both.

## changes

- `benchmarks/baselines.py` resolves flag_gems, flashinfer and vllm, plus the reference through inductor. A resolver raises when its library is absent: the image installs every baseline non-fatally, so a degraded image has to fail the row it degraded rather than report torch under a tag that names a library.
- New tags, each checked against the reference — every output the reference returns, not just the first — before the case is timed:

  | family | added |
  | --- | --- |
  | convolution | `flaggems` (conv1d/2d/3d), `torch-compile` |
  | RMSNorm | `flaggems`, `flashinfer`, `vllm`, `torch-compile` |
  | LayerNorm | `flaggems`, `flashinfer`, `torch-compile` |
  | fused-add RMSNorm | `flashinfer`, `vllm`, `torch-compile` |
  | softmax, log_softmax | `flaggems`, `torch-compile` |
  | 8 reduces, vector norms, argreduce, any/all, cumsum | `flaggems`, `torch-compile` |
  | group / instance / batch norm | `flaggems`, `torch-compile` |
  | gemm, bmm | `flaggems` (`mm` on NN rows, `bmm`) |
  | position-ids RoPE | `vllm` rotary embedding, `torch-compile` |
  | 3 fused gated activations | `flashinfer`, `torch-compile` |
  | 15 further families | `torch-compile` |

- mamba, mamba2 and gla recurrence time the torch reference alongside the library kernel rather than in its place.
- Two hazards a bench author cannot see are held in code, not in the rules:

  | hazard | what holds it |
  | --- | --- |
  | vllm must reach the registry before flag_gems | a `sys.meta_path` finder that imports vllm first whenever anything imports flag_gems; `benchmarks/conftest.py` imports the module so every bench process is armed; `vllm_op` raises a named error if flag_gems still got there first |
  | flag_gems' pointwise kernels cannot be timed | `flaggems_op` refuses them, structurally — the module defining such an op holds a `pointwise_dynamic` object and no other flag_gems module does (checked across 10 pointwise and 23 other entry points). Its error names the cause, LibEntry's argument cache under triton 3.7, and the way around it `bench_pool.py` already uses |

- `.claude/domain-rules/benchmark.md`: +5/−9 lines, one bullet fewer than before this PR. The import-order rule, the tag-name list and the pointwise-family rule are gone because code holds them; `calculate_flops`/`calculate_memory` returning `None` moved to the docstrings of the two abstract methods it describes. The one new bullet — a baseline that overwrites shared inputs — says why it stays a rule: nothing catches it.
- `benchmarks/tests/test_baselines.py`: new file, 7 nodes. The import-order hazard and its guard run in subprocesses, since neither survives in-process; when the hazard test starts failing, the guard and the vllm import it costs can go.
- `bench_gated_deltanet_prefill`'s BHTD row still records no baseline and now carries a `FIXME(staged-rollout)` naming the invariant it breaks, rather than the rule carrying an exception for it.

Rows left as they are:

| left alone | why |
| --- | --- |
| every elementwise row's flag_gems tag | the pointwise refusal above |
| topk selector | flag_gems' top-k reduces the last dimension only; this op reduces dim 2 of 4 |
| amin, cumprod, dropout | no flag_gems entry point in 5.0.2, or it raises on this torch |
| fp8 quant | no library does per-row dynamic fp8; vllm's is per-tensor or fused into rms_norm |
| MoE and attention families | already timed against vllm, triton, sgl-kernel, FA3, flashinfer |
| fused-add LayerNorm | nobody ships a fused add + layer_norm kernel |

Measured on an H200 in the runner image, RMSNorm 2048x4096 bf16: flashinfer 0.0101 ms, tileops 0.0113, flag_gems 0.0117, vllm 0.0117, inductor 0.0130, torch eager 0.1315 across 9 kernels. Convolution's smoke tier goes 402s → 515s for five cases, the extra time being flag_gems' Triton autotuning and one inductor compile per case. What that adds up to across the nightly's 6h budget is unmeasured: the per-family cost varies with how much each library autotunes, and the first scheduled run answers it more cheaply than a local reproduction.

Verified in `cu132-torch2.13-tl-afcebed1-dev`: conv 5, norm 4, reduce 61 (with vector norms, logical, cumsum), group/instance/batch norm 52, elementwise 86, rope and friends 26, gemm/bmm/grouped-gemm/moe 36 + 68, mamba and linear attention 49, engram/fp8/deepseek 13, `benchmarks/tests` 34. Two review rounds by an independent reviewer; their findings — a vacuous tuple assertion, a cast charged to a flag_gems tag, three duplicated adapters, a docstring overstating its own tags — are fixed in this diff. `scripts/validate_manifest.py` passes; test node delta is a new file only, so no report.
