### PR TITLE
[Refactor][Reduction] Move the family onto the op/backend boundary, and the layout into its kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,14 @@ boundary between them.
 TileOPs installs from source; a PyPI release lands with the first stable version. A
 CUDA-capable GPU is required.
 
-**Prerequisites** — Python >= 3.10 · PyTorch >= 2.1, < 2.11 (CI validates 2.10) · CUDA Toolkit
-12.x · NVIDIA Hopper (SM_90) · [TileLang](https://github.com/tile-ai/tilelang) >= 0.1.9, < 0.2.0
-(CI validates 0.1.11 at a pinned main snapshot — see [development.md](docs/development.md#dev-docker-image))
+**Prerequisites**
+
+- Python >= 3.10 (CI validates 3.12)
+- PyTorch >= 2.1, < 2.14 (CI validates 2.13)
+- CUDA Toolkit 13.2
+- NVIDIA Hopper (SM_90)
+- [TileLang](https://github.com/tile-ai/tilelang) >= 0.1.9, < 0.2.0 (CI validates 0.1.11 at a
+  pinned main snapshot — see [development.md](docs/development.md#dev-docker-image))
 
 ```bash
 git clone https://github.com/tile-ai/TileOPs

--- a/docs/design/ops-design-reference.md
+++ b/docs/design/ops-design-reference.md
@@ -12,14 +12,13 @@ This document holds the contracts those rules emit against.
 
 Per-family protocol variables, declared by L2 bases and overridden by L3 ops.
 
-| Variable                  | Family      | Purpose                                                                                                          |
-| ------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------- |
-| `_kernel_key`             | reduction   | Kernel-map lookup key                                                                                            |
-| `_kernel_cls`             | reduction   | Kernel class reference                                                                                           |
-| `_op_kind`                | reduction   | Kernel-dispatch op-kind string (`"sum"` / `"prod"` for `CumulativeOp`; `"sum"`, `"mean"`, … for `_ReduceOpBase`) |
-| `_kernel_handles_padding` | reduction   | `True` → kernel uses masked loads, skip host-side padding                                                        |
-| `_op_name`                | elementwise | `torch.library.custom_op` registration key                                                                       |
-| `kernel_cls`              | elementwise | Kernel class reference                                                                                           |
+| Variable      | Family      | Purpose                                                                                                          |
+| ------------- | ----------- | ---------------------------------------------------------------------------------------------------------------- |
+| `_kernel_key` | reduction   | Kernel-map lookup key                                                                                            |
+| `_kernel_cls` | reduction   | Kernel class reference                                                                                           |
+| `_op_kind`    | reduction   | Kernel-dispatch op-kind string (`"sum"` / `"prod"` for `CumulativeOp`; `"sum"`, `"mean"`, … for `_ReduceOpBase`) |
+| `_op_name`    | elementwise | `torch.library.custom_op` registration key                                                                       |
+| `kernel_cls`  | elementwise | Kernel class reference                                                                                           |
 
 **The `scaffold-op` skill does NOT emit these variables** — kernel-dispatch-convention-dependent (e.g., `VectorNormKernel` uses `{"l1", "l2", "inf"}`, `ReduceKernel` uses `{"sum", "mean", ...}`); Adding a new protocol variable requires updating the L2 base, all concrete ops, and the manifest schema if applicable.
 
@@ -68,12 +67,11 @@ Abstract interface: `forward()`. Key methods: `init_config(config, tune)`, `auto
 
 Hooks family bases expose for op-specific semantics. The `scaffold-op` skill does NOT emit these.
 
-| Hook              | Family    | Default                     | Override example                                                   |
-| ----------------- | --------- | --------------------------- | ------------------------------------------------------------------ |
-| `_pad_value()`    | reduction | `0.0` (neutral for sum)     | `ArgmaxFwdOp._pad_value → -inf`                                    |
-| `_validate_dim()` | reduction | accept `int` or `list[int]` | `ArgmaxFwdOp._validate_dim` restricts to scalar `int`              |
-| `_pre_kernel()`   | reduction | identity                    | `AllFwdOp._pre_kernel` converts unsupported storage dtypes to fp32 |
-| `_post_kernel()`  | reduction | identity                    | Convert kernel output dtype to the manifest-declared output dtype  |
+| Hook              | Family    | Default                     | Override example                                      |
+| ----------------- | --------- | --------------------------- | ----------------------------------------------------- |
+| `_validate_dim()` | reduction | accept `int` or `list[int]` | `ArgmaxFwdOp._validate_dim` restricts to scalar `int` |
+
+A hook that compensates for what a kernel cannot do belongs to that kernel, not here: the op hands over the tensor its manifest declares.
 
 ### `_cache_key` override (L1-level, not family-specific)
 

--- a/docs/design/ops-design.md
+++ b/docs/design/ops-design.md
@@ -170,8 +170,6 @@ class ExampleCumsumFwdOp(Op):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         self._validate_dtypes(x)
-        if not x.is_cuda:
-            raise ValueError("x must be a CUDA tensor")
         # Validate `dim` against shape_rule `-x.ndim <= dim < x.ndim`
         # and normalize to a non-negative axis (Op._static_axes contract).
         if not -x.ndim <= self.dim < x.ndim:
@@ -189,30 +187,26 @@ class ExampleCumsumFwdOp(Op):
         M = math.prod(s for i, s in enumerate(x.shape) if i != dim)
         self.M = M  # stored for eval_roofline
         self.dtype = x.dtype  # ditto; the op commits to no dtype before this
+        x = x.contiguous()          # handed over as the manifest declares it
         kernel = self.get_or_build_kernel(
             "example_cumsum_fwd",
             (x,),                        # the tensors the kernel will be handed
-            key=((M,), x.dtype),         # what the in-tree kernel specializes on
+            key=(tuple(x.shape), dim, x.dtype, x.device.index),
             build=lambda: self.kernel_map["example_cumsum_fwd"](
-                M, self.N, "sum", x.dtype, tune=self.tune),
+                M, self.N, "sum", x.dtype, scan_axis=dim, tune=self.tune),
         )
-        # Move reduction axis to last, reshape to (M, N), compute, restore.
-        orig_shape = x.shape
-        x2 = x.movedim(dim, -1).contiguous().reshape(M, self.N)
-        y2 = kernel(x2)
-        y = y2.reshape(*orig_shape[:dim], *orig_shape[dim + 1:], self.N)
-        return y.movedim(-1, dim)
+        return kernel(x)
 ```
 
 **Validation.**
 
 - `default_kernel_map` keys / values match manifest `source.kernel_map` verbatim.
-- `forward` calls `self._validate_dtypes(...)` first — not inline dtype comparisons, which are Step 5's job.
+- `forward` calls `self._validate_dtypes(...)` first — not inline dtype comparisons, which are Step 5's job. It checks no device kind: a kernel states which devices it runs on.
 - Every `static_dims` commitment is checked against the tensor shape at the normalized axis, and `_static_axes` is bound from that (non-negative) axis. Both before the get-or-build call.
 - The kernel comes from `self.get_or_build_kernel`, never a cache dict the op owns:
   - `key=` and `build=` are the in-tree recipe. The kernel is built from `x.dtype` and the key carries it, so a call with another dtype builds a second kernel rather than reusing the first.
   - `inputs=` is the tensors the kernel is handed, which is what an external target's builder is described with. A new op passes it; an op not yet migrated omits it and stays in-tree only.
-- The op never trims kernel output: a kernel that pads internally returns the semantic shape.
+- The op never trims kernel output, and never reshapes its input for the kernel: a kernel that pads or permutes internally takes and returns the shapes the manifest declares.
 
 **Reference.** [Slot S14](../../.claude/skills/scaffold-op/slot-rules.md#slot-s14), [S15](../../.claude/skills/scaffold-op/slot-rules.md#slot-s15), [S16](../../.claude/skills/scaffold-op/slot-rules.md#slot-s16).
 
@@ -291,8 +285,8 @@ from .example_cumsum import ExampleCumsumFwdOp
 
 This playbook emits exactly the 17 slots above. The following are **not** produced by the scaffold — each needs separate treatment:
 
-- **Family-specific protocol variables.** `_op_kind` (reduction), `_kernel_key`, `_kernel_cls` (norm + reduction T1 wrappers), `_kernel_handles_padding`, `_op_name`, `kernel_cls`. Kernel-dispatch-convention-dependent; cannot be mechanically derived from the manifest. See [Family-Base Protocol (Appendix)](ops-design-reference.md#base-class-protocol).
-- **Optional hooks.** `_pad_value`, `_validate_dim`, `_pre_kernel`, `_post_kernel`. Op-specific business logic (e.g., `ArgmaxFwdOp._pad_value = -inf`). See [Optional Hooks (Appendix)](ops-design-reference.md#optional-hooks-appendix).
+- **Family-specific protocol variables.** `_op_kind` (reduction), `_kernel_key`, `_kernel_cls` (norm + reduction T1 wrappers), `_op_name`, `kernel_cls`. Kernel-dispatch-convention-dependent; cannot be mechanically derived from the manifest. See [Family-Base Protocol (Appendix)](ops-design-reference.md#base-class-protocol).
+- **Optional hooks.** `_validate_dim`. Op-specific business logic (e.g., `ArgmaxFwdOp._validate_dim` narrows the accepted `dim`). See [Optional Hooks (Appendix)](ops-design-reference.md#optional-hooks-appendix).
 - **`_cache_key` override.** The default projection via `_static_axes` is correct but sometimes over-fragmenting. Override logic depends on what subset of the input shape the kernel actually depends on — kernel-math-specific.
 - **Family-base (T1) subclassing.** See [Family-Base Refactoring](#family-base-refactoring).
 - **Kernel implementations themselves.** The playbook's scope is the Op (host) layer. See [Implementing a Kernel](#implementing-a-kernel) for the kernel-side interface surface.

--- a/src/tileops/backend/__init__.py
+++ b/src/tileops/backend/__init__.py
@@ -18,8 +18,9 @@ and, in its pyproject::
     [project.entry-points."tileops.backends"]
     acme = "tileops_acme"
 
-``build_kernel``'s signature is the op's manifest signature: tensors in
-``signature.inputs`` order, params under ``signature.params`` names. Choosing among its own
+``build_kernel``'s signature is the op's manifest signature: one argument per
+``signature.inputs`` entry in that order, with an ``optional: true`` input the call did not
+pass arriving as ``None``, then params under ``signature.params`` names. Choosing among its own
 kernels, constructing, caching and compiling all happen inside it, so nothing here names a
 kernel class, a specialization axis, a priority or a fallback: this layer picks a target,
 the target picks a kernel.

--- a/src/tileops/backend/protocol.py
+++ b/src/tileops/backend/protocol.py
@@ -25,8 +25,10 @@ class TensorSpec(NamedTuple):
 KernelResult = Union[torch.Tensor, tuple[torch.Tensor, ...], None]
 
 #: Called ``build_kernel(*inputs, **params)``: a :class:`TensorSpec` per input in
-#: ``signature.inputs`` order, then ``signature.params`` by keyword. Both lists are per-op,
-#: which the type system cannot express, hence ``...``.
+#: ``signature.inputs`` order — ``None`` for an ``optional: true`` input the call did not
+#: pass, so presence is read off the slot rather than off how many slots there are — then
+#: ``signature.params`` by keyword. Both lists are per-op, which the type system cannot
+#: express, hence ``...``.
 BuildKernel = Callable[..., Callable[..., KernelResult]]
 
 #: "Is this the kind of device my kernels are written for" — ``False``, not an exception,

--- a/src/tileops/kernels/bmm.py
+++ b/src/tileops/kernels/bmm.py
@@ -432,9 +432,7 @@ def _bmm_fp8_persistent_ws_kernel(
 
                 tx = T.get_thread_binding()
 
-                # ═════════════════════════════════════════════════════════
                 # Producer WG: tx < 128
-                # ═════════════════════════════════════════════════════════
                 if tx < 128:
                     T.dec_max_nreg(24)
 
@@ -482,9 +480,7 @@ def _bmm_fp8_persistent_ws_kernel(
                                 T.barrier_arrive(ab_full[slot])
                                 gi_prod = gi_prod + 1
 
-                # ═════════════════════════════════════════════════════════
                 # Consumer WG0: 128 ≤ tx < 256 — top half (rows 0..half_m)
-                # ═════════════════════════════════════════════════════════
                 elif tx < 256:
                     T.inc_max_nreg(240)
 
@@ -531,9 +527,7 @@ def _bmm_fp8_persistent_ws_kernel(
                             T.sync_threads(barrier_id=4, arrive_count=128)
                             T.copy(C_shared_wg0, c[bs[0], ms[0], ns_[0]])
 
-                # ═════════════════════════════════════════════════════════
                 # Consumer WG1: tx ≥ 256 — bottom half (rows half_m..block_m)
-                # ═════════════════════════════════════════════════════════
                 else:
                     T.inc_max_nreg(240)
 

--- a/src/tileops/kernels/grouped_gemm/grouped_gemm_persistent_3wg.py
+++ b/src/tileops/kernels/grouped_gemm/grouped_gemm_persistent_3wg.py
@@ -419,9 +419,7 @@ def _make_pingpong_kernel(
 
             tx = T.get_thread_binding()
 
-            # ═════════════════════════════════════════════════════════
             # Producer WG: tx < 128
-            # ═════════════════════════════════════════════════════════
             # Static-wave scheduler: each CTA enumerates tile IDs
             # ``flat_id_0 = 2*(sm_count*w + pid)`` and
             # ``flat_id_1 = flat_id_0 + 1`` for wave w.  No atomic.
@@ -504,9 +502,7 @@ def _make_pingpong_kernel(
                             T.barrier_arrive(ab_full_wg1[slot1])
                             gi_prod_1 = gi_prod_1 + 1
 
-            # ═════════════════════════════════════════════════════════
             # Consumer WG0: 128 ≤ tx < 256 — processes flat_id_0 per wave
-            # ═════════════════════════════════════════════════════════
             elif tx < 256:
                 T.inc_max_nreg(240)
                 # CTA-wide sync (pairs with producer's post-init sync).
@@ -576,9 +572,7 @@ def _make_pingpong_kernel(
                                 if i < arows_0 and j < acols_0:
                                     C[m_start_0 + i, n_start_0 + j] = C_local_cast_wg0[i, j]
 
-            # ═════════════════════════════════════════════════════════
             # Consumer WG1: tx ≥ 256 — processes flat_id_1 per wave
-            # ═════════════════════════════════════════════════════════
             else:
                 T.inc_max_nreg(240)
                 # CTA-wide sync (pairs with producer's post-init sync).
@@ -796,11 +790,9 @@ def _make_cooperative_kernel(
 
             tx = T.get_thread_binding()
 
-            # ═════════════════════════════════════════════════════════
             # Producer WG: tx < 128
             # Static-wave scheduler: flat_id = sm_count * w + pid (one
             # tile per CTA per wave; both math WGs co-process it).
-            # ═════════════════════════════════════════════════════════
             if tx < 128:
                 T.dec_max_nreg(24)
 
@@ -855,9 +847,7 @@ def _make_cooperative_kernel(
                             T.barrier_arrive(ab_full[slot])
                             gi_prod = gi_prod + 1
 
-            # ═════════════════════════════════════════════════════════
             # Consumer WG0: 128 ≤ tx < 256 — top half (rows 0..half_m)
-            # ═════════════════════════════════════════════════════════
             elif tx < 256:
                 T.inc_max_nreg(240)
                 T.sync_threads()
@@ -931,9 +921,7 @@ def _make_cooperative_kernel(
                                 if i < arows0:
                                     C[m_start + i, n_start + j] = C_local_cast_wg0[i, j]
 
-            # ═════════════════════════════════════════════════════════
             # Consumer WG1: tx ≥ 256 — bottom half (rows half_m..block_m)
-            # ═════════════════════════════════════════════════════════
             else:
                 T.inc_max_nreg(240)
                 T.sync_threads()

--- a/src/tileops/kernels/kernel_base.py
+++ b/src/tileops/kernels/kernel_base.py
@@ -69,7 +69,8 @@ class Kernel(ABC):
         "num_per_thread_arg": "num_per_thread",
     }
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args, device_index: "int | None" = None, **kwargs) -> None:
+        self.device_index = device_index
         self._check_arch()
         self.config = {}
 
@@ -123,33 +124,37 @@ class Kernel(ABC):
             return "does not serve this call"
         return None
 
-    @classmethod
-    def _check_arch(cls) -> None:
+    def _check_arch(self) -> None:
         """Reject construction on a device this kernel is not built for.
 
-        The device is probed only by a class that constrains the architecture,
-        and only here — kernel construction is deferred to the first forward,
-        so a device is present by the time this runs. The op layer performs no
-        architecture check of its own; a role served by several kernels filters
-        candidates during selection instead.
+        Read from ``device_index``, the device the op handed over — not from whichever
+        device happens to be current, which need not be the one the input lives on. The op
+        layer performs no architecture check of its own; a role served by several kernels
+        filters candidates during selection instead.
+
+        ``device_index`` is ``None`` for a kernel whose op does not pass one yet, and the
+        current device answers instead. That is the pre-migration behaviour, kept so a
+        family that has not moved yet is unaffected; a migrated kernel states the device.
 
         Raises:
-            ValueError: When the current device architecture is not among
-                ``supported_archs``. Selection raises the same class when no
-                candidate for a dispatch key can serve a call, so a caller
-                catches one exception type whether the key has one
-                implementation or several.
+            ValueError: The device's architecture is not among ``supported_archs``.
+                Selection raises the same class when no candidate for a dispatch key can
+                serve a call, so a caller catches one exception type whether the key has
+                one implementation or several.
         """
+        cls = type(self)
         if cls.supported_archs is None:
             return
         from tileops.utils import get_sm_version
 
-        arch = get_sm_version()
+        arch = get_sm_version(self.device_index)
         if arch not in cls.supported_archs:
+            where = (
+                "the current device" if self.device_index is None else f"cuda:{self.device_index}"
+            )
             raise ValueError(
                 f"{cls.__name__} is built for architectures "
-                f"{sorted(cls.supported_archs)}, but the current device reports "
-                f"{arch}"
+                f"{sorted(cls.supported_archs)}, but {where} reports {arch}"
             )
 
     def init_config(self, config: Optional[Dict[str, Any]] = None, tune: bool = False) -> None:

--- a/src/tileops/kernels/moe/moe_grouped_gemm_persistent_3wg_fused_act.py
+++ b/src/tileops/kernels/moe/moe_grouped_gemm_persistent_3wg_fused_act.py
@@ -391,9 +391,7 @@ def _make_pingpong_fused_act_kernel(
 
             tx = T.get_thread_binding()
 
-            # ═════════════════════════════════════════════════════════
             # Producer WG: tx < 128
-            # ═════════════════════════════════════════════════════════
             if tx < 128:
                 T.dec_max_nreg(24)
 
@@ -489,9 +487,7 @@ def _make_pingpong_fused_act_kernel(
                             T.barrier_arrive(ab_full_wg1[slot1])
                             gi_prod_1 = gi_prod_1 + 1
 
-            # ═════════════════════════════════════════════════════════
             # Consumer WG0: 128 ≤ tx < 256 — processes flat_id_0 per wave
-            # ═════════════════════════════════════════════════════════
             elif tx < 256:
                 T.inc_max_nreg(240)
                 # CTA-wide sync (pairs with producer's post-init sync).
@@ -567,9 +563,7 @@ def _make_pingpong_fused_act_kernel(
                                 if i < arows_0:
                                     C[m_start_0 + i, n_start_0 + j] = C_local_cast_wg0[i, j]
 
-            # ═════════════════════════════════════════════════════════
             # Consumer WG1: tx ≥ 256 — processes flat_id_1 per wave
-            # ═════════════════════════════════════════════════════════
             else:
                 T.inc_max_nreg(240)
                 # CTA-wide sync (pairs with producer's post-init sync).
@@ -758,11 +752,9 @@ def _make_cooperative_fused_act_kernel(
 
             tx = T.get_thread_binding()
 
-            # ═════════════════════════════════════════════════════════
             # Producer WG: tx < 128
             # Static-wave scheduler: flat_id = sm_count * w + pid (one
             # tile per CTA per wave; both math WGs co-process it).
-            # ═════════════════════════════════════════════════════════
             if tx < 128:
                 T.dec_max_nreg(24)
 
@@ -832,9 +824,7 @@ def _make_cooperative_fused_act_kernel(
                             T.barrier_arrive(ab_full[slot])
                             gi_prod = gi_prod + 1
 
-            # ═════════════════════════════════════════════════════════
             # Consumer WG0: 128 ≤ tx < 256 — top half (rows 0..half_m)
-            # ═════════════════════════════════════════════════════════
             elif tx < 256:
                 T.inc_max_nreg(240)
                 # CTA-wide sync (pairs with producer's post-init sync).
@@ -911,9 +901,7 @@ def _make_cooperative_fused_act_kernel(
                                 if i < arows0:
                                     C[m_start + i, n_start + j] = C_local_cast_wg0[i, j]
 
-            # ═════════════════════════════════════════════════════════
             # Consumer WG1: tx ≥ 256 — bottom half (rows half_m..block_m)
-            # ═════════════════════════════════════════════════════════
             else:
                 T.inc_max_nreg(240)
                 # CTA-wide sync (pairs with producer's post-init sync).

--- a/src/tileops/kernels/reduction/_primitives.py
+++ b/src/tileops/kernels/reduction/_primitives.py
@@ -2,13 +2,18 @@
 
 Provides reusable utility functions, constants, and T.macro factories
 used across all reduction sub-category kernels (sum, max, softmax,
-variance, prefix-scan, etc.).
+variance, prefix-scan, etc.), plus the row layout every one of them wants.
 
-This module must land before any sub-category kernel PR so that shared
-infrastructure is available from the start.
+A reduction kernel reduces the trailing axis of a 2-D ``(M, N)`` buffer, while an op
+declares an arbitrary-rank tensor and the axes to reduce; the permute and flatten between
+the two is a kernel's business, so both sides of the op/backend boundary speak the shapes
+the manifest declares. ``axes`` below is the sorted tuple of non-negative axis indices the
+reduction runs over — which forms an empty ``dim`` takes, and which ranks it may name, are
+the op's contract rather than a kernel's.
 """
 
 import itertools
+from math import prod
 
 import tilelang.language as T
 import torch
@@ -31,6 +36,9 @@ __all__ = [
     "make_softmax_epilogue",
     "make_welford_update",
     "reduce_column_alignment",
+    "restore_reduced",
+    "restore_same_shape",
+    "rows_for_axes",
     "tune_by_forward",
 ]
 
@@ -431,15 +439,32 @@ _SOFTMAX_KINDS = {"softmax", "log_softmax"}
 _SCAN_KINDS = {"sum", "prod"}
 
 
-def tune_by_forward(kernel, *probe_inputs, warmup: int = 10, rep: int = 10) -> None:
-    """Select the fastest candidate config by timing ``kernel.forward``.
+def tune_by_forward(
+    kernel,
+    *probe_inputs,
+    warmup: int = 10,
+    rep: int = 10,
+    forward=None,
+) -> None:
+    """Select the fastest candidate config by timing one call per candidate.
 
     The tiled reduction paths have no single ``self.kernel`` object for
     TileLang's autotuner to decorate — they dispatch through wrapped helper
-    functions — so each candidate is timed through ``forward`` instead.
+    functions — so each candidate is timed through a call instead.
     Leaves ``kernel.config`` set to the winner, or to ``default_config`` when
     the kernel declares no candidates.
+
+    Args:
+        kernel: The kernel whose ``config`` is being chosen.
+        probe_inputs: What to call with.
+        warmup: Untimed calls per candidate.
+        rep: Timed calls per candidate.
+        forward: What to call. Defaults to ``kernel.forward``. A kernel that reshapes
+            its input inside ``forward`` passes the row-level entry point instead, so the
+            probe is a ``(M, N)`` buffer and the timing excludes a config-independent
+            permute.
     """
+    call = kernel.forward if forward is None else forward
     configs = kernel.autotune_configs
     if not configs:
         kernel.config = kernel.default_config
@@ -450,14 +475,14 @@ def tune_by_forward(kernel, *probe_inputs, warmup: int = 10, rep: int = 10) -> N
     for cfg in configs:
         kernel.config = cfg
         for _ in range(warmup):
-            kernel.forward(*probe_inputs)
+            call(*probe_inputs)
         torch.cuda.synchronize()
 
         start = torch.cuda.Event(enable_timing=True)
         end = torch.cuda.Event(enable_timing=True)
         start.record()
         for _ in range(rep):
-            kernel.forward(*probe_inputs)
+            call(*probe_inputs)
         end.record()
         torch.cuda.synchronize()
         elapsed = start.elapsed_time(end) / rep
@@ -676,3 +701,59 @@ def make_cumulative_scan(op_kind: str):
                     output_buf[i, j] = output_buf[i, j - 1] * input_buf[i, j]
 
     return scan
+
+
+# The row layout a reduction kernel reduces, and the shape its caller declared.
+
+
+def _kept(ndim: int, axes: "tuple[int, ...]") -> "list[int]":
+    """The axes the reduction leaves, in order."""
+    return [i for i in range(ndim) if i not in axes]
+
+
+def rows_for_axes(x: torch.Tensor, axes: "tuple[int, ...]") -> torch.Tensor:
+    """Move *axes* to the end and flatten to ``(M, N)``.
+
+    Reducing every axis gives ``M == 1``.
+    """
+    kept = _kept(x.ndim, axes)
+    n = prod(x.shape[a] for a in axes)
+    m = prod(x.shape[i] for i in kept)
+    return x.permute(kept + list(axes)).contiguous().reshape(m, n)
+
+
+def restore_reduced(
+    y: torch.Tensor,
+    in_shape: "tuple[int, ...]",
+    axes: "tuple[int, ...]",
+    keepdim: bool,
+) -> torch.Tensor:
+    """Shape an ``(M,)`` result the way the reduction's caller expects.
+
+    Reducing every axis without *keepdim* gives a 0-D tensor.
+    """
+    if keepdim:
+        return y.reshape([1 if i in axes else d for i, d in enumerate(in_shape)])
+    kept = [in_shape[i] for i in _kept(len(in_shape), axes)]
+    return y.reshape(kept) if kept else y.reshape(())
+
+
+def restore_same_shape(
+    y: torch.Tensor,
+    in_shape: "tuple[int, ...]",
+    axes: "tuple[int, ...]",
+) -> torch.Tensor:
+    """Undo :func:`rows_for_axes` on a result that kept its input's shape.
+
+    For an op that writes one element per input element — softmax, a prefix scan — whose
+    row layout is unwound rather than collapsed.
+    """
+    kept = _kept(len(in_shape), axes)
+    perm = kept + list(axes)
+    y = y.reshape([in_shape[i] for i in perm])
+    inverse = [0] * len(perm)
+    for position, axis in enumerate(perm):
+        inverse[axis] = position
+    # Contiguous, because the op's fake reports contiguous strides and a mismatch there is
+    # a silent wrong answer, not a failure. Free when the reduced axis is already last.
+    return y.permute(inverse).contiguous()

--- a/src/tileops/kernels/reduction/argreduce.py
+++ b/src/tileops/kernels/reduction/argreduce.py
@@ -12,7 +12,8 @@ import tilelang
 import tilelang.language as T
 import torch
 
-from tileops.kernels.kernel_base import Kernel
+from tileops.kernels.kernel_base import Kernel, require_cuda
+from tileops.kernels.reduction._primitives import restore_reduced, rows_for_axes
 
 __all__ = ["ArgreduceKernel"]
 
@@ -532,51 +533,28 @@ def _argreduce_multicta_final_kernel(
     return _func
 
 
-@torch.library.custom_op("top::argreduce_fwd", mutates_args=())
-def _argreduce_fwd_wrapped(
-    M: int,
-    N: int,
-    op_kind: str,
-    dtype_str: str,
-    strategy: str,
-    inner_stride: int,
-    ctas_per_row: int,
-    block_m: int,
-    threads: int,
-    x: torch.Tensor,
-) -> torch.Tensor:
-    if strategy == "output":
-        return _argreduce_output_kernel(M, N, inner_stride, op_kind, dtype_str)(block_m, threads)(x)
-    if strategy == "cta":
-        return _argreduce_cta_kernel(M, N, op_kind, dtype_str)(threads)(x)
-    if strategy == "multi_cta":
-        partial_values, partial_indices = _argreduce_multicta_partial_kernel(
-            M, N, op_kind, dtype_str
-        )(threads, ctas_per_row)(x)
-        return _argreduce_multicta_final_kernel(M, N, op_kind, ctas_per_row)()(
-            partial_values, partial_indices
-        )
-    return _argreduce_warp_kernel(M, N, op_kind, dtype_str)(block_m, threads)(x)
-
-
-@_argreduce_fwd_wrapped.register_fake
-def _(
-    M,
-    N,
-    op_kind,
-    dtype_str,
-    strategy,
-    inner_stride,
-    ctas_per_row,
-    block_m,
-    threads,
-    x,
-):
-    return torch.empty((M,), dtype=torch.int64, device=x.device)
-
-
 class ArgreduceKernel(Kernel):
-    """Adaptive streaming argmax/argmin over contiguous rows."""
+    """Adaptive streaming argmax/argmin over contiguous rows.
+
+    ``forward`` takes the tensor the op declares and reduces *reduce_axes* of it. Which of
+    the four layouts runs is decided here, from the row count, the axis length and the
+    axis's stride — so an op hands over the declared tensor and asks for nothing else.
+
+    Args:
+        M: Rows the reduction leaves.
+        N: Length of the axis it reduces.
+        op_kind: One of "argmax", "argmin".
+        dtype: Input data type.
+        reduce_axes: Non-negative axis indices, ascending, that the reduction runs over.
+        keepdim: Whether a reduced axis stays as a length-1 axis.
+        inner_stride: Elements between two neighbours along the reduced axis. Greater than
+            one means the axis is not the contiguous one, which the strided layout reads
+            without transposing.
+        config: Optional kernel configuration dict.
+        tune: Whether to autotune (default False).
+        device_index: The device the input lives on. None of the four layouts plans against
+            shared memory, so this is here for the architecture check alone.
+    """
 
     supported_archs: list[int] = [80, 86, 89, 90, 100]
 
@@ -586,11 +564,14 @@ class ArgreduceKernel(Kernel):
         N: int,
         op_kind: str,
         dtype: torch.dtype,
+        reduce_axes: "tuple[int, ...]",
+        keepdim: bool = False,
         inner_stride: int = 1,
         config: Optional[dict] = None,
         tune: bool = False,
+        device_index: "int | None" = None,
     ):
-        super().__init__()
+        super().__init__(device_index=device_index)
         if op_kind not in _ARGREDUCE_KINDS:
             raise ValueError(
                 f"Unsupported op_kind '{op_kind}'. Expected one of {sorted(_ARGREDUCE_KINDS)}."
@@ -605,6 +586,8 @@ class ArgreduceKernel(Kernel):
         self.N = N
         self.op_kind = op_kind
         self.dtype = dtype
+        self.reduce_axes = tuple(reduce_axes)
+        self.keepdim = keepdim
         self.inner_stride = inner_stride
 
         if inner_stride > 1 and N <= _STRIDED_AXIS_MAX_N:
@@ -680,17 +663,46 @@ class ArgreduceKernel(Kernel):
         return ranked
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Return the index of the extremum along *reduce_axes* of *x*.
+
+        Args:
+            x: The tensor the op declares, contiguous, on a CUDA device.
+
+        Returns:
+            Int64 indices into the reduced axis.
+
+        Raises:
+            ValueError: *x* is not on a CUDA device.
+        """
+        require_cuda(self, x=x)
+        in_shape = tuple(x.shape)
         if self.M == 0:
-            return torch.empty((0,), dtype=torch.int64, device=x.device)
-        return _argreduce_fwd_wrapped(
-            self.M,
-            self.N,
-            self.op_kind,
-            self.dtype_str,
-            self.strategy,
-            self.inner_stride,
-            self.config.get("ctas_per_row", 1),
-            self.config.get("block_m", 1),
-            self.config["threads"],
-            x,
-        )
+            empty = torch.empty((0,), dtype=torch.int64, device=x.device)
+            return restore_reduced(empty, in_shape, self.reduce_axes, self.keepdim)
+        # The strided layout walks the original buffer, which is why it skips the
+        # transpose the other three need.
+        buffer = x.reshape(-1) if self.strategy == "output" else rows_for_axes(x, self.reduce_axes)
+        y = self._argreduce_rows(buffer)
+        return restore_reduced(y, in_shape, self.reduce_axes, self.keepdim)
+
+    def _argreduce_rows(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the selected layout over an already-laid-out buffer."""
+        block_m = self.config.get("block_m", 1)
+        threads = self.config["threads"]
+        if self.strategy == "output":
+            program = _argreduce_output_kernel(
+                self.M, self.N, self.inner_stride, self.op_kind, self.dtype_str
+            )
+            return program(block_m, threads)(x)
+        if self.strategy == "cta":
+            return _argreduce_cta_kernel(self.M, self.N, self.op_kind, self.dtype_str)(threads)(x)
+        if self.strategy == "multi_cta":
+            ctas_per_row = self.config.get("ctas_per_row", 1)
+            partial = _argreduce_multicta_partial_kernel(
+                self.M, self.N, self.op_kind, self.dtype_str
+            )
+            partial_values, partial_indices = partial(threads, ctas_per_row)(x)
+            final = _argreduce_multicta_final_kernel(self.M, self.N, self.op_kind, ctas_per_row)
+            return final()(partial_values, partial_indices)
+        program = _argreduce_warp_kernel(self.M, self.N, self.op_kind, self.dtype_str)
+        return program(block_m, threads)(x)

--- a/src/tileops/kernels/reduction/cumulative.py
+++ b/src/tileops/kernels/reduction/cumulative.py
@@ -38,11 +38,13 @@ import tilelang
 import tilelang.language as T
 import torch
 
-from tileops.kernels.kernel_base import Kernel
+from tileops.kernels.kernel_base import Kernel, require_cuda
 from tileops.kernels.reduction._primitives import (
     DEFAULT_ALIGNMENT,
     SHARED_MEMORY_BUDGET_BYTES,
     align_up,
+    restore_same_shape,
+    rows_for_axes,
 )
 
 __all__ = ["CumulativeKernel"]
@@ -268,54 +270,6 @@ def _cumulative_kernel(M: int, N: int, op_kind: str, dtype: str):
     return _func
 
 
-# custom_op wrappers for torch.compile compatibility
-
-
-@torch.library.custom_op("top::cumulative_parallel_fwd", mutates_args=())
-def _cumulative_parallel_fwd_wrapped(
-    M: int,
-    N: int,
-    dtype_str: str,
-    block_m: int,
-    block_n: int,
-    threads: int,
-    x: torch.Tensor,
-) -> torch.Tensor:
-    n_tiles = align_up(N, DEFAULT_ALIGNMENT) // block_n
-    local_fn = _parallel_scan_local_kernel(M, N, "sum", dtype_str)(block_m, block_n, threads)
-    y_local, tile_sums = local_fn(x)
-    carry_fn = _parallel_scan_carry_kernel(M, n_tiles)(threads)
-    tile_carries_exclusive = carry_fn(tile_sums)
-    propagate_fn = _parallel_scan_propagate_kernel(M, N, dtype_str)(block_m, block_n, threads)
-    return propagate_fn(y_local, tile_carries_exclusive)
-
-
-@_cumulative_parallel_fwd_wrapped.register_fake
-def _(M, N, dtype_str, block_m, block_n, threads, x):
-    N_padded = align_up(N, DEFAULT_ALIGNMENT)
-    return torch.empty((M, N_padded), dtype=x.dtype, device=x.device)
-
-
-@torch.library.custom_op("top::cumulative_fwd", mutates_args=())
-def _cumulative_fwd_wrapped(
-    M: int,
-    N: int,
-    op_kind: str,
-    dtype_str: str,
-    block_m: int,
-    block_n: int,
-    threads: int,
-    x: torch.Tensor,
-) -> torch.Tensor:
-    return _cumulative_kernel(M, N, op_kind, dtype_str)(block_m, block_n, threads)(x)
-
-
-@_cumulative_fwd_wrapped.register_fake
-def _(M, N, op_kind, dtype_str, block_m, block_n, threads, x):
-    N_padded = align_up(N, DEFAULT_ALIGNMENT)
-    return torch.empty((M, N_padded), dtype=x.dtype, device=x.device)
-
-
 # CumulativeKernel class
 
 
@@ -329,16 +283,22 @@ class CumulativeKernel(Kernel):
 
     Boundary handling for non-aligned N is performed inside the kernel via
     masked loads with identity-element fills (0 for sum, 1 for prod), so
-    no host-side ``F.pad`` is needed.  The ``forward()`` method accepts
-    raw ``(M, N)`` tensors and returns ``(M, N_padded)`` output.
+    no host-side ``F.pad`` is needed.
+
+    ``forward`` takes the tensor the op declares and scans *scan_axis* of it; moving that
+    axis to the end, flattening to rows and putting the result back are this kernel's
+    business, so both sides of the op/backend boundary speak the declared shape.
 
     Args:
-        M: Number of rows (product of all dims except last).
-        N: Hidden dimension (last dim).
+        M: Rows the scan runs over — the product of every axis but *scan_axis*.
+        N: Length of the scanned axis.
         op_kind: One of "sum", "prod".
         dtype: Data type (float32, float16, or bfloat16).
+        scan_axis: Non-negative index of the axis the scan runs along.
         config: Optional kernel configuration dict.
         tune: Whether to autotune (default False).
+        device_index: The device the input lives on. The shared-memory budget here is a
+            constant, so this is for the architecture check alone.
     """
 
     supported_archs: list[int] = [80, 86, 89, 90]
@@ -349,16 +309,19 @@ class CumulativeKernel(Kernel):
         N: int,
         op_kind: str,
         dtype: torch.dtype,
+        scan_axis: int,
         config: Optional[dict] = None,
         tune: bool = False,
+        device_index: "int | None" = None,
     ):
-        super().__init__()
+        super().__init__(device_index=device_index)
         if op_kind not in ("sum", "prod"):
             raise ValueError(f"Unsupported op_kind '{op_kind}'. Expected one of 'sum', 'prod'.")
         self.M = M
         self.N = N
         self.op_kind = op_kind
         self.dtype = dtype
+        self.scan_axis = scan_axis
         self.N_padded = align_up(N, DEFAULT_ALIGNMENT)
 
         # Parallel scan only pays off for small-M, large-N; cumprod has no
@@ -423,38 +386,49 @@ class CumulativeKernel(Kernel):
         return configs
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Run the cumulative scan kernel (sequential or parallel).
+        """Scan *scan_axis* of *x*.
 
         Args:
-            x: Input tensor of shape (M, N).  Alignment padding is
-                handled internally via masked loads.
+            x: The tensor the op declares, contiguous, on a CUDA device. Alignment
+                padding is handled internally via masked loads.
 
         Returns:
-            Output tensor of shape (M, N). The prim_func writes an
-            alignment-padded row; the surplus columns are trimmed here.
+            A tensor shaped like *x*.
+
+        Raises:
+            ValueError: *x* is not on a CUDA device.
         """
+        require_cuda(self, x=x)
+        in_shape = tuple(x.shape)
+        axes = (self.scan_axis,)
+        y = self._scan_rows(rows_for_axes(x, axes))
+        return restore_same_shape(y, in_shape, axes)
+
+    def _scan_rows(self, x: torch.Tensor) -> torch.Tensor:
+        """Scan the trailing axis of an ``(M, N)`` buffer.
+
+        The prim_func writes an alignment-padded row; the surplus columns are trimmed
+        here.
+        """
+        block_m, block_n = self.config["block_m"], self.config["block_n"]
+        threads = self.config["threads"]
         if self.use_parallel:
-            y = _cumulative_parallel_fwd_wrapped(
-                self.M,
-                self.N,
-                self.dtype_str,
-                self.config["block_m"],
-                self.config["block_n"],
-                self.config["threads"],
-                x,
-            )
+            y = self._parallel_scan(x, block_m, block_n, threads)
         else:
-            y = _cumulative_fwd_wrapped(
-                self.M,
-                self.N,
-                self.op_kind,
-                self.dtype_str,
-                self.config["block_m"],
-                self.config["block_n"],
-                self.config["threads"],
-                x,
-            )
+            program = _cumulative_kernel(self.M, self.N, self.op_kind, self.dtype_str)
+            y = program(block_m, block_n, threads)(x)
         return y[:, : self.N] if y.shape[1] > self.N else y
+
+    def _parallel_scan(
+        self, x: torch.Tensor, block_m: int, block_n: int, threads: int
+    ) -> torch.Tensor:
+        """Three passes: scan each tile, scan the tile totals, add the carries."""
+        n_tiles = align_up(self.N, DEFAULT_ALIGNMENT) // block_n
+        local = _parallel_scan_local_kernel(self.M, self.N, "sum", self.dtype_str)
+        y_local, tile_sums = local(block_m, block_n, threads)(x)
+        carries = _parallel_scan_carry_kernel(self.M, n_tiles)(threads)(tile_sums)
+        propagate = _parallel_scan_propagate_kernel(self.M, self.N, self.dtype_str)
+        return propagate(block_m, block_n, threads)(y_local, carries)
 
 
 # ---------------------------------------------------------------------------

--- a/src/tileops/kernels/reduction/logical_reduce.py
+++ b/src/tileops/kernels/reduction/logical_reduce.py
@@ -18,13 +18,15 @@ import tilelang
 import tilelang.language as T
 import torch
 
-from tileops.kernels.kernel_base import Kernel
+from tileops.kernels.kernel_base import Kernel, require_cuda
 from tileops.kernels.reduction._primitives import (
     DEFAULT_ALIGNMENT,
     DEFAULT_THREADS,
     BlockConfigPlanner,
     align_up,
     device_smem_budget,
+    restore_reduced,
+    rows_for_axes,
     tune_by_forward,
 )
 
@@ -247,59 +249,6 @@ def _logical_reduce_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_
     return _func
 
 
-# custom_op wrappers for torch.compile compatibility
-
-
-@torch.library.custom_op("top::logical_reduce_fwd", mutates_args=())
-def _logical_reduce_fwd_wrapped(
-    M: int,
-    N: int,
-    op_kind: str,
-    dtype_str: str,
-    block_m: int,
-    threads: int,
-    x: torch.Tensor,
-) -> torch.Tensor:
-    out_raw = _logical_reduce_kernel(M, N, op_kind, dtype_str)(block_m, threads)(x)
-    if op_kind == "count_nonzero":
-        return out_raw.to(torch.int64)
-    return out_raw.bool()
-
-
-@torch.library.custom_op("top::logical_reduce_tiled_fwd", mutates_args=())
-def _logical_reduce_tiled_fwd_wrapped(
-    M: int,
-    N: int,
-    op_kind: str,
-    dtype_str: str,
-    tile_n: int,
-    block_m: int,
-    threads: int,
-    x: torch.Tensor,
-) -> torch.Tensor:
-    out_raw = _logical_reduce_kernel_tiled(M, N, op_kind, dtype_str, tile_n)(block_m, threads)(x)
-    if op_kind == "count_nonzero":
-        return out_raw.to(torch.int64)
-    return out_raw.bool()
-
-
-@_logical_reduce_fwd_wrapped.register_fake
-def _(M, N, op_kind, dtype_str, block_m, threads, x):
-    if op_kind == "count_nonzero":
-        return torch.empty((M,), dtype=torch.int64, device=x.device)
-    return torch.empty((M,), dtype=torch.bool, device=x.device)
-
-
-@_logical_reduce_tiled_fwd_wrapped.register_fake
-def _(M, N, op_kind, dtype_str, tile_n, block_m, threads, x):
-    if op_kind == "count_nonzero":
-        return torch.empty((M,), dtype=torch.int64, device=x.device)
-    return torch.empty((M,), dtype=torch.bool, device=x.device)
-
-
-# LogicalReduceKernel class
-
-
 class LogicalReduceKernel(Kernel):
     """Any / all / count_nonzero forward kernel.
 
@@ -310,19 +259,25 @@ class LogicalReduceKernel(Kernel):
 
     Output dtype is bool for any/all and int64 for count_nonzero.
 
-    Note: TileLang does not support bool, integer, or complex dtypes as a
-    storage dtype for shared memory. When dtype is one of these, the kernel is
-    compiled for float32 internally and the Op layer is responsible for
-    pre-converting the input tensor to float32 before calling forward().
+    ``forward`` takes the tensor the op declares and reduces *reduce_axes* of it; the
+    permute to rows and the shape of the result are this kernel's business.
+
+    TileLang does not support bool, integer, or complex dtypes as a shared-memory storage
+    dtype. When *dtype* is one of these the kernel is compiled for float32 and ``forward``
+    converts the input, so an op hands over the tensor its manifest declares and this
+    restriction stays inside the implementation that has it.
 
     Args:
-        M: Number of rows (product of all dims except last).
-        N: Hidden dimension (last dim).
+        M: Rows the reduction leaves.
+        N: Elements each row reduces.
         op_kind: One of "any", "all", "count_nonzero".
         dtype: Input data type (float32, float16, bfloat16, bool, complex64,
                or complex128).
+        reduce_axes: Non-negative axis indices, ascending, that the reduction runs over.
+        keepdim: Whether a reduced axis stays as a length-1 axis.
         config: Optional kernel configuration dict.
         tune: Whether to autotune (default False).
+        device_index: CUDA device the input lives on, for the shared-memory budget.
     """
 
     supported_archs: list[int] = [80, 86, 89, 90]
@@ -333,10 +288,13 @@ class LogicalReduceKernel(Kernel):
         N: int,
         op_kind: str,
         dtype: torch.dtype,
+        reduce_axes: "tuple[int, ...]",
+        keepdim: bool = False,
         config: Optional[dict] = None,
         tune: bool = False,
+        device_index: "int | None" = None,
     ):
-        super().__init__()
+        super().__init__(device_index=device_index)
         if op_kind not in _LOGICAL_REDUCE_KINDS:
             raise ValueError(
                 f"Unsupported op_kind '{op_kind}'. Expected one of {sorted(_LOGICAL_REDUCE_KINDS)}."
@@ -345,6 +303,8 @@ class LogicalReduceKernel(Kernel):
         self.N = N
         self.op_kind = op_kind
         self.dtype = dtype
+        self.reduce_axes = tuple(reduce_axes)
+        self.keepdim = keepdim
         # TileLang cannot handle bool, integer, or complex dtypes as
         # shared-memory storage dtypes; remap all unsupported dtypes -> float32.
         self._kernel_dtype = (
@@ -352,7 +312,7 @@ class LogicalReduceKernel(Kernel):
         )
         self.N_padded = align_up(N, DEFAULT_ALIGNMENT)
         self._elem_bytes = torch.tensor([], dtype=self._kernel_dtype).element_size()
-        self._smem_budget = device_smem_budget()
+        self._smem_budget = device_smem_budget(device_index)
         self._planner = BlockConfigPlanner(
             self.N_padded,
             self._elem_bytes,
@@ -392,36 +352,43 @@ class LogicalReduceKernel(Kernel):
         x = torch.randn(
             self.M, self.N, dtype=self._kernel_dtype, device=torch.cuda.current_device()
         )
-        tune_by_forward(self, x, warmup=warmup, rep=rep)
+        tune_by_forward(self, x, warmup=warmup, rep=rep, forward=self._reduce_rows)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Run the any/all/count_nonzero kernel.
+        """Reduce *reduce_axes* of *x*.
 
         Args:
-            x: Input tensor of shape (M, N). Must have dtype matching
-               _kernel_dtype (float32 when the original dtype is bool).
+            x: The tensor the op declares, contiguous, on a CUDA device. A dtype TileLang
+                cannot store is converted here.
 
         Returns:
-            Output tensor of shape (M,) with dtype bool (any/all) or int64
-            (count_nonzero).
+            The reduced tensor, dtype bool (any/all) or int64 (count_nonzero).
+
+        Raises:
+            ValueError: *x* is not on a CUDA device.
         """
+        require_cuda(self, x=x)
+        in_shape = tuple(x.shape)
+        if x.dtype in _UNSUPPORTED_STORAGE_DTYPES:
+            x = to_logical_float32(x)
+        rows = rows_for_axes(x, self.reduce_axes)
+        y = self._reduce_rows(rows)
+        return restore_reduced(y, in_shape, self.reduce_axes, self.keepdim)
+
+    def _reduce_rows(self, x: torch.Tensor) -> torch.Tensor:
+        """Reduce the trailing axis of an ``(M, N)`` buffer.
+
+        The prim_func counts in the storage dtype; the declared output dtype is applied
+        here.
+        """
+        dtype_str = self.dtype_to_str(self._kernel_dtype)
         if self._needs_tiling:
-            return _logical_reduce_tiled_fwd_wrapped(
-                self.M,
-                self.N,
-                self.op_kind,
-                self.dtype_to_str(self._kernel_dtype),
-                self.config["tile_n"],
-                self.config["block_m"],
-                self.config["threads"],
-                x,
+            program = _logical_reduce_kernel_tiled(
+                self.M, self.N, self.op_kind, dtype_str, self.config["tile_n"]
             )
-        return _logical_reduce_fwd_wrapped(
-            self.M,
-            self.N,
-            self.op_kind,
-            self.dtype_to_str(self._kernel_dtype),
-            self.config["block_m"],
-            self.config["threads"],
-            x,
-        )
+        else:
+            program = _logical_reduce_kernel(self.M, self.N, self.op_kind, dtype_str)
+        counted = program(self.config["block_m"], self.config["threads"])(x)
+        if self.op_kind == "count_nonzero":
+            return counted.to(torch.int64)
+        return counted.bool()

--- a/src/tileops/kernels/reduction/logsumexp.py
+++ b/src/tileops/kernels/reduction/logsumexp.py
@@ -22,7 +22,7 @@ import tilelang
 import tilelang.language as T
 import torch
 
-from tileops.kernels.kernel_base import Kernel
+from tileops.kernels.kernel_base import Kernel, require_cuda
 from tileops.kernels.reduction._primitives import (
     AUTOTUNE_THREADS,
     DEFAULT_ALIGNMENT,
@@ -30,6 +30,8 @@ from tileops.kernels.reduction._primitives import (
     align_up,
     compute_tile_n,
     device_smem_budget,
+    restore_reduced,
+    rows_for_axes,
 )
 
 # These two kernels bake tile_n in at build time and default to the wider
@@ -224,30 +226,6 @@ def _compute_padded_cols(N: int, tile_n: int) -> int:
     return num_tiles * tile_n
 
 
-# custom_op wrappers for torch.compile compatibility
-
-
-@torch.library.custom_op("top::logsumexp_fwd", mutates_args=())
-def _logsumexp_fwd_wrapped(
-    M: int,
-    N: int,
-    dtype_str: str,
-    block_m: int,
-    threads: int,
-    tile_n: int,
-    x: torch.Tensor,
-) -> torch.Tensor:
-    return _logsumexp_kernel(M, N, dtype_str, tile_n)(block_m, threads)(x)
-
-
-@_logsumexp_fwd_wrapped.register_fake
-def _(M, N, dtype_str, block_m, threads, tile_n, x):
-    return torch.empty((M,), dtype=x.dtype, device=x.device)
-
-
-# Kernel class
-
-
 def _elem_bytes(dtype: torch.dtype) -> int:
     """Return bytes per element for the given dtype."""
     return torch.tensor([], dtype=dtype).element_size()
@@ -266,11 +244,17 @@ class LogSumExpKernel(Kernel):
     via masked loads and ``-inf`` fills, so no host-side ``F.pad`` is
     needed.
 
+    ``forward`` takes the tensor the op declares and reduces *reduce_axes* of it; moving
+    those axes to the end, flattening to rows and shaping the result back are this
+    kernel's business, so both sides of the op/backend boundary speak the declared shape.
+
     Args:
-        M: Number of rows (product of all dims except last).
-        N: Hidden dimension (last dim).
+        M: Rows the reduction leaves.
+        N: Elements each row reduces.
         op_kind: Must be "logsumexp" (kept for API consistency with SoftmaxKernel).
         dtype: Data type (float32, float16, or bfloat16).
+        reduce_axes: Non-negative axis indices, ascending, that the reduction runs over.
+        keepdim: Whether a reduced axis stays as a length-1 axis.
         config: Optional kernel configuration dict.
         tune: Whether to autotune (default False).
         device_index: CUDA device index for shared memory budget query.
@@ -286,17 +270,21 @@ class LogSumExpKernel(Kernel):
         N: int,
         op_kind: str,
         dtype: torch.dtype,
+        reduce_axes: "tuple[int, ...]",
+        keepdim: bool = False,
         config: Optional[dict] = None,
         tune: bool = False,
         device_index: int | None = None,
     ):
-        super().__init__()
+        super().__init__(device_index=device_index)
         if op_kind != "logsumexp":
             raise ValueError(f"Unsupported op_kind '{op_kind}'. Expected 'logsumexp'.")
         self.M = M
         self.N = N
         self.op_kind = op_kind
         self.dtype = dtype
+        self.reduce_axes = tuple(reduce_axes)
+        self.keepdim = keepdim
         self.N_padded = align_up(N, DEFAULT_ALIGNMENT)
         self._elem_bytes = _elem_bytes(dtype)
         self._smem_budget = device_smem_budget(device_index)
@@ -554,20 +542,25 @@ class LogSumExpKernel(Kernel):
                 )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Run the logsumexp kernel.
+        """Reduce *reduce_axes* of *x*.
 
-        Accepts an ``(M, N)`` tensor.  Boundary handling for non-aligned
-        ``N`` is performed inside the GPU kernel (masked loads + ``-inf``
-        fill), so no host-side ``F.pad`` is needed.
+        Args:
+            x: The tensor the op declares, contiguous, on a CUDA device. Boundary
+                handling for non-aligned ``N`` is performed inside the GPU kernel
+                (masked loads + ``-inf`` fill), so no host-side ``F.pad`` is needed.
+
+        Returns:
+            The reduced tensor.
+
+        Raises:
+            ValueError: *x* is not on a CUDA device.
         """
-        tile_n = self._tile_n
+        require_cuda(self, x=x)
+        in_shape = tuple(x.shape)
+        y = self._reduce_rows(rows_for_axes(x, self.reduce_axes))
+        return restore_reduced(y, in_shape, self.reduce_axes, self.keepdim)
 
-        return _logsumexp_fwd_wrapped(
-            self.M,
-            self.N,
-            self.dtype_str,
-            self.config["block_m"],
-            self.config["threads"],
-            tile_n,
-            x,
-        )
+    def _reduce_rows(self, x: torch.Tensor) -> torch.Tensor:
+        """Reduce the trailing axis of an ``(M, N)`` buffer."""
+        program = _logsumexp_kernel(self.M, self.N, self.dtype_str, self._tile_n)
+        return program(self.config["block_m"], self.config["threads"])(x)

--- a/src/tileops/kernels/reduction/reduce.py
+++ b/src/tileops/kernels/reduction/reduce.py
@@ -25,13 +25,15 @@ import tilelang
 import tilelang.language as T
 import torch
 
-from tileops.kernels.kernel_base import Kernel
+from tileops.kernels.kernel_base import Kernel, require_cuda
 from tileops.kernels.reduction._primitives import (
     DEFAULT_ALIGNMENT,
     DEFAULT_THREADS,
     BlockConfigPlanner,
     align_up,
     device_smem_budget,
+    restore_reduced,
+    rows_for_axes,
     tune_by_forward,
 )
 
@@ -801,106 +803,6 @@ def _welford_reduce_kernel_tiled(M, N, op_kind, correction, dtype, tile_n):
     return _func
 
 
-# custom_op wrappers
-
-
-@torch.library.custom_op("top::reduce_simple_fwd", mutates_args=())
-def _reduce_simple_wrapped(
-    M: int,
-    N: int,
-    op_kind: str,
-    dtype_str: str,
-    block_m: int,
-    threads: int,
-    x: torch.Tensor,
-) -> torch.Tensor:
-    return _simple_reduce_kernel(M, N, op_kind, dtype_str)(block_m, threads)(x)
-
-
-@_reduce_simple_wrapped.register_fake
-def _(M, N, op_kind, dtype_str, block_m, threads, x):
-    return torch.empty((M,), dtype=x.dtype, device=x.device)
-
-
-@torch.library.custom_op("top::reduce_simple_tiled_fwd", mutates_args=())
-def _reduce_simple_tiled_wrapped(
-    M: int,
-    N: int,
-    op_kind: str,
-    dtype_str: str,
-    tile_n: int,
-    block_m: int,
-    threads: int,
-    x: torch.Tensor,
-) -> torch.Tensor:
-    return _simple_reduce_kernel_tiled(M, N, op_kind, dtype_str, tile_n)(block_m, threads)(x)
-
-
-@_reduce_simple_tiled_wrapped.register_fake
-def _(M, N, op_kind, dtype_str, tile_n, block_m, threads, x):
-    return torch.empty((M,), dtype=x.dtype, device=x.device)
-
-
-@torch.library.custom_op("top::reduce_welford_fwd", mutates_args=())
-def _reduce_welford_wrapped(
-    M: int,
-    N: int,
-    op_kind: str,
-    correction: int,
-    dtype_str: str,
-    block_m: int,
-    threads: int,
-    x: torch.Tensor,
-) -> list[torch.Tensor]:
-    kernel = _welford_reduce_kernel(M, N, op_kind, correction, dtype_str)
-    result = kernel(block_m, threads)(x)
-    if op_kind == "var_mean":
-        # Returns (var, mean)
-        return [result[0], result[1]]
-    else:
-        return [result]
-
-
-@_reduce_welford_wrapped.register_fake
-def _(M, N, op_kind, correction, dtype_str, block_m, threads, x):
-    if op_kind == "var_mean":
-        return [
-            torch.empty((M,), dtype=x.dtype, device=x.device),
-            torch.empty((M,), dtype=x.dtype, device=x.device),
-        ]
-    return [torch.empty((M,), dtype=x.dtype, device=x.device)]
-
-
-@torch.library.custom_op("top::reduce_welford_tiled_fwd", mutates_args=())
-def _reduce_welford_tiled_wrapped(
-    M: int,
-    N: int,
-    op_kind: str,
-    correction: int,
-    dtype_str: str,
-    tile_n: int,
-    block_m: int,
-    threads: int,
-    x: torch.Tensor,
-) -> list[torch.Tensor]:
-    kernel = _welford_reduce_kernel_tiled(M, N, op_kind, correction, dtype_str, tile_n)
-    result = kernel(block_m, threads)(x)
-    if op_kind == "var_mean":
-        return [result[0], result[1]]
-    else:
-        return [result]
-
-
-@_reduce_welford_tiled_wrapped.register_fake
-def _(M, N, op_kind, correction, dtype_str, tile_n, block_m, threads, x):
-    if op_kind == "var_mean":
-        return [
-            torch.empty((M,), dtype=x.dtype, device=x.device),
-            torch.empty((M,), dtype=x.dtype, device=x.device),
-        ]
-    return [torch.empty((M,), dtype=x.dtype, device=x.device)]
-
-
 # ReduceKernel class
 
 
@@ -916,7 +818,24 @@ class ReduceKernel(Kernel):
 
     Boundary handling for non-aligned N is performed inside the kernel via
     masked loads with identity-element fills, so no host-side ``F.pad`` is
-    needed.  The ``forward()`` method accepts raw ``(M, N)`` tensors.
+    needed.
+
+    ``forward`` takes the tensor the op declares and reduces *reduce_axes* of it: moving
+    those axes to the end, flattening to ``(M, N)`` and shaping the result back are this
+    kernel's business, so both sides of the op/backend boundary speak the declared shape.
+
+    Args:
+        M: Rows the reduction leaves — the product of the axes it keeps.
+        N: Elements each row reduces — the product of *reduce_axes*.
+        op_kind: One of sum, mean, amin, amax, prod, std, var, var_mean.
+        dtype: Element type of the input.
+        reduce_axes: Non-negative axis indices, ascending, that the reduction runs over.
+        keepdim: Whether a reduced axis stays as a length-1 axis.
+        correction: Bessel's correction, for the Welford kinds.
+        config: Optional kernel configuration dict.
+        tune: Whether to autotune (default False).
+        device_index: CUDA device the input lives on, for the shared-memory budget.
+            ``None`` reads the current device.
     """
 
     supported_archs: list[int] = [80, 86, 89, 90]
@@ -927,20 +846,25 @@ class ReduceKernel(Kernel):
         N: int,
         op_kind: str,
         dtype: torch.dtype,
+        reduce_axes: "tuple[int, ...]",
+        keepdim: bool = False,
         correction: int = 1,
         config: Optional[dict] = None,
         tune: bool = False,
+        device_index: "int | None" = None,
     ):
-        super().__init__()
+        super().__init__(device_index=device_index)
         self.M = M
         self.N = N
         self.op_kind = op_kind
         self.dtype = dtype
+        self.reduce_axes = tuple(reduce_axes)
+        self.keepdim = keepdim
         self.correction = correction
         self.N_padded = align_up(N, DEFAULT_ALIGNMENT)
         self._is_welford = op_kind in _WELFORD_KINDS
         self._elem_bytes = torch.tensor([], dtype=dtype).element_size()
-        self._smem_budget = device_smem_budget()
+        self._smem_budget = device_smem_budget(device_index)
         self._planner = BlockConfigPlanner(
             self.N_padded,
             self._elem_bytes,
@@ -994,55 +918,57 @@ class ReduceKernel(Kernel):
         if not self._needs_tiling:
             return super().autotune(warmup=warmup, rep=rep)
         x = torch.randn(self.M, self.N, dtype=self.dtype, device=torch.cuda.current_device())
-        tune_by_forward(self, x, warmup=warmup, rep=rep)
+        tune_by_forward(self, x, warmup=warmup, rep=rep, forward=self._reduce_rows)
 
     def forward(self, x: torch.Tensor) -> object:
+        """Reduce *reduce_axes* of *x*.
+
+        Args:
+            x: The tensor the op declares, contiguous, on a CUDA device.
+
+        Returns:
+            The reduced tensor, or ``(var, mean)`` for ``op_kind="var_mean"``.
+
+        Raises:
+            ValueError: *x* is not on a CUDA device.
+        """
+        require_cuda(self, x=x)
+        in_shape = tuple(x.shape)
+        rows = rows_for_axes(x, self.reduce_axes)
+        result = self._reduce_rows(rows)
+        if self.op_kind == "var_mean":
+            var, mean = result
+            return (
+                restore_reduced(var, in_shape, self.reduce_axes, self.keepdim),
+                restore_reduced(mean, in_shape, self.reduce_axes, self.keepdim),
+            )
+        return restore_reduced(result, in_shape, self.reduce_axes, self.keepdim)
+
+    def _reduce_rows(self, x: torch.Tensor) -> object:
+        """Reduce the trailing axis of an ``(M, N)`` buffer."""
+        block_m, threads = self.config["block_m"], self.config["threads"]
         if self._is_welford:
             if self._needs_tiling:
-                results = _reduce_welford_tiled_wrapped(
+                program = _welford_reduce_kernel_tiled(
                     self.M,
                     self.N,
                     self.op_kind,
                     self.correction,
                     self.dtype_str,
                     self.config["tile_n"],
-                    self.config["block_m"],
-                    self.config["threads"],
-                    x,
                 )
             else:
-                results = _reduce_welford_wrapped(
-                    self.M,
-                    self.N,
-                    self.op_kind,
-                    self.correction,
-                    self.dtype_str,
-                    self.config["block_m"],
-                    self.config["threads"],
-                    x,
+                program = _welford_reduce_kernel(
+                    self.M, self.N, self.op_kind, self.correction, self.dtype_str
                 )
+            results = program(block_m, threads)(x)
             if self.op_kind == "var_mean":
                 return results[0], results[1]
-            return results[0]
+            return results
+        if self._needs_tiling:
+            program = _simple_reduce_kernel_tiled(
+                self.M, self.N, self.op_kind, self.dtype_str, self.config["tile_n"]
+            )
         else:
-            if self._needs_tiling:
-                return _reduce_simple_tiled_wrapped(
-                    self.M,
-                    self.N,
-                    self.op_kind,
-                    self.dtype_str,
-                    self.config["tile_n"],
-                    self.config["block_m"],
-                    self.config["threads"],
-                    x,
-                )
-            else:
-                return _reduce_simple_wrapped(
-                    self.M,
-                    self.N,
-                    self.op_kind,
-                    self.dtype_str,
-                    self.config["block_m"],
-                    self.config["threads"],
-                    x,
-                )
+            program = _simple_reduce_kernel(self.M, self.N, self.op_kind, self.dtype_str)
+        return program(block_m, threads)(x)

--- a/src/tileops/kernels/reduction/softmax.py
+++ b/src/tileops/kernels/reduction/softmax.py
@@ -23,7 +23,7 @@ import tilelang
 import tilelang.language as T
 import torch
 
-from tileops.kernels.kernel_base import Kernel
+from tileops.kernels.kernel_base import Kernel, require_cuda
 from tileops.kernels.reduction._primitives import (
     AUTOTUNE_THREADS,
     DEFAULT_ALIGNMENT,
@@ -31,6 +31,8 @@ from tileops.kernels.reduction._primitives import (
     align_up,
     compute_tile_n,
     device_smem_budget,
+    restore_same_shape,
+    rows_for_axes,
 )
 
 # These two kernels bake tile_n in at build time and default to the wider
@@ -487,9 +489,6 @@ def _softmax_kernel(M: int, N: int, op_kind: str, dtype: str, tile_n: int = 0):
     return _softmax_kernel_tiled(M, N, op_kind, dtype, tile_n)
 
 
-# custom_op wrappers for torch.compile compatibility
-
-
 def _compute_padded_cols(N: int, tile_n: int) -> int:
     """Compute the total column count (may exceed N_padded for tiled path)."""
     N_padded = align_up(N, DEFAULT_ALIGNMENT)
@@ -497,26 +496,6 @@ def _compute_padded_cols(N: int, tile_n: int) -> int:
         return N_padded
     num_tiles = (N_padded + tile_n - 1) // tile_n
     return num_tiles * tile_n
-
-
-@torch.library.custom_op("top::softmax_fwd", mutates_args=())
-def _softmax_fwd_wrapped(
-    M: int,
-    N: int,
-    op_kind: str,
-    dtype_str: str,
-    block_m: int,
-    threads: int,
-    tile_n: int,
-    x: torch.Tensor,
-) -> torch.Tensor:
-    return _softmax_kernel(M, N, op_kind, dtype_str, tile_n)(block_m, threads)(x)
-
-
-@_softmax_fwd_wrapped.register_fake
-def _(M, N, op_kind, dtype_str, block_m, threads, tile_n, x):
-    total_cols = _compute_padded_cols(N, tile_n)
-    return torch.empty((M, total_cols), dtype=x.dtype, device=x.device)
 
 
 # Kernel class
@@ -540,11 +519,16 @@ class SoftmaxKernel(Kernel):
     via masked loads and ``-inf`` fills, so no host-side ``F.pad`` is
     needed.
 
+    ``forward`` takes the tensor the op declares and normalizes over *norm_axis*; moving
+    that axis to the end, flattening to rows and putting the result back are this kernel's
+    business, so both sides of the op/backend boundary speak the declared shape.
+
     Args:
-        M: Number of rows (product of all dims except last).
-        N: Hidden dimension (last dim).
+        M: Rows the normalization runs over — the product of every axis but *norm_axis*.
+        N: Length of the normalized axis.
         op_kind: One of "softmax", "log_softmax".
         dtype: Data type (float32, float16, or bfloat16).
+        norm_axis: Non-negative index of the axis the normalization runs over.
         config: Optional kernel configuration dict.
         tune: Whether to autotune (default False).
         device_index: CUDA device index for shared memory budget query.
@@ -559,11 +543,12 @@ class SoftmaxKernel(Kernel):
         N: int,
         op_kind: str,
         dtype: torch.dtype,
+        norm_axis: int,
         config: Optional[dict] = None,
         tune: bool = False,
         device_index: int | None = None,
     ):
-        super().__init__()
+        super().__init__(device_index=device_index)
         if op_kind not in ("softmax", "log_softmax"):
             raise ValueError(
                 f"Unsupported op_kind '{op_kind}'. Expected one of 'softmax', 'log_softmax'."
@@ -572,6 +557,7 @@ class SoftmaxKernel(Kernel):
         self.N = N
         self.op_kind = op_kind
         self.dtype = dtype
+        self.norm_axis = norm_axis
         self.N_padded = align_up(N, DEFAULT_ALIGNMENT)
         self._elem_bytes = _elem_bytes(dtype)
         self._smem_budget = device_smem_budget(device_index)
@@ -849,28 +835,31 @@ class SoftmaxKernel(Kernel):
                 )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Run the softmax/log_softmax kernel.
+        """Normalize *x* over *norm_axis*.
 
         Args:
-            x: Input of shape ``(M, N)``. Boundary handling for non-aligned
-                ``N`` happens inside the GPU kernel (masked loads + ``-inf``
-                fill), so no host-side ``F.pad`` is needed.
+            x: The tensor the op declares, contiguous, on a CUDA device. Boundary
+                handling for non-aligned ``N`` happens inside the GPU kernel (masked
+                loads + ``-inf`` fill), so no host-side ``F.pad`` is needed.
 
         Returns:
-            Tensor of shape ``(M, N)``. The prim_func writes an
-            alignment-padded row; the surplus columns are trimmed here.
+            A tensor shaped like *x*.
+
+        Raises:
+            ValueError: *x* is not on a CUDA device.
         """
-        tile_n = self._tile_n
+        require_cuda(self, x=x)
+        in_shape = tuple(x.shape)
+        axes = (self.norm_axis,)
+        y = self._normalize_rows(rows_for_axes(x, axes))
+        return restore_same_shape(y, in_shape, axes)
 
-        y = _softmax_fwd_wrapped(
-            self.M,
-            self.N,
-            self.op_kind,
-            self.dtype_str,
-            self.config["block_m"],
-            self.config["threads"],
-            tile_n,
-            x,
-        )
+    def _normalize_rows(self, x: torch.Tensor) -> torch.Tensor:
+        """Normalize the trailing axis of an ``(M, N)`` buffer.
 
+        The prim_func writes an alignment-padded row; the surplus columns are trimmed
+        here.
+        """
+        program = _softmax_kernel(self.M, self.N, self.op_kind, self.dtype_str, self._tile_n)
+        y = program(self.config["block_m"], self.config["threads"])(x)
         return y[:, : self.N] if y.shape[1] > self.N else y

--- a/src/tileops/kernels/reduction/vector_norm.py
+++ b/src/tileops/kernels/reduction/vector_norm.py
@@ -18,13 +18,15 @@ import tilelang
 import tilelang.language as T
 import torch
 
-from tileops.kernels.kernel_base import Kernel
+from tileops.kernels.kernel_base import Kernel, require_cuda
 from tileops.kernels.reduction._primitives import (
     DEFAULT_ALIGNMENT,
     DEFAULT_THREADS,
     BlockConfigPlanner,
     align_up,
     device_smem_budget,
+    restore_reduced,
+    rows_for_axes,
     tune_by_forward,
 )
 
@@ -209,46 +211,6 @@ def _vector_norm_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_n: 
     return _func
 
 
-# custom_op wrappers for torch.compile compatibility
-
-
-@torch.library.custom_op("top::vector_norm_fwd", mutates_args=())
-def _vector_norm_fwd_wrapped(
-    M: int,
-    N: int,
-    op_kind: str,
-    dtype_str: str,
-    block_m: int,
-    threads: int,
-    x: torch.Tensor,
-) -> torch.Tensor:
-    return _vector_norm_kernel(M, N, op_kind, dtype_str)(block_m, threads)(x)
-
-
-@torch.library.custom_op("top::vector_norm_tiled_fwd", mutates_args=())
-def _vector_norm_tiled_fwd_wrapped(
-    M: int,
-    N: int,
-    op_kind: str,
-    dtype_str: str,
-    tile_n: int,
-    block_m: int,
-    threads: int,
-    x: torch.Tensor,
-) -> torch.Tensor:
-    return _vector_norm_kernel_tiled(M, N, op_kind, dtype_str, tile_n)(block_m, threads)(x)
-
-
-@_vector_norm_fwd_wrapped.register_fake
-def _(M, N, op_kind, dtype_str, block_m, threads, x):
-    return torch.empty((M,), dtype=x.dtype, device=x.device)
-
-
-@_vector_norm_tiled_fwd_wrapped.register_fake
-def _(M, N, op_kind, dtype_str, tile_n, block_m, threads, x):
-    return torch.empty((M,), dtype=x.dtype, device=x.device)
-
-
 # VectorNormKernel class
 
 
@@ -262,13 +224,23 @@ class VectorNormKernel(Kernel):
 
     Output dtype matches input dtype; internal computation in fp32.
 
+    ``forward`` takes the tensor the op declares and reduces *reduce_axes* of it; the
+    permute to rows and the shape of the result are this kernel's business.
+
+    A row holding a NaN norms to NaN, matching ``torch.linalg.vector_norm``. The prim_func
+    drops NaN values, so the ``inf`` kind patches those rows here — the compensation
+    belongs to the implementation that needs it.
+
     Args:
-        M: Number of rows (product of all dims except last).
-        N: Hidden dimension (last dim).
+        M: Rows the reduction leaves.
+        N: Elements each row reduces.
         op_kind: One of "l1", "l2", "inf".
         dtype: Input data type (float32, float16, bfloat16).
+        reduce_axes: Non-negative axis indices, ascending, that the reduction runs over.
+        keepdim: Whether a reduced axis stays as a length-1 axis.
         config: Optional kernel configuration dict.
         tune: Whether to autotune (default False).
+        device_index: CUDA device the input lives on, for the shared-memory budget.
     """
 
     supported_archs: list[int] = [80, 86, 89, 90]
@@ -279,10 +251,13 @@ class VectorNormKernel(Kernel):
         N: int,
         op_kind: str,
         dtype: torch.dtype,
+        reduce_axes: "tuple[int, ...]",
+        keepdim: bool = False,
         config: Optional[dict] = None,
         tune: bool = False,
+        device_index: "int | None" = None,
     ):
-        super().__init__()
+        super().__init__(device_index=device_index)
         if op_kind not in _VECTOR_NORM_KINDS:
             raise ValueError(
                 f"Unsupported op_kind '{op_kind}'. Expected one of {sorted(_VECTOR_NORM_KINDS)}."
@@ -291,9 +266,11 @@ class VectorNormKernel(Kernel):
         self.N = N
         self.op_kind = op_kind
         self.dtype = dtype
+        self.reduce_axes = tuple(reduce_axes)
+        self.keepdim = keepdim
         self.N_padded = align_up(N, DEFAULT_ALIGNMENT)
         self._elem_bytes = torch.tensor([], dtype=dtype).element_size()
-        self._smem_budget = device_smem_budget()
+        self._smem_budget = device_smem_budget(device_index)
         self._planner = BlockConfigPlanner(
             self.N_padded,
             self._elem_bytes,
@@ -331,34 +308,37 @@ class VectorNormKernel(Kernel):
         if not self._needs_tiling:
             return super().autotune(warmup=warmup, rep=rep)
         x = torch.randn(self.M, self.N, dtype=self.dtype, device=torch.cuda.current_device())
-        tune_by_forward(self, x, warmup=warmup, rep=rep)
+        tune_by_forward(self, x, warmup=warmup, rep=rep, forward=self._norm_rows)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Run the l1/l2/inf norm kernel.
+        """Norm *reduce_axes* of *x*.
 
         Args:
-            x: Input tensor of shape (M, N).
+            x: The tensor the op declares, contiguous, on a CUDA device.
 
         Returns:
-            Output tensor of shape (M,) with same dtype as input.
+            The normed tensor, same dtype as *x*.
+
+        Raises:
+            ValueError: *x* is not on a CUDA device.
         """
+        require_cuda(self, x=x)
+        in_shape = tuple(x.shape)
+        rows = rows_for_axes(x, self.reduce_axes)
+        y = self._norm_rows(rows)
+        if self.op_kind == "inf":
+            nan_rows = rows.isnan().any(dim=-1)
+            if nan_rows.any():
+                y[nan_rows] = float("nan")
+        return restore_reduced(y, in_shape, self.reduce_axes, self.keepdim)
+
+    def _norm_rows(self, x: torch.Tensor) -> torch.Tensor:
+        """Norm the trailing axis of an ``(M, N)`` buffer."""
+        dtype_str = self.dtype_to_str(self.dtype)
         if self._needs_tiling:
-            return _vector_norm_tiled_fwd_wrapped(
-                self.M,
-                self.N,
-                self.op_kind,
-                self.dtype_to_str(self.dtype),
-                self.config["tile_n"],
-                self.config["block_m"],
-                self.config["threads"],
-                x,
+            program = _vector_norm_kernel_tiled(
+                self.M, self.N, self.op_kind, dtype_str, self.config["tile_n"]
             )
-        return _vector_norm_fwd_wrapped(
-            self.M,
-            self.N,
-            self.op_kind,
-            self.dtype_to_str(self.dtype),
-            self.config["block_m"],
-            self.config["threads"],
-            x,
-        )
+        else:
+            program = _vector_norm_kernel(self.M, self.N, self.op_kind, dtype_str)
+        return program(self.config["block_m"], self.config["threads"])(x)

--- a/src/tileops/manifest/reduction.yaml
+++ b/src/tileops/manifest/reduction.yaml
@@ -8,6 +8,7 @@ SoftmaxFwdOp:
   ref_api: "torch.nn.functional.softmax"
   family: reduction
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -56,6 +57,7 @@ LogSoftmaxFwdOp:
   ref_api: "torch.nn.functional.log_softmax"
   family: reduction
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -108,10 +110,11 @@ LogSumExpFwdOp:
   ref_api: "torch.logsumexp"
   family: reduction
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
-      x: {dtype: "float16 | bfloat16"}
+      x: {dtype: "float16 | bfloat16 | float32"}
     outputs:
       output: {dtype: "same_as(x)"}
     params:
@@ -159,6 +162,7 @@ SumFwdOp:
   ref_api: "torch.sum"
   family: reduction
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -210,6 +214,7 @@ MeanFwdOp:
   ref_api: "torch.mean"
   family: reduction
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -257,6 +262,7 @@ AmaxFwdOp:
   ref_api: "torch.amax"
   family: reduction
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -300,6 +306,7 @@ AminFwdOp:
   ref_api: "torch.amin"
   family: reduction
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -343,6 +350,7 @@ ProdFwdOp:
   ref_api: "torch.prod"
   family: reduction
   status: implemented
+  torch_compile_fullgraph: true
   # NOTE: torch.prod has two overloads -- prod(input) for full reduction (no
   # dim arg) and prod(input, dim, keepdim=False) where dim is a required int.
   # Unlike torch.sum, torch.prod's dim overload rejects dim=None at runtime
@@ -398,6 +406,7 @@ VarFwdOp:
   ref_api: "torch.var"
   family: reduction
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -442,6 +451,7 @@ StdFwdOp:
   ref_api: "torch.std"
   family: reduction
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -486,6 +496,7 @@ VarMeanFwdOp:
   ref_api: "torch.var_mean"
   family: reduction
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -536,6 +547,7 @@ ArgmaxFwdOp:
   ref_api: "torch.argmax"
   family: reduction
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -580,6 +592,7 @@ ArgminFwdOp:
   ref_api: "torch.argmin"
   family: reduction
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -625,6 +638,7 @@ AllFwdOp:
   ref_api: "torch.all"
   family: reduction
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -670,6 +684,7 @@ AnyFwdOp:
   ref_api: "torch.any"
   family: reduction
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -715,6 +730,7 @@ CountNonzeroFwdOp:
   ref_api: "torch.count_nonzero"
   family: reduction
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -761,6 +777,7 @@ L1NormFwdOp:
   ref_api: "torch.linalg.vector_norm"
   family: reduction
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -810,6 +827,7 @@ L2NormFwdOp:
   ref_api: "torch.linalg.vector_norm"
   family: reduction
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -859,6 +877,7 @@ InfNormFwdOp:
   ref_api: "torch.linalg.vector_norm"
   family: reduction
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:

--- a/src/tileops/manifest/scan.yaml
+++ b/src/tileops/manifest/scan.yaml
@@ -8,6 +8,7 @@ CumsumFwdOp:
   ref_api: "torch.cumsum"
   family: scan
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -48,6 +49,7 @@ CumprodFwdOp:
   ref_api: "torch.cumprod"
   family: scan
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:

--- a/src/tileops/ops/_output_dtype.py
+++ b/src/tileops/ops/_output_dtype.py
@@ -1,0 +1,83 @@
+"""The dtype an op's fake reports, read off the manifest.
+
+A registered fake is all the compiler learns about an op's node, and the only statement
+about output dtype that holds for every target is the manifest's. So the fake reads it from
+here rather than from a kernel class, which would make the compiled graph depend on which
+target served the op.
+"""
+
+import torch
+
+from tileops.manifest import load_manifest
+from tileops.manifest.dtype_rules import promote_int_to_float_ref, same_as_ref
+
+__all__ = ["resolve_output_dtype"]
+
+#: What ``promote_int_to_float`` promotes an integral input to.
+_PROMOTED_FLOAT_DTYPE = torch.float32
+
+
+def _declared_expr(op_class_name: str, output: "str | None") -> str:
+    """The manifest ``signature.outputs`` dtype expression for one output.
+
+    Args:
+        op_class_name: Op class name, which is the manifest entry key.
+        output: Which output to read, or ``None`` for an op that declares one.
+
+    Returns:
+        The declared expression, e.g. ``"same_as(input)"`` or ``"bool"``.
+
+    Raises:
+        KeyError: The manifest has no entry for *op_class_name*, or no such output.
+        ValueError: *output* is ``None`` and the entry declares more than one.
+    """
+    entry = load_manifest().get(op_class_name)
+    if entry is None:
+        raise KeyError(
+            f"{op_class_name} has no manifest entry; the output dtype is "
+            "declared under signature.outputs"
+        )
+    outputs = entry["signature"]["outputs"]
+    if output is not None:
+        if output not in outputs:
+            raise KeyError(f"{op_class_name} declares no output named {output!r}")
+        return outputs[output]["dtype"]
+    if len(outputs) != 1:
+        raise ValueError(
+            f"{op_class_name} declares {len(outputs)} outputs, so the caller has to say "
+            "which one's dtype it wants"
+        )
+    return next(iter(outputs.values()))["dtype"]
+
+
+def resolve_output_dtype(
+    op_class_name: str,
+    input_dtype: torch.dtype,
+    output: "str | None" = None,
+) -> torch.dtype:
+    """Resolve an op's output dtype from its manifest declaration.
+
+    Args:
+        op_class_name: Op class name, which is the manifest entry key.
+        input_dtype: Dtype of the input the declaration refers to.
+        output: Which output to resolve. ``None`` for an op that declares one.
+
+    Returns:
+        The output dtype. ``same_as(...)`` and dtype unions follow the input;
+        ``promote_int_to_float(...)`` promotes integral inputs to float32; a
+        bare dtype name resolves to that dtype.
+
+    Raises:
+        ValueError: The declared expression names an unknown dtype.
+    """
+    expr = _declared_expr(op_class_name, output)
+    if same_as_ref(expr) is not None or "|" in expr:
+        return input_dtype
+    if promote_int_to_float_ref(expr) is not None:
+        if input_dtype.is_floating_point:
+            return input_dtype
+        return _PROMOTED_FLOAT_DTYPE
+    resolved = getattr(torch, expr, None)
+    if not isinstance(resolved, torch.dtype):
+        raise ValueError(f"{op_class_name}: manifest output dtype {expr!r} is not a torch dtype")
+    return resolved

--- a/src/tileops/ops/convolution.py
+++ b/src/tileops/ops/convolution.py
@@ -1352,9 +1352,7 @@ class Conv3dFwdOp(Op):
 # cannot appear; the instance comes back from the string key. See
 # src/tileops/ops/compile_boundary.py.
 #
-# Each fake returns ``new_empty``, not ``empty_like``: ``_eager_forward`` normalizes
-# contiguity, so a non-contiguous public input's strides must not survive into the fake.
-# The dtype is the manifest's ``same_as(input)``.
+# ``new_empty``, not ``empty_like``: a non-contiguous input's strides must not reach the fake.
 
 
 @torch.library.custom_op("top::conv_conv1d_fwd", mutates_args=())

--- a/src/tileops/ops/elementwise/_base.py
+++ b/src/tileops/ops/elementwise/_base.py
@@ -34,9 +34,8 @@ import torch
 
 from tileops.backend import Target
 from tileops.kernels.kernel_base import Kernel
-from tileops.manifest import load_manifest
-from tileops.manifest.dtype_rules import promote_int_to_float_ref, same_as_ref
 
+from .._output_dtype import resolve_output_dtype
 from ..compile_boundary import get_instance
 from ..op_base import Op
 
@@ -286,62 +285,6 @@ _PROMOTED_FLOAT_DTYPE = torch.float32
 
 
 @functools.lru_cache(maxsize=None)
-def _manifest_output_dtype_expr(op_class_name: str) -> str:
-    """Return the manifest ``signature.outputs`` dtype expression for an op.
-
-    Args:
-        op_class_name: Op class name, which is the manifest entry key.
-
-    Returns:
-        The declared dtype expression, e.g. ``"same_as(input)"`` or ``"bool"``.
-
-    Raises:
-        KeyError: If the manifest has no entry for *op_class_name*.
-        ValueError: If the entry declares other than exactly one output.
-    """
-    entry = load_manifest().get(op_class_name)
-    if entry is None:
-        raise KeyError(
-            f"{op_class_name} has no manifest entry; the output dtype is "
-            "declared under signature.outputs"
-        )
-    outputs = entry["signature"]["outputs"]
-    if len(outputs) != 1:
-        raise ValueError(
-            f"{op_class_name} declares {len(outputs)} outputs; the elementwise "
-            "bases resolve a single output dtype"
-        )
-    return next(iter(outputs.values()))["dtype"]
-
-
-def resolve_output_dtype(op_class_name: str, input_dtype: torch.dtype) -> torch.dtype:
-    """Resolve an op's output dtype from its manifest declaration.
-
-    Args:
-        op_class_name: Op class name, which is the manifest entry key.
-        input_dtype: Declared input dtype of the op instance.
-
-    Returns:
-        The output dtype. ``same_as(...)`` and dtype unions follow the input;
-        ``promote_int_to_float(...)`` promotes integral inputs to float32; a
-        bare dtype name resolves to that dtype.
-
-    Raises:
-        ValueError: If the declared expression names an unknown dtype.
-    """
-    expr = _manifest_output_dtype_expr(op_class_name)
-    if same_as_ref(expr) is not None or "|" in expr:
-        return input_dtype
-    if promote_int_to_float_ref(expr) is not None:
-        if input_dtype.is_floating_point:
-            return input_dtype
-        return _PROMOTED_FLOAT_DTYPE
-    resolved = getattr(torch, expr, None)
-    if not isinstance(resolved, torch.dtype):
-        raise ValueError(f"{op_class_name}: manifest output dtype {expr!r} is not a torch dtype")
-    return resolved
-
-
 def _require_one_device(op_name: str, **tensors: Optional[torch.Tensor]) -> None:
     """Refuse a call whose tensors are not all on one device.
 

--- a/src/tileops/ops/moe/routed_expert/gate_up.py
+++ b/src/tileops/ops/moe/routed_expert/gate_up.py
@@ -186,7 +186,5 @@ def _moe_gate_up_fwd_fake(
     shapes = op._infer_output_shapes(
         tuple(a.shape), tuple(b.shape), tuple(true_sizes.shape), tuple(true_offsets.shape)
     )
-    # ``new_empty``, not ``empty_like``: ``_eager_forward`` normalizes contiguity, so a
-    # non-contiguous public input's strides must not survive into the fake. Dtype is the
-    # manifest's ``same_as(a)``.
+    # ``new_empty``, not ``empty_like``: a non-contiguous input's strides must not reach the fake.
     return a.new_empty(shapes["c"])

--- a/src/tileops/ops/moe/routed_expert/moe_grouped_gemm_nopad.py
+++ b/src/tileops/ops/moe/routed_expert/moe_grouped_gemm_nopad.py
@@ -166,7 +166,5 @@ def _moe_grouped_gemm_nopad_fwd_fake(
     shapes = op._infer_output_shapes(
         tuple(a.shape), tuple(b.shape), tuple(true_sizes.shape), tuple(true_offsets.shape)
     )
-    # ``new_empty``, not ``empty_like``: ``_eager_forward`` normalizes contiguity, so a
-    # non-contiguous public input's strides must not survive into the fake. Dtype is the
-    # manifest's ``same_as(a)``.
+    # ``new_empty``, not ``empty_like``: a non-contiguous input's strides must not reach the fake.
     return a.new_empty(shapes["c"])

--- a/src/tileops/ops/norm/ada_layer_norm.py
+++ b/src/tileops/ops/norm/ada_layer_norm.py
@@ -117,8 +117,7 @@ class AdaLayerNormFwdOp(Op):
         if shift.shape != x.shape:
             raise ValueError(f"Expected shift shape {tuple(x.shape)}, got {tuple(shift.shape)}")
 
-        # The op normalizes contiguity and hands over what the manifest declares; how a
-        # kernel wants that laid out is its own business.
+        # Handed over as the manifest declares it; the layout a kernel wants is its own business.
         x = x.contiguous()
         scale = scale.contiguous()
         shift = shift.contiguous()
@@ -158,6 +157,5 @@ def _norm_ada_layer_norm_fwd_fake(
 ) -> torch.Tensor:
     op = get_instance(instance_key)
     shapes = op._infer_output_shapes(tuple(x.shape), tuple(scale.shape), tuple(shift.shape))
-    # ``new_empty``, not ``empty_like``: ``_eager_forward`` normalizes contiguity, so a
-    # non-contiguous public input's strides must not survive into the fake.
+    # ``new_empty``, not ``empty_like``: a non-contiguous input's strides must not reach the fake.
     return x.new_empty(shapes["output"])

--- a/src/tileops/ops/norm/ada_layer_norm_zero.py
+++ b/src/tileops/ops/norm/ada_layer_norm_zero.py
@@ -126,8 +126,7 @@ class AdaLayerNormZeroFwdOp(Op):
         if gate.shape != x.shape:
             raise ValueError(f"Expected gate shape {tuple(x.shape)}, got {tuple(gate.shape)}")
 
-        # The op normalizes contiguity and hands over what the manifest declares; how a
-        # kernel wants that laid out is its own business.
+        # Handed over as the manifest declares it; the layout a kernel wants is its own business.
         x = x.contiguous()
         scale = scale.contiguous()
         shift = shift.contiguous()
@@ -172,6 +171,5 @@ def _norm_ada_layer_norm_zero_fwd_fake(
     shapes = op._infer_output_shapes(
         tuple(x.shape), tuple(scale.shape), tuple(shift.shape), tuple(gate.shape)
     )
-    # ``new_empty``, not ``empty_like``: ``_eager_forward`` normalizes contiguity, so a
-    # non-contiguous public input's strides must not survive into the fake.
+    # ``new_empty``, not ``empty_like``: a non-contiguous input's strides must not reach the fake.
     return x.new_empty(shapes["output"])

--- a/src/tileops/ops/norm/batch_norm.py
+++ b/src/tileops/ops/norm/batch_norm.py
@@ -168,8 +168,7 @@ class BatchNormFwdOp(Op):
         self._validate_channel_tensor("bias", bias, C, x.device, torch.float32)
         self._bind_spec(C, L, dtype)
 
-        # The op normalizes contiguity and hands over what the manifest declares; how a
-        # kernel wants that laid out is its own business.
+        # Handed over as the manifest declares it; the layout a kernel wants is its own business.
         x = x.contiguous()
         weight = weight.contiguous()
         bias = bias.contiguous()

--- a/src/tileops/ops/norm/fused_add_layer_norm.py
+++ b/src/tileops/ops/norm/fused_add_layer_norm.py
@@ -136,8 +136,7 @@ class FusedAddLayerNormFwdOp(Op):
         if bias.ndim != 1 or bias.shape[0] != n:
             raise ValueError(f"Expected bias shape ({n},), got {tuple(bias.shape)}")
 
-        # The op normalizes contiguity and hands over what the manifest declares; how a
-        # kernel wants that laid out is its own business.
+        # Handed over as the manifest declares it; the layout a kernel wants is its own business.
         x = x.contiguous()
         residual = residual.contiguous()
         weight = weight.contiguous()

--- a/src/tileops/ops/norm/fused_add_rms_norm.py
+++ b/src/tileops/ops/norm/fused_add_rms_norm.py
@@ -130,8 +130,7 @@ class FusedAddRMSNormFwdOp(Op):
         if weight.ndim != 1 or weight.shape[0] != n:
             raise ValueError(f"Expected weight shape ({n},), got {tuple(weight.shape)}")
 
-        # The op normalizes contiguity and hands over what the manifest declares; how a
-        # kernel wants that laid out is its own business.
+        # Handed over as the manifest declares it; the layout a kernel wants is its own business.
         x = x.contiguous()
         residual = residual.contiguous()
         weight = weight.contiguous()

--- a/src/tileops/ops/norm/group_norm.py
+++ b/src/tileops/ops/norm/group_norm.py
@@ -189,8 +189,7 @@ class GroupNormFwdOp(Op):
 
         self._bind_spec(N, C, spatial_size, dtype, affine)
 
-        # The op normalizes contiguity and hands over what the manifest declares; how a
-        # kernel wants that laid out is its own business.
+        # Handed over as the manifest declares it; the layout a kernel wants is its own business.
         x = x.contiguous()
         if affine:
             weight = weight.contiguous()
@@ -238,6 +237,5 @@ def _norm_group_norm_fwd_fake(
         None if weight is None else tuple(weight.shape),
         None if bias is None else tuple(bias.shape),
     )
-    # ``new_empty``, not ``empty_like``: ``_eager_forward`` normalizes contiguity, so a
-    # non-contiguous public input's strides must not survive into the fake.
+    # ``new_empty``, not ``empty_like``: a non-contiguous input's strides must not reach the fake.
     return x.new_empty(shapes["output"])

--- a/src/tileops/ops/norm/instance_norm.py
+++ b/src/tileops/ops/norm/instance_norm.py
@@ -317,8 +317,7 @@ class InstanceNormFwdOp(Op):
             y = (x.float() - mean_b) * torch.rsqrt(var_b + self.eps)
             return y.to(x.dtype)
 
-        # The op normalizes contiguity and hands over what the manifest declares; how a
-        # kernel wants that laid out is its own business.
+        # Handed over as the manifest declares it; the layout a kernel wants is its own business.
         x = x.contiguous()
         if affine:
             weight = weight.contiguous()
@@ -377,6 +376,5 @@ def _norm_instance_norm_fwd_fake(
         None if weight is None else tuple(weight.shape),
         None if bias is None else tuple(bias.shape),
     )
-    # ``new_empty``, not ``empty_like``: ``_eager_forward`` normalizes contiguity, so a
-    # non-contiguous public input's strides must not survive into the fake.
+    # ``new_empty``, not ``empty_like``: a non-contiguous input's strides must not reach the fake.
     return x.new_empty(shapes["output"])

--- a/src/tileops/ops/norm/layer_norm.py
+++ b/src/tileops/ops/norm/layer_norm.py
@@ -147,8 +147,7 @@ class LayerNormFwdOp(Op):
         if tuple(bias.shape) != ns:
             raise ValueError(f"Expected bias shape {ns}, got {tuple(bias.shape)}")
 
-        # The op normalizes contiguity and hands over what the manifest declares; how a
-        # kernel wants that laid out is its own business.
+        # Handed over as the manifest declares it; the layout a kernel wants is its own business.
         x = x.contiguous()
         weight = weight.contiguous()
         bias = bias.contiguous()
@@ -186,6 +185,5 @@ def _layer_norm_fwd_fake(
 ) -> torch.Tensor:
     op = get_instance(instance_key)
     shapes = op._infer_output_shapes(tuple(x.shape), tuple(weight.shape), tuple(bias.shape))
-    # ``new_empty``, not ``empty_like``: ``_eager_forward`` normalizes contiguity, so a
-    # non-contiguous public input's strides must not survive into the fake.
+    # ``new_empty``, not ``empty_like``: a non-contiguous input's strides must not reach the fake.
     return x.new_empty(shapes["output"])

--- a/src/tileops/ops/norm/rms_norm.py
+++ b/src/tileops/ops/norm/rms_norm.py
@@ -145,8 +145,7 @@ class RMSNormFwdOp(Op):
         if tuple(weight.shape) != ns:
             raise ValueError(f"Expected weight shape {ns}, got {tuple(weight.shape)}")
 
-        # The op normalizes contiguity and hands over what the manifest declares; how a
-        # kernel wants that laid out is its own business.
+        # Handed over as the manifest declares it; the layout a kernel wants is its own business.
         x = x.contiguous()
         weight = weight.contiguous()
         kernel = self.get_or_build_kernel(
@@ -188,7 +187,5 @@ def _rms_norm_fwd_fake(
 ) -> torch.Tensor:
     op = get_instance(instance_key)
     shapes = op._infer_output_shapes(tuple(x.shape), tuple(weight.shape))
-    # ``new_empty``, not ``empty_like``: ``_eager_forward`` normalizes contiguity, so a
-    # non-contiguous public input's strides must not survive into the fake. Dtype is the
-    # manifest's ``same_as(x)``.
+    # ``new_empty``, not ``empty_like``: a non-contiguous input's strides must not reach the fake.
     return x.new_empty(shapes["output"])

--- a/src/tileops/ops/pool.py
+++ b/src/tileops/ops/pool.py
@@ -1332,8 +1332,7 @@ def _register_pool_operator(op_cls: type, name: str) -> None:
             instance_key: str,
         ) -> Tuple[torch.Tensor, torch.Tensor]:
             shapes = get_instance(instance_key)._infer_output_shapes(tuple(input.shape))
-            # ``new_empty``, not ``empty_like``: ``_eager_forward`` normalizes contiguity, so
-            # a non-contiguous input's strides must not survive into the fake.
+            # ``new_empty``, not ``empty_like``: a non-contiguous input's strides must not reach the fake.
             return (
                 input.new_empty(shapes["output"]),
                 input.new_empty(shapes["indices"], dtype=torch.int64),

--- a/src/tileops/ops/reduction/_boundary.py
+++ b/src/tileops/ops/reduction/_boundary.py
@@ -1,0 +1,100 @@
+"""The reduction family's compile boundary: one opaque operator per op.
+
+Every op in this family takes one tensor, so what differs between them is only how many
+tensors come back. Two factories cover that, and both put the boundary in the op layer:
+the node in a traced graph is the op's, which is what keeps the graph the same when
+another target serves the op.
+
+The fake reads its shape from the op's ``_infer_output_shapes`` and its dtype from the
+manifest, never from a kernel class. The operator's name comes from the manifest too — the
+family and the entry key — so ``compile_op_names`` and the name cannot drift apart.
+"""
+
+import re
+
+import torch
+
+from tileops.manifest import load_manifest
+
+from .._output_dtype import resolve_output_dtype
+from ..compile_boundary import get_instance
+
+__all__ = ["register_reduction_op"]
+
+
+def _snake(name: str) -> str:
+    """``"VarMeanFwdOp"`` -> ``"var_mean_fwd"``."""
+    spaced = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", name)
+    return re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", spaced).lower().removesuffix("_op")
+
+
+def register_reduction_op(op_cls) -> None:
+    """Register *op_cls* as one opaque operator and name it on the class.
+
+    Sets ``op_cls._wrapped``, which the op's ``forward`` calls, and
+    ``op_cls.compile_op_names``, which lets a test assert the traced graph holds nothing
+    else.
+
+    Raises:
+        KeyError: *op_cls* has no manifest entry.
+        ValueError: The entry declares a number of outputs no factory here covers.
+    """
+    entry = load_manifest().get(op_cls.__name__)
+    if entry is None:
+        raise KeyError(
+            f"{op_cls.__name__} registers a compile boundary but has no manifest entry; "
+            "the operator name, the output names and their dtypes all come from it"
+        )
+    op_name = f"top::{entry['family']}_{_snake(op_cls.__name__)}"
+    outputs = tuple(entry["signature"]["outputs"])
+    if len(outputs) == 1:
+        _register_single(op_cls, op_name, outputs[0])
+    elif len(outputs) == 2:
+        _register_pair(op_cls, op_name, outputs)
+    else:
+        raise ValueError(
+            f"{op_cls.__name__} declares {len(outputs)} outputs; this family registers one or two"
+        )
+    op_cls.compile_op_names = (op_name,)
+
+
+def _register_single(op_cls, op_name: str, output: str) -> None:
+    """Register the operator for an op returning one tensor."""
+
+    @torch.library.custom_op(op_name, mutates_args=())
+    def _wrapped(x: torch.Tensor, instance_key: str) -> torch.Tensor:
+        return get_instance(instance_key)._eager_forward(x)
+
+    @_wrapped.register_fake
+    def _(x: torch.Tensor, instance_key: str) -> torch.Tensor:
+        op = get_instance(instance_key)
+        shapes = op._infer_output_shapes(tuple(x.shape))
+        # ``new_empty``, not ``empty_like``: the real path writes fresh contiguous storage.
+        return x.new_empty(
+            shapes[output],
+            dtype=resolve_output_dtype(op_cls.__name__, x.dtype, output),
+        )
+
+    op_cls._wrapped = _wrapped
+
+
+def _register_pair(op_cls, op_name: str, outputs: "tuple[str, str]") -> None:
+    """Register the operator for an op returning two tensors."""
+    first, second = outputs
+
+    @torch.library.custom_op(op_name, mutates_args=())
+    def _wrapped(x: torch.Tensor, instance_key: str) -> "tuple[torch.Tensor, torch.Tensor]":
+        return get_instance(instance_key)._eager_forward(x)
+
+    @_wrapped.register_fake
+    def _(x: torch.Tensor, instance_key: str) -> "tuple[torch.Tensor, torch.Tensor]":
+        op = get_instance(instance_key)
+        shapes = op._infer_output_shapes(tuple(x.shape))
+        return (
+            x.new_empty(shapes[first], dtype=resolve_output_dtype(op_cls.__name__, x.dtype, first)),
+            x.new_empty(
+                shapes[second], dtype=resolve_output_dtype(op_cls.__name__, x.dtype, second)
+            ),
+        )
+
+    op_cls._wrapped = _wrapped

--- a/src/tileops/ops/reduction/_boundary.py
+++ b/src/tileops/ops/reduction/_boundary.py
@@ -69,7 +69,7 @@ def _register_single(op_cls, op_name: str, output: str) -> None:
     def _(x: torch.Tensor, instance_key: str) -> torch.Tensor:
         op = get_instance(instance_key)
         shapes = op._infer_output_shapes(tuple(x.shape))
-        # ``new_empty``, not ``empty_like``: the real path writes fresh contiguous storage.
+        # ``new_empty``, not ``empty_like``: a non-contiguous input's strides must not reach the fake.
         return x.new_empty(
             shapes[output],
             dtype=resolve_output_dtype(op_cls.__name__, x.dtype, output),

--- a/src/tileops/ops/reduction/_multidim.py
+++ b/src/tileops/ops/reduction/_multidim.py
@@ -1,24 +1,17 @@
-"""Multi-dim reduction utilities for the Op layer.
+"""How a reduction op reads its ``dim`` param.
 
-Provides helpers to flatten multiple reduction dims into a single dim,
-so that existing single-dim kernels can handle ``dim=list[int]`` by
-reducing over the flattened dimension.
-
-Strategy: move all target dims to the end, flatten them into one dim,
-reduce along that single dim, then restore the output shape with or
-without keepdim.
+Turning ``dim`` into the axes a call reduces is the op's contract: which forms an empty
+``dim`` takes, and which values a given rank accepts, differ per op and are declared in
+the manifest. What a kernel then does with those axes — the permute to rows and back —
+lives in :mod:`tileops.kernels.reduction._primitives`.
 """
 
 from __future__ import annotations
 
 from typing import Literal, Union
 
-import torch
-
 __all__ = [
-    "flatten_for_multidim",
     "normalize_dim",
-    "restore_multidim_shape",
 ]
 
 EmptyDimPolicy = Literal["reject", "full", "noop"]
@@ -84,77 +77,3 @@ def normalize_dim(
         raise ValueError(f"Duplicate dims in reduction: {dims}")
 
     return sorted(normalized)
-
-
-def flatten_for_multidim(
-    x: torch.Tensor,
-    dims: list[int],
-) -> tuple[torch.Tensor, torch.Size, list[int]]:
-    """Move target dims to end and flatten them into one dim.
-
-    Args:
-        x: Input tensor (any shape).
-        dims: Sorted list of non-negative dim indices to reduce.
-
-    Returns:
-        (x_reshaped, orig_shape, kept_dims) where:
-        - x_reshaped has the target dims flattened into the last dim
-        - orig_shape is the original tensor shape
-        - kept_dims is the list of dims NOT being reduced (in order)
-    """
-    orig_shape = x.shape
-    ndim = x.ndim
-
-    # Determine which dims are kept vs reduced.
-    kept_dims = [i for i in range(ndim) if i not in dims]
-
-    # Permute: kept dims first, then reduced dims.
-    perm = kept_dims + dims
-    x = x.permute(perm).contiguous()
-
-    # Compute shapes.
-    kept_shape = [orig_shape[i] for i in kept_dims]
-    reduced_size = 1
-    for d in dims:
-        reduced_size *= orig_shape[d]
-
-    # Flatten reduced dims into one.
-    # All dims being reduced -> (1, reduced_size); otherwise append flattened dim.
-    new_shape = kept_shape + [reduced_size] if kept_shape else [1, reduced_size]
-
-    x = x.reshape(new_shape)
-    return x, orig_shape, kept_dims
-
-
-def restore_multidim_shape(
-    y: torch.Tensor,
-    orig_shape: torch.Size,
-    dims: list[int],
-    keepdim: bool,
-) -> torch.Tensor:
-    """Reshape the output of a single-dim reduction back to multi-dim output shape.
-
-    Args:
-        y: Output tensor from single-dim reduction (reduced dim removed).
-        orig_shape: Original input tensor shape.
-        dims: Sorted list of non-negative dim indices that were reduced.
-        keepdim: Whether to retain reduced dims as size 1.
-
-    Returns:
-        Tensor with the correct output shape.
-    """
-    ndim = len(orig_shape)
-    kept_dims = [i for i in range(ndim) if i not in dims]
-
-    if keepdim:
-        # Build shape with 1 at each reduced dim position.
-        out_shape = list(orig_shape)
-        for d in dims:
-            out_shape[d] = 1
-        return y.reshape(out_shape)
-    else:
-        # Output shape is just the kept dims.
-        out_shape = [orig_shape[i] for i in kept_dims]
-        if not out_shape:
-            return y.squeeze()
-        return y.reshape(out_shape)

--- a/src/tileops/ops/reduction/argreduce.py
+++ b/src/tileops/ops/reduction/argreduce.py
@@ -1,84 +1,46 @@
 """Arg-reduction operators (argmax, argmin)."""
 
 from math import prod
-from typing import Dict, Optional, Tuple, Union
+from typing import Dict, Optional
 
 import torch
 
+from tileops.backend import Target
 from tileops.kernels.kernel_base import Kernel
-from tileops.kernels.reduction.argreduce import _STRIDED_AXIS_MAX_N, ArgreduceKernel
+from tileops.kernels.reduction.argreduce import ArgreduceKernel
 
+from ._boundary import register_reduction_op
 from .reduce import _ReduceOpBase
 
 __all__ = ["ArgmaxFwdOp", "ArgminFwdOp"]
 
 
 class _ArgreduceOpBase(_ReduceOpBase):
-    """Reduce a non-last axis in place rather than transposing to reach it.
+    """Tell the kernel the reduced axis's stride, and let it pick the layout.
 
-    The base transposes so the reduction axis is last, which copies the whole
-    tensor. When the input is contiguous the copy is avoidable: the output axis
-    is the contiguous one, so a kernel that assigns a thread per output element
-    and strides along the reduction axis reads the original buffer coalesced.
-    Only the preparation differs, so that is all this overrides.
+    Reducing a non-last axis can be done two ways: transpose so the axis is last, which
+    copies the whole tensor, or give a thread each output element and stride along the
+    axis, which reads the original buffer coalesced. Which one pays off follows from the
+    row count, the axis length and its stride — all three facts the kernel already holds,
+    so the choice is the kernel's (:class:`~tileops.kernels.reduction.argreduce.ArgreduceKernel`).
+    This op's part is the stride, which the shape and the reduced axis decide.
     """
 
-    def _get_or_create_strided_kernel(
-        self,
-        inputs: "tuple[torch.Tensor | None, ...]",
-        M: int,
-        N: int,
-        inner_stride: int,
-        dtype,
-    ):
-        return self.get_or_build_kernel(
-            self._kernel_key,
-            inputs,
-            key=(M, N, dtype, inner_stride),
-            build=lambda: self.kernel_map[self._kernel_key](
-                M,
-                N,
-                self._op_kind,
-                dtype,
-                inner_stride=inner_stride,
-                tune=self.tune,
-                **self._build_kernel_kwargs(),
-            ),
-        )
+    def _build_kernel_kwargs(self, x: torch.Tensor, axes: "tuple[int, ...]") -> dict:
+        """Elements between two neighbours along the reduced axis, on top of the shared set.
 
-    def _prepare_input(
-        self,
-        x: torch.Tensor,
-    ) -> Tuple[torch.Tensor, torch.Size, Union[int, list], object]:
-        # Binds self.dtype, which the strided path below never reaches.
-        self._validate_input_tensor(x)
-        if self.dim is None or not x.is_contiguous():
-            return super()._prepare_input(x)
-        if self.dim < -x.ndim or self.dim >= x.ndim:
-            return super()._prepare_input(x)  # the base raises with the right message
-        dim = self.dim % x.ndim
-        inner_stride = prod(x.shape[dim + 1 :])
-        if inner_stride == 1:
-            return super()._prepare_input(x)
-
-        N = x.shape[dim]
-        if N > _STRIDED_AXIS_MAX_N:
-            # A long axis is faster transposed and reduced in parallel than
-            # walked serially by one thread per output.
-            return super()._prepare_input(x)
-
-        M = prod(s for i, s in enumerate(x.shape) if i != dim)
-        self._last_roofline_mn = (M, N)
-        kernel = self._get_or_create_strided_kernel((x,), M, N, inner_stride, x.dtype)
-        return x.reshape(-1), x.shape, dim, kernel
+        One for the last axis and for a full reduction, which is the flattened buffer.
+        """
+        return {
+            **super()._build_kernel_kwargs(x, axes),
+            "inner_stride": prod(x.shape[axes[-1] + 1 :]) if len(axes) == 1 else 1,
+        }
 
 
 class ArgmaxFwdOp(_ArgreduceOpBase):
     """Argmax reduction along an arbitrary dim, returning int64 indices.
 
-    Construction: ``ArgmaxFwdOp(dim=None, keepdim=False)``.  M and N are
-    derived from the input tensor at forward time, and kernels are cached
-    by ``(M, N)`` to avoid rebuilds.
+    Construction: ``ArgmaxFwdOp(dim=None, keepdim=False)``.
 
     Args:
         dim: Reduction dimension. ``None`` (the default) matches
@@ -86,6 +48,8 @@ class ArgmaxFwdOp(_ArgreduceOpBase):
             contiguous flattened 1D buffer and the returned index is into
             that flattened tensor.
         keepdim: Whether to retain the reduced dimension as size 1.
+        target: Which set of kernels serves this op — a target name, ``BUILTIN``
+            for the in-tree kernels, or ``None`` to decide from the input device.
         kernel_map: Optional custom kernel map.
         tune: Whether to autotune the kernel.
     """
@@ -99,12 +63,14 @@ class ArgmaxFwdOp(_ArgreduceOpBase):
         dim: Optional[int] = None,
         keepdim: bool = False,
         *,
+        target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
         super().__init__(
             dim=dim,
             keepdim=keepdim,
+            target=target,
             kernel_map=kernel_map,
             tune=tune,
         )
@@ -127,9 +93,7 @@ class ArgmaxFwdOp(_ArgreduceOpBase):
 class ArgminFwdOp(_ArgreduceOpBase):
     """Argmin reduction along an arbitrary dim, returning int64 indices.
 
-    Construction: ``ArgminFwdOp(dim=None, keepdim=False)``.  M and N are
-    derived from the input tensor at forward time, and kernels are cached
-    by ``(M, N)`` to avoid rebuilds.
+    Construction: ``ArgminFwdOp(dim=None, keepdim=False)``.
 
     Args:
         dim: Reduction dimension. ``None`` (the default) matches
@@ -137,6 +101,8 @@ class ArgminFwdOp(_ArgreduceOpBase):
             contiguous flattened 1D buffer and the returned index is into
             that flattened tensor.
         keepdim: Whether to retain the reduced dimension as size 1.
+        target: Which set of kernels serves this op — a target name, ``BUILTIN``
+            for the in-tree kernels, or ``None`` to decide from the input device.
         kernel_map: Optional custom kernel map.
         tune: Whether to autotune the kernel.
     """
@@ -150,12 +116,14 @@ class ArgminFwdOp(_ArgreduceOpBase):
         dim: Optional[int] = None,
         keepdim: bool = False,
         *,
+        target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
         super().__init__(
             dim=dim,
             keepdim=keepdim,
+            target=target,
             kernel_map=kernel_map,
             tune=tune,
         )
@@ -173,3 +141,10 @@ class ArgminFwdOp(_ArgreduceOpBase):
             f"ArgminFwdOp only supports scalar dim (int) or None, "
             f"got {type(self.dim).__name__}: {self.dim!r}"
         )
+
+
+for _op_cls in (
+    ArgmaxFwdOp,
+    ArgminFwdOp,
+):
+    register_reduction_op(_op_cls)

--- a/src/tileops/ops/reduction/cumulative.py
+++ b/src/tileops/ops/reduction/cumulative.py
@@ -1,14 +1,16 @@
 """Cumulative scan operators (cumsum, cumprod)."""
 
-from abc import abstractmethod
+from math import prod
 from typing import Dict, Optional, Tuple
 
 import torch
 
+from tileops.backend import Target
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.reduction.cumulative import CumulativeKernel
 
 from ..op_base import Op
+from ._boundary import register_reduction_op
 
 __all__ = ["CumprodFwdOp", "CumsumFwdOp", "CumulativeOp"]
 
@@ -22,26 +24,28 @@ class CumulativeOp(Op):
     Args:
         dim: Reduction axis (default -1). Negative values are normalized at
             forward time (`dim % x.ndim`).
+        target: Which set of kernels serves this op — a target name, ``BUILTIN``
+            for the in-tree kernels, or ``None`` to decide from the input device.
         kernel_map: Optional kernel override dict.
         tune: If True, autotune tile configs.
     """
 
     _op_kind: str
 
-    # `static_dims.N = x.shape[dim]` is param-dependent (depends on `dim`),
-    # so the static-axis frozenset is bound at forward time after dim
-    # normalization, not at the class level (per docs/design/ops-design.md § Step 3).
-    _static_axes: frozenset = frozenset()
+    #: Set by ``register_reduction_op`` on each concrete op; a base registers none.
+    _wrapped = None
 
     def __init__(
         self,
         dim: int = -1,
         *,
+        target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
         self.N = None
         self.dim = dim
+        self.target = target
         self.tune = tune
         self.dispatch_kernel(kernel_map)
         self._last_roofline_mn: Optional[Tuple[int, int]] = None
@@ -71,75 +75,57 @@ class CumulativeOp(Op):
         # Read x + write y = 2 * M * N elements.
         return (M * N, 2 * M * N * elem_bytes)
 
-    def _get_kernel(
-        self,
-        inputs: "tuple[torch.Tensor | None, ...]",
-        M: int,
-        N: int,
-        dtype: torch.dtype,
-        device_index: int | None,
-    ) -> Kernel:
-        """Return a kernel built for (M, N, dtype), caching by specialization.
+    def _validate_and_normalize_dim(self, x: torch.Tensor) -> int:
+        """Validate the input and return the non-negative axis to scan.
 
-        A cache miss builds a Kernel, so a ``fullgraph=True`` caller must warm
-        every (M, N, dtype, device) it will feed the compiled callable.
+        Which devices a set of kernels runs on is the kernel's own statement, so no
+        device kind is checked here.
+
+        Raises:
+            ValueError: ``dim`` names an axis this rank does not have.
         """
-        key = (M, N, dtype, device_index)
-        return self.get_or_build_kernel(
-            "cumulative_fwd",
-            inputs,
-            key=key,
-            build=lambda: self.kernel_map["cumulative_fwd"](
-                M,
-                N,
-                self._op_kind,
-                dtype,
-                tune=self.tune,
-            ),
-        )
-
-    def _validate_and_normalize_dim(self, x: torch.Tensor) -> tuple[int, int, torch.dtype]:
-        if not x.is_cuda:
-            raise ValueError("x must be a CUDA tensor")
         self._validate_dtypes(x)
         ndim = x.ndim
         if not (-ndim <= self.dim < ndim):
             raise ValueError(f"dim={self.dim} out of range for {ndim}-D input")
-        dim_norm = self.dim % ndim
-        N = x.shape[dim_norm]
-        self.N = N
         self.dtype = x.dtype
-        # Bind the dynamic static-axis (param-dependent N axis) so
-        # Op-layer cache-key / introspection consumers see the committed axis.
-        self._static_axes = frozenset({(0, dim_norm)})
-        return dim_norm, N, x.dtype
+        return self.dim % ndim
 
-    @abstractmethod
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Subclasses implement: validate, movedim, kernel call, restore."""
-        raise NotImplementedError
+        """Run the scan.
 
-    def _run(self, x: torch.Tensor) -> torch.Tensor:
-        """Shared forward implementation. Subclasses call this from `forward`."""
-        ndim = x.ndim
-        # The tensor this op declares, before the row layout its kernel wants.
-        declared = x
-        dim_norm, N, dtype = self._validate_and_normalize_dim(x)
+        One call to the operator this op registers: this is as far as dynamo traces.
+        """
+        return type(self)._wrapped(x, self._instance_key)
 
-        if dim_norm != ndim - 1:
-            x = x.movedim(dim_norm, -1)
-        post_move_shape = tuple(x.shape)
-        x = x.contiguous().reshape(-1, N)
-        M = x.shape[0]
+    def _eager_forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Validate, resolve the kernel and launch, inside the operator.
 
-        # Alignment padding is handled inside the kernel via masked loads.
-        y = self._get_kernel((declared,), M, N, dtype, x.device.index)(x)
-        self._last_roofline_mn = (M, N)
-
-        y = y.reshape(post_move_shape)
-        if dim_norm != ndim - 1:
-            y = y.movedim(-1, dim_norm)
-        return y
+        Never traced: kernel construction enters a TileLang builder.
+        """
+        axis = self._validate_and_normalize_dim(x)
+        x = x.contiguous()  # handed over as the manifest declares it
+        n = x.shape[axis]
+        self.N = n
+        # From the shape, not from ``numel``: an empty scanned axis makes ``n`` zero.
+        m = prod(d for i, d in enumerate(x.shape) if i != axis)
+        self._last_roofline_mn = (m, n)
+        kernel = self.get_or_build_kernel(
+            "cumulative_fwd",
+            (x,),
+            # The kernel owns the permute, so the whole shape decides which kernel it is.
+            key=(tuple(x.shape), axis, x.dtype, x.device.index),
+            build=lambda: self.kernel_map["cumulative_fwd"](
+                m,
+                n,
+                self._op_kind,
+                x.dtype,
+                scan_axis=axis,
+                tune=self.tune,
+                device_index=x.device.index,
+            ),
+        )
+        return kernel(x)
 
 
 class CumsumFwdOp(CumulativeOp):
@@ -154,6 +140,8 @@ class CumsumFwdOp(CumulativeOp):
     Args:
         dim: Reduction axis (default -1). Negative values are normalized
             at forward time.
+        target: Which set of kernels serves this op — a target name, ``BUILTIN``
+            for the in-tree kernels, or ``None`` to decide from the input device.
         kernel_map: Optional override for kernel dispatch.
         tune: Whether to autotune (default False).
 
@@ -165,9 +153,6 @@ class CumsumFwdOp(CumulativeOp):
 
     _op_kind = "sum"
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return self._run(x)
-
 
 class CumprodFwdOp(CumulativeOp):
     """Cumulative product operator: ``y = cumprod(x, dim)``.
@@ -178,6 +163,8 @@ class CumprodFwdOp(CumulativeOp):
     Args:
         dim: Reduction axis (default -1). Negative values are normalized
             at forward time.
+        target: Which set of kernels serves this op — a target name, ``BUILTIN``
+            for the in-tree kernels, or ``None`` to decide from the input device.
         kernel_map: Optional override for kernel dispatch.
         tune: Whether to autotune (default False).
 
@@ -189,5 +176,6 @@ class CumprodFwdOp(CumulativeOp):
 
     _op_kind = "prod"
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return self._run(x)
+
+for _op_cls in (CumsumFwdOp, CumprodFwdOp):
+    register_reduction_op(_op_cls)

--- a/src/tileops/ops/reduction/logical_reduce.py
+++ b/src/tileops/ops/reduction/logical_reduce.py
@@ -4,14 +4,12 @@ from typing import Dict, List, Optional, Tuple, Union
 
 import torch
 
+from tileops.backend import Target
 from tileops.kernels.kernel_base import Kernel
-from tileops.kernels.reduction.logical_reduce import (
-    _UNSUPPORTED_STORAGE_DTYPES,
-    LogicalReduceKernel,
-    to_logical_float32,
-)
+from tileops.kernels.reduction.logical_reduce import LogicalReduceKernel
 from tileops.manifest.shape_rules import reduced_shape
 
+from ._boundary import register_reduction_op
 from ._multidim import EmptyDimPolicy
 from .reduce import _ReduceOpBase
 
@@ -21,13 +19,13 @@ __all__ = ["AllFwdOp", "AnyFwdOp", "CountNonzeroFwdOp"]
 class AllFwdOp(_ReduceOpBase):
     """All reduction along ``dim``, returning bool.
 
-    Construction: ``AllFwdOp(dim=None, keepdim=False)``.  M and N
+    Construction: ``AllFwdOp(dim=None, keepdim=False)``.
     are derived from the input tensor at forward time, and kernels are
     cached by ``(M, N)`` to avoid rebuilds.
 
     Supports any numeric dtype including torch.bool, int32, int64, and complex
-    types. Inputs with unsupported TileLang storage dtypes (bool, int32, int64,
-    complex64, complex128) are pre-converted to float32 in forward().
+    types. A dtype TileLang cannot store as shared memory is converted inside the
+    kernel, so this op hands over the tensor its manifest declares.
 
     Empty-dim contract: ``dim=[]`` / ``dim=()`` is a no-op -- forward returns
     ``x.bool()`` with the input shape, matching ``torch.all`` semantics.
@@ -37,6 +35,8 @@ class AllFwdOp(_ReduceOpBase):
             Accepts ``int``, ``list[int]``, or ``tuple[int, ...]`` for
             multi-dim reduction.
         keepdim: Whether to retain the reduced dimension as size 1.
+        target: Which set of kernels serves this op — a target name, ``BUILTIN``
+            for the in-tree kernels, or ``None`` to decide from the input device.
         kernel_map: Optional custom kernel map.
         tune: Whether to autotune the kernel.
     """
@@ -51,6 +51,7 @@ class AllFwdOp(_ReduceOpBase):
         dim: Union[int, List[int], Tuple[int, ...], None] = None,
         keepdim: bool = False,
         *,
+        target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
@@ -61,12 +62,15 @@ class AllFwdOp(_ReduceOpBase):
                 Accepts ``int``, ``list[int]``, ``tuple[int, ...]``, or
                 ``None``.
             keepdim: Whether to retain reduced dims as size 1.
+            target: Which set of kernels serves this op — a target name, ``BUILTIN``
+                for the in-tree kernels, or ``None`` to decide from the input device.
             kernel_map: Optional override for kernel dispatch.
             tune: Whether to autotune (default ``False``).
         """
         super().__init__(
             dim=dim,
             keepdim=keepdim,
+            target=target,
             kernel_map=kernel_map,
             tune=tune,
         )
@@ -75,23 +79,17 @@ class AllFwdOp(_ReduceOpBase):
         """All returns bool per manifest contract."""
         return torch.bool
 
-    def _pre_kernel(self, x: torch.Tensor) -> Tuple[torch.Tensor, object]:
-        """Convert unsupported storage dtypes to float32."""
-        if x.dtype in _UNSUPPORTED_STORAGE_DTYPES:
-            x = to_logical_float32(x)
-        return x, None
-
 
 class AnyFwdOp(_ReduceOpBase):
     """Any reduction along ``dim``, returning bool.
 
-    Construction: ``AnyFwdOp(dim=None, keepdim=False)``.  M and N
+    Construction: ``AnyFwdOp(dim=None, keepdim=False)``.
     are derived from the input tensor at forward time, and kernels are
     cached by ``(M, N)`` to avoid rebuilds.
 
     Supports any numeric dtype including torch.bool, int32, int64, and complex
-    types. Inputs with unsupported TileLang storage dtypes (bool, int32, int64,
-    complex64, complex128) are pre-converted to float32 in forward().
+    types. A dtype TileLang cannot store as shared memory is converted inside the
+    kernel, so this op hands over the tensor its manifest declares.
 
     Empty-dim contract: ``dim=[]`` / ``dim=()`` is a no-op -- forward returns
     ``x.bool()`` with the input shape, matching ``torch.any`` semantics.
@@ -101,6 +99,8 @@ class AnyFwdOp(_ReduceOpBase):
             Accepts ``int``, ``list[int]``, or ``tuple[int, ...]`` for
             multi-dim reduction.
         keepdim: Whether to retain the reduced dimension as size 1.
+        target: Which set of kernels serves this op — a target name, ``BUILTIN``
+            for the in-tree kernels, or ``None`` to decide from the input device.
         kernel_map: Optional custom kernel map.
         tune: Whether to autotune the kernel.
     """
@@ -115,6 +115,7 @@ class AnyFwdOp(_ReduceOpBase):
         dim: Union[int, List[int], Tuple[int, ...], None] = None,
         keepdim: bool = False,
         *,
+        target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
@@ -125,12 +126,15 @@ class AnyFwdOp(_ReduceOpBase):
                 Accepts ``int``, ``list[int]``, ``tuple[int, ...]``, or
                 ``None``.
             keepdim: Whether to retain reduced dims as size 1.
+            target: Which set of kernels serves this op — a target name, ``BUILTIN``
+                for the in-tree kernels, or ``None`` to decide from the input device.
             kernel_map: Optional override for kernel dispatch.
             tune: Whether to autotune (default ``False``).
         """
         super().__init__(
             dim=dim,
             keepdim=keepdim,
+            target=target,
             kernel_map=kernel_map,
             tune=tune,
         )
@@ -139,31 +143,25 @@ class AnyFwdOp(_ReduceOpBase):
         """Any returns bool per manifest contract."""
         return torch.bool
 
-    def _pre_kernel(self, x: torch.Tensor) -> Tuple[torch.Tensor, object]:
-        """Convert unsupported storage dtypes to float32."""
-        if x.dtype in _UNSUPPORTED_STORAGE_DTYPES:
-            x = to_logical_float32(x)
-        return x, None
-
 
 class CountNonzeroFwdOp(_ReduceOpBase):
     """Count nonzero reduction along ``dim``, returning int64.
 
-    Construction: ``CountNonzeroFwdOp(dim=None)``.  M and N are
-    derived from the input tensor at forward time, and kernels are cached
-    by ``(M, N)`` to avoid rebuilds.
+    Construction: ``CountNonzeroFwdOp(dim=None)``.
 
     Note: No ``keepdim`` parameter -- the reduction dimension is always
     removed, matching ``torch.count_nonzero`` semantics.
 
     Supports any numeric dtype including torch.bool, int32, int64, and complex
-    types. Inputs with unsupported TileLang storage dtypes (bool, int32, int64,
-    complex64, complex128) are pre-converted to float32 in forward().
+    types. A dtype TileLang cannot store as shared memory is converted inside the
+    kernel, so this op hands over the tensor its manifest declares.
 
     Args:
         dim: Reduction dimension (default ``None``, i.e. full reduction).
             Accepts ``int``, ``list[int]``, or ``tuple[int, ...]`` for
             multi-dim reduction.
+        target: Which set of kernels serves this op — a target name, ``BUILTIN``
+            for the in-tree kernels, or ``None`` to decide from the input device.
         kernel_map: Optional custom kernel map.
         tune: Whether to autotune the kernel.
     """
@@ -177,6 +175,7 @@ class CountNonzeroFwdOp(_ReduceOpBase):
         self,
         dim: Union[int, List[int], Tuple[int, ...], None] = None,
         *,
+        target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
@@ -184,6 +183,7 @@ class CountNonzeroFwdOp(_ReduceOpBase):
         super().__init__(
             dim=dim,
             keepdim=False,
+            target=target,
             kernel_map=kernel_map,
             tune=tune,
         )
@@ -202,8 +202,10 @@ class CountNonzeroFwdOp(_ReduceOpBase):
         """
         return torch.int64
 
-    def _pre_kernel(self, x: torch.Tensor) -> Tuple[torch.Tensor, object]:
-        """Convert unsupported storage dtypes to float32."""
-        if x.dtype in _UNSUPPORTED_STORAGE_DTYPES:
-            x = to_logical_float32(x)
-        return x, None
+
+for _op_cls in (
+    AllFwdOp,
+    AnyFwdOp,
+    CountNonzeroFwdOp,
+):
+    register_reduction_op(_op_cls)

--- a/src/tileops/ops/reduction/reduce.py
+++ b/src/tileops/ops/reduction/reduce.py
@@ -5,11 +5,12 @@ The ``dim`` parameter accepts ``int``, ``list[int]``, or ``tuple[int, ...]``
 for multi-dim reduction. Constructor ``dim`` defaults to ``None`` (full
 reduction) for the ten ops whose manifest declares ``default: null``;
 ``ProdFwdOp`` preserves ``dim=-1``.
-The Op layer validates inputs, reshapes to 2D (M, N), and calls the kernel.
-Alignment padding belongs to the kernel, which masks its loads and fills with
-the reduction's identity element; the Op layer never pads.
-Kernels are cached by ``(M, N)`` so that the same op instance can handle
-varying shapes.
+
+The Op layer validates the input, normalizes its contiguity, and hands it over as the
+manifest declares it. Moving the reduced axes to the end, flattening to ``(M, N)``, the
+alignment padding and shaping the result back all belong to the kernel, so both sides of
+the op/backend boundary speak the declared shape. Kernels are cached by shape, axes,
+dtype and device, so one op instance handles varying shapes.
 """
 
 import warnings
@@ -18,12 +19,14 @@ from typing import Dict, List, Optional, Tuple, Union
 
 import torch
 
+from tileops.backend import Target
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.reduction.reduce import ReduceKernel
 from tileops.manifest.shape_rules import reduced_shape
 
 from ..op_base import Op
-from ._multidim import EmptyDimPolicy, flatten_for_multidim, normalize_dim, restore_multidim_shape
+from ._boundary import register_reduction_op
+from ._multidim import EmptyDimPolicy, normalize_dim
 
 # Op kinds that accept 0-D (scalar) input. The kernel path assumes
 # ``ndim >= 1`` (and the Welford kernel's Bessel correction is undefined for
@@ -65,24 +68,22 @@ __all__ = [
 class _ReduceOpBase(Op):
     """Common base for all reduce ops (simple, Welford, argreduce, logical, vector_norm).
 
-    Consolidates shared init params (dtype, dim, keepdim, tune), initializes
-    and owns an internal kernel cache, and handles input preparation
-    (validate, transpose, reshape to 2D) and output reshaping.
-    Subclasses declare ``_op_kind``, ``_kernel_key``, ``_kernel_cls``, and
-    override hooks as needed.  ``forward()`` is provided by this base class;
-    only ops with non-standard returns (e.g. ``VarMeanFwdOp``) need to
-    override it.
+    Holds the shared init params, the reading of ``dim``, and the one place a kernel is
+    resolved. Subclasses declare ``_op_kind``, ``_kernel_key``, ``_kernel_cls``, and
+    override hooks as needed. ``forward`` is one call to the operator the op registers;
+    an op whose returns are not a single tensor (``VarMeanFwdOp``) overrides
+    ``_eager_forward``, which runs behind that operator.
 
     Hooks for subclass customization:
 
     - ``_kernel_key``: kernel map key (default ``"reduce"``).
     - ``_kernel_cls``: kernel class (default ``ReduceKernel``).
     - ``_validate_dim()``: validate ``dim`` at init (default: accept int/list/None).
-    - ``_build_kernel_kwargs()``: extra kwargs for kernel constructor.
-    - ``_pre_kernel(x)``: transform 2D input before kernel call (default identity).
-      Returns ``(x, context)`` where *context* is passed to ``_post_kernel``.
-    - ``_post_kernel(y, context)``: transform kernel output (default identity).
+    - ``_build_kernel_kwargs(x, axes)``: extra kwargs for the kernel constructor.
     """
+
+    #: Set by ``register_reduction_op`` on each concrete op; a base registers none.
+    _wrapped = None
 
     _op_kind: str = ""  # overridden by subclasses
     _kernel_key: str = "reduce"  # overridden by subclasses for different kernel families
@@ -94,6 +95,7 @@ class _ReduceOpBase(Op):
         dim: Union[int, List[int], Tuple[int, ...], None] = None,
         keepdim: bool = False,
         *,
+        target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
@@ -104,11 +106,14 @@ class _ReduceOpBase(Op):
                 Accepts ``int``, ``list[int]``, ``tuple[int, ...]``, or
                 ``None``.
             keepdim: Whether to retain reduced dims as size 1.
+            target: Which set of kernels serves this op — a target name, ``BUILTIN``
+                for the in-tree kernels, or ``None`` to decide from the input device.
             kernel_map: Optional override for kernel dispatch.
             tune: Whether to autotune (default ``False``).
         """
         self.dim = dim
         self.keepdim = keepdim
+        self.target = target
         self.tune = tune
         self._validate_dim()
         self.dispatch_kernel(kernel_map)
@@ -161,45 +166,29 @@ class _ReduceOpBase(Op):
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {self._kernel_key: self._kernel_cls}
 
-    # Extra kernel kwargs (subclasses may override)
-
-    def _build_kernel_kwargs(self) -> dict:
-        """Return extra keyword arguments for the kernel constructor.
-
-        Override in subclasses to pass additional params like ``correction``.
-        """
-        return {}
-
-    # Pre/post kernel hooks (subclasses may override)
-
-    def _pre_kernel(self, x: torch.Tensor) -> Tuple[torch.Tensor, object]:
-        """Transform 2D input before kernel call.
-
-        Returns ``(x, context)`` where *context* is an opaque value
-        passed through to ``_post_kernel``.  Default: identity.
-        """
-        return x, None
-
-    def _post_kernel(self, y: torch.Tensor, context: object) -> torch.Tensor:
-        """Transform kernel output.  Default: identity."""
-        return y
-
     # Forward (subclasses with non-standard returns, e.g. VarMeanFwdOp,
-    # must override)
+    # must override ``_eager_forward``)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Run the reduce op on *x* along the configured dim."""
+        """Run the reduce op on *x* along the configured dim.
+
+        One call to the operator this op registers: this is as far as dynamo traces.
+        """
+        return type(self)._wrapped(x, self._instance_key)
+
+    def _eager_forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Validate, resolve the kernel and launch, inside the operator.
+
+        Never traced: kernel construction enters a TileLang builder.
+        """
         scalar_out = self._maybe_scalar(x)
         if scalar_out is not None:
             return scalar_out
         noop_out = self._maybe_noop(x)
         if noop_out is not None:
             return noop_out
-        x, orig_shape, dim_info, kernel = self._prepare_input(x)
-        x, ctx = self._pre_kernel(x)
-        y = kernel(x)
-        y = self._post_kernel(y, ctx)
-        return self._reshape_output(y, orig_shape, dim_info)
+        x, kernel = self._prepare_input(x)
+        return kernel(x)
 
     # Empty-dim no-op short-circuit
 
@@ -219,10 +208,9 @@ class _ReduceOpBase(Op):
         """Validate device, dtype, and rank of the forward input.
 
         Shared by ``_prepare_input`` and the ``dim=[]`` noop short-circuit
-        so both paths enforce the same forward contract.
+        so both paths enforce the same forward contract. Which devices a set of kernels
+        runs on is the kernel's own statement, so no device kind is checked here.
         """
-        if not x.is_cuda:
-            raise ValueError("x must be a CUDA tensor")
         self._validate_dtypes(x)
         self.dtype = x.dtype
         if x.ndim == 0:
@@ -301,8 +289,6 @@ class _ReduceOpBase(Op):
             # l1/l2/inf) fall through to the kernel path, which raises the
             # pre-existing ``ValueError("Input tensor must be at least 1D")``.
             return None
-        if not x.is_cuda:
-            raise ValueError("x must be a CUDA tensor")
         self._validate_dtypes(x)
         self.dtype = x.dtype
         self._validate_scalar_dim()
@@ -336,10 +322,11 @@ class _ReduceOpBase(Op):
         # for the read plus the output term, instead of collapsing to
         # zero, which would under-count the actual data-movement cost.
         self._last_roofline_mn = (x.numel(), 1)
+        # ``copy=True`` because the operator this runs inside may not return an alias of
+        # its input, and ``to`` hands back the same object when the dtype already matches
+        # — which a bool input to All or Any does.
         out_dtype = self._noop_output_dtype()
-        if out_dtype is None:
-            return x
-        return x.to(out_dtype)
+        return x.clone() if out_dtype is None else x.to(out_dtype, copy=True)
 
     def eval_roofline(self) -> tuple[int, int]:
         if self._last_roofline_mn is None:
@@ -394,105 +381,63 @@ class _ReduceOpBase(Op):
 
     # Kernel cache
 
-    def _get_or_create_kernel(
-        self,
-        inputs: "tuple[torch.Tensor | None, ...]",
-        M: int,
-        N: int,
-        dtype: torch.dtype,
-    ) -> object:
-        """Return a cached kernel for (M, N, dtype), creating one if needed."""
-        return self.get_or_build_kernel(
-            self._kernel_key,
-            inputs,
-            key=(M, N, dtype),
-            build=lambda: self.kernel_map[self._kernel_key](
-                M,
-                N,
-                self._op_kind,
-                dtype,
-                tune=self.tune,
-                **self._build_kernel_kwargs(),
-            ),
-        )
+    def _build_kernel_kwargs(self, x: torch.Tensor, axes: "tuple[int, ...]") -> dict:
+        """What this op's kernel takes beyond the shared arguments.
 
-    # Input preparation (validate → transpose → reshape)
+        The device is one of them: a kernel that plans against shared memory has to plan
+        against the device the input lives on, not whichever one is current.
+        """
+        return {"device_index": x.device.index}
 
-    def _prepare_input(
-        self,
-        x: torch.Tensor,
-    ) -> Tuple[torch.Tensor, torch.Size, object, object]:
-        """Validate, derive M/N, transpose, and reshape to 2D.
+    def _reduce_axes(self, x: torch.Tensor) -> "tuple[int, ...]":
+        """The axes this call reduces, ascending and non-negative.
 
-        Returns ``(x_2d, orig_shape, dim_info, kernel)`` where
-        *dim_info* is either an ``int`` (single-dim) or ``list[int]``
-        (multi-dim).
+        Raises:
+            IndexError: ``dim`` names an axis this rank does not have. Raised before any
+                kernel is built, so an out-of-range call reaches no backend.
+        """
+        return tuple(normalize_dim(self.dim, x.ndim, empty_dim_policy=self._empty_dim_policy))
+
+    # Input preparation (validate → normalize contiguity → resolve the kernel)
+
+    def _prepare_input(self, x: torch.Tensor) -> Tuple[torch.Tensor, object]:
+        """Validate, normalize contiguity, and resolve the kernel for this call.
+
+        The row layout the kernel wants is the kernel's business, so what comes back is
+        the declared tensor and a kernel that takes it.
+
+        Returns:
+            ``(x, kernel)``, where *x* is the contiguous declared input.
         """
         self._validate_input_tensor(x)
-
-        # The tensor this op declares, before the row layout its kernel wants.
-        declared = x
-        orig_shape = x.shape
-
-        # --- multi-dim path (includes dim=None for full reduction) ---
-        if isinstance(self.dim, (list, tuple)) or self.dim is None:
-            dims = normalize_dim(
-                self.dim,
-                x.ndim,
-                empty_dim_policy=self._empty_dim_policy,
-            )
-            x, orig_shape, _kept = flatten_for_multidim(x, dims)
-            N = x.shape[-1]
-            M = prod(x.shape[:-1])
-            self._last_roofline_mn = (M, N)
-            x = x.reshape(M, N)
-            kernel = self._get_or_create_kernel((declared,), M, N, x.dtype)
-            return x, orig_shape, dims, kernel
-
-        # --- single-dim path ---
-        if self.dim < -x.ndim or self.dim >= x.ndim:
-            raise IndexError(
-                f"Dimension out of range (expected to be in range of "
-                f"[{-x.ndim}, {x.ndim - 1}], but got {self.dim})"
-            )
-        dim = self.dim % x.ndim
-
-        N = x.shape[dim]
-        M = prod(s for i, s in enumerate(x.shape) if i != dim)
-        self._last_roofline_mn = (M, N)
-
-        if dim != x.ndim - 1:
-            x = x.movedim(dim, -1)
-
-        x = x.contiguous().reshape(M, N)
-
-        kernel = self._get_or_create_kernel((declared,), M, N, x.dtype)
-        return x, orig_shape, dim, kernel
-
-    # Output reshape
-
-    def _reshape_output(
-        self,
-        y: torch.Tensor,
-        orig_shape: torch.Size,
-        dim_info: Union[int, List[int]],
-    ) -> torch.Tensor:
-        """Reshape (M,) kernel output to match keepdim setting.
-
-        *dim_info* is either an ``int`` (single-dim) or ``list[int]``
-        (multi-dim).
-        """
-        if isinstance(dim_info, list):
-            return restore_multidim_shape(y, orig_shape, dim_info, self.keepdim)
-
-        dim = dim_info
-        if self.keepdim:
-            kept_shape = list(orig_shape)
-            kept_shape[dim] = 1
-            return y.reshape(kept_shape)
-        else:
-            reduced_shape = [s for i, s in enumerate(orig_shape) if i != dim]
-            return y.squeeze() if len(reduced_shape) == 0 else y.reshape(reduced_shape)
+        # Normalized here and handed over as the manifest declares it; how a kernel wants
+        # that laid out is its own business.
+        x = x.contiguous()
+        axes = self._reduce_axes(x)
+        # From the shape, not from ``numel``: an empty reduced axis makes ``n`` zero.
+        n = prod(x.shape[a] for a in axes)
+        m = prod(d for i, d in enumerate(x.shape) if i not in axes)
+        self._last_roofline_mn = (m, n)
+        extra = self._build_kernel_kwargs(x, axes)
+        kernel = self.get_or_build_kernel(
+            self._kernel_key,
+            (x,),
+            # The kernel now owns the permute, so the whole shape decides what it is,
+            # not just the row count and width it reduces. The device is in the key
+            # because the kernel plans against that device's shared memory.
+            key=(tuple(x.shape), axes, self.keepdim, x.dtype, x.device.index),
+            build=lambda: self.kernel_map[self._kernel_key](
+                m,
+                n,
+                self._op_kind,
+                x.dtype,
+                reduce_axes=axes,
+                keepdim=self.keepdim,
+                tune=self.tune,
+                **extra,
+            ),
+        )
+        return x, kernel
 
 
 # Simple reduce ops (sum, mean, amin, amax, prod)
@@ -500,9 +445,6 @@ class _ReduceOpBase(Op):
 
 class _SimpleReduceOp(_ReduceOpBase):
     """Base for single-output reduce ops (sum, mean, amin, amax, prod).
-
-    M and N are derived from the input tensor at forward time, and kernels
-    are cached by ``(M, N)`` to avoid rebuilds.
 
     The ``dim`` default follows each op's manifest entry: ``sum``, ``mean``,
     ``amin``, and ``amax`` default to ``None`` (full reduction); ``prod``
@@ -513,6 +455,8 @@ class _SimpleReduceOp(_ReduceOpBase):
             ``tuple[int, ...]``, or ``None`` on the base class; subclasses
             may narrow this (see ``ProdFwdOp``).
         keepdim: Whether to retain the reduced dimension as size 1.
+        target: Which set of kernels serves this op — a target name, ``BUILTIN``
+            for the in-tree kernels, or ``None`` to decide from the input device.
         kernel_map: Optional override for kernel dispatch.
         tune: Whether to autotune (default False).
     """
@@ -560,20 +504,24 @@ class ProdFwdOp(_SimpleReduceOp):
         dim: int = -1,
         keepdim: bool = False,
         *,
+        target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
         """Construct ProdFwdOp.
 
         Args:
-            dim (int): reduction dimension (default ``-1``).
+            dim: Reduction dimension (default ``-1``).
             keepdim: Whether to retain reduced dims as size 1.
+            target: Which set of kernels serves this op — a target name, ``BUILTIN``
+                for the in-tree kernels, or ``None`` to decide from the input device.
             kernel_map: Optional override for kernel dispatch.
             tune: Whether to autotune (default ``False``).
         """
         super().__init__(
             dim=dim,
             keepdim=keepdim,
+            target=target,
             kernel_map=kernel_map,
             tune=tune,
         )
@@ -592,15 +540,14 @@ class _WelfordReduceOp(_ReduceOpBase):
     """Base for Welford-based reduce ops (std, var, var_mean).
 
     Construction: ``op(dim=None, correction=1, keepdim=False)``.
-    M and N are derived from the input tensor at forward time, and kernels
-    are cached by ``(M, N)`` to avoid rebuilds.
-
     Args:
         dim: Reduction dimension (default ``None``, i.e. full reduction).
             Accepts ``int``, ``list[int]``, or ``tuple[int, ...]`` for
             multi-dim reduction.
         correction: Bessel's correction (default 1).
         keepdim: Whether to retain the reduced dimension as size 1.
+        target: Which set of kernels serves this op — a target name, ``BUILTIN``
+            for the in-tree kernels, or ``None`` to decide from the input device.
         kernel_map: Optional override for kernel dispatch.
         tune: Whether to autotune (default False).
     """
@@ -613,6 +560,7 @@ class _WelfordReduceOp(_ReduceOpBase):
         correction: int = 1,
         keepdim: bool = False,
         *,
+        target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
@@ -624,6 +572,8 @@ class _WelfordReduceOp(_ReduceOpBase):
                 ``None``.
             correction: Bessel's correction (default 1).
             keepdim: Whether to retain reduced dims as size 1.
+            target: Which set of kernels serves this op — a target name, ``BUILTIN``
+                for the in-tree kernels, or ``None`` to decide from the input device.
             kernel_map: Optional override for kernel dispatch.
             tune: Whether to autotune (default ``False``).
         """
@@ -631,23 +581,20 @@ class _WelfordReduceOp(_ReduceOpBase):
         super().__init__(
             dim=dim,
             keepdim=keepdim,
+            target=target,
             kernel_map=kernel_map,
             tune=tune,
         )
 
-    def _build_kernel_kwargs(self) -> dict:
+    def _build_kernel_kwargs(self, x: torch.Tensor, axes: "tuple[int, ...]") -> dict:
         """Pass correction to the kernel constructor."""
-        return {"correction": self.correction}
+        return {**super()._build_kernel_kwargs(x, axes), "correction": self.correction}
 
     def _scalar_forward(self, x: torch.Tensor):
         """Compute Welford ops on a 0-D input from closed-form.
 
         For a single-element reduction with reduction factor ``N = 1`` and
         Bessel ``correction``:
-
-        Both branches construct the result as an operation on ``x`` so
-        the output keeps a ``grad_fn`` when ``x.requires_grad`` is
-        true, matching the PyTorch backward contract.
 
         - ``N - correction <= 0`` (i.e. ``correction >= 1``): variance
           and standard deviation are mathematically undefined; the
@@ -656,8 +603,7 @@ class _WelfordReduceOp(_ReduceOpBase):
         - ``correction == 0``: the unbiased denominator is ``N``, so the
           deviation from the mean (which equals the element itself) is
           zero for finite inputs. The result is computed as ``x - x``
-          so non-finite inputs propagate (``nan`` / ``inf`` → ``nan``)
-          and autograd history on ``x`` is preserved.
+          so non-finite inputs propagate (``nan`` / ``inf`` → ``nan``).
 
         ``VarMeanFwdOp`` overrides this hook to additionally return the
         mean (the input element).
@@ -679,28 +625,29 @@ class _WelfordReduceOp(_ReduceOpBase):
         The TileLang Welford kernel bakes ``N`` and ``correction`` into the
         generated code, so a zero denominator fails at compile time. PyTorch
         defines this degree-of-freedom case as NaN; handle it before kernel
-        dispatch.
+        dispatch. The shape comes from the manifest's rule, the same source the
+        kernel path's result is shaped by.
         """
         if self._last_roofline_mn is None:
             return None
-        M, N = self._last_roofline_mn
+        _M, N = self._last_roofline_mn
         if self.correction < N:
             return None
-        return torch.full((M,), float("nan"), dtype=x.dtype, device=x.device)
+        shape = self._reduced_shape(tuple(x.shape))
+        return torch.full(shape, float("nan"), dtype=x.dtype, device=x.device)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def _eager_forward(self, x: torch.Tensor) -> torch.Tensor:
         scalar_out = self._maybe_scalar(x)
         if scalar_out is not None:
             return scalar_out
         noop_out = self._maybe_noop(x)
         if noop_out is not None:
             return noop_out
-        x, orig_shape, dim_info, kernel = self._prepare_input(x)
+        x, kernel = self._prepare_input(x)
         invalid_dof = self._invalid_dof_output(x)
         if invalid_dof is not None:
-            return self._reshape_output(invalid_dof, orig_shape, dim_info)
-        y = kernel(x)
-        return self._reshape_output(y, orig_shape, dim_info)
+            return invalid_dof
+        return kernel(x)
 
 
 class StdFwdOp(_WelfordReduceOp):
@@ -735,20 +682,27 @@ class VarMeanFwdOp(_WelfordReduceOp):
         var_out = super()._scalar_forward(x)
         return var_out, x.clone()
 
-    def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    def _eager_forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
         scalar_out = self._maybe_scalar(x)
         if scalar_out is not None:
             return scalar_out
-        x, orig_shape, dim_info, kernel = self._prepare_input(x)
+        x, kernel = self._prepare_input(x)
         invalid_dof = self._invalid_dof_output(x)
         if invalid_dof is not None:
-            mean_out = x.float().mean(dim=-1).to(x.dtype)
-            return (
-                self._reshape_output(invalid_dof, orig_shape, dim_info),
-                self._reshape_output(mean_out, orig_shape, dim_info),
-            )
-        var_out, mean_out = kernel(x)
-        return (
-            self._reshape_output(var_out, orig_shape, dim_info),
-            self._reshape_output(mean_out, orig_shape, dim_info),
-        )
+            axes = self._reduce_axes(x)
+            mean_out = x.float().mean(dim=axes, keepdim=self.keepdim).to(x.dtype)
+            return invalid_dof, mean_out.reshape(invalid_dof.shape)
+        return kernel(x)
+
+
+for _op_cls in (
+    SumFwdOp,
+    MeanFwdOp,
+    AminFwdOp,
+    AmaxFwdOp,
+    ProdFwdOp,
+    StdFwdOp,
+    VarFwdOp,
+    VarMeanFwdOp,
+):
+    register_reduction_op(_op_cls)

--- a/src/tileops/ops/reduction/softmax.py
+++ b/src/tileops/ops/reduction/softmax.py
@@ -6,13 +6,15 @@ from typing import Dict, List, Optional, Tuple, Union
 
 import torch
 
+from tileops.backend import Target
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.reduction.logsumexp import LogSumExpKernel
 from tileops.kernels.reduction.softmax import SoftmaxKernel
 from tileops.manifest.shape_rules import reduced_shape
 
 from ..op_base import Op
-from ._multidim import EmptyDimPolicy, flatten_for_multidim, normalize_dim, restore_multidim_shape
+from ._boundary import register_reduction_op
+from ._multidim import EmptyDimPolicy, normalize_dim
 
 __all__ = ["LogSoftmaxFwdOp", "LogSumExpFwdOp", "SoftmaxFwdOp", "_SoftmaxBaseOp"]
 
@@ -33,42 +35,40 @@ def _resolve_implicit_softmax_dim(name: str, ndim: int) -> int:
 class _SoftmaxBaseOp(Op):
     """Base class for softmax-family ops.
 
-    Handles shared validation and reshape logic. Subclasses only
-    need to set ``_op_kind``, ``_kernel_key``, ``_kernel_class`` and
-    override output reshaping if needed.
+    Holds the shared validation, the reading of ``dim``, and the one place a kernel is
+    resolved. A subclass sets ``_op_kind``, ``_kernel_key`` and ``_kernel_cls``, and
+    overrides ``_kernel_ctor_kwargs`` when its kernel takes something else.
 
     Args:
         dim: Reduction dimension (default -1).
-        N: Optional committed reduction dim for subclasses that still expose it.
+        target: Which set of kernels serves this op — a target name, ``BUILTIN``
+            for the in-tree kernels, or ``None`` to decide from the input device.
         kernel_map: Optional override for kernel dispatch.
         tune: Whether to autotune (default False).
     """
 
+    #: Set by ``register_reduction_op`` on each concrete op; a base registers none.
+    _wrapped = None
+
     _op_kind: str  # set by subclass
     _kernel_key: str  # set by subclass
-    _kernel_class: type  # set by subclass
+    _kernel_cls: type  # set by subclass
     _supports_multidim: bool = False  # override to True in reduced-dim ops (e.g. LogSumExpFwdOp)
     _empty_dim_policy: EmptyDimPolicy = "reject"
-
-    # `static_dims.N = x.shape[dim]` is param-dependent (depends on `dim`),
-    # so the static-axis frozenset is bound at forward time after dim
-    # normalization, not at the class level (per docs/design/ops-design.md § Step 3).
-    _static_axes: frozenset = frozenset()
 
     def __init__(
         self,
         dim: Union[int, List[int]] = -1,
-        N: Optional[int] = None,
         *,
+        target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
         self.dim = dim
-        self.N = N
         self.keepdim = False
+        self.target = target
         self.tune = tune
         self.dispatch_kernel(kernel_map)
-        self.kernel: object | None = None
         self._last_roofline_spec: tuple[int, int, torch.dtype] | None = None
 
     def _infer_output_shapes(self, x_shape: tuple[int, ...]) -> dict[str, tuple[int, ...]]:
@@ -77,116 +77,85 @@ class _SoftmaxBaseOp(Op):
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
-        return {self._kernel_key: self._kernel_class}
+        return {self._kernel_key: self._kernel_cls}
 
     # Validation
 
     def _validate(self, x: torch.Tensor) -> None:
-        """Validate input tensor."""
-        if not x.is_cuda:
-            raise ValueError("x must be a CUDA tensor")
-        if x.dtype not in (torch.float16, torch.bfloat16, torch.float32):
-            raise ValueError(f"x.dtype must be float16, bfloat16, or float32, got {x.dtype}")
+        """Validate the input against the manifest dtype union and the minimum rank.
+
+        Which devices a set of kernels runs on is the kernel's own statement, so no
+        device kind is checked here.
+        """
+        self._validate_dtypes(x)
         if x.ndim == 0:
             raise ValueError("Input tensor must be at least 1D")
         self.dtype = x.dtype
 
     # Forward
 
+    def _reduce_axes(self, x: torch.Tensor) -> "tuple[int, ...]":
+        """The axes this call runs over, ascending and non-negative.
+
+        ``dim=None`` means two different things and neither is "every axis": for softmax
+        and log-softmax it is PyTorch's implicit-axis rule, for logsumexp it is the full
+        reduction. Getting this wrong keeps the output shape and changes the values.
+
+        Raises:
+            IndexError: ``dim`` names an axis this rank does not have.
+            ValueError: A sequence ``dim`` reached an op that reduces one axis.
+        """
+        # Resolved per call rather than written back to ``self.dim``, so one instance
+        # accepts inputs of different ranks, matching F.softmax.
+        dim: Union[int, List[int], Tuple[int, ...], None] = self.dim
+        if dim is None and not self._supports_multidim:
+            dim = _resolve_implicit_softmax_dim(self._op_kind, x.ndim)
+        if (isinstance(dim, (list, tuple)) or dim is None) and not self._supports_multidim:
+            raise ValueError(
+                f"{type(self).__name__} does not support multi-dim reduction. Use a scalar dim."
+            )
+        return tuple(normalize_dim(dim, x.ndim, empty_dim_policy=self._empty_dim_policy))
+
+    def _kernel_ctor_kwargs(self, axes: "tuple[int, ...]") -> dict:
+        """What this op's kernel takes beyond the shared arguments."""
+        (axis,) = axes
+        return {"norm_axis": axis}
+
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Run the softmax-family op.
 
-        Accepts arbitrary-dim input along the configured dim.
-        Supports ``dim=list[int]`` for multi-dim reduction (logsumexp).
+        One call to the operator this op registers: this is as far as dynamo traces.
+        """
+        return type(self)._wrapped(x, self._instance_key)
+
+    def _eager_forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Validate, resolve the kernel and launch, inside the operator.
+
+        Never traced: kernel construction enters a TileLang builder.
         """
         self._validate(x)
-        # The tensor this op declares, before the row layout its kernel wants.
-        declared = x
-        orig_shape = x.shape
-
-        # Resolve dim=None per call (don't mutate self.dim) so the same op
-        # instance accepts inputs of different ranks, matching F.softmax.
-        effective_dim: Union[int, List[int], Tuple[int, ...], None] = self.dim
-        if effective_dim is None and not self._supports_multidim:
-            effective_dim = _resolve_implicit_softmax_dim(self._op_kind, x.ndim)
-
-        if isinstance(effective_dim, (list, tuple)) or effective_dim is None:
-            if not self._supports_multidim:
-                raise ValueError(
-                    f"{type(self).__name__} does not support multi-dim reduction. Use a scalar dim."
-                )
-            dims = normalize_dim(
-                effective_dim,
-                x.ndim,
-                empty_dim_policy=self._empty_dim_policy,
-            )
-            # Bind the dynamic static-axes (param-dependent reduction axes) so
-            # the Op-layer cache-key / introspection consumers see the
-            # committed axes. Mirrors the single-dim path below.
-            self._static_axes = frozenset((0, d) for d in dims)
-            x, orig_shape, _kept = flatten_for_multidim(x, dims)
-            N = x.shape[-1]
-            M = prod(x.shape[:-1])
-            dtype = x.dtype
-            self._last_roofline_spec = (M, N, dtype)
-            x = x.reshape(M, N)
-            kernel = self._get_or_create_kernel(
-                (declared,),
-                M,
-                N,
-                dtype=dtype,
+        x = x.contiguous()  # handed over as the manifest declares it
+        axes = self._reduce_axes(x)
+        # From the shape, not from ``numel``: an empty reduced axis makes ``n`` zero.
+        n = prod(x.shape[a] for a in axes)
+        m = prod(d for i, d in enumerate(x.shape) if i not in axes)
+        self._last_roofline_spec = (m, n, x.dtype)
+        kernel = self.get_or_build_kernel(
+            self._kernel_key,
+            (x,),
+            # The kernel owns the permute, so the whole shape decides which kernel it is.
+            key=(tuple(x.shape), axes, self.keepdim, x.dtype, x.device.index),
+            build=lambda: self.kernel_map[self._kernel_key](
+                m,
+                n,
+                self._op_kind,
+                x.dtype,
+                tune=self.tune,
                 device_index=x.device.index,
-            )
-            self.kernel = kernel
-            # Alignment padding is handled by the kernel's forward().
-            y = kernel(x)
-            return restore_multidim_shape(y, orig_shape, dims, self.keepdim)
-
-        # --- single-dim path ---
-        # Validate and normalize dim (match PyTorch IndexError behavior).
-        assert isinstance(effective_dim, int)
-        if effective_dim < -x.ndim or effective_dim >= x.ndim:
-            raise IndexError(
-                f"Dimension out of range (expected to be in range of "
-                f"[{-x.ndim}, {x.ndim - 1}], but got {effective_dim})"
-            )
-        dim = effective_dim % x.ndim
-
-        # N = size along reduction dim, M = product of all other dims.
-        N = x.shape[dim]
-        if self.N is not None and N != self.N:
-            raise ValueError(
-                f"{type(self).__name__}: committed N={self.N} does not match "
-                f"x.shape[{effective_dim}]={N}"
-            )
-        # Bind the dynamic static-axis (param-dependent N axis) so the
-        # Op-layer cache-key / introspection consumers see the committed axis.
-        self._static_axes = frozenset({(0, dim)})
-        M = prod(s for i, s in enumerate(x.shape) if i != dim)
-        dtype = x.dtype
-        self._last_roofline_spec = (M, N, dtype)
-
-        # If reduction dim is not the last, move it to the end.
-        needs_transpose = dim != x.ndim - 1
-        if needs_transpose:
-            x = x.movedim(dim, -1)
-
-        x = x.contiguous().reshape(M, N)
-
-        # Get or create cached kernel for this (M, N, device).
-        kernel = self._get_or_create_kernel(
-            (declared,),
-            M,
-            N,
-            dtype=dtype,
-            device_index=x.device.index,
+                **self._kernel_ctor_kwargs(axes),
+            ),
         )
-        self.kernel = kernel
-
-        # Alignment padding is handled by the kernel's forward().
-        y = kernel(x)
-
-        return self._reshape_output(y, orig_shape, dim, needs_transpose)
+        return kernel(x)
 
     def eval_roofline(self) -> tuple[int, int]:
         if self._last_roofline_spec is None:
@@ -206,65 +175,6 @@ class _SoftmaxBaseOp(Op):
             f"{type(self).__name__} has unknown roofline op kind {self._op_kind!r}"
         )
 
-    def _get_or_create_kernel(
-        self,
-        inputs: "tuple[torch.Tensor | None, ...]",
-        M: int,
-        N: int,
-        dtype: torch.dtype,
-        device_index: int | None = None,
-    ) -> object:
-        """Return a cached kernel for (M, N, dtype, device), creating one if needed."""
-        return self.get_or_build_kernel(
-            self._kernel_key,
-            inputs,
-            key=(M, N, dtype, device_index),
-            build=lambda: self.kernel_map[self._kernel_key](
-                M,
-                N,
-                self._op_kind,
-                dtype,
-                tune=self.tune,
-                device_index=device_index,
-            ),
-        )
-
-    # Output reshaping
-
-    def _reshape_output(
-        self,
-        y: torch.Tensor,
-        orig_shape: torch.Size,
-        dim: int,
-        needs_transpose: bool,
-    ) -> torch.Tensor:
-        """Restore original shape.
-
-        Default (softmax/log_softmax): output same shape as input.
-        Reduced-dim ops (logsumexp): remove or keep dim based on keepdim.
-        """
-        # y is (M, N) or (M,) depending on op kind.
-        if y.ndim == 2:
-            # Same-shape ops: rebuild the transposed shape, then move dim back.
-            if needs_transpose:
-                transposed_shape = list(orig_shape)
-                transposed_shape.append(transposed_shape.pop(dim))
-                y = y.reshape(transposed_shape)
-                y = y.movedim(-1, dim)
-            else:
-                y = y.reshape(orig_shape)
-        else:
-            # Reduced-dim ops (logsumexp): (M,) -> remove or keep dim.
-            if self.keepdim:
-                kept_shape = list(orig_shape)
-                kept_shape[dim] = 1
-                y = y.reshape(kept_shape)
-            else:
-                reduced_shape = [s for i, s in enumerate(orig_shape) if i != dim]
-                y = y.squeeze() if len(reduced_shape) == 0 else y.reshape(reduced_shape)
-
-        return y
-
 
 class SoftmaxFwdOp(_SoftmaxBaseOp):
     """Softmax operator: y = softmax(x, dim).
@@ -278,22 +188,25 @@ class SoftmaxFwdOp(_SoftmaxBaseOp):
             resolved at forward time using PyTorch's implicit-axis rule
             (``0`` for ``ndim in {0, 1, 3}`` else ``1``) and the same
             deprecation ``UserWarning`` is emitted.
+        target: Which set of kernels serves this op — a target name, ``BUILTIN``
+            for the in-tree kernels, or ``None`` to decide from the input device.
         kernel_map: Optional override for kernel dispatch.
         tune: Whether to autotune (default False).
     """
 
     _op_kind = "softmax"
     _kernel_key = "softmax_fwd"
-    _kernel_class = SoftmaxKernel
+    _kernel_cls = SoftmaxKernel
 
     def __init__(
         self,
         dim: Optional[int] = None,
         *,
+        target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
-        super().__init__(dim=dim, kernel_map=kernel_map, tune=tune)
+        super().__init__(dim=dim, target=target, kernel_map=kernel_map, tune=tune)
 
 
 class LogSoftmaxFwdOp(_SoftmaxBaseOp):
@@ -308,22 +221,25 @@ class LogSoftmaxFwdOp(_SoftmaxBaseOp):
             resolved at forward time using PyTorch's implicit-axis rule
             (``0`` for ``ndim in {0, 1, 3}`` else ``1``) and the same
             deprecation ``UserWarning`` is emitted.
+        target: Which set of kernels serves this op — a target name, ``BUILTIN``
+            for the in-tree kernels, or ``None`` to decide from the input device.
         kernel_map: Optional override for kernel dispatch.
         tune: Whether to autotune (default False).
     """
 
     _op_kind = "log_softmax"
     _kernel_key = "softmax_fwd"
-    _kernel_class = SoftmaxKernel
+    _kernel_cls = SoftmaxKernel
 
     def __init__(
         self,
         dim: Optional[int] = None,
         *,
+        target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
-        super().__init__(dim=dim, kernel_map=kernel_map, tune=tune)
+        super().__init__(dim=dim, target=target, kernel_map=kernel_map, tune=tune)
 
 
 class LogSumExpFwdOp(_SoftmaxBaseOp):
@@ -335,13 +251,15 @@ class LogSumExpFwdOp(_SoftmaxBaseOp):
     Args:
         dim: Reduction dimension (default -1).
         keepdim: Retain reduced dimension (default False).
+        target: Which set of kernels serves this op — a target name, ``BUILTIN``
+            for the in-tree kernels, or ``None`` to decide from the input device.
         kernel_map: Optional override for kernel dispatch.
         tune: Whether to autotune (default False).
     """
 
     _op_kind = "logsumexp"
     _kernel_key = "logsumexp_fwd"
-    _kernel_class = LogSumExpKernel
+    _kernel_cls = LogSumExpKernel
     _supports_multidim = True
 
     def __init__(
@@ -349,12 +267,21 @@ class LogSumExpFwdOp(_SoftmaxBaseOp):
         dim: Union[int, List[int]] = -1,
         keepdim: bool = False,
         *,
+        target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
-        super().__init__(dim=dim, kernel_map=kernel_map, tune=tune)
+        super().__init__(dim=dim, target=target, kernel_map=kernel_map, tune=tune)
         self.keepdim = keepdim
 
     def _infer_output_shapes(self, x_shape: tuple[int, ...]) -> dict[str, tuple[int, ...]]:
         """Manifest ``shape_rules``: this one reduces, unlike its siblings."""
         return {"output": reduced_shape(x_shape, self.dim, self.keepdim)}
+
+    def _kernel_ctor_kwargs(self, axes: "tuple[int, ...]") -> dict:
+        """This kernel reduces the axes away, so it is told which and whether they stay."""
+        return {"reduce_axes": axes, "keepdim": self.keepdim}
+
+
+for _op_cls in (SoftmaxFwdOp, LogSoftmaxFwdOp, LogSumExpFwdOp):
+    register_reduction_op(_op_cls)

--- a/src/tileops/ops/reduction/vector_norm.py
+++ b/src/tileops/ops/reduction/vector_norm.py
@@ -1,13 +1,13 @@
 """Vector-norm reduction operators (L1, L2, inf)."""
 
 from math import inf
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Union
 
-import torch
-
+from tileops.backend import Target
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.reduction.vector_norm import VectorNormKernel
 
+from ._boundary import register_reduction_op
 from ._multidim import EmptyDimPolicy
 from .reduce import _ReduceOpBase
 
@@ -17,9 +17,7 @@ __all__ = ["InfNormFwdOp", "L1NormFwdOp", "L2NormFwdOp"]
 class L1NormFwdOp(_ReduceOpBase):
     """L1 norm reduction along a configurable dim.
 
-    Construction: ``L1NormFwdOp(dim=None, keepdim=False)``.  M and N
-    are derived from the input tensor at forward time, and kernels are cached
-    by ``(M, N)`` to avoid rebuilds.
+    Construction: ``L1NormFwdOp(dim=None, keepdim=False)``.
 
     Args:
         dim: Reduction dimension (default ``None`` -> full reduction, matching
@@ -29,6 +27,8 @@ class L1NormFwdOp(_ReduceOpBase):
         ord: Norm order. Must equal 1 for ``L1NormFwdOp`` (manifest fixes
             ``ord == 1``); accepted as a kwarg to mirror
             ``torch.linalg.vector_norm``.
+        target: Which set of kernels serves this op — a target name, ``BUILTIN``
+            for the in-tree kernels, or ``None`` to decide from the input device.
         kernel_map: Optional custom kernel map.
         tune: Whether to autotune the kernel.
     """
@@ -45,6 +45,7 @@ class L1NormFwdOp(_ReduceOpBase):
         dim: Union[int, List[int], None] = None,
         keepdim: bool = False,
         *,
+        target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
@@ -56,6 +57,7 @@ class L1NormFwdOp(_ReduceOpBase):
         super().__init__(
             dim=dim,
             keepdim=keepdim,
+            target=target,
             kernel_map=kernel_map,
             tune=tune,
         )
@@ -64,9 +66,7 @@ class L1NormFwdOp(_ReduceOpBase):
 class L2NormFwdOp(_ReduceOpBase):
     """L2 norm reduction along a configurable dim.
 
-    Construction: ``L2NormFwdOp(dim=None, keepdim=False)``.  M and N
-    are derived from the input tensor at forward time, and kernels are cached
-    by ``(M, N)`` to avoid rebuilds.
+    Construction: ``L2NormFwdOp(dim=None, keepdim=False)``.
 
     Args:
         dim: Reduction dimension (default ``None`` -> full reduction, matching
@@ -76,6 +76,8 @@ class L2NormFwdOp(_ReduceOpBase):
         ord: Norm order. Must equal 2 for ``L2NormFwdOp`` (manifest fixes
             ``ord == 2``); accepted as a kwarg to mirror
             ``torch.linalg.vector_norm``.
+        target: Which set of kernels serves this op — a target name, ``BUILTIN``
+            for the in-tree kernels, or ``None`` to decide from the input device.
         kernel_map: Optional custom kernel map.
         tune: Whether to autotune the kernel.
     """
@@ -92,6 +94,7 @@ class L2NormFwdOp(_ReduceOpBase):
         dim: Union[int, List[int], None] = None,
         keepdim: bool = False,
         *,
+        target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
@@ -103,6 +106,7 @@ class L2NormFwdOp(_ReduceOpBase):
         super().__init__(
             dim=dim,
             keepdim=keepdim,
+            target=target,
             kernel_map=kernel_map,
             tune=tune,
         )
@@ -111,12 +115,11 @@ class L2NormFwdOp(_ReduceOpBase):
 class InfNormFwdOp(_ReduceOpBase):
     """Infinity norm reduction along a configurable dim.
 
-    Construction: ``InfNormFwdOp(dim=None, keepdim=False)``.  M and
-    N are derived from the input tensor at forward time, and kernels are cached
-    by ``(M, N)`` to avoid rebuilds.
+    Construction: ``InfNormFwdOp(dim=None, keepdim=False)``.
 
     NaN handling: rows containing any NaN produce NaN output, matching
-    torch.linalg.vector_norm(ord=inf) semantics.
+    torch.linalg.vector_norm(ord=inf) semantics. The kernel drops NaN values and patches
+    those rows itself, so the compensation stays with the implementation that needs it.
 
     Args:
         dim: Reduction dimension (default ``None`` -> full reduction, matching
@@ -126,6 +129,8 @@ class InfNormFwdOp(_ReduceOpBase):
         ord: Norm order. Must equal ``float('inf')`` for ``InfNormFwdOp``
             (manifest fixes ``ord == float('inf')``); accepted as a kwarg to
             mirror ``torch.linalg.vector_norm``.
+        target: Which set of kernels serves this op — a target name, ``BUILTIN``
+            for the in-tree kernels, or ``None`` to decide from the input device.
         kernel_map: Optional custom kernel map.
         tune: Whether to autotune the kernel.
     """
@@ -142,6 +147,7 @@ class InfNormFwdOp(_ReduceOpBase):
         dim: Union[int, List[int], None] = None,
         keepdim: bool = False,
         *,
+        target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
@@ -153,18 +159,15 @@ class InfNormFwdOp(_ReduceOpBase):
         super().__init__(
             dim=dim,
             keepdim=keepdim,
+            target=target,
             kernel_map=kernel_map,
             tune=tune,
         )
 
-    def _pre_kernel(self, x: torch.Tensor) -> Tuple[torch.Tensor, object]:
-        """Detect NaN rows before kernel call (kernel drops NaN values)."""
-        nan_mask = x.isnan().any(dim=-1)  # shape (M,)
-        return x, nan_mask
 
-    def _post_kernel(self, y: torch.Tensor, context: object) -> torch.Tensor:
-        """Patch NaN into output rows that had NaN in the input."""
-        nan_mask = context
-        if nan_mask.any():
-            y[nan_mask] = float("nan")
-        return y
+for _op_cls in (
+    L1NormFwdOp,
+    L2NormFwdOp,
+    InfNormFwdOp,
+):
+    register_reduction_op(_op_cls)

--- a/src/tileops/perf/formulas.py
+++ b/src/tileops/perf/formulas.py
@@ -372,98 +372,6 @@ def _chunkwise_dims_bound(data: dict) -> tuple[int, int, int, int, int]:
     )
 
 
-def deltanet_fwd_roofline(op: Any | None = None, **kwargs: Any) -> tuple[int, int]:
-    """Roofline for the chunked DeltaNet training forward, head-major.
-
-    Two state matmuls per token. In: q, k, v, beta. Out: the output, the four chunk
-    buffers the backward reads, and the per-chunk state, which is fp32 whatever the
-    inputs are.
-    """
-    data = _shape_or_attrs(op, kwargs)
-    batch, heads, seq_len, dim_k, dim_v = _chunkwise_dims_bhsd(data)
-    chunk = int(data.get("chunk_size", 64))
-    elem_bytes = _dtype_itemsize(data.get("dtype", data.get("dtypes", "float16")))
-
-    flops = 2 * batch * heads * seq_len * dim_k * dim_v
-    per_token = (2 * dim_k + dim_v + 1) + (dim_v + 2 * chunk + dim_k + dim_v)
-    state = batch * heads * (seq_len // chunk + 1) * dim_k * dim_v
-    nbytes = batch * heads * seq_len * per_token * elem_bytes + state * 4
-    return int(flops), int(nbytes)
-
-
-def deltanet_bwd_roofline(op: Any | None = None, **kwargs: Any) -> tuple[int, int]:
-    """Roofline for the chunked DeltaNet backward, head-major.
-
-    Twice the forward's matmul work. In: do, q, k, v, beta and the chunk buffers the
-    forward saved, the fp32 state among them. Out: the four gradients.
-    """
-    data = _shape_or_attrs(op, kwargs)
-    batch, heads, seq_len, dim_k, dim_v = _chunkwise_dims_bhsd(data)
-    chunk = int(data.get("chunk_size", 64))
-    elem_bytes = _dtype_itemsize(data.get("dtype", data.get("dtypes", "float16")))
-
-    flops = 4 * batch * heads * seq_len * dim_k * dim_v
-    per_token = (3 * dim_k + 3 * dim_v + 1 + 2 * chunk) + (2 * dim_k + dim_v + 1)
-    state = batch * heads * (seq_len // chunk + 1) * dim_k * dim_v
-    nbytes = batch * heads * seq_len * per_token * elem_bytes + state * 4
-    return int(flops), int(nbytes)
-
-
-def gated_deltanet_bwd_roofline(op: Any | None = None, **kwargs: Any) -> tuple[int, int]:
-    """Roofline for the Gated DeltaNet backward, head-major.
-
-    The gate adds one tensor in and one gradient out over the ungated backward. The
-    per-chunk state the forward saved is read in the input dtype.
-    """
-    data = _shape_or_attrs(op, kwargs)
-    batch, heads, seq_len, dim_k, dim_v = _chunkwise_dims_bhsd(data)
-    chunk = int(data.get("chunk_size", 64))
-    elem_bytes = _dtype_itemsize(data.get("dtype", data.get("dtypes", "float16")))
-
-    flops = 4 * batch * heads * seq_len * dim_k * dim_v
-    tokens = batch * heads * seq_len
-    state = batch * heads * (seq_len // chunk + 1) * dim_k * dim_v
-    nbytes = (tokens * (4 * dim_k + 3 * dim_v + 4) + state) * elem_bytes
-    return int(flops), int(nbytes)
-
-
-def gla_fwd_roofline(op: Any | None = None, **kwargs: Any) -> tuple[int, int]:
-    """Roofline for the chunked GLA forward, token-major: one state matmul pair per token."""
-    data = _shape_or_attrs(op, kwargs)
-    batch, heads, seq_len, dim_k, dim_v = _chunkwise_dims_bshd(data)
-    elem_bytes = _dtype_itemsize(data.get("dtype", data.get("dtypes", "float16")))
-
-    flops = 2 * batch * heads * seq_len * dim_k * dim_v
-    tokens = batch * seq_len * heads
-    state = batch * heads * dim_k * dim_v
-    seeded = data.get("initial_state") is not None or data.get("initial_state_shape") is not None
-    # in: q, k, v, g and the fp32 state a caller may seed; out: o and the fp32 final state.
-    nbytes = tokens * (3 * dim_k + 2 * dim_v) * elem_bytes + state * (2 if seeded else 1) * 4
-    return int(flops), int(nbytes)
-
-
-def gla_bwd_roofline(op: Any | None = None, **kwargs: Any) -> tuple[int, int]:
-    """Roofline for the chunked GLA backward, token-major: twice the forward's matmuls.
-
-    In: q, k, v, g, do in the input dtype, plus the fp32 per-chunk states and the
-    final-state gradient. Out: four gradients, which the kernel accumulates in fp32.
-    """
-    data = _shape_or_attrs(op, kwargs)
-    batch, heads, seq_len, dim_k, dim_v = _chunkwise_dims_bshd(data)
-    chunk = int(data.get("chunk_size", 64))
-    elem_bytes = _dtype_itemsize(data.get("dtype", data.get("dtypes", "float16")))
-
-    flops = 4 * batch * heads * seq_len * dim_k * dim_v
-    tokens = batch * seq_len * heads
-    states = batch * heads * dim_k * dim_v * (seq_len // chunk + 2)
-    nbytes = (
-        tokens * (3 * dim_k + 2 * dim_v) * elem_bytes
-        + tokens * (3 * dim_k + dim_v) * 4
-        + states * 4
-    )
-    return int(flops), int(nbytes)
-
-
 def _distribute_total(total: int, batch: int, max_len: int) -> list[int]:
     lengths = [0] * batch
     remaining = total
@@ -1102,26 +1010,6 @@ def gemm_fwd_roofline(op: "Op") -> tuple[int, int]:
     return int(flops), int(nbytes)
 
 
-def gemm_fp8_fwd_roofline(op: "Op") -> tuple[int, int]:
-    """Roofline for dense FP8 ``GemmFp8FwdOp``."""
-    if getattr(op, "m", None) is None or getattr(op, "dtype", None) is None:
-        raise RuntimeError(
-            "GemmFp8FwdOp.eval_roofline() is valid only after the first forward(); "
-            "m/n/k and dtype are inferred from the inputs."
-        )
-    m, n, k = op.m, op.n, op.k
-    input_bytes = op.dtype.itemsize
-    out_bytes = op.out_dtype.itemsize
-    scale_a_shape = getattr(op, "scale_a_shape", (1, 1))
-    scale_b_shape = getattr(op, "scale_b_shape", (1, 1))
-    scale_elems = scale_a_shape[0] * scale_a_shape[1] + scale_b_shape[0] * scale_b_shape[1]
-    flops = 2 * m * n * k
-    nbytes = (m * k + n * k) * input_bytes + m * n * out_bytes + scale_elems * 4
-    if getattr(op, "has_bias", False):
-        nbytes += n * out_bytes
-    return int(flops), int(nbytes)
-
-
 def gemm_w4a16_fwd_roofline(op: "Op") -> tuple[int, int]:
     """Roofline for dense W4A16 ``GemmW4A16FwdOp``."""
     if getattr(op, "m", None) is None or getattr(op, "dtype", None) is None:
@@ -1360,29 +1248,6 @@ def bmm_fwd_roofline(op: "Op") -> tuple[int, int]:
     elem_bytes = op.dtype.itemsize
     flops = 2 * batch * m * n * k
     nbytes = batch * (m * k + n * k + m * n) * elem_bytes
-    return int(flops), int(nbytes)
-
-
-def bmm_fp8_fwd_roofline(op: "Op") -> tuple[int, int]:
-    """Roofline for batched FP8 GEMM ``BmmFp8KNFwdOp``.
-
-    Layout matches the fp16 ``bmm_fwd_roofline``: ``a: [B, M, K]``,
-    ``b: [B, K, N]``. Per-tensor scales only and no fused bias, so bytes are
-    ``B*M*K`` (A, fp8) + ``B*K*N`` (B, fp8) + ``B*M*N`` (C, ``out_dtype``)
-    + 8 for the two batch-independent fp32 scales.
-
-    Valid only after the first ``forward()`` binds dims and dtype.
-    """
-    if getattr(op, "m", None) is None or getattr(op, "dtype", None) is None:
-        raise RuntimeError(
-            "BmmFp8KNFwdOp.eval_roofline() is valid only after the first forward(); "
-            "batch/m/n/k and dtype are inferred from the inputs."
-        )
-    batch, m, n, k = op.batch, op.m, op.n, op.k
-    input_bytes = op.dtype.itemsize
-    out_bytes = op.out_dtype.itemsize
-    flops = 2 * batch * m * n * k
-    nbytes = batch * ((m * k + n * k) * input_bytes + m * n * out_bytes) + 8
     return int(flops), int(nbytes)
 
 

--- a/src/tileops/perf/formulas.py
+++ b/src/tileops/perf/formulas.py
@@ -372,6 +372,98 @@ def _chunkwise_dims_bound(data: dict) -> tuple[int, int, int, int, int]:
     )
 
 
+def deltanet_fwd_roofline(op: Any | None = None, **kwargs: Any) -> tuple[int, int]:
+    """Roofline for the chunked DeltaNet training forward, head-major.
+
+    Two state matmuls per token. In: q, k, v, beta. Out: the output, the four chunk
+    buffers the backward reads, and the per-chunk state, which is fp32 whatever the
+    inputs are.
+    """
+    data = _shape_or_attrs(op, kwargs)
+    batch, heads, seq_len, dim_k, dim_v = _chunkwise_dims_bhsd(data)
+    chunk = int(data.get("chunk_size", 64))
+    elem_bytes = _dtype_itemsize(data.get("dtype", data.get("dtypes", "float16")))
+
+    flops = 2 * batch * heads * seq_len * dim_k * dim_v
+    per_token = (2 * dim_k + dim_v + 1) + (dim_v + 2 * chunk + dim_k + dim_v)
+    state = batch * heads * (seq_len // chunk + 1) * dim_k * dim_v
+    nbytes = batch * heads * seq_len * per_token * elem_bytes + state * 4
+    return int(flops), int(nbytes)
+
+
+def deltanet_bwd_roofline(op: Any | None = None, **kwargs: Any) -> tuple[int, int]:
+    """Roofline for the chunked DeltaNet backward, head-major.
+
+    Twice the forward's matmul work. In: do, q, k, v, beta and the chunk buffers the
+    forward saved, the fp32 state among them. Out: the four gradients.
+    """
+    data = _shape_or_attrs(op, kwargs)
+    batch, heads, seq_len, dim_k, dim_v = _chunkwise_dims_bhsd(data)
+    chunk = int(data.get("chunk_size", 64))
+    elem_bytes = _dtype_itemsize(data.get("dtype", data.get("dtypes", "float16")))
+
+    flops = 4 * batch * heads * seq_len * dim_k * dim_v
+    per_token = (3 * dim_k + 3 * dim_v + 1 + 2 * chunk) + (2 * dim_k + dim_v + 1)
+    state = batch * heads * (seq_len // chunk + 1) * dim_k * dim_v
+    nbytes = batch * heads * seq_len * per_token * elem_bytes + state * 4
+    return int(flops), int(nbytes)
+
+
+def gated_deltanet_bwd_roofline(op: Any | None = None, **kwargs: Any) -> tuple[int, int]:
+    """Roofline for the Gated DeltaNet backward, head-major.
+
+    The gate adds one tensor in and one gradient out over the ungated backward. The
+    per-chunk state the forward saved is read in the input dtype.
+    """
+    data = _shape_or_attrs(op, kwargs)
+    batch, heads, seq_len, dim_k, dim_v = _chunkwise_dims_bhsd(data)
+    chunk = int(data.get("chunk_size", 64))
+    elem_bytes = _dtype_itemsize(data.get("dtype", data.get("dtypes", "float16")))
+
+    flops = 4 * batch * heads * seq_len * dim_k * dim_v
+    tokens = batch * heads * seq_len
+    state = batch * heads * (seq_len // chunk + 1) * dim_k * dim_v
+    nbytes = (tokens * (4 * dim_k + 3 * dim_v + 4) + state) * elem_bytes
+    return int(flops), int(nbytes)
+
+
+def gla_fwd_roofline(op: Any | None = None, **kwargs: Any) -> tuple[int, int]:
+    """Roofline for the chunked GLA forward, token-major: one state matmul pair per token."""
+    data = _shape_or_attrs(op, kwargs)
+    batch, heads, seq_len, dim_k, dim_v = _chunkwise_dims_bshd(data)
+    elem_bytes = _dtype_itemsize(data.get("dtype", data.get("dtypes", "float16")))
+
+    flops = 2 * batch * heads * seq_len * dim_k * dim_v
+    tokens = batch * seq_len * heads
+    state = batch * heads * dim_k * dim_v
+    seeded = data.get("initial_state") is not None or data.get("initial_state_shape") is not None
+    # in: q, k, v, g and the fp32 state a caller may seed; out: o and the fp32 final state.
+    nbytes = tokens * (3 * dim_k + 2 * dim_v) * elem_bytes + state * (2 if seeded else 1) * 4
+    return int(flops), int(nbytes)
+
+
+def gla_bwd_roofline(op: Any | None = None, **kwargs: Any) -> tuple[int, int]:
+    """Roofline for the chunked GLA backward, token-major: twice the forward's matmuls.
+
+    In: q, k, v, g, do in the input dtype, plus the fp32 per-chunk states and the
+    final-state gradient. Out: four gradients, which the kernel accumulates in fp32.
+    """
+    data = _shape_or_attrs(op, kwargs)
+    batch, heads, seq_len, dim_k, dim_v = _chunkwise_dims_bshd(data)
+    chunk = int(data.get("chunk_size", 64))
+    elem_bytes = _dtype_itemsize(data.get("dtype", data.get("dtypes", "float16")))
+
+    flops = 4 * batch * heads * seq_len * dim_k * dim_v
+    tokens = batch * seq_len * heads
+    states = batch * heads * dim_k * dim_v * (seq_len // chunk + 2)
+    nbytes = (
+        tokens * (3 * dim_k + 2 * dim_v) * elem_bytes
+        + tokens * (3 * dim_k + dim_v) * 4
+        + states * 4
+    )
+    return int(flops), int(nbytes)
+
+
 def _distribute_total(total: int, batch: int, max_len: int) -> list[int]:
     lengths = [0] * batch
     remaining = total
@@ -1010,6 +1102,26 @@ def gemm_fwd_roofline(op: "Op") -> tuple[int, int]:
     return int(flops), int(nbytes)
 
 
+def gemm_fp8_fwd_roofline(op: "Op") -> tuple[int, int]:
+    """Roofline for dense FP8 ``GemmFp8FwdOp``."""
+    if getattr(op, "m", None) is None or getattr(op, "dtype", None) is None:
+        raise RuntimeError(
+            "GemmFp8FwdOp.eval_roofline() is valid only after the first forward(); "
+            "m/n/k and dtype are inferred from the inputs."
+        )
+    m, n, k = op.m, op.n, op.k
+    input_bytes = op.dtype.itemsize
+    out_bytes = op.out_dtype.itemsize
+    scale_a_shape = getattr(op, "scale_a_shape", (1, 1))
+    scale_b_shape = getattr(op, "scale_b_shape", (1, 1))
+    scale_elems = scale_a_shape[0] * scale_a_shape[1] + scale_b_shape[0] * scale_b_shape[1]
+    flops = 2 * m * n * k
+    nbytes = (m * k + n * k) * input_bytes + m * n * out_bytes + scale_elems * 4
+    if getattr(op, "has_bias", False):
+        nbytes += n * out_bytes
+    return int(flops), int(nbytes)
+
+
 def gemm_w4a16_fwd_roofline(op: "Op") -> tuple[int, int]:
     """Roofline for dense W4A16 ``GemmW4A16FwdOp``."""
     if getattr(op, "m", None) is None or getattr(op, "dtype", None) is None:
@@ -1248,6 +1360,29 @@ def bmm_fwd_roofline(op: "Op") -> tuple[int, int]:
     elem_bytes = op.dtype.itemsize
     flops = 2 * batch * m * n * k
     nbytes = batch * (m * k + n * k + m * n) * elem_bytes
+    return int(flops), int(nbytes)
+
+
+def bmm_fp8_fwd_roofline(op: "Op") -> tuple[int, int]:
+    """Roofline for batched FP8 GEMM ``BmmFp8KNFwdOp``.
+
+    Layout matches the fp16 ``bmm_fwd_roofline``: ``a: [B, M, K]``,
+    ``b: [B, K, N]``. Per-tensor scales only and no fused bias, so bytes are
+    ``B*M*K`` (A, fp8) + ``B*K*N`` (B, fp8) + ``B*M*N`` (C, ``out_dtype``)
+    + 8 for the two batch-independent fp32 scales.
+
+    Valid only after the first ``forward()`` binds dims and dtype.
+    """
+    if getattr(op, "m", None) is None or getattr(op, "dtype", None) is None:
+        raise RuntimeError(
+            "BmmFp8KNFwdOp.eval_roofline() is valid only after the first forward(); "
+            "batch/m/n/k and dtype are inferred from the inputs."
+        )
+    batch, m, n, k = op.batch, op.m, op.n, op.k
+    input_bytes = op.dtype.itemsize
+    out_bytes = op.out_dtype.itemsize
+    flops = 2 * batch * m * n * k
+    nbytes = batch * ((m * k + n * k) * input_bytes + m * n * out_bytes) + 8
     return int(flops), int(nbytes)
 
 

--- a/tests/compile_contract.py
+++ b/tests/compile_contract.py
@@ -24,6 +24,7 @@ _EVIDENCE_MODULES = (
     "tests.ops.test_moe_compile",
     "tests.ops.test_norm_compile",
     "tests.ops.test_pool",
+    "tests.ops.test_reduction_compile",
     "tests.ops.test_rms_norm",
     "tests.test_compile",
 )

--- a/tests/ops/test_argreduce.py
+++ b/tests/ops/test_argreduce.py
@@ -696,7 +696,9 @@ def test_argreduce_tuning_space_matches_its_kernel(
     """
     from tileops.kernels.reduction.argreduce import ArgreduceKernel
 
-    kernel = ArgreduceKernel(m, n, "argmax", torch.float16, inner_stride=inner_stride)
+    kernel = ArgreduceKernel(
+        m, n, "argmax", torch.float16, reduce_axes=(1,), inner_stride=inner_stride
+    )
     assert kernel.strategy == strategy
     accepted = set(kernel.kernel.signature.parameters)
     assert set(kernel.default_config) <= accepted

--- a/tests/ops/test_cumulative.py
+++ b/tests/ops/test_cumulative.py
@@ -318,7 +318,9 @@ def test_cumsum_backend_dispatch(M: int, N: int, dtype: torch.dtype, parallel: b
         f"({M}, {N}) {dtype}: max_diff={torch.abs(y - ref).max()}"
     )
 
-    kernel = op._get_kernel((), M, N, dtype, x.device.index)
+    # The kernel the call built, not one refetched by a key: the key is a read-back of
+    # the arguments and says nothing about which backend was chosen.
+    (kernel,) = op.built_kernels("cumulative_fwd").values()
     assert kernel.use_parallel == parallel, f"({M}, {N}): unexpected backend"
     if parallel:
         assert kernel.config["block_n"] == (256 if N > 16384 else 128)

--- a/tests/ops/test_logical_reduce.py
+++ b/tests/ops/test_logical_reduce.py
@@ -651,7 +651,7 @@ def test_logical_reduce_long_sequence_tiled(op_kind: str, dtype: torch.dtype) ->
     )
     compare = _exact_compare_int64 if op_kind == "count_nonzero" else _exact_compare
     test.check(op, *test.gen_inputs(), compare=compare)
-    kernel = op.built_kernels(op._kernel_key)[(3, 33024, dtype)]
+    (kernel,) = op.built_kernels(op._kernel_key).values()
     assert kernel.config["block_m"] > test.shape[0]
     assert kernel.config["tile_n"] > 0
 
@@ -670,7 +670,7 @@ def test_logical_reduce_tiled_autotune() -> None:
     op = AnyFwdOp(dim=-1, tune=True)
     test.check(op, *test.gen_inputs(), compare=_exact_compare)
 
-    kernel = op.built_kernels(op._kernel_key)[(m, n, dtype)]
+    (kernel,) = op.built_kernels(op._kernel_key).values()
     assert kernel._needs_tiling
     assert kernel.config in kernel.autotune_configs
 

--- a/tests/ops/test_reduce.py
+++ b/tests/ops/test_reduce.py
@@ -245,6 +245,7 @@ def test_reduce_caller_tile_n_validated() -> None:
             N=n,
             op_kind="sum",
             dtype=dtype,
+            reduce_axes=(1,),
             tune=False,
             config={"block_m": block_m, "threads": 128, "tile_n": tile_n},
         )
@@ -282,7 +283,7 @@ def test_reduce_untiled_autotune_unaligned_n() -> None:
     op = SumFwdOp(dim=-1, tune=True)
     test.check(op, *test.gen_inputs(), **_tol(dtype))
 
-    kernel = op.built_kernels(op._kernel_key)[(m, n, dtype)]
+    (kernel,) = op.built_kernels(op._kernel_key).values()
     assert not kernel._needs_tiling
     assert {c["block_m"] for c in kernel.autotune_configs} == {1}
 
@@ -312,7 +313,7 @@ def test_reduce_tiled_autotune(op_kind: str) -> None:
         op = VarFwdOp(dim=-1, tune=True)
     test.check(op, *test.gen_inputs(), **_tol(dtype))
 
-    kernel = op.built_kernels(op._kernel_key)[(m, n, dtype)]
+    (kernel,) = op.built_kernels(op._kernel_key).values()
     assert kernel._needs_tiling
     assert kernel.config in kernel.autotune_configs
 

--- a/tests/ops/test_reduce_scalar_conformance.py
+++ b/tests/ops/test_reduce_scalar_conformance.py
@@ -1,9 +1,12 @@
 """Spec-conformance tests for scalar (0-D) reduction inputs.
 
-Covers the reduction families whose manifest/API contract accepts scalar
-inputs and must match PyTorch on 0-D tensors. This is the missing piece that
-lets the shared reduction base promote `implemented` from a shape-limited
-claim to the full PyTorch scalar contract.
+A 0-D input is answered by the op itself — every family's kernel is undefined at that
+extent — so what is under test is the closed form each one returns and its agreement with
+PyTorch.
+
+``keepdim`` cannot add an axis to a 0-D result and the element type reaches no branch, so
+neither is crossed with ``dim``; each is swept once. ``dim`` is crossed with nothing but
+carries every form ``_validate_scalar_dim`` accepts.
 """
 
 from __future__ import annotations
@@ -14,177 +17,133 @@ import torch
 pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 
 _FLOAT_DTYPES = [torch.float16, torch.bfloat16, torch.float32]
+_DTYPE_IDS = ["fp16", "bf16", "fp32"]
 _DIMS = [None, 0, -1, (), []]
 _DIM_IDS = ["dim=None", "dim=0", "dim=-1", "dim=()", "dim=[]"]
 
+#: A 0-D input and the reference each op must match on it. ``prod`` takes no ``None``
+#: dim, so it is asked about an int one.
+_ARITHMETIC = [
+    pytest.param("SumFwdOp", torch.sum, id="sum"),
+    pytest.param("MeanFwdOp", torch.mean, id="mean"),
+    pytest.param("AmaxFwdOp", torch.amax, id="amax"),
+    pytest.param("AminFwdOp", torch.amin, id="amin"),
+]
+_WELFORD = ["VarFwdOp", "StdFwdOp", "VarMeanFwdOp"]
+_LOGICAL = [
+    pytest.param("AllFwdOp", torch.all, torch.bool, id="all"),
+    pytest.param("AnyFwdOp", torch.any, torch.bool, id="any"),
+    pytest.param("CountNonzeroFwdOp", torch.count_nonzero, torch.int64, id="count-nonzero"),
+]
 
-def _make_scalar(dtype: torch.dtype) -> torch.Tensor:
-    return torch.tensor(1.5, dtype=dtype, device="cuda")
+
+def _op(name: str, **kwargs):
+    import tileops.ops.reduction.logical_reduce as logical
+    import tileops.ops.reduction.reduce as reduce_ops
+
+    module = logical if hasattr(logical, name) else reduce_ops
+    return getattr(module, name)(**kwargs)
 
 
-def _make_zero_scalar(dtype: torch.dtype) -> torch.Tensor:
-    return torch.tensor(0.0, dtype=dtype, device="cuda")
+def _as_tuple(value):
+    return value if isinstance(value, tuple) else (value,)
+
+
+def _welford_ref(name: str, x, dim, keepdim):
+    fn = {"VarFwdOp": torch.var, "StdFwdOp": torch.std, "VarMeanFwdOp": torch.var_mean}[name]
+    out = fn(x.float(), dim=dim, keepdim=keepdim, correction=1)
+    return tuple(t.to(x.dtype) for t in _as_tuple(out))
 
 
 @pytest.mark.smoke
+@pytest.mark.parametrize("op_name, torch_fn", _ARITHMETIC)
 @pytest.mark.parametrize("dim", _DIMS, ids=_DIM_IDS)
-@pytest.mark.parametrize("keepdim", [False, True], ids=["keepdim=False", "keepdim=True"])
-@pytest.mark.parametrize("dtype", _FLOAT_DTYPES, ids=["fp16", "bf16", "fp32"])
-def test_scalar_arithmetic_reductions(dim, keepdim: bool, dtype: torch.dtype) -> None:
-    from tileops.ops.reduction.reduce import AmaxFwdOp, AminFwdOp, MeanFwdOp, SumFwdOp
+def test_an_arithmetic_reduction_of_one_element_is_that_element(op_name, torch_fn, dim) -> None:
+    x = torch.tensor(1.5, dtype=torch.float16, device="cuda")
 
-    x = _make_scalar(dtype)
-    cases = [
-        (SumFwdOp, torch.sum),
-        (MeanFwdOp, torch.mean),
-        (AmaxFwdOp, torch.amax),
-        (AminFwdOp, torch.amin),
-    ]
+    y = _op(op_name, dim=dim)(x)
 
-    for op_cls, torch_fn in cases:
-        op = op_cls(dim=dim, keepdim=keepdim)
-        y = op(x)
-        ref = torch_fn(x.float(), dim=dim, keepdim=keepdim).to(dtype)
-        assert y.shape == ref.shape, (
-            f"{op_cls.__name__} scalar dim={dim} keepdim={keepdim} dtype={dtype}: "
-            f"shape {y.shape} vs ref {ref.shape}"
-        )
-        torch.testing.assert_close(y, ref, atol=1e-4, rtol=1e-4)
-
-
-@pytest.mark.smoke
-@pytest.mark.parametrize("dim", [0, -1], ids=["dim=0", "dim=-1"])
-@pytest.mark.parametrize("keepdim", [False, True], ids=["keepdim=False", "keepdim=True"])
-@pytest.mark.parametrize("dtype", _FLOAT_DTYPES, ids=["fp16", "bf16", "fp32"])
-def test_scalar_prod_reduction(dim: int, keepdim: bool, dtype: torch.dtype) -> None:
-    from tileops.ops.reduction.reduce import ProdFwdOp
-
-    x = _make_scalar(dtype)
-    op = ProdFwdOp(dim=dim, keepdim=keepdim)
-    y = op(x)
-    ref = torch.prod(x.float(), dim=dim, keepdim=keepdim).to(dtype)
-    assert y.shape == ref.shape, (
-        f"ProdFwdOp scalar dim={dim} keepdim={keepdim} dtype={dtype}: "
-        f"shape {y.shape} vs ref {ref.shape}"
-    )
+    ref = torch_fn(x.float(), dim=dim).to(x.dtype)
+    assert y.shape == ref.shape, f"{op_name} dim={dim}: {y.shape} vs {ref.shape}"
     torch.testing.assert_close(y, ref, atol=1e-4, rtol=1e-4)
 
 
 @pytest.mark.smoke
-# A scalar input leaves correction=1 with no degrees of freedom, so both the
-# op and the PyTorch reference warn. That is the contract under test.
-@pytest.mark.filterwarnings("ignore:.*degrees of freedom:UserWarning")
-@pytest.mark.parametrize("dim", _DIMS, ids=_DIM_IDS)
+@pytest.mark.parametrize("dtype", _FLOAT_DTYPES, ids=_DTYPE_IDS)
 @pytest.mark.parametrize("keepdim", [False, True], ids=["keepdim=False", "keepdim=True"])
-@pytest.mark.parametrize("dtype", _FLOAT_DTYPES, ids=["fp16", "bf16", "fp32"])
-def test_scalar_welford_reductions(dim, keepdim: bool, dtype: torch.dtype) -> None:
-    from tileops.ops.reduction.reduce import StdFwdOp, VarFwdOp, VarMeanFwdOp
+def test_the_scalar_path_honours_dtype_and_keepdim(dtype, keepdim) -> None:
+    """Swept rather than crossed: neither reaches a branch ``dim`` does not."""
+    x = torch.tensor(1.5, dtype=dtype, device="cuda")
 
-    x = _make_scalar(dtype)
-    cases = [
-        (
-            VarFwdOp,
-            lambda t, *, dim, keepdim: torch.var(
-                t.float(), dim=dim, keepdim=keepdim, correction=1
-            ).to(dtype),
-        ),
-        (
-            StdFwdOp,
-            lambda t, *, dim, keepdim: torch.std(
-                t.float(), dim=dim, keepdim=keepdim, correction=1
-            ).to(dtype),
-        ),
-    ]
+    y = _op("SumFwdOp", dim=None, keepdim=keepdim)(x)
 
-    for op_cls, ref_fn in cases:
-        op = op_cls(dim=dim, keepdim=keepdim)
-        y = op(x)
-        ref = ref_fn(x, dim=dim, keepdim=keepdim)
-        assert y.shape == ref.shape, (
-            f"{op_cls.__name__} scalar dim={dim} keepdim={keepdim} dtype={dtype}: "
-            f"shape {y.shape} vs ref {ref.shape}"
-        )
-        torch.testing.assert_close(y, ref, atol=1e-4, rtol=1e-4, equal_nan=True)
+    ref = torch.sum(x.float(), dim=None, keepdim=keepdim).to(dtype)
+    assert y.shape == ref.shape
+    assert y.dtype == dtype
+    torch.testing.assert_close(y, ref, atol=1e-4, rtol=1e-4)
 
-    op = VarMeanFwdOp(dim=dim, keepdim=keepdim)
-    var_y, mean_y = op(x)
-    ref_var, ref_mean = torch.var_mean(
-        x.float(),
-        dim=dim,
-        keepdim=keepdim,
-        correction=1,
-    )
-    ref_var = ref_var.to(dtype)
-    ref_mean = ref_mean.to(dtype)
-    assert var_y.shape == ref_var.shape
-    assert mean_y.shape == ref_mean.shape
-    torch.testing.assert_close(var_y, ref_var, atol=1e-4, rtol=1e-4, equal_nan=True)
-    torch.testing.assert_close(mean_y, ref_mean, atol=1e-4, rtol=1e-4, equal_nan=True)
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("dim", [0, -1], ids=["dim=0", "dim=-1"])
+def test_prod_of_one_element_is_that_element(dim) -> None:
+    """``ProdFwdOp`` narrows ``dim`` to an int, so it is asked about the two it takes."""
+    x = torch.tensor(1.5, dtype=torch.float16, device="cuda")
+
+    y = _op("ProdFwdOp", dim=dim)(x)
+
+    ref = torch.prod(x.float(), dim=dim).to(x.dtype)
+    assert y.shape == ref.shape
+    torch.testing.assert_close(y, ref, atol=1e-4, rtol=1e-4)
+
+
+@pytest.mark.smoke
+# One element leaves correction=1 without degrees of freedom, so both sides warn. That is
+# the contract under test.
+@pytest.mark.filterwarnings("ignore:.*degrees of freedom:UserWarning")
+@pytest.mark.parametrize("op_name", _WELFORD)
+@pytest.mark.parametrize("dim", _DIMS, ids=_DIM_IDS)
+def test_a_welford_reduction_of_one_element_matches_torch(op_name, dim) -> None:
+    """``correction=1`` over one element is undefined, and PyTorch calls that ``nan``."""
+    x = torch.tensor(1.5, dtype=torch.float16, device="cuda")
+
+    got = _as_tuple(_op(op_name, dim=dim)(x))
+
+    for g, w in zip(got, _welford_ref(op_name, x, dim, False), strict=True):
+        assert g.shape == w.shape, f"{op_name} dim={dim}: {g.shape} vs {w.shape}"
+        torch.testing.assert_close(g, w, atol=1e-4, rtol=1e-4, equal_nan=True)
 
 
 @pytest.mark.smoke
 @pytest.mark.filterwarnings("ignore:.*degrees of freedom:UserWarning")
+@pytest.mark.parametrize("op_name", _WELFORD)
 @pytest.mark.parametrize(
     ("shape", "dim"),
     [((1,), None), ((1,), 0), ((2, 1), -1)],
-    ids=["shape=(1,),dim=None", "shape=(1,),dim=0", "shape=(2,1),dim=-1"],
+    ids=["1d-full", "1d-axis", "2d-inner-axis"],
 )
-@pytest.mark.parametrize("keepdim", [False, True], ids=["keepdim=False", "keepdim=True"])
-def test_invalid_dof_welford_reductions_match_pytorch(
-    shape: tuple[int, ...],
-    dim,
-    keepdim: bool,
-) -> None:
-    from tileops.ops.reduction.reduce import StdFwdOp, VarFwdOp, VarMeanFwdOp
+def test_a_reduction_with_no_degrees_of_freedom_matches_torch(op_name, shape, dim) -> None:
+    """A length-1 axis with ``correction=1``: the kernel cannot be built for it."""
+    x = torch.ones(shape, dtype=torch.float32, device="cuda").cumsum(0)
 
-    if shape == (2, 1):
-        x = torch.tensor([[1.5], [2.5]], dtype=torch.float32, device="cuda")
-    else:
-        x = torch.tensor([1.5], dtype=torch.float32, device="cuda")
+    got = _as_tuple(_op(op_name, dim=dim)(x))
 
-    for op_cls, torch_fn in [
-        (VarFwdOp, torch.var),
-        (StdFwdOp, torch.std),
-    ]:
-        op = op_cls(dim=dim, keepdim=keepdim)
-        y = op(x)
-        ref = torch_fn(x, dim=dim, keepdim=keepdim, correction=1)
-        torch.testing.assert_close(y, ref, atol=1e-4, rtol=1e-4, equal_nan=True)
-
-    op = VarMeanFwdOp(dim=dim, keepdim=keepdim)
-    var_y, mean_y = op(x)
-    ref_var, ref_mean = torch.var_mean(x, dim=dim, keepdim=keepdim, correction=1)
-    torch.testing.assert_close(var_y, ref_var, atol=1e-4, rtol=1e-4, equal_nan=True)
-    torch.testing.assert_close(mean_y, ref_mean, atol=1e-4, rtol=1e-4, equal_nan=True)
+    for g, w in zip(got, _welford_ref(op_name, x, dim, False), strict=True):
+        torch.testing.assert_close(g, w, atol=1e-4, rtol=1e-4, equal_nan=True)
 
 
 @pytest.mark.smoke
+@pytest.mark.parametrize("op_name, torch_fn, out_dtype", _LOGICAL)
 @pytest.mark.parametrize("dim", _DIMS, ids=_DIM_IDS)
-@pytest.mark.parametrize("dtype", _FLOAT_DTYPES, ids=["fp16", "bf16", "fp32"])
-@pytest.mark.parametrize(
-    "make_input",
-    [_make_zero_scalar, _make_scalar],
-    ids=["zero", "nonzero"],
-)
-def test_scalar_logical_and_count_reductions(
-    dim,
-    dtype: torch.dtype,
-    make_input,
+@pytest.mark.parametrize("value", [0.0, 1.5], ids=["zero", "nonzero"])
+def test_a_logical_reduction_of_one_element_matches_torch(
+    op_name, torch_fn, out_dtype, dim, value
 ) -> None:
-    from tileops.ops.reduction.logical_reduce import AllFwdOp, AnyFwdOp, CountNonzeroFwdOp
+    """Both truth values, because the predicate is what these ops compute."""
+    x = torch.tensor(value, dtype=torch.float16, device="cuda")
 
-    x = make_input(dtype)
+    y = _op(op_name, dim=dim)(x)
 
-    for op_cls, torch_fn, out_dtype in [
-        (AllFwdOp, torch.all, torch.bool),
-        (AnyFwdOp, torch.any, torch.bool),
-        (CountNonzeroFwdOp, torch.count_nonzero, torch.int64),
-    ]:
-        op = op_cls(dim=dim)
-        y = op(x)
-        ref = torch_fn(x, dim=dim)
-        assert y.dtype == out_dtype, f"{op_cls.__name__} scalar dtype {y.dtype}"
-        assert y.shape == ref.shape, (
-            f"{op_cls.__name__} scalar dim={dim} dtype={dtype}: shape {y.shape} vs ref {ref.shape}"
-        )
-        torch.testing.assert_close(y, ref, atol=0, rtol=0)
+    ref = torch_fn(x, dim=dim)
+    assert y.dtype == out_dtype, f"{op_name}: {y.dtype}"
+    assert y.shape == ref.shape, f"{op_name} dim={dim}: {y.shape} vs {ref.shape}"
+    torch.testing.assert_close(y, ref, atol=0, rtol=0)

--- a/tests/ops/test_reduce_variance_conformance.py
+++ b/tests/ops/test_reduce_variance_conformance.py
@@ -1,17 +1,12 @@
 """Spec-conformance tests for variance reductions.
 
-Covers ``VarFwdOp``, ``StdFwdOp``, ``VarMeanFwdOp`` against the PyTorch
-references (``torch.var`` / ``torch.std`` / ``torch.var_mean``) across the
-three ``dim`` shapes the manifest signature declares — ``int``,
-``tuple[int, ...]``, ``None`` — every ``correction`` value in ``{0, 1, 2}``,
-and both ``keepdim`` values.
+``VarFwdOp``, ``StdFwdOp`` and ``VarMeanFwdOp`` against ``torch.var`` / ``torch.std`` /
+``torch.var_mean``. The three share a forward, so they share a case table.
 
-These tests assert the output shape matches PyTorch (in particular, a 0-D
-tensor for ``dim=None, keepdim=False``) and that the numerics match within
-standard reduction tolerances. ``VarMeanFwdOp`` additionally asserts the
-returned tuple shape/dtype matches ``torch.var_mean`` element-by-element.
-Once green, the corresponding manifest entries can flip from
-``status: spec-only`` to ``status: implemented``.
+The axes are kept apart rather than crossed, because each answers a different question:
+the ``dim`` shape picks a ``normalize_dim`` branch and ``keepdim`` an output-shape branch,
+so those two are crossed; ``correction`` is a constant the kernel bakes in, where only
+"zero" and "nonzero" differ; and the element type has to be swept but changes no branch.
 """
 
 from __future__ import annotations
@@ -19,240 +14,114 @@ from __future__ import annotations
 import pytest
 import torch
 
-from tileops.ops.reduction.reduce import (
-    StdFwdOp,
-    VarFwdOp,
-    VarMeanFwdOp,
-)
+from tileops.ops.reduction.reduce import StdFwdOp, VarFwdOp, VarMeanFwdOp
 
 _SHAPE = (4, 8, 256)
-_UNALIGNED_SHAPE = (4, 8, 255)
+_UNALIGNED_SHAPE = (4, 8, 255)  # innermost off a tile multiple: the masked-load boundary
+
+_DIMS = [
+    pytest.param(-1, id="dim=int"),
+    pytest.param((0, 2), id="dim=tuple"),
+    pytest.param(None, id="dim=None"),
+]
 
 
 def _tol(dtype: torch.dtype) -> dict:
-    # Match the reduction-test convention shared by test_reduce_dim_none.py /
-    # test_reduce_multidim.py / test_reduce_arithmetic_conformance.py: 1e-4
-    # for fp32, 1e-2 for half precision (Welford accumulates in fp32 but the
-    # narrowing cast at the boundary still produces ULP-scale rounding that
-    # tighter tolerances catch noisily on real GPUs).
+    # The reduction-test convention: 1e-4 for fp32, 1e-2 for half precision. Welford
+    # accumulates in fp32, but the narrowing cast at the boundary still rounds.
     if dtype == torch.float32:
         return {"atol": 1e-4, "rtol": 1e-4}
     return {"atol": 1e-2, "rtol": 1e-2}
 
 
-def _ref_var(x: torch.Tensor, dim, keepdim: bool, correction: int) -> torch.Tensor:
-    return torch.var(
-        x.float(),
-        dim=dim,
-        keepdim=keepdim,
-        correction=correction,
-    ).to(x.dtype)
+def _ref_var(x, dim, keepdim, correction):
+    return (torch.var(x.float(), dim=dim, keepdim=keepdim, correction=correction).to(x.dtype),)
 
 
-def _ref_std(x: torch.Tensor, dim, keepdim: bool, correction: int) -> torch.Tensor:
-    return torch.std(
-        x.float(),
-        dim=dim,
-        keepdim=keepdim,
-        correction=correction,
-    ).to(x.dtype)
+def _ref_std(x, dim, keepdim, correction):
+    return (torch.std(x.float(), dim=dim, keepdim=keepdim, correction=correction).to(x.dtype),)
 
 
-def _ref_var_mean(
-    x: torch.Tensor,
-    dim,
-    keepdim: bool,
-    correction: int,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    var, mean = torch.var_mean(
-        x.float(),
-        dim=dim,
-        keepdim=keepdim,
-        correction=correction,
-    )
+def _ref_var_mean(x, dim, keepdim, correction):
+    var, mean = torch.var_mean(x.float(), dim=dim, keepdim=keepdim, correction=correction)
     return var.to(x.dtype), mean.to(x.dtype)
 
 
+#: Each op with the reference it must match. Every reference returns a tuple, so one
+#: comparison serves the two single-output ops and the one that returns a pair.
+_OPS = [
+    pytest.param(VarFwdOp, _ref_var, id="var"),
+    pytest.param(StdFwdOp, _ref_std, id="std"),
+    pytest.param(VarMeanFwdOp, _ref_var_mean, id="var-mean"),
+]
+
+
+def _check(op_cls, ref_fn, x, dim, keepdim, correction) -> None:
+    """Run *op_cls* against its reference and compare every output it returns."""
+    out = op_cls(dim=dim, correction=correction, keepdim=keepdim)(x)
+    got = out if isinstance(out, tuple) else (out,)
+    want = ref_fn(x, dim, keepdim, correction)
+    for g, w in zip(got, want, strict=True):
+        assert g.shape == w.shape, f"shape {g.shape} vs ref {w.shape}"
+        assert g.dtype == w.dtype, f"dtype {g.dtype} vs ref {w.dtype}"
+        torch.testing.assert_close(g, w, **_tol(x.dtype))
+
+
 @pytest.mark.smoke
-@pytest.mark.parametrize(
-    "dim",
-    [
-        pytest.param(-1, id="dim=int"),
-        pytest.param((0, 2), id="dim=tuple"),
-        pytest.param(None, id="dim=None"),
-    ],
-)
-@pytest.mark.parametrize("correction", [0, 1, 2], ids=["c=0", "c=1", "c=2"])
+@pytest.mark.parametrize("op_cls, ref_fn", _OPS)
+@pytest.mark.parametrize("dim", _DIMS)
 @pytest.mark.parametrize("keepdim", [False, True], ids=["keepdim=False", "keepdim=True"])
+def test_the_output_shape_matches_torch(op_cls, ref_fn, dim, keepdim) -> None:
+    """The two axes that pick branches, crossed: ``dim=None, keepdim=False`` is 0-D."""
+    torch.manual_seed(0)
+    x = torch.randn(*_SHAPE, dtype=torch.float16, device="cuda")
+
+    _check(op_cls, ref_fn, x, dim, keepdim, correction=1)
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("op_cls, ref_fn", _OPS)
 @pytest.mark.parametrize(
-    "dtype",
-    [torch.float16, torch.bfloat16, torch.float32],
-    ids=["fp16", "bf16", "fp32"],
+    "dtype", [torch.float16, torch.bfloat16, torch.float32], ids=["fp16", "bf16", "fp32"]
 )
-def test_var_conformance(
-    dim,
-    correction: int,
-    keepdim: bool,
-    dtype: torch.dtype,
-) -> None:
-    """Each (dim-shape, correction, keepdim, dtype) cell must match torch.var."""
+def test_every_declared_dtype_matches_torch(op_cls, ref_fn, dtype) -> None:
+    """Swept, not crossed: the element type reaches no branch the shape axes do not."""
     torch.manual_seed(0)
     x = torch.randn(*_SHAPE, dtype=dtype, device="cuda")
-    op = VarFwdOp(dim=dim, correction=correction, keepdim=keepdim)
-    y = op(x)
-    ref = _ref_var(x, dim, keepdim, correction)
-    assert y.shape == ref.shape, (
-        f"VarFwdOp dim={dim} correction={correction} keepdim={keepdim} "
-        f"dtype={dtype}: shape {y.shape} vs ref {ref.shape}"
-    )
-    torch.testing.assert_close(y, ref, **_tol(dtype))
+
+    _check(op_cls, ref_fn, x, dim=-1, keepdim=False, correction=1)
 
 
 @pytest.mark.smoke
-@pytest.mark.parametrize(
-    "dim",
-    [
-        pytest.param(-1, id="dim=int"),
-        pytest.param((0, 2), id="dim=tuple"),
-        pytest.param(None, id="dim=None"),
-    ],
-)
-@pytest.mark.parametrize("correction", [0, 1, 2], ids=["c=0", "c=1", "c=2"])
-@pytest.mark.parametrize("keepdim", [False, True], ids=["keepdim=False", "keepdim=True"])
-@pytest.mark.parametrize(
-    "dtype",
-    [torch.float16, torch.bfloat16, torch.float32],
-    ids=["fp16", "bf16", "fp32"],
-)
-def test_std_conformance(
-    dim,
-    correction: int,
-    keepdim: bool,
-    dtype: torch.dtype,
-) -> None:
-    """Each (dim-shape, correction, keepdim, dtype) cell must match torch.std."""
+@pytest.mark.parametrize("op_cls, ref_fn", _OPS)
+def test_a_zero_correction_matches_torch(op_cls, ref_fn) -> None:
+    """The one ``correction`` that differs in kind: the denominator is ``N``, not ``N - c``."""
     torch.manual_seed(0)
-    x = torch.randn(*_SHAPE, dtype=dtype, device="cuda")
-    op = StdFwdOp(dim=dim, correction=correction, keepdim=keepdim)
-    y = op(x)
-    ref = _ref_std(x, dim, keepdim, correction)
-    assert y.shape == ref.shape, (
-        f"StdFwdOp dim={dim} correction={correction} keepdim={keepdim} "
-        f"dtype={dtype}: shape {y.shape} vs ref {ref.shape}"
-    )
-    torch.testing.assert_close(y, ref, **_tol(dtype))
+    x = torch.randn(*_SHAPE, dtype=torch.float16, device="cuda")
+
+    _check(op_cls, ref_fn, x, dim=-1, keepdim=False, correction=0)
 
 
 @pytest.mark.smoke
-@pytest.mark.parametrize(
-    "dim",
-    [
-        pytest.param(-1, id="dim=int"),
-        pytest.param((0, 2), id="dim=tuple"),
-        pytest.param(None, id="dim=None"),
-    ],
-)
-@pytest.mark.parametrize("correction", [0, 1, 2], ids=["c=0", "c=1", "c=2"])
-@pytest.mark.parametrize("keepdim", [False, True], ids=["keepdim=False", "keepdim=True"])
-@pytest.mark.parametrize(
-    "dtype",
-    [torch.float16, torch.bfloat16, torch.float32],
-    ids=["fp16", "bf16", "fp32"],
-)
-def test_var_mean_conformance(
-    dim,
-    correction: int,
-    keepdim: bool,
-    dtype: torch.dtype,
-) -> None:
-    """Each (dim-shape, correction, keepdim, dtype) cell must match torch.var_mean.
-
-    Asserts both elements of the returned 2-tuple match PyTorch in shape,
-    dtype, and numerics.
-    """
+@pytest.mark.parametrize("op_cls, ref_fn", _OPS)
+@pytest.mark.parametrize("dim", _DIMS)
+def test_an_unaligned_innermost_dim_matches_torch(op_cls, ref_fn, dim) -> None:
+    """255 flushes the masked-load boundary that a tile-multiple extent skips."""
     torch.manual_seed(0)
-    x = torch.randn(*_SHAPE, dtype=dtype, device="cuda")
-    op = VarMeanFwdOp(dim=dim, correction=correction, keepdim=keepdim)
-    out = op(x)
-    assert isinstance(out, tuple) and len(out) == 2, (
-        f"VarMeanFwdOp must return a 2-tuple, got {type(out).__name__}"
-    )
-    var_y, mean_y = out
-    ref_var, ref_mean = _ref_var_mean(x, dim, keepdim, correction)
-    # Tuple field order: (var, mean) — same as torch.var_mean.
-    assert var_y.shape == ref_var.shape, f"var shape {var_y.shape} vs ref {ref_var.shape}"
-    assert mean_y.shape == ref_mean.shape, f"mean shape {mean_y.shape} vs ref {ref_mean.shape}"
-    assert var_y.dtype == ref_var.dtype, f"var dtype {var_y.dtype} vs ref {ref_var.dtype}"
-    assert mean_y.dtype == ref_mean.dtype, f"mean dtype {mean_y.dtype} vs ref {ref_mean.dtype}"
-    torch.testing.assert_close(var_y, ref_var, **_tol(dtype))
-    torch.testing.assert_close(mean_y, ref_mean, **_tol(dtype))
+    x = torch.randn(*_UNALIGNED_SHAPE, dtype=torch.float16, device="cuda")
+
+    _check(op_cls, ref_fn, x, dim, keepdim=False, correction=1)
 
 
 @pytest.mark.smoke
-@pytest.mark.parametrize(
-    "dim",
-    [
-        pytest.param(-1, id="dim=int"),
-        pytest.param((0, 2), id="dim=tuple"),
-        pytest.param(None, id="dim=None"),
-    ],
-)
-def test_var_unaligned_innermost(dim) -> None:
-    """Unaligned innermost dim must still match torch.var.
-
-    The aligned ``_SHAPE`` (innermost = 256, a kernel-tile multiple) bypasses
-    the Welford kernel's masked-load boundary path. Use 255 to flush the pad
-    branch on every dim-mode cell.
-    """
+def test_var_mean_returns_the_pair_in_torch_s_order() -> None:
+    """The only shape-of-return difference in the family, so the only test that needs it."""
     torch.manual_seed(0)
-    dtype = torch.float16
-    x = torch.randn(*_UNALIGNED_SHAPE, dtype=dtype, device="cuda")
-    op = VarFwdOp(dim=dim, correction=1, keepdim=False)
-    y = op(x)
-    ref = _ref_var(x, dim, False, 1)
-    assert y.shape == ref.shape
-    torch.testing.assert_close(y, ref, **_tol(dtype))
+    x = torch.randn(*_SHAPE, dtype=torch.float16, device="cuda")
 
+    out = VarMeanFwdOp(dim=-1)(x)
 
-@pytest.mark.smoke
-@pytest.mark.parametrize(
-    "dim",
-    [
-        pytest.param(-1, id="dim=int"),
-        pytest.param((0, 2), id="dim=tuple"),
-        pytest.param(None, id="dim=None"),
-    ],
-)
-def test_var_mean_unaligned_innermost(dim) -> None:
-    """Unaligned innermost dim must still match torch.var_mean on both outputs."""
-    torch.manual_seed(0)
-    dtype = torch.float16
-    x = torch.randn(*_UNALIGNED_SHAPE, dtype=dtype, device="cuda")
-    op = VarMeanFwdOp(dim=dim, correction=1, keepdim=False)
-    var_y, mean_y = op(x)
-    ref_var, ref_mean = _ref_var_mean(x, dim, False, 1)
-    assert var_y.shape == ref_var.shape
-    assert mean_y.shape == ref_mean.shape
-    torch.testing.assert_close(var_y, ref_var, **_tol(dtype))
-    torch.testing.assert_close(mean_y, ref_mean, **_tol(dtype))
-
-
-@pytest.mark.smoke
-@pytest.mark.parametrize(
-    "dim",
-    [
-        pytest.param(-1, id="dim=int"),
-        pytest.param((0, 2), id="dim=tuple"),
-        pytest.param(None, id="dim=None"),
-    ],
-)
-def test_std_unaligned_innermost(dim) -> None:
-    """Unaligned innermost dim must still match torch.std."""
-    torch.manual_seed(0)
-    dtype = torch.float16
-    x = torch.randn(*_UNALIGNED_SHAPE, dtype=dtype, device="cuda")
-    op = StdFwdOp(dim=dim, correction=1, keepdim=False)
-    y = op(x)
-    ref = _ref_std(x, dim, False, 1)
-    assert y.shape == ref.shape
-    torch.testing.assert_close(y, ref, **_tol(dtype))
+    assert isinstance(out, tuple) and len(out) == 2, out
+    ref_var, ref_mean = _ref_var_mean(x, -1, False, 1)
+    torch.testing.assert_close(out[0], ref_var, **_tol(x.dtype))
+    torch.testing.assert_close(out[1], ref_mean, **_tol(x.dtype))

--- a/tests/ops/test_reduction_compile.py
+++ b/tests/ops/test_reduction_compile.py
@@ -1,0 +1,150 @@
+"""Compile-boundary contract for the reduction family.
+
+One case per op: a cold ``torch.compile(op, fullgraph=True)`` must match eager and the
+traced graph must hold nothing but that op's own operator. Cold is the whole contract — a
+warm op has nothing left for dynamo to trace into.
+
+``dim`` is spelled out in every case. Left implicit, softmax resolves it by PyTorch's rule
+and logsumexp reduces everything, and either choice keeps the output shape while changing
+the values, so a case that does not say which axis it means proves little.
+"""
+
+import pytest
+import torch
+
+from tests.compile_contract import assert_op_owns_graph_nodes, register_compile_contract
+from tileops.ops.reduction import (
+    AllFwdOp,
+    AmaxFwdOp,
+    AminFwdOp,
+    AnyFwdOp,
+    ArgmaxFwdOp,
+    ArgminFwdOp,
+    CountNonzeroFwdOp,
+    CumprodFwdOp,
+    CumsumFwdOp,
+    InfNormFwdOp,
+    L1NormFwdOp,
+    L2NormFwdOp,
+    LogSoftmaxFwdOp,
+    LogSumExpFwdOp,
+    MeanFwdOp,
+    ProdFwdOp,
+    SoftmaxFwdOp,
+    StdFwdOp,
+    SumFwdOp,
+    VarFwdOp,
+    VarMeanFwdOp,
+)
+
+_DTYPE = torch.float16
+_ROWS = 8
+_COLS = 256
+
+_OP_CLASSES = (
+    SumFwdOp,
+    MeanFwdOp,
+    AminFwdOp,
+    AmaxFwdOp,
+    ProdFwdOp,
+    StdFwdOp,
+    VarFwdOp,
+    VarMeanFwdOp,
+    ArgmaxFwdOp,
+    ArgminFwdOp,
+    AllFwdOp,
+    AnyFwdOp,
+    CountNonzeroFwdOp,
+    L1NormFwdOp,
+    L2NormFwdOp,
+    InfNormFwdOp,
+    SoftmaxFwdOp,
+    LogSoftmaxFwdOp,
+    LogSumExpFwdOp,
+    CumsumFwdOp,
+    CumprodFwdOp,
+)
+
+for _op_cls in _OP_CLASSES:
+    register_compile_contract(_op_cls)
+
+
+def _x(*shape, dtype=_DTYPE):
+    return torch.randn(*shape, dtype=dtype, device="cuda")
+
+
+def _cases():
+    """One builder per op. Built inside the test, not at import: this module is imported on
+    the CPU-only runner that enforces the compile-contract gate."""
+    rows = (_ROWS, _COLS)
+
+    def one_tensor(op_cls, *args, **kwargs):
+        return lambda: (op_cls(*args, **kwargs), (_x(*rows),))
+
+    cases = {
+        # A reduced last axis, then a reduced leading one: the second is the case whose
+        # rows the kernel has to permute for.
+        "sum": one_tensor(SumFwdOp, dim=-1),
+        "sum-leading-axis": one_tensor(SumFwdOp, dim=0),
+        "sum-keepdim": one_tensor(SumFwdOp, dim=-1, keepdim=True),
+        "sum-full": one_tensor(SumFwdOp, dim=None),
+        "mean": one_tensor(MeanFwdOp, dim=-1),
+        "amin": one_tensor(AminFwdOp, dim=-1),
+        "amax": one_tensor(AmaxFwdOp, dim=-1),
+        "prod": one_tensor(ProdFwdOp, dim=-1),
+        "std": one_tensor(StdFwdOp, dim=-1),
+        "var": one_tensor(VarFwdOp, dim=-1),
+        # Two outputs, so two names in the fake and a getitem per result in the graph.
+        "var-mean": one_tensor(VarMeanFwdOp, dim=-1),
+        "argmax": one_tensor(ArgmaxFwdOp, dim=-1),
+        "argmin": one_tensor(ArgminFwdOp, dim=-1),
+        # A non-contiguous reduced axis, which is the layout argreduce strides along
+        # instead of transposing.
+        "argmax-strided-axis": one_tensor(ArgmaxFwdOp, dim=0),
+        # bool out, not same_as(x): the fake reads the manifest, not the input.
+        "all": one_tensor(AllFwdOp, dim=-1),
+        # dim=[] is a no-op, and a bool input makes the cast to bool one too, so the
+        # result must still be a tensor of its own.
+        "all-empty-dim-bool": lambda: (
+            AllFwdOp(dim=[]),
+            (torch.randint(2, (_ROWS, _COLS), dtype=torch.bool, device="cuda"),),
+        ),
+        "any": one_tensor(AnyFwdOp, dim=-1),
+        # int64 out.
+        "count-nonzero": one_tensor(CountNonzeroFwdOp, dim=-1),
+        "l1-norm": one_tensor(L1NormFwdOp, dim=-1),
+        "l2-norm": one_tensor(L2NormFwdOp, dim=-1),
+        "inf-norm": one_tensor(InfNormFwdOp, dim=-1),
+        "softmax": one_tensor(SoftmaxFwdOp, dim=-1),
+        # A same-shape result over a non-last axis comes back through a permute, so its
+        # strides have to match what the fake promised.
+        "softmax-leading-axis": one_tensor(SoftmaxFwdOp, dim=0),
+        "log-softmax": one_tensor(LogSoftmaxFwdOp, dim=-1),
+        "logsumexp": one_tensor(LogSumExpFwdOp, dim=-1),
+        "cumsum": one_tensor(CumsumFwdOp, dim=-1),
+        "cumsum-leading-axis": one_tensor(CumsumFwdOp, dim=0),
+        "cumprod": one_tensor(CumprodFwdOp, dim=-1),
+    }
+    return [pytest.param(builder, id=name) for name, builder in cases.items()]
+
+
+@pytest.mark.smoke
+@pytest.mark.usefixtures("isolated_dynamo")
+@pytest.mark.parametrize("build_case", _cases())
+def test_a_cold_op_traces_fullgraph_and_matches_eager(build_case) -> None:
+    """Cold is the whole contract: a warm op has nothing left for dynamo to trace into."""
+    op, inputs = build_case()
+
+    compiled = torch.compile(op, fullgraph=True)(*inputs)
+
+    torch.testing.assert_close(compiled, op(*inputs))
+
+
+@pytest.mark.smoke
+@pytest.mark.usefixtures("isolated_dynamo")
+@pytest.mark.parametrize("build_case", _cases())
+def test_the_traced_graph_holds_only_this_ops_operator(build_case) -> None:
+    """The node is the op's, so replacing the kernel cannot change the graph."""
+    op, inputs = build_case()
+
+    assert_op_owns_graph_nodes(op, *inputs)

--- a/tests/ops/test_reduction_defaults.py
+++ b/tests/ops/test_reduction_defaults.py
@@ -249,24 +249,26 @@ def test_empty_dim_policy_class_attrs() -> None:
 
 
 @pytest.mark.smoke
-def test_all_empty_dim_noop_rejects_cpu_tensor() -> None:
-    """dim=[] must still validate device; non-CUDA input must raise."""
-    from tileops.ops.reduction.logical_reduce import AllFwdOp
+@pytest.mark.parametrize("op_name", ["AllFwdOp", "AnyFwdOp"])
+def test_empty_dim_noop_answers_without_a_target(op_name: str) -> None:
+    """``dim=[]`` reduces nothing, so it needs no kernel and no device of any kind.
+
+    The op computes the degenerate answer itself. Nothing about it is a target's to
+    serve, so there is nobody to refuse a CPU tensor: which devices a *kernel* runs on is
+    that kernel's statement, and this call reaches none. The same op with ``dim=-1`` does
+    reach one and is refused there — that asymmetry is the edge of what the installed
+    targets cover, not an inconsistency in the op.
+    """
+    import tileops.ops.reduction.logical_reduce as logical_reduce
 
     x = (torch.randint(-1, 2, _LOGICAL_SHAPE)).to(torch.float16)  # cpu
-    op = AllFwdOp(dim=[])
-    with pytest.raises(ValueError, match="CUDA tensor"):
-        op(x)
+    op = getattr(logical_reduce, op_name)(dim=[])
 
+    out = op(x)
 
-@pytest.mark.smoke
-def test_any_empty_dim_noop_rejects_cpu_tensor() -> None:
-    from tileops.ops.reduction.logical_reduce import AnyFwdOp
-
-    x = (torch.randint(-1, 2, _LOGICAL_SHAPE)).to(torch.float16)  # cpu
-    op = AnyFwdOp(dim=[])
-    with pytest.raises(ValueError, match="CUDA tensor"):
-        op(x)
+    assert out.device == x.device
+    assert out.dtype == torch.bool
+    assert torch.equal(out, x != 0)
 
 
 @pytest.mark.smoke
@@ -349,3 +351,32 @@ def test_validate_dim_rejects_bool_in_list() -> None:
 
     with pytest.raises(TypeError, match="must be int .not bool"):
         SumFwdOp(dim=[True, 0])
+
+
+# A kernel's architecture check reads the device the op handed over
+
+
+@pytest.mark.smoke
+def test_the_arch_check_asks_about_the_input_s_device(monkeypatch) -> None:
+    """Not whichever device is current: the two differ on a mixed-architecture host.
+
+    A homogeneous host cannot show the wrong answer, so what is asserted is which device
+    was asked about.
+    """
+    import tileops.utils as utils
+    from tileops.ops.reduction.reduce import SumFwdOp
+
+    asked: list = []
+    real = utils.get_sm_version
+
+    def recording(index=None):
+        asked.append(index)
+        return real(index)
+
+    monkeypatch.setattr(utils, "get_sm_version", recording)
+
+    x = torch.randn(4, 8, dtype=torch.float16, device="cuda")
+    SumFwdOp(dim=-1)(x)
+
+    assert asked, "the kernel declares supported_archs, so it must have probed"
+    assert all(i == x.device.index for i in asked), asked

--- a/tests/ops/test_vector_norm.py
+++ b/tests/ops/test_vector_norm.py
@@ -585,7 +585,7 @@ def test_vector_norm_long_sequence_tiled(op_kind: str) -> None:
     )
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
-    kernel = op.built_kernels(op._kernel_key)[(3, 33024, dtype)]
+    (kernel,) = op.built_kernels(op._kernel_key).values()
     assert kernel.config["block_m"] > test.shape[0]
     assert kernel.config["tile_n"] > 0
 
@@ -603,6 +603,6 @@ def test_vector_norm_tiled_autotune() -> None:
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
-    kernel = op.built_kernels(op._kernel_key)[(m, n, dtype)]
+    (kernel,) = op.built_kernels(op._kernel_key).values()
     assert kernel._needs_tiling
     assert kernel.config in kernel.autotune_configs

--- a/tests/test_op_backend_seam.py
+++ b/tests/test_op_backend_seam.py
@@ -610,3 +610,62 @@ def test_a_five_input_op_hands_over_its_inputs_in_the_manifest_order():
     ):
         assert torch.equal(got, expected)
     assert torch.equal(out, torch.full_like(x, 7))
+
+
+# --------------------------------------------------------------------------------------
+# A reduction op at the seam: the declared rank, and the axes as a param
+# --------------------------------------------------------------------------------------
+
+
+class _ReduceRecorder:
+    """A target for a reduction op, returning a result of the shape the op declares."""
+
+    def __init__(self, out_shape):
+        self.calls = []
+        self._out_shape = out_shape
+
+    def build_kernel(self, *inputs, **params):
+        self.calls.append((inputs, params))
+        (spec,) = inputs
+
+        def kernel(x):
+            assert x.is_contiguous(), "the op normalizes contiguity before handing over"
+            return torch.full(self._out_shape, 7, dtype=spec.dtype, device=spec.device)
+
+        return kernel
+
+
+def test_a_reduction_op_hands_over_the_declared_rank():
+    """Not the ``(M, N)`` rows the in-tree kernel wants: that permute is the kernel's."""
+    recorder = _ReduceRecorder((4,))
+    _register(recorder, op="SumFwdOp")
+    from tileops.ops.reduction import SumFwdOp
+
+    x = torch.randn(4, 8, 16, dtype=DTYPE)
+    out = SumFwdOp(dim=[1, 2])(x)
+
+    ((inputs, params),) = recorder.calls
+    assert inputs == (TensorSpec.of(x),), "the rank the manifest declares, not (4, 128)"
+    assert params == {"dim": [1, 2], "keepdim": False}
+    assert torch.equal(out, torch.full((4,), 7, dtype=DTYPE))
+
+
+def test_a_non_contiguous_reduction_input_reaches_the_backend_contiguous():
+    recorder = _ReduceRecorder((4,))
+    _register(recorder, op="SumFwdOp")
+    from tileops.ops.reduction import SumFwdOp
+
+    SumFwdOp(dim=-1)(torch.randn(8, 4, dtype=DTYPE).t())
+
+    assert len(recorder.calls) == 1  # the assertion that matters is inside the kernel
+
+
+def test_a_reduction_call_naming_an_absent_axis_never_reaches_the_backend():
+    recorder = _ReduceRecorder((4,))
+    _register(recorder, op="SumFwdOp")
+    from tileops.ops.reduction import SumFwdOp
+
+    with pytest.raises(IndexError):
+        SumFwdOp(dim=5)(torch.randn(4, 8, dtype=DTYPE))
+
+    assert recorder.calls == []


### PR DESCRIPTION
The reduction family (21 ops, 7 kernels) moves onto the op/backend boundary.

## the core

A reduction kernel reduces the trailing axis of an `(M, N)` buffer, and the op layer was
building that buffer — permuting, flattening, and shaping the result back. So the tensor a
kernel was *described* with was not the tensor it was *called* with: an external target
would get a `TensorSpec` for one shape and then be handed another.

**The permute, the flatten and the restore move into the kernels.** A kernel takes the axes
it reduces and whether they stay; its `forward` takes the tensor the op declares. Both
sides of the boundary now speak the shape the manifest declares.

Everything else follows from that:

- One operator per op, 21 of them, named from the manifest — so the traced graph node is the
  op's and does not change when another target serves it. The 13 `custom_op` /
  `register_fake` pairs in the kernel files are gone.
- Every op takes `target=`; every manifest entry declares `torch_compile_fullgraph`.
- The op layer's 4 CUDA checks are gone; `require_cuda` in each kernel is where a set of
  kernels says which devices it runs on.
- Argmax and argmin fetched a kernel at two sites, one per layout. The kernel holds all
  three facts the choice needs, so the choice is its and the fetch is one site.
- Memo keys become `(shape, axes, keepdim, dtype, device)` — the kernel owns the permute, so
  the whole shape decides which kernel it is.

## three bugs the move exposed, each with a regression

| | |
| --- | --- |
| rows came from `numel // n` | divides by zero on an empty reduced axis, and reports zero rows where there are some |
| a same-shape result came back through a permute | the fake reports contiguous strides, so a mismatch is a wrong answer rather than a failure |
| `x.to(bool)` on a bool input | returns the input, and an operator may not return an alias |

## also here

- `Kernel` is told which device to check its architecture against instead of reading
  whichever is current. The 7 reduction kernels pass it; `None` keeps the old behaviour for
  families that have not migrated.
- README prerequisites: a middot-separated line that never rendered as a list, with three
  stale versions.
- A bloat pass: two conformance suites crossed axes that answer different questions (279
  cases → 122, same paths); two comment blocks that stood in 11 and 9 copies; 30
  box-drawing rules. Left alone: the `@tilelang.jit` boilerplate — 106 sites where fast math
  is genuinely on at 58 and off at 18, so it needs its own reading of each. Counting the
  names the manifest spells in YAML, the repo has no unreferenced public symbols; a commit
  here that deleted seven on a Python-only scan is reverted in the next one.

## verification

Dev runner image, one GPU: the 21 suites that import `ops.reduction` plus pool / norm /
rms_norm / convolution / elementwise / gemm / kernels, `scripts/validate_manifest.py`, and
`bench_reduce` (sum 0.0079 ms, 2.11 TB/s, 5.6x torch). Test nodes: -157 net.
