### PR TITLE
[Bench][Norm] Drop a dead xfail and the duplication it was hiding

### DIFF
--- a/benchmarks/ops/bench_norm.py
+++ b/benchmarks/ops/bench_norm.py
@@ -102,13 +102,14 @@ def _assert_fused_add_matches(fn, reference, x, residual, weight, eps, **toleran
     torch.testing.assert_close(residual_copy, expected_add, **tolerance)
 
 
-_RMS_OP_NAME = "RMSNormFwdOp"
+def _norm_params(workloads: list[dict]) -> list:
+    """One param per manifest row and dtype: ``(m, n, dtype, tune)``.
 
-
-def _rms_params():
-    """Convert manifest workloads to pytest params: (m, n, dtype, tune)."""
+    Takes rows, not an op name, so each call site keeps the literal
+    ``load_workloads(<OpName>)`` the manifest validator matches.
+    """
     params = []
-    for w in load_workloads(_RMS_OP_NAME):
+    for w in workloads:
         m, n = w["x_shape"]
         label = w.get("label", f"{m}x{n}")
         for dtype_str in w["dtypes"]:
@@ -117,7 +118,10 @@ def _rms_params():
     return params
 
 
-@pytest.mark.parametrize("m, n, dtype, tune", _rms_params())
+_RMS_OP_NAME = "RMSNormFwdOp"
+
+
+@pytest.mark.parametrize("m, n, dtype, tune", _norm_params(load_workloads(_RMS_OP_NAME)))
 def test_rms_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
     test = RMSNormWorkload(m, n, dtype)
     inputs = test.gen_inputs()
@@ -150,25 +154,7 @@ def test_rms_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
 _FUSED_RMS_OP_NAME = "FusedAddRMSNormFwdOp"
 
 
-def _fused_rms_params():
-    params = []
-    # Autotune has no valid configs for N=16384 (Llama-405B hidden_dim).
-    _XFAIL_LABELS = {"llama-3.1-405b-prefill", "llama-3.1-405b-decode"}
-    for w in load_workloads(_FUSED_RMS_OP_NAME):
-        m, n = w["x_shape"]
-        label = w.get("label", f"{m}x{n}")
-        for dtype_str in w["dtypes"]:
-            dtype = getattr(torch, dtype_str)
-            marks = ()
-            if label in _XFAIL_LABELS:
-                marks = pytest.mark.xfail(
-                    reason="autotune has no valid configs for N=16384", strict=False
-                )
-            params.append(pytest.param(m, n, dtype, True, id=f"{label}-{dtype_str}", marks=marks))
-    return params
-
-
-@pytest.mark.parametrize("m, n, dtype, tune", _fused_rms_params())
+@pytest.mark.parametrize("m, n, dtype, tune", _norm_params(load_workloads(_FUSED_RMS_OP_NAME)))
 def test_fused_add_rms_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
     test = FusedAddRMSNormWorkload(m, n, dtype)
     inputs = test.gen_inputs()
@@ -201,18 +187,7 @@ def test_fused_add_rms_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool
 _LN_OP_NAME = "LayerNormFwdOp"
 
 
-def _ln_params():
-    params = []
-    for w in load_workloads(_LN_OP_NAME):
-        m, n = w["x_shape"]
-        label = w.get("label", f"{m}x{n}")
-        for dtype_str in w["dtypes"]:
-            dtype = getattr(torch, dtype_str)
-            params.append(pytest.param(m, n, dtype, True, id=f"{label}-{dtype_str}"))
-    return params
-
-
-@pytest.mark.parametrize("m, n, dtype, tune", _ln_params())
+@pytest.mark.parametrize("m, n, dtype, tune", _norm_params(load_workloads(_LN_OP_NAME)))
 def test_layer_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
     test = LayerNormWorkload(m, n, dtype)
     inputs = test.gen_inputs()
@@ -255,18 +230,7 @@ def test_layer_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool) -> Non
 _FUSED_LN_OP_NAME = "FusedAddLayerNormFwdOp"
 
 
-def _fused_ln_params():
-    params = []
-    for w in load_workloads(_FUSED_LN_OP_NAME):
-        m, n = w["x_shape"]
-        label = w.get("label", f"{m}x{n}")
-        for dtype_str in w["dtypes"]:
-            dtype = getattr(torch, dtype_str)
-            params.append(pytest.param(m, n, dtype, True, id=f"{label}-{dtype_str}"))
-    return params
-
-
-@pytest.mark.parametrize("m, n, dtype, tune", _fused_ln_params())
+@pytest.mark.parametrize("m, n, dtype, tune", _norm_params(load_workloads(_FUSED_LN_OP_NAME)))
 def test_fused_add_layer_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
     test = FusedAddLayerNormWorkload(m, n, dtype)
     inputs = test.gen_inputs()

--- a/benchmarks/tests/test_baselines.py
+++ b/benchmarks/tests/test_baselines.py
@@ -19,7 +19,7 @@ from benchmarks.baselines import (
     vllm_op,
 )
 
-# flag_gems refuses to import without a device, so both tests below need one.
+# flag_gems refuses to import without a device, so its tests need one.
 _BOTH_LIBRARIES = (
     find_spec("flag_gems") is not None
     and find_spec("vllm") is not None
@@ -92,17 +92,12 @@ def test_flaggems_op_refuses_a_pointwise_entry_point():
 
 
 def test_reference_tolerance_follows_the_dtype():
-    import torch
-
     assert reference_tolerance(torch.float16) == {"rtol": 1e-3, "atol": 1e-3}
-    assert reference_tolerance(torch.bfloat16) == {"rtol": 1.6e-2, "atol": 1.6e-2}
-    # An unlisted dtype leaves assert_close on its own defaults.
+    # The other branch: an unlisted dtype leaves assert_close on its own defaults.
     assert reference_tolerance(torch.int32) == {}
 
 
 def test_assert_matches_reference_compares_every_output_the_reference_returns():
-    import torch
-
     value = torch.ones(4)
     other = torch.zeros(4)
 


### PR DESCRIPTION
## problems

- `xfail("autotune has no valid configs for N=16384")` on the fused-add RMSNorm rows keyed on `llama-3.1-405b-*`; #1955 renamed those labels `llama-405b-*`, so it has matched nothing since.
- The limitation is gone too: 3 xpassed before the rename, 9 passed / 0 xfailed / 0 xpassed now.
- Without the marker, `_rms_params`, `_fused_rms_params`, `_ln_params` and `_fused_ln_params` are byte-identical apart from an op-name constant.
- `test_baselines.py`: one assertion repeats another's path through the same lookup, two tests re-import `torch` over the module-level import, one comment says "both tests below" of three.

## changes

- Drop the marker and its `_XFAIL_LABELS`.
- Four builders become `_norm_params`, taking manifest rows rather than an op name.
- Each call site keeps its literal `load_workloads(<OpName>)`: the L4 AST check wants one per op in the file, and moving it into the helper fails all four. `bench_convolution.py` and `bench_topk_selector.py` do the same; the docstring says why, since the indirection looks needless until you try the other form.
- Drop the redundant assertion, the two shadowing imports, the stale comment.
- 40 passed, 0 xfailed, 0 xpassed; collected node ids byte-identical, 33 either side; `validate_manifest.py` and ruff clean; `test_baselines.py` keeps 7 nodes, one assertion fewer.
