### PR TITLE
[Refactor][Ops] Give linear attention, Mamba, sequence modeling and GEMM their own packages

### DIFF
--- a/benchmarks/ops/bench_engram.py
+++ b/benchmarks/ops/bench_engram.py
@@ -17,8 +17,8 @@ from benchmarks.benchmark_base import (
     workload_field_params,
 )
 from tileops.manifest import load_workloads
-from tileops.ops.engram import EngramGateConvBwdOp, EngramGateConvFwdOp
-from tileops.ops.engram_decode import EngramDecodeFwdOp
+from tileops.ops.sequence_modeling.engram import EngramGateConvBwdOp, EngramGateConvFwdOp
+from tileops.ops.sequence_modeling.engram_decode import EngramDecodeFwdOp
 from workloads.engram import (
     EngramDecodeWorkload,
     EngramGateConvBwdWorkload,

--- a/benchmarks/ops/bench_mamba.py
+++ b/benchmarks/ops/bench_mamba.py
@@ -6,12 +6,12 @@ from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
 from benchmarks.benchmark_base import ManifestBenchmark
 from benchmarks.ops.attention.manifest_params import manifest_params
 from tileops.manifest import load_workloads
-from tileops.ops.cb_producer import CBProducerFwdOp
-from tileops.ops.da_cumsum import DaCumsumFwdOp
-from tileops.ops.ssd_chunk_scan import SSDChunkScanFwdOp
-from tileops.ops.ssd_chunk_state import SSDChunkStateFwdOp
-from tileops.ops.ssd_decode import SSDDecodeFwdOp
-from tileops.ops.ssd_state_passing import SSDStatePassingFwdOp
+from tileops.ops.mamba.cb_producer import CBProducerFwdOp
+from tileops.ops.mamba.da_cumsum import DaCumsumFwdOp
+from tileops.ops.mamba.ssd_chunk_scan import SSDChunkScanFwdOp
+from tileops.ops.mamba.ssd_chunk_state import SSDChunkStateFwdOp
+from tileops.ops.mamba.ssd_decode import SSDDecodeFwdOp
+from tileops.ops.mamba.ssd_state_passing import SSDStatePassingFwdOp
 from workloads.mamba import (
     CBProducerFwdWorkload,
     DaCumsumFwdWorkload,

--- a/benchmarks/ops/bench_mamba2_e2e.py
+++ b/benchmarks/ops/bench_mamba2_e2e.py
@@ -17,7 +17,7 @@ from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
 from benchmarks.benchmark_base import ManifestBenchmark
 from benchmarks.ops.attention.manifest_params import manifest_params
 from tileops.manifest import load_workloads
-from tileops.ops.mamba2_fwd import Mamba2FwdOp
+from tileops.ops.mamba.mamba2_fwd import Mamba2FwdOp
 from workloads.mamba2_e2e import Mamba2FwdWorkload
 
 # Optional mamba_ssm Triton baseline

--- a/src/tileops/manifest/bmm.yaml
+++ b/src/tileops/manifest/bmm.yaml
@@ -1,9 +1,10 @@
-# Batched GEMM family.
+# Batched GEMM. A shard of the gemm family, kept in its own file because the
+# batched entries share a shape contract the dense ones do not.
 #
 # BmmFwdOp: strict 3D-3D batched matrix multiplication
 BmmFwdOp:
   ref_api: "torch.bmm"
-  family: bmm
+  family: gemm
   status: implemented
 
   signature:
@@ -35,7 +36,7 @@ BmmFwdOp:
 
   source:
     kernel: tileops/kernels/bmm.py
-    op: tileops/ops/bmm.py
+    op: tileops/ops/gemm/bmm.py
     test: tests/ops/test_bmm.py
     bench: benchmarks/ops/bench_bmm.py
     bench_manifest_driven: true
@@ -47,7 +48,7 @@ BmmFwdOp:
 # mirroring flashinfer.bmm_fp8's A_scale / B_scale signature 1:1.
 BmmFp8KNFwdOp:
   ref_api: "none"
-  family: bmm
+  family: gemm
   status: implemented
 
   signature:
@@ -87,7 +88,7 @@ BmmFp8KNFwdOp:
 
   source:
     kernel: tileops/kernels/bmm.py
-    op: tileops/ops/bmm.py
+    op: tileops/ops/gemm/bmm.py
     test: tests/ops/test_bmm.py
     bench: benchmarks/ops/bench_bmm.py
     bench_manifest_driven: true
@@ -98,7 +99,7 @@ BmmFp8NKFwdOp:
   # K innermost, the order the fp8-TN kernel reads, so b arrives without a
   # transpose. Same kernel as BmmFp8KNFwdOp; only b's memory order differs.
   ref_api: "none"
-  family: bmm
+  family: gemm
   status: implemented
 
   signature:
@@ -138,7 +139,7 @@ BmmFp8NKFwdOp:
 
   source:
     kernel: tileops/kernels/bmm.py
-    op: tileops/ops/bmm.py
+    op: tileops/ops/gemm/bmm.py
     test: tests/ops/test_bmm.py
     bench: benchmarks/ops/bench_bmm.py
     bench_manifest_driven: true

--- a/src/tileops/manifest/gemm.yaml
+++ b/src/tileops/manifest/gemm.yaml
@@ -50,7 +50,7 @@ GemmFwdOp:
 
   source:
     kernel: tileops/kernels/gemm.py
-    op: tileops/ops/gemm.py
+    op: tileops/ops/gemm/gemm.py
     test: tests/ops/test_gemm.py
     bench: benchmarks/ops/bench_gemm.py
     bench_manifest_driven: true
@@ -101,7 +101,7 @@ GemmFp8FwdOp:
 
   source:
     kernel: tileops/kernels/gemm.py
-    op: tileops/ops/gemm.py
+    op: tileops/ops/gemm/gemm.py
     test: tests/ops/test_gemm.py
     bench: benchmarks/ops/bench_gemm.py
     bench_manifest_driven: true
@@ -146,7 +146,7 @@ GemmW4A16FwdOp:
 
   source:
     kernel: tileops/kernels/gemm_w4a16.py
-    op: tileops/ops/gemm.py
+    op: tileops/ops/gemm/gemm.py
     test: tests/ops/test_gemm.py
     bench: benchmarks/ops/bench_gemm.py
     bench_manifest_driven: true
@@ -200,7 +200,7 @@ GroupedGemmFwdOp:
     kernel_map:
       grouped_gemm_kernel: GroupedGemmKernel
       grouped_gemm_persistent_3wg_kernel: GroupedGemmPersistent3WGKernel
-    op: tileops/ops/grouped_gemm.py
+    op: tileops/ops/gemm/grouped_gemm.py
     test: tests/ops/test_grouped_gemm.py
     bench: benchmarks/ops/bench_grouped_gemm.py
     bench_manifest_driven: true

--- a/src/tileops/manifest/linear_attention.yaml
+++ b/src/tileops/manifest/linear_attention.yaml
@@ -57,7 +57,7 @@ GatedDeltaNetPrefillBTHDFwdOp:
     kernel: tileops/kernels/gated_deltanet/gated_deltanet_prefill.py
     kernel_map:
       GatedDeltaNetPrefillFwdKernel: GatedDeltaNetPrefillFwdKernel
-    op: tileops/ops/gated_deltanet.py
+    op: tileops/ops/linear_attention/gated_deltanet.py
     test: tests/ops/test_gated_deltanet_prefill.py
     bench: benchmarks/ops/bench_gated_deltanet_prefill.py
     bench_manifest_driven: true
@@ -104,7 +104,7 @@ GatedDeltaNetPrefillBHTDFwdOp:
     kernel: tileops/kernels/gated_deltanet/gated_deltanet_prefill.py
     kernel_map:
       GatedDeltaNetPrefillFwdKernel: GatedDeltaNetPrefillFwdKernel
-    op: tileops/ops/gated_deltanet.py
+    op: tileops/ops/linear_attention/gated_deltanet.py
     test: tests/ops/test_gated_deltanet_prefill.py
     bench: benchmarks/ops/bench_gated_deltanet_prefill.py
     bench_manifest_driven: true
@@ -160,7 +160,7 @@ GatedDeltaNetDecodeFwdOp:
       GatedDeltaNetDecodeKernel: GatedDeltaNetDecodeKernel
       GatedDeltaNetDecodeFP32Kernel: GatedDeltaNetDecodeFP32Kernel
       GatedDeltaNetDecodeRawCudaFlaStyleKernel: GatedDeltaNetDecodeRawCudaFlaStyleKernel
-    op: tileops/ops/gated_deltanet.py
+    op: tileops/ops/linear_attention/gated_deltanet.py
     test: tests/ops/test_gated_deltanet_recurrence.py
     bench: benchmarks/ops/bench_gated_deltanet_recurrence.py
     bench_manifest_driven: true
@@ -211,7 +211,7 @@ DeltaNetDecodeFwdOp:
       DeltaNetDecodeKernel: DeltaNetDecodeKernel
       DeltaNetDecodeFP32Kernel: DeltaNetDecodeFP32Kernel
       DeltaNetDecodeRawCudaFlaStyleKernel: DeltaNetDecodeRawCudaFlaStyleKernel
-    op: tileops/ops/deltanet_recurrence.py
+    op: tileops/ops/linear_attention/deltanet_recurrence.py
     test: tests/ops/test_deltanet_recurrence.py
     bench: benchmarks/ops/bench_deltanet_recurrence.py
     bench_manifest_driven: true
@@ -262,7 +262,7 @@ GLADecodeFwdOp:
     kernel_map:
       GLADecodeKernel: GLADecodeKernel
       GLADecodeFP32Kernel: GLADecodeFP32Kernel
-    op: tileops/ops/gated_linear_attn.py
+    op: tileops/ops/linear_attention/gla_recurrence.py
     test: tests/ops/test_gla_recurrence.py
     bench: benchmarks/ops/bench_gla_recurrence.py
     bench_manifest_driven: true
@@ -300,7 +300,7 @@ GatedDeltaNetBHTDFwdOp:
     kernel: tileops/kernels/gated_deltanet/gated_deltanet_fwd.py
     kernel_map:
       GatedDeltaNetFwdKernel: GatedDeltaNetFwdKernel
-    op: tileops/ops/gated_deltanet.py
+    op: tileops/ops/linear_attention/gated_deltanet.py
     test: tests/ops/test_gated_deltanet_fwd.py
     bench: benchmarks/ops/bench_gated_deltanet.py
     bench_manifest_driven: true
@@ -343,7 +343,7 @@ GatedDeltaNetBTHDFwdOp:
     kernel: tileops/kernels/gated_deltanet/gated_deltanet_fwd.py
     kernel_map:
       GatedDeltaNetFwdProductionKernel: GatedDeltaNetFwdProductionKernel
-    op: tileops/ops/gated_deltanet.py
+    op: tileops/ops/linear_attention/gated_deltanet.py
     test: tests/ops/test_gated_deltanet_fwd.py
     bench: benchmarks/ops/bench_gated_deltanet.py
     bench_manifest_driven: true
@@ -382,7 +382,7 @@ GatedDeltaNetBwdOp:
     kernel: tileops/kernels/gated_deltanet/gated_deltanet_bwd.py
     kernel_map:
       GatedDeltaNetBwdKernel: GatedDeltaNetBwdKernel
-    op: tileops/ops/gated_deltanet.py
+    op: tileops/ops/linear_attention/gated_deltanet.py
     test: tests/ops/test_gated_deltanet_chunkwise_bwd.py
     bench: benchmarks/ops/bench_gated_deltanet.py
     bench_manifest_driven: true
@@ -421,7 +421,7 @@ DeltaNetFwdOp:
     kernel: tileops/kernels/deltanet/deltanet_fwd.py
     kernel_map:
       DeltaNetFwdKernel: DeltaNetFwdKernel
-    op: tileops/ops/deltanet.py
+    op: tileops/ops/linear_attention/deltanet.py
     test: tests/ops/test_deltanet_fwd.py
     bench: benchmarks/ops/bench_deltanet.py
     bench_manifest_driven: true
@@ -463,7 +463,7 @@ DeltaNetBwdOp:
     kernel: tileops/kernels/deltanet/deltanet_bwd.py
     kernel_map:
       DeltaNetBwdKernel: DeltaNetBwdKernel
-    op: tileops/ops/deltanet.py
+    op: tileops/ops/linear_attention/deltanet.py
     test: tests/ops/test_deltanet_chunkwise_bwd.py
     bench: benchmarks/ops/bench_deltanet.py
     bench_manifest_driven: true
@@ -500,7 +500,7 @@ GLAFwdOp:
     kernel: tileops/kernels/gla/gla_fwd.py
     kernel_map:
       GLAFwdKernel: GLAFwdKernel
-    op: tileops/ops/gla.py
+    op: tileops/ops/linear_attention/gla.py
     test: tests/ops/test_gla_chunkwise_fwd.py
     bench: benchmarks/ops/bench_gla_chunkwise.py
     bench_manifest_driven: true
@@ -541,7 +541,7 @@ GLABwdOp:
     kernel: tileops/kernels/gla/gla_bwd.py
     kernel_map:
       GLABwdKernel: GLABwdKernel
-    op: tileops/ops/gla.py
+    op: tileops/ops/linear_attention/gla.py
     test: tests/ops/test_gla_chunkwise_bwd.py
     bench: benchmarks/ops/bench_gla_chunkwise.py
     bench_manifest_driven: true

--- a/src/tileops/manifest/mamba.yaml
+++ b/src/tileops/manifest/mamba.yaml
@@ -62,7 +62,7 @@ DaCumsumFwdOp:
     kernel: tileops/kernels/mamba/da_cumsum.py
     kernel_map:
       da_cumsum_fwd: DaCumsumFwdKernel
-    op: tileops/ops/da_cumsum.py
+    op: tileops/ops/mamba/da_cumsum.py
     test: tests/ops/test_mamba.py
     bench: benchmarks/ops/bench_mamba.py
     bench_manifest_driven: true
@@ -105,7 +105,7 @@ CBProducerFwdOp:
     kernel: tileops/kernels/mamba/cb_producer.py
     kernel_map:
       cb_producer: CBProducerKernel
-    op: tileops/ops/cb_producer.py
+    op: tileops/ops/mamba/cb_producer.py
     test: tests/ops/test_mamba.py
     bench: benchmarks/ops/bench_mamba.py
     bench_manifest_driven: true
@@ -144,7 +144,7 @@ SSDChunkStateFwdOp:
     kernel: tileops/kernels/mamba/ssd_chunk_state.py
     kernel_map:
       ssd_chunk_state_fwd: SSDChunkStateFwdKernel
-    op: tileops/ops/ssd_chunk_state.py
+    op: tileops/ops/mamba/ssd_chunk_state.py
     test: tests/ops/test_mamba.py
     bench: benchmarks/ops/bench_mamba.py
     bench_manifest_driven: true
@@ -183,7 +183,7 @@ SSDStatePassingFwdOp:
     kernel: tileops/kernels/mamba/ssd_state_passing.py
     kernel_map:
       ssd_state_passing_fwd: SSDStatePassingFwdKernel
-    op: tileops/ops/ssd_state_passing.py
+    op: tileops/ops/mamba/ssd_state_passing.py
     test: tests/ops/test_mamba.py
     bench: benchmarks/ops/bench_mamba.py
     bench_manifest_driven: true
@@ -222,7 +222,7 @@ SSDChunkScanFwdOp:
     kernel: tileops/kernels/mamba/ssd_chunk_scan.py
     kernel_map:
       ssd_chunk_scan_fwd: SSDChunkScanFwdKernel
-    op: tileops/ops/ssd_chunk_scan.py
+    op: tileops/ops/mamba/ssd_chunk_scan.py
     test: tests/ops/test_mamba.py
     bench: benchmarks/ops/bench_mamba.py
     bench_manifest_driven: true
@@ -261,7 +261,7 @@ SSDDecodeFwdOp:
     kernel: tileops/kernels/mamba/ssd_decode.py
     kernel_map:
       ssd_decode: SSDDecodeKernel
-    op: tileops/ops/ssd_decode.py
+    op: tileops/ops/mamba/ssd_decode.py
     test: tests/ops/test_mamba.py
     bench: benchmarks/ops/bench_mamba.py
     bench_manifest_driven: true
@@ -313,7 +313,7 @@ Mamba2FwdOp:
     func: "tileops.perf.formulas.mamba2_fwd_roofline"
 
   source:
-    kernel: tileops/ops/mamba2_fwd.py
+    kernel: tileops/ops/mamba/mamba2_fwd.py
     # This composite registers no kernel of its own; the five it drives belong
     # to the sub-ops it builds, and each is a replacement point.
     kernel_map:
@@ -322,7 +322,7 @@ Mamba2FwdOp:
       ssd_chunk_state_fwd: SSDChunkStateFwdKernel
       ssd_state_passing_fwd: SSDStatePassingFwdKernel
       ssd_chunk_scan_fwd: SSDChunkScanFwdKernel
-    op: tileops/ops/mamba2_fwd.py
+    op: tileops/ops/mamba/mamba2_fwd.py
     test: tests/ops/test_mamba.py
     bench: benchmarks/ops/bench_mamba2_e2e.py
     bench_manifest_driven: true

--- a/src/tileops/manifest/sequence_modeling.yaml
+++ b/src/tileops/manifest/sequence_modeling.yaml
@@ -47,7 +47,7 @@ EngramGateConvFwdOp:
     kernel: tileops/kernels/engram/engram_fwd.py
     kernel_map:
       engram_gate_conv_fwd: EngramGateConvFwdKernel
-    op: tileops/ops/engram.py
+    op: tileops/ops/sequence_modeling/engram.py
     test: tests/ops/test_engram.py
     bench: benchmarks/ops/bench_engram.py
     bench_manifest_driven: true
@@ -107,7 +107,7 @@ EngramGateConvBwdOp:
     kernel: tileops/kernels/engram/engram_bwd.py
     kernel_map:
       engram_gate_conv_bwd: EngramGateConvBwdKernel
-    op: tileops/ops/engram.py
+    op: tileops/ops/sequence_modeling/engram.py
     test: tests/ops/test_engram.py
     bench: benchmarks/ops/bench_engram.py
     bench_manifest_driven: true
@@ -159,7 +159,7 @@ EngramDecodeFwdOp:
     kernel: tileops/kernels/engram/engram_decode.py
     kernel_map:
       engram_decode: EngramDecodeKernel
-    op: tileops/ops/engram_decode.py
+    op: tileops/ops/sequence_modeling/engram_decode.py
     test: tests/ops/test_engram.py
     bench: benchmarks/ops/bench_engram.py
     bench_manifest_driven: true
@@ -233,7 +233,7 @@ MHCPreFwdOp:
     kernel: tileops/kernels/mhc/mhc_pre.py
     kernel_map:
       mhc_pre_kernel: MHCPreKernel
-    op: tileops/ops/mhc.py
+    op: tileops/ops/sequence_modeling/mhc.py
     test: tests/ops/test_mhc.py
     bench: benchmarks/ops/bench_mhc.py
     bench_manifest_driven: true
@@ -268,7 +268,7 @@ MHCPostFwdOp:
     kernel: tileops/kernels/mhc/mhc_post.py
     kernel_map:
       mhc_post_kernel: MHCPostKernel
-    op: tileops/ops/mhc.py
+    op: tileops/ops/sequence_modeling/mhc.py
     test: tests/ops/test_mhc.py
     bench: benchmarks/ops/bench_mhc.py
     bench_manifest_driven: true

--- a/src/tileops/ops/__init__.py
+++ b/src/tileops/ops/__init__.py
@@ -18,21 +18,30 @@ from .attention import (
     NSAFwdVarlenOp,
     NSATopkVarlenOp,
 )
-from .bmm import BmmFp8KNFwdOp, BmmFp8NKFwdOp, BmmFwdOp
 from .convolution import (
     Conv1dFwdOp,
     Conv2dFwdOp,
     Conv3dFwdOp,
 )
-from .da_cumsum import DaCumsumFwdOp
-from .deltanet import DeltaNetBwdOp, DeltaNetFwdOp, DeltaNetOp
-from .deltanet_recurrence import DeltaNetDecodeFwdOp
 from .dropout import DropoutFwdOp
 from .elementwise import BinaryOp, FusedGatedOp, UnaryOp
 from .fft import FFTC2CFwdOp
 from .fp8_lightning_indexer import FP8LightningIndexerFwdOp
 from .fp8_quant import FP8QuantFwdOp
-from .gated_deltanet import (
+from .gemm import (
+    BmmFp8KNFwdOp,
+    BmmFp8NKFwdOp,
+    BmmFwdOp,
+    GemmFp8FwdOp,
+    GemmFwdOp,
+    GemmW4A16FwdOp,
+    GroupedGemmFwdOp,
+)
+from .linear_attention import (
+    DeltaNetBwdOp,
+    DeltaNetDecodeFwdOp,
+    DeltaNetFwdOp,
+    DeltaNetOp,
     GatedDeltaNetBHTDFwdOp,
     GatedDeltaNetBTHDFwdOp,
     GatedDeltaNetBwdOp,
@@ -40,13 +49,18 @@ from .gated_deltanet import (
     GatedDeltaNetOp,
     GatedDeltaNetPrefillBHTDFwdOp,
     GatedDeltaNetPrefillBTHDFwdOp,
+    GLABwdOp,
+    GLADecodeFwdOp,
+    GLAFwdOp,
 )
-from .gated_linear_attn import GLADecodeFwdOp
-from .gemm import GemmFp8FwdOp, GemmFwdOp, GemmW4A16FwdOp
-from .gla import GLABwdOp, GLAFwdOp
-from .grouped_gemm import GroupedGemmFwdOp
-from .mamba2_fwd import Mamba2FwdOp
-from .mhc import MHCPostFwdOp, MHCPreFwdOp
+from .mamba import (
+    DaCumsumFwdOp,
+    Mamba2FwdOp,
+    SSDChunkScanFwdOp,
+    SSDChunkStateFwdOp,
+    SSDDecodeFwdOp,
+    SSDStatePassingFwdOp,
+)
 from .moe import MoePermuteAlignFwdOp
 from .norm import (
     AdaLayerNormFwdOp,
@@ -111,10 +125,7 @@ from .rope import (
     RopeNonNeoxFwdOp,
     RopeYarnFwdOp,
 )
-from .ssd_chunk_scan import SSDChunkScanFwdOp
-from .ssd_chunk_state import SSDChunkStateFwdOp
-from .ssd_decode import SSDDecodeFwdOp
-from .ssd_state_passing import SSDStatePassingFwdOp
+from .sequence_modeling import MHCPostFwdOp, MHCPreFwdOp
 from .topk_selector import TopkSelectorFwdOp
 
 __all__ = [

--- a/src/tileops/ops/gemm/__init__.py
+++ b/src/tileops/ops/gemm/__init__.py
@@ -1,0 +1,13 @@
+from .bmm import BmmFp8KNFwdOp, BmmFp8NKFwdOp, BmmFwdOp
+from .gemm import GemmFp8FwdOp, GemmFwdOp, GemmW4A16FwdOp
+from .grouped_gemm import GroupedGemmFwdOp
+
+__all__: list[str] = [
+    "BmmFp8KNFwdOp",
+    "BmmFp8NKFwdOp",
+    "BmmFwdOp",
+    "GemmFp8FwdOp",
+    "GemmFwdOp",
+    "GemmW4A16FwdOp",
+    "GroupedGemmFwdOp",
+]

--- a/src/tileops/ops/gemm/bmm.py
+++ b/src/tileops/ops/gemm/bmm.py
@@ -12,7 +12,7 @@ import torch
 from tileops.kernels.bmm import BmmFp8Kernel, BmmKernel
 from tileops.kernels.kernel_base import Kernel
 
-from .op_base import Op
+from ..op_base import Op
 
 __all__ = ["BmmFp8KNFwdOp", "BmmFp8NKFwdOp", "BmmFwdOp"]
 

--- a/src/tileops/ops/gemm/gemm.py
+++ b/src/tileops/ops/gemm/gemm.py
@@ -13,7 +13,7 @@ from tileops.kernels.gemm_w4a16 import GROUP_SIZE, GemmW4A16Kernel
 from tileops.kernels.gemm_w4a16_decode import GemmW4A16DecodeKernel
 from tileops.kernels.kernel_base import Kernel
 
-from .op_base import Op
+from ..op_base import Op
 
 __all__ = ["GemmFp8FwdOp", "GemmFwdOp", "GemmW4A16FwdOp"]
 

--- a/src/tileops/ops/gemm/grouped_gemm.py
+++ b/src/tileops/ops/gemm/grouped_gemm.py
@@ -10,7 +10,7 @@ from tileops.kernels.grouped_gemm import (
 from tileops.kernels.kernel_base import Kernel
 from tileops.utils import get_sm_version
 
-from .op_base import Op
+from ..op_base import Op
 
 __all__ = ["GroupedGemmFwdOp"]
 

--- a/src/tileops/ops/linear_attention/__init__.py
+++ b/src/tileops/ops/linear_attention/__init__.py
@@ -1,0 +1,30 @@
+from .deltanet import DeltaNetBwdOp, DeltaNetFwdOp, DeltaNetOp
+from .deltanet_recurrence import DeltaNetDecodeFwdOp
+from .gated_deltanet import (
+    GatedDeltaNetBHTDFwdOp,
+    GatedDeltaNetBTHDFwdOp,
+    GatedDeltaNetBwdOp,
+    GatedDeltaNetDecodeFwdOp,
+    GatedDeltaNetOp,
+    GatedDeltaNetPrefillBHTDFwdOp,
+    GatedDeltaNetPrefillBTHDFwdOp,
+)
+from .gla import GLABwdOp, GLAFwdOp
+from .gla_recurrence import GLADecodeFwdOp
+
+__all__: list[str] = [
+    "DeltaNetBwdOp",
+    "DeltaNetDecodeFwdOp",
+    "DeltaNetFwdOp",
+    "DeltaNetOp",
+    "GLABwdOp",
+    "GLADecodeFwdOp",
+    "GLAFwdOp",
+    "GatedDeltaNetBHTDFwdOp",
+    "GatedDeltaNetBTHDFwdOp",
+    "GatedDeltaNetBwdOp",
+    "GatedDeltaNetDecodeFwdOp",
+    "GatedDeltaNetOp",
+    "GatedDeltaNetPrefillBHTDFwdOp",
+    "GatedDeltaNetPrefillBTHDFwdOp",
+]

--- a/src/tileops/ops/linear_attention/deltanet.py
+++ b/src/tileops/ops/linear_attention/deltanet.py
@@ -8,7 +8,7 @@ from tileops.kernels.deltanet import (
 )
 from tileops.kernels.kernel_base import Kernel
 
-from .op_base import Op, UnmanifestedOp, check_tensor_shape
+from ..op_base import Op, UnmanifestedOp, check_tensor_shape
 
 __all__ = ["DeltaNetBwdOp", "DeltaNetFwdOp", "DeltaNetOp"]
 

--- a/src/tileops/ops/linear_attention/deltanet_recurrence.py
+++ b/src/tileops/ops/linear_attention/deltanet_recurrence.py
@@ -2,20 +2,33 @@ from typing import Dict, Optional, Tuple
 
 import torch
 
-from tileops.kernels.gla_recurrence import GLADecodeFP32Kernel, GLADecodeKernel
+from tileops.kernels.deltanet_call import DeltaNetDecodeCall
+from tileops.kernels.deltanet_recurrence import (
+    DeltaNetDecodeFP32Kernel,
+    DeltaNetDecodeKernel,
+    DeltaNetDecodeRawCudaFlaStyleKernel,
+)
 from tileops.kernels.kernel_base import Kernel
 
-from .op_base import Op
+from ..op_base import Op
 
-__all__ = ["GLADecodeFwdOp"]
+__all__ = ["DeltaNetDecodeFwdOp"]
+
+#: Implementations of the DeltaNet decode slot.
+DELTANET_DECODE_KEYS = (
+    "DeltaNetDecodeFP32Kernel",
+    "DeltaNetDecodeRawCudaFlaStyleKernel",
+    "DeltaNetDecodeKernel",
+)
 
 
-class GLADecodeFwdOp(Op):
-    """GLA (Gated Linear Attention) decode (single-step recurrence).
+class DeltaNetDecodeFwdOp(Op):
+    """DeltaNet decode (single-step recurrence, ungated).
 
-    Computes one step of the gated linear attention recurrence:
-        S_new = diag(exp(gk)) @ S + outer(k, v)
-        o     = scale * q^T @ S_new
+    Computes one step of the delta rule (no gate):
+        v_new = beta * (v - S @ k)
+        o     = S @ q + (q . k) * v_new
+        S_new = S + outer(k, v_new)
 
     Layout: BHD (batch, head, dim).
     Supports float32, float16, and bfloat16 with fp32 accumulation.
@@ -26,7 +39,6 @@ class GLADecodeFwdOp(Op):
 
     def __init__(
         self,
-        scale: float = -1.0,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
@@ -34,18 +46,19 @@ class GLADecodeFwdOp(Op):
         self.heads = None
         self.dim_k = None
         self.dim_v = None
-        self.scale = scale
         self.dtype = None
         self.tune = tune
 
         self.dispatch_kernel(kernel_map)
+        self._active_sig: Optional[tuple] = None
         self.kernel = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {
-            "GLADecodeKernel": GLADecodeKernel,
-            "GLADecodeFP32Kernel": GLADecodeFP32Kernel,
+            "DeltaNetDecodeKernel": DeltaNetDecodeKernel,
+            "DeltaNetDecodeFP32Kernel": DeltaNetDecodeFP32Kernel,
+            "DeltaNetDecodeRawCudaFlaStyleKernel": DeltaNetDecodeRawCudaFlaStyleKernel,
         }
 
     def _get_kernel(
@@ -58,34 +71,33 @@ class GLADecodeFwdOp(Op):
         dtype: torch.dtype,
         device_index: int | None,
     ) -> Kernel:
-        key = (batch, heads, dim_k, dim_v, self.scale, dtype, device_index, self.tune)
+        key = (batch, heads, dim_k, dim_v, dtype, device_index, self.tune)
+        call = DeltaNetDecodeCall(
+            batch=batch, heads=heads, dim_k=dim_k, dim_v=dim_v, dtype=dtype, tune=self.tune
+        )
+        chosen = self.select_kernel_key(DELTANET_DECODE_KEYS, call)
 
         def build() -> Kernel:
-            if dtype == torch.float32:
-                kernel_cls = self.kernel_map["GLADecodeFP32Kernel"]
-            else:
-                kernel_cls = self.kernel_map["GLADecodeKernel"]
-            return kernel_cls(
+            return self.kernel_map[chosen](
                 batch,
                 heads,
                 dim_k,
                 dim_v,
-                scale=self.scale,
                 dtype=Kernel.dtype_to_str(dtype),
                 tune=self.tune,
             )
 
-        return self.get_or_build_kernel("GLADecodeKernel", inputs, key=key, build=build)
+        return self.get_or_build_kernel(chosen, inputs, key=key, build=build)
 
     def _infer_output_shapes(
         self,
         q_shape: tuple[int, ...],
         k_shape: tuple[int, ...],
         v_shape: tuple[int, ...],
-        gk_shape: tuple[int, ...],
+        beta_shape: tuple[int, ...],
         state_shape: tuple[int, ...],
     ) -> dict[str, tuple[int, ...]]:
-        del k_shape, gk_shape
+        del k_shape, beta_shape
         return {
             "o": (q_shape[0], q_shape[1], v_shape[-1]),
             "new_state": state_shape,
@@ -96,13 +108,13 @@ class GLADecodeFwdOp(Op):
         q: torch.Tensor,
         k: torch.Tensor,
         v: torch.Tensor,
-        gk: torch.Tensor,
+        beta: torch.Tensor,
         state: torch.Tensor,
     ) -> None:
         dtype = q.dtype
         if dtype not in (torch.float32, torch.float16, torch.bfloat16):
             raise ValueError(f"Unsupported dtype: {dtype}")
-        for name, tensor in (("q", q), ("k", k), ("v", v), ("gk", gk), ("state", state)):
+        for name, tensor in (("q", q), ("k", k), ("v", v), ("beta", beta), ("state", state)):
             if tensor.dtype != dtype:
                 raise ValueError(f"{name}.dtype must be {dtype}, got {tensor.dtype}")
 
@@ -111,7 +123,7 @@ class GLADecodeFwdOp(Op):
         q: torch.Tensor,
         k: torch.Tensor,
         v: torch.Tensor,
-        gk: torch.Tensor,
+        beta: torch.Tensor,
         state: torch.Tensor,
     ) -> None:
         if q.ndim != 3:
@@ -122,26 +134,27 @@ class GLADecodeFwdOp(Op):
         dim_v = v.shape[2]
         q_shape = (batch, heads, dim_k)
         v_shape = (batch, heads, dim_v)
+        beta_shape = (batch, heads)
         state_shape = (batch, heads, dim_k, dim_v)
         expected_shapes = (
             ("q", q, q_shape),
             ("k", k, q_shape),
             ("v", v, v_shape),
-            ("gk", gk, q_shape),
+            ("beta", beta, beta_shape),
             ("state", state, state_shape),
         )
         for name, tensor, expected in expected_shapes:
             if tuple(tensor.shape) != expected:
                 raise ValueError(f"{name} must have shape {expected}, got {tuple(tensor.shape)}")
-        if not all(tensor.is_cuda for tensor in (q, k, v, gk, state)):
-            raise ValueError("q, k, v, gk, and state must be CUDA tensors")
+        if not all(tensor.is_cuda for tensor in (q, k, v, beta, state)):
+            raise ValueError("q, k, v, beta, and state must be CUDA tensors")
         self.batch = batch
         self.heads = heads
         self.dim_k = dim_k
         self.dim_v = dim_v
         self.dtype = q.dtype
         self.kernel = self._get_kernel(
-            (q, k, v, gk, state), batch, heads, dim_k, dim_v, q.dtype, q.device.index
+            (q, k, v, beta, state), batch, heads, dim_k, dim_v, q.dtype, q.device.index
         )
 
     def _validate_output_shapes(
@@ -159,20 +172,40 @@ class GLADecodeFwdOp(Op):
             )
 
     def eval_roofline(self) -> tuple[int, int]:
-        from tileops.perf.formulas import gla_decode_roofline
+        from tileops.perf.formulas import deltanet_decode_roofline
 
-        return gla_decode_roofline(self)
+        return deltanet_decode_roofline(self)
 
     def forward(
         self,
         q: torch.Tensor,
         k: torch.Tensor,
         v: torch.Tensor,
-        gk: torch.Tensor,
+        beta: torch.Tensor,
         state: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        self._validate_dtypes(q, k, v, gk, state)
-        self._validate_shapes(q, k, v, gk, state)
-        o, new_state = self.kernel(q, k, v, gk, state)
+        sig = (
+            q.shape,
+            k.shape,
+            v.shape,
+            beta.shape,
+            state.shape,
+            q.dtype,
+            k.dtype,
+            v.dtype,
+            beta.dtype,
+            state.dtype,
+            q.device,
+            k.device,
+            v.device,
+            beta.device,
+            state.device,
+            getattr(self, "tune", None),
+        )
+        if sig != getattr(self, "_active_sig", None):
+            self._validate_dtypes(q, k, v, beta, state)
+            self._validate_shapes(q, k, v, beta, state)
+            self._active_sig = sig
+        o, new_state = self.kernel(q, k, v, beta, state)
         self._validate_output_shapes(o, new_state)
         return o, new_state

--- a/src/tileops/ops/linear_attention/gated_deltanet.py
+++ b/src/tileops/ops/linear_attention/gated_deltanet.py
@@ -17,7 +17,7 @@ from tileops.kernels.gated_deltanet_recurrence import (
 )
 from tileops.kernels.kernel_base import Kernel
 
-from .op_base import Op, UnmanifestedOp, check_tensor_shape
+from ..op_base import Op, UnmanifestedOp, check_tensor_shape
 
 __all__ = [
     "GatedDeltaNetBHTDFwdOp",

--- a/src/tileops/ops/linear_attention/gla.py
+++ b/src/tileops/ops/linear_attention/gla.py
@@ -5,7 +5,7 @@ import torch
 from tileops.kernels.gla import GLABwdKernel, GLAFwdKernel
 from tileops.kernels.kernel_base import Kernel
 
-from .op_base import Op, check_tensor_shape
+from ..op_base import Op, check_tensor_shape
 
 __all__ = ["GLABwdOp", "GLAFwdOp"]
 

--- a/src/tileops/ops/linear_attention/gla_recurrence.py
+++ b/src/tileops/ops/linear_attention/gla_recurrence.py
@@ -2,33 +2,20 @@ from typing import Dict, Optional, Tuple
 
 import torch
 
-from tileops.kernels.deltanet_call import DeltaNetDecodeCall
-from tileops.kernels.deltanet_recurrence import (
-    DeltaNetDecodeFP32Kernel,
-    DeltaNetDecodeKernel,
-    DeltaNetDecodeRawCudaFlaStyleKernel,
-)
+from tileops.kernels.gla_recurrence import GLADecodeFP32Kernel, GLADecodeKernel
 from tileops.kernels.kernel_base import Kernel
 
-from .op_base import Op
+from ..op_base import Op
 
-__all__ = ["DeltaNetDecodeFwdOp"]
-
-#: Implementations of the DeltaNet decode slot.
-DELTANET_DECODE_KEYS = (
-    "DeltaNetDecodeFP32Kernel",
-    "DeltaNetDecodeRawCudaFlaStyleKernel",
-    "DeltaNetDecodeKernel",
-)
+__all__ = ["GLADecodeFwdOp"]
 
 
-class DeltaNetDecodeFwdOp(Op):
-    """DeltaNet decode (single-step recurrence, ungated).
+class GLADecodeFwdOp(Op):
+    """GLA (Gated Linear Attention) decode (single-step recurrence).
 
-    Computes one step of the delta rule (no gate):
-        v_new = beta * (v - S @ k)
-        o     = S @ q + (q . k) * v_new
-        S_new = S + outer(k, v_new)
+    Computes one step of the gated linear attention recurrence:
+        S_new = diag(exp(gk)) @ S + outer(k, v)
+        o     = scale * q^T @ S_new
 
     Layout: BHD (batch, head, dim).
     Supports float32, float16, and bfloat16 with fp32 accumulation.
@@ -39,6 +26,7 @@ class DeltaNetDecodeFwdOp(Op):
 
     def __init__(
         self,
+        scale: float = -1.0,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
@@ -46,19 +34,18 @@ class DeltaNetDecodeFwdOp(Op):
         self.heads = None
         self.dim_k = None
         self.dim_v = None
+        self.scale = scale
         self.dtype = None
         self.tune = tune
 
         self.dispatch_kernel(kernel_map)
-        self._active_sig: Optional[tuple] = None
         self.kernel = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {
-            "DeltaNetDecodeKernel": DeltaNetDecodeKernel,
-            "DeltaNetDecodeFP32Kernel": DeltaNetDecodeFP32Kernel,
-            "DeltaNetDecodeRawCudaFlaStyleKernel": DeltaNetDecodeRawCudaFlaStyleKernel,
+            "GLADecodeKernel": GLADecodeKernel,
+            "GLADecodeFP32Kernel": GLADecodeFP32Kernel,
         }
 
     def _get_kernel(
@@ -71,33 +58,34 @@ class DeltaNetDecodeFwdOp(Op):
         dtype: torch.dtype,
         device_index: int | None,
     ) -> Kernel:
-        key = (batch, heads, dim_k, dim_v, dtype, device_index, self.tune)
-        call = DeltaNetDecodeCall(
-            batch=batch, heads=heads, dim_k=dim_k, dim_v=dim_v, dtype=dtype, tune=self.tune
-        )
-        chosen = self.select_kernel_key(DELTANET_DECODE_KEYS, call)
+        key = (batch, heads, dim_k, dim_v, self.scale, dtype, device_index, self.tune)
 
         def build() -> Kernel:
-            return self.kernel_map[chosen](
+            if dtype == torch.float32:
+                kernel_cls = self.kernel_map["GLADecodeFP32Kernel"]
+            else:
+                kernel_cls = self.kernel_map["GLADecodeKernel"]
+            return kernel_cls(
                 batch,
                 heads,
                 dim_k,
                 dim_v,
+                scale=self.scale,
                 dtype=Kernel.dtype_to_str(dtype),
                 tune=self.tune,
             )
 
-        return self.get_or_build_kernel(chosen, inputs, key=key, build=build)
+        return self.get_or_build_kernel("GLADecodeKernel", inputs, key=key, build=build)
 
     def _infer_output_shapes(
         self,
         q_shape: tuple[int, ...],
         k_shape: tuple[int, ...],
         v_shape: tuple[int, ...],
-        beta_shape: tuple[int, ...],
+        gk_shape: tuple[int, ...],
         state_shape: tuple[int, ...],
     ) -> dict[str, tuple[int, ...]]:
-        del k_shape, beta_shape
+        del k_shape, gk_shape
         return {
             "o": (q_shape[0], q_shape[1], v_shape[-1]),
             "new_state": state_shape,
@@ -108,13 +96,13 @@ class DeltaNetDecodeFwdOp(Op):
         q: torch.Tensor,
         k: torch.Tensor,
         v: torch.Tensor,
-        beta: torch.Tensor,
+        gk: torch.Tensor,
         state: torch.Tensor,
     ) -> None:
         dtype = q.dtype
         if dtype not in (torch.float32, torch.float16, torch.bfloat16):
             raise ValueError(f"Unsupported dtype: {dtype}")
-        for name, tensor in (("q", q), ("k", k), ("v", v), ("beta", beta), ("state", state)):
+        for name, tensor in (("q", q), ("k", k), ("v", v), ("gk", gk), ("state", state)):
             if tensor.dtype != dtype:
                 raise ValueError(f"{name}.dtype must be {dtype}, got {tensor.dtype}")
 
@@ -123,7 +111,7 @@ class DeltaNetDecodeFwdOp(Op):
         q: torch.Tensor,
         k: torch.Tensor,
         v: torch.Tensor,
-        beta: torch.Tensor,
+        gk: torch.Tensor,
         state: torch.Tensor,
     ) -> None:
         if q.ndim != 3:
@@ -134,27 +122,26 @@ class DeltaNetDecodeFwdOp(Op):
         dim_v = v.shape[2]
         q_shape = (batch, heads, dim_k)
         v_shape = (batch, heads, dim_v)
-        beta_shape = (batch, heads)
         state_shape = (batch, heads, dim_k, dim_v)
         expected_shapes = (
             ("q", q, q_shape),
             ("k", k, q_shape),
             ("v", v, v_shape),
-            ("beta", beta, beta_shape),
+            ("gk", gk, q_shape),
             ("state", state, state_shape),
         )
         for name, tensor, expected in expected_shapes:
             if tuple(tensor.shape) != expected:
                 raise ValueError(f"{name} must have shape {expected}, got {tuple(tensor.shape)}")
-        if not all(tensor.is_cuda for tensor in (q, k, v, beta, state)):
-            raise ValueError("q, k, v, beta, and state must be CUDA tensors")
+        if not all(tensor.is_cuda for tensor in (q, k, v, gk, state)):
+            raise ValueError("q, k, v, gk, and state must be CUDA tensors")
         self.batch = batch
         self.heads = heads
         self.dim_k = dim_k
         self.dim_v = dim_v
         self.dtype = q.dtype
         self.kernel = self._get_kernel(
-            (q, k, v, beta, state), batch, heads, dim_k, dim_v, q.dtype, q.device.index
+            (q, k, v, gk, state), batch, heads, dim_k, dim_v, q.dtype, q.device.index
         )
 
     def _validate_output_shapes(
@@ -172,40 +159,20 @@ class DeltaNetDecodeFwdOp(Op):
             )
 
     def eval_roofline(self) -> tuple[int, int]:
-        from tileops.perf.formulas import deltanet_decode_roofline
+        from tileops.perf.formulas import gla_decode_roofline
 
-        return deltanet_decode_roofline(self)
+        return gla_decode_roofline(self)
 
     def forward(
         self,
         q: torch.Tensor,
         k: torch.Tensor,
         v: torch.Tensor,
-        beta: torch.Tensor,
+        gk: torch.Tensor,
         state: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        sig = (
-            q.shape,
-            k.shape,
-            v.shape,
-            beta.shape,
-            state.shape,
-            q.dtype,
-            k.dtype,
-            v.dtype,
-            beta.dtype,
-            state.dtype,
-            q.device,
-            k.device,
-            v.device,
-            beta.device,
-            state.device,
-            getattr(self, "tune", None),
-        )
-        if sig != getattr(self, "_active_sig", None):
-            self._validate_dtypes(q, k, v, beta, state)
-            self._validate_shapes(q, k, v, beta, state)
-            self._active_sig = sig
-        o, new_state = self.kernel(q, k, v, beta, state)
+        self._validate_dtypes(q, k, v, gk, state)
+        self._validate_shapes(q, k, v, gk, state)
+        o, new_state = self.kernel(q, k, v, gk, state)
         self._validate_output_shapes(o, new_state)
         return o, new_state

--- a/src/tileops/ops/mamba/__init__.py
+++ b/src/tileops/ops/mamba/__init__.py
@@ -1,0 +1,17 @@
+from .cb_producer import CBProducerFwdOp
+from .da_cumsum import DaCumsumFwdOp
+from .mamba2_fwd import Mamba2FwdOp
+from .ssd_chunk_scan import SSDChunkScanFwdOp
+from .ssd_chunk_state import SSDChunkStateFwdOp
+from .ssd_decode import SSDDecodeFwdOp
+from .ssd_state_passing import SSDStatePassingFwdOp
+
+__all__: list[str] = [
+    "CBProducerFwdOp",
+    "DaCumsumFwdOp",
+    "Mamba2FwdOp",
+    "SSDChunkScanFwdOp",
+    "SSDChunkStateFwdOp",
+    "SSDDecodeFwdOp",
+    "SSDStatePassingFwdOp",
+]

--- a/src/tileops/ops/mamba/cb_producer.py
+++ b/src/tileops/ops/mamba/cb_producer.py
@@ -8,7 +8,8 @@ import torch
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.mamba.cb_producer import CBProducerKernel
-from tileops.ops.op_base import Op, check_tensor_shape
+
+from ..op_base import Op, check_tensor_shape
 
 __all__ = ["CBProducerFwdOp"]
 

--- a/src/tileops/ops/mamba/da_cumsum.py
+++ b/src/tileops/ops/mamba/da_cumsum.py
@@ -7,7 +7,7 @@ from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.mamba import DaCumsumFwdKernel
 from tileops.manifest import load_manifest
 
-from .op_base import Op
+from ..op_base import Op
 
 __all__ = ["DaCumsumFwdOp"]
 

--- a/src/tileops/ops/mamba/mamba2_fwd.py
+++ b/src/tileops/ops/mamba/mamba2_fwd.py
@@ -31,9 +31,9 @@ import torch
 
 from tileops.kernels.kernel_base import Kernel
 
+from ..op_base import Op
 from .cb_producer import CBProducerFwdOp
 from .da_cumsum import DaCumsumFwdOp
-from .op_base import Op
 from .ssd_chunk_scan import SSDChunkScanFwdOp
 from .ssd_chunk_state import SSDChunkStateFwdOp
 from .ssd_state_passing import SSDStatePassingFwdOp

--- a/src/tileops/ops/mamba/ssd_chunk_scan.py
+++ b/src/tileops/ops/mamba/ssd_chunk_scan.py
@@ -5,7 +5,7 @@ import torch
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.mamba import SSDChunkScanFwdKernel
 
-from .op_base import Op
+from ..op_base import Op
 
 __all__ = ["SSDChunkScanFwdOp"]
 

--- a/src/tileops/ops/mamba/ssd_chunk_state.py
+++ b/src/tileops/ops/mamba/ssd_chunk_state.py
@@ -5,7 +5,7 @@ import torch
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.mamba import SSDChunkStateFwdKernel
 
-from .op_base import Op
+from ..op_base import Op
 
 __all__ = ["SSDChunkStateFwdOp"]
 

--- a/src/tileops/ops/mamba/ssd_decode.py
+++ b/src/tileops/ops/mamba/ssd_decode.py
@@ -5,7 +5,7 @@ import torch
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.mamba import SSDDecodeKernel
 
-from .op_base import Op
+from ..op_base import Op
 
 __all__ = ["SSDDecodeFwdOp"]
 

--- a/src/tileops/ops/mamba/ssd_state_passing.py
+++ b/src/tileops/ops/mamba/ssd_state_passing.py
@@ -5,7 +5,7 @@ import torch
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.mamba import SSDStatePassingFwdKernel
 
-from .op_base import Op
+from ..op_base import Op
 
 __all__ = ["SSDStatePassingFwdOp"]
 

--- a/src/tileops/ops/sequence_modeling/__init__.py
+++ b/src/tileops/ops/sequence_modeling/__init__.py
@@ -1,0 +1,11 @@
+from .engram import EngramGateConvBwdOp, EngramGateConvFwdOp
+from .engram_decode import EngramDecodeFwdOp
+from .mhc import MHCPostFwdOp, MHCPreFwdOp
+
+__all__: list[str] = [
+    "EngramDecodeFwdOp",
+    "EngramGateConvBwdOp",
+    "EngramGateConvFwdOp",
+    "MHCPostFwdOp",
+    "MHCPreFwdOp",
+]

--- a/src/tileops/ops/sequence_modeling/engram.py
+++ b/src/tileops/ops/sequence_modeling/engram.py
@@ -5,7 +5,7 @@ import torch
 from tileops.kernels.engram import EngramGateConvBwdKernel, EngramGateConvFwdKernel
 from tileops.kernels.kernel_base import Kernel
 
-from .op_base import Op
+from ..op_base import Op
 
 __all__ = ["EngramGateConvBwdOp", "EngramGateConvFwdOp"]
 

--- a/src/tileops/ops/sequence_modeling/engram_decode.py
+++ b/src/tileops/ops/sequence_modeling/engram_decode.py
@@ -5,7 +5,7 @@ import torch
 from tileops.kernels.engram import EngramDecodeKernel
 from tileops.kernels.kernel_base import Kernel
 
-from .op_base import Op
+from ..op_base import Op
 
 __all__ = ["EngramDecodeFwdOp"]
 

--- a/src/tileops/ops/sequence_modeling/mhc.py
+++ b/src/tileops/ops/sequence_modeling/mhc.py
@@ -6,7 +6,7 @@ import torch
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.mhc import MHCPostKernel, MHCPreKernel
 
-from .op_base import Op
+from ..op_base import Op
 
 __all__ = ["MHCPostFwdOp", "MHCPreFwdOp"]
 

--- a/tests/ops/test_deltanet_recurrence.py
+++ b/tests/ops/test_deltanet_recurrence.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-import tileops.ops.deltanet_recurrence as deltanet_ops
+import tileops.ops.linear_attention.deltanet_recurrence as deltanet_ops
 from tests.test_base import FixtureBase, TestBase
 from tileops.kernels.deltanet_call import DeltaNetDecodeCall
 from tileops.kernels.deltanet_recurrence import (
@@ -10,7 +10,7 @@ from tileops.kernels.deltanet_recurrence import (
     DeltaNetDecodeRawCudaFlaStyleKernel,
 )
 from tileops.ops import DeltaNetDecodeFwdOp
-from tileops.ops.deltanet_recurrence import DELTANET_DECODE_KEYS
+from tileops.ops.linear_attention.deltanet_recurrence import DELTANET_DECODE_KEYS
 from workloads.linear_attention import DeltaNetDecodeWorkload, deltanet_decode_torch
 
 

--- a/tests/ops/test_engram.py
+++ b/tests/ops/test_engram.py
@@ -2,8 +2,8 @@ import pytest
 import torch
 
 from tests.test_base import FixtureBase, TestBase
-from tileops.ops.engram import EngramGateConvBwdOp, EngramGateConvFwdOp
-from tileops.ops.engram_decode import EngramDecodeFwdOp
+from tileops.ops.sequence_modeling.engram import EngramGateConvBwdOp, EngramGateConvFwdOp
+from tileops.ops.sequence_modeling.engram_decode import EngramDecodeFwdOp
 from workloads.engram import (
     EngramDecodeWorkload,
     EngramGateConvBwdWorkload,

--- a/tests/ops/test_family_dispatch.py
+++ b/tests/ops/test_family_dispatch.py
@@ -13,9 +13,15 @@ import torch
 
 from tileops.kernels.deltanet_call import DeltaNetDecodeCall
 from tileops.kernels.gemm_call import GemmCall
-from tileops.ops.deltanet_recurrence import DELTANET_DECODE_KEYS, DeltaNetDecodeFwdOp
-from tileops.ops.gated_deltanet import GATED_DELTANET_DECODE_KEYS, GatedDeltaNetDecodeFwdOp
-from tileops.ops.gemm import GemmFwdOp
+from tileops.ops.gemm.gemm import GemmFwdOp
+from tileops.ops.linear_attention.deltanet_recurrence import (
+    DELTANET_DECODE_KEYS,
+    DeltaNetDecodeFwdOp,
+)
+from tileops.ops.linear_attention.gated_deltanet import (
+    GATED_DELTANET_DECODE_KEYS,
+    GatedDeltaNetDecodeFwdOp,
+)
 
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available(), reason="selection reads the device architecture"

--- a/tests/ops/test_gated_deltanet_recurrence.py
+++ b/tests/ops/test_gated_deltanet_recurrence.py
@@ -5,7 +5,7 @@ from tests.test_base import FixtureBase, TestBase
 from tileops.kernels.deltanet_call import DeltaNetDecodeCall
 from tileops.kernels.gated_deltanet_recurrence import GatedDeltaNetDecodeRawCudaFlaStyleKernel
 from tileops.ops import GatedDeltaNetDecodeFwdOp
-from tileops.ops.gated_deltanet import GATED_DELTANET_DECODE_KEYS
+from tileops.ops.linear_attention.gated_deltanet import GATED_DELTANET_DECODE_KEYS
 from workloads.linear_attention import (
     GatedDeltaNetDecodeWorkload,
     gated_deltanet_decode_torch,

--- a/tests/ops/test_grouped_gemm.py
+++ b/tests/ops/test_grouped_gemm.py
@@ -3,7 +3,7 @@ import torch
 
 from tests.test_base import FixtureBase, TestBase
 from tileops.kernels.grouped_gemm import GroupedGemmCall, GroupedGemmKernel
-from tileops.ops.grouped_gemm import GroupedGemmFwdOp
+from tileops.ops.gemm.grouped_gemm import GroupedGemmFwdOp
 from tileops.utils import get_sm_version
 from workloads.grouped_gemm import (
     GroupedGemmWorkload,

--- a/tests/ops/test_mamba.py
+++ b/tests/ops/test_mamba.py
@@ -5,13 +5,13 @@ import torch
 import torch.nn.functional as F
 
 from tests.test_base import TestBase, allclose_compare
-from tileops.ops.cb_producer import CBProducerFwdOp
-from tileops.ops.da_cumsum import DaCumsumFwdOp
-from tileops.ops.mamba2_fwd import Mamba2FwdOp
-from tileops.ops.ssd_chunk_scan import SSDChunkScanFwdOp
-from tileops.ops.ssd_chunk_state import SSDChunkStateFwdOp
-from tileops.ops.ssd_decode import SSDDecodeFwdOp
-from tileops.ops.ssd_state_passing import SSDStatePassingFwdOp
+from tileops.ops.mamba.cb_producer import CBProducerFwdOp
+from tileops.ops.mamba.da_cumsum import DaCumsumFwdOp
+from tileops.ops.mamba.mamba2_fwd import Mamba2FwdOp
+from tileops.ops.mamba.ssd_chunk_scan import SSDChunkScanFwdOp
+from tileops.ops.mamba.ssd_chunk_state import SSDChunkStateFwdOp
+from tileops.ops.mamba.ssd_decode import SSDDecodeFwdOp
+from tileops.ops.mamba.ssd_state_passing import SSDStatePassingFwdOp
 from tileops.perf import formulas
 from workloads.mamba import (
     DaCumsumFwdFixture,

--- a/tests/ops/test_multi_dtype_instance.py
+++ b/tests/ops/test_multi_dtype_instance.py
@@ -152,7 +152,7 @@ def test_moe_unpermute_serves_two_dtypes_from_one_instance():
 
 @pytest.mark.smoke
 def test_cb_producer_serves_two_dtypes_from_one_instance():
-    from tileops.ops.cb_producer import CBProducerFwdOp
+    from tileops.ops.mamba.cb_producer import CBProducerFwdOp
 
     batch, chunks, groups, chunk_len, d_state = 1, 2, 1, 64, 64
     op = CBProducerFwdOp(batch, chunks, groups, chunk_len, d_state)


### PR DESCRIPTION
## problems

- 18 op files sat flat in `src/tileops/ops/` next to the 5 infrastructure modules, so one algorithm's chunkwise forward, backward and decode recurrence were unrelated-looking filenames in a list of thirty.
- `src/tileops/kernels/` already has `mamba/`, `deltanet/`, `gated_deltanet/`, `gla/`, `engram/` and `mhc/`. The op layer had no matching structure.
- `gated_linear_attn.py` holds only `GLADecodeFwdOp`, matching neither its contents nor its sibling `deltanet_recurrence.py`.
- `bmm.yaml` declared `family: bmm` on its three entries. bmm belongs to the gemm family.

## changes

- Four new subpackages take 18 op files: `linear_attention/` (5 files / 12 ops), `mamba/` (7 / 7), `sequence_modeling/` (3 / 5), `gemm/` (3 / 7). Each gets an `__init__.py` with explicit re-exports and `__all__`.
- `gated_linear_attn.py` → `linear_attention/gla_recurrence.py`.
- Single-file families stay at the top level: `convolution.py`, `pool.py`, `rope.py`, `dropout.py`, `fft.py`, `fp8_quant.py`, `fp8_lightning_indexer.py`, `topk_selector.py`.
- Moved files change `from .op_base` to `from ..op_base`; `mamba/cb_producer.py`'s absolute import becomes relative with them.
- Manifest: 32 `source.op` paths and 1 `source.kernel` path retargeted (`Mamba2FwdOp` is an op-as-kernel entry, so both fields name the same file). `bmm.yaml`'s three `family: bmm` become `gemm`.
- 27 module-path imports across 10 test and benchmark files point at the new paths.
- `tileops.ops.__all__` is unchanged — 110 symbols, same order. Test node delta 0.
- One public-surface change: `tileops.ops.<moved module>` drops a level, e.g. `tileops.ops.deltanet` is now `tileops.ops.linear_attention.deltanet`. Nothing in the repo reaches for them that way, and `tileops.ops.gemm` still resolves — to the new subpackage.
