### PR TITLE
[Bench] One builder turns a workload row into a case, one id rule for every label

### DIFF
--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -6,6 +6,7 @@ are re-exported here, so a bench file keeps importing what it always did.
 
 import statistics
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from typing import Any, Generic, Optional, TypeVar
 
 import pytest
@@ -37,7 +38,9 @@ __all__ = [
     "ManifestBenchmark",
     "backward_of",
     "bench_kernel",
-    "workload_field_params",
+    "fields",
+    "then_dtype",
+    "workload_params",
     "workloads_to_params",
 ]
 
@@ -206,16 +209,103 @@ def _workload_extra_params(w: dict, shape_key: str) -> dict[str, Any]:
     }
 
 
+def workload_params(
+    workloads: list,
+    build_args: "Callable[[dict, torch.dtype], tuple]",
+    *,
+    smoke_first: bool = False,
+    dedupe_on: "tuple[str, ...] | None" = None,
+    marks: "Callable[[dict, torch.dtype, int], tuple] | None" = None,
+) -> list:
+    """The one place a manifest workload becomes a pytest case.
+
+    One case per (row, dtype in that row's ``dtypes``), with the id
+    ``f"{label}-{dtype}"`` — so a label never has to spell a dtype. What varies
+    per family is only how a row becomes positional args, which is *build_args*;
+    compose it with :func:`fields` and :func:`then_dtype`.
+
+    Args:
+        workloads: Rows from ``load_workloads``.
+        build_args: ``(row, dtype) -> positional args`` for one case.
+        smoke_first: Mark the first row's cases ``smoke`` and the rest ``full``.
+        marks: ``(row, dtype, row_index) -> marks`` when a case's marks depend on
+            its dtype; it replaces *smoke_first* for the rows it is given.
+        dedupe_on: Row keys that identify a measurement. A row repeating an
+            earlier row's values under these keys is dropped, for a bench whose
+            workload generator makes the dtype rows one measurement.
+    """
+    params: list = []
+    seen: set = set()
+    rows = 0
+    for w in workloads:
+        if dedupe_on is not None:
+            identity = tuple(str(w.get(k)) for k in dedupe_on)
+            if identity in seen:
+                continue
+            seen.add(identity)
+        row_marks: tuple = ()
+        if reason := w.get("bench_skip_reason"):
+            row_marks = (pytest.mark.skip(reason=reason),)
+        elif smoke_first:
+            row_marks = (pytest.mark.smoke if rows == 0 else pytest.mark.full,)
+        index = rows
+        rows += 1
+        label = w.get("label", "manifest")
+        for dtype_str in w["dtypes"]:
+            dtype = getattr(torch, dtype_str)
+            case_marks = row_marks if marks is None else tuple(marks(w, dtype, index))
+            params.append(
+                pytest.param(
+                    *build_args(w, dtype),
+                    id=f"{label}-{dtype_str}",
+                    marks=case_marks,
+                )
+            )
+    return params
+
+
+def fields(*keys: str, dtype_last: bool = False) -> "Callable[[dict, torch.dtype], tuple]":
+    """Row values under *keys*, positionally.
+
+    A key ending in ``dtype`` resolves to the ``torch.dtype`` it names, so a row
+    declaring an input and an output dtype keeps them apart. With *dtype_last*
+    the case's dtype follows the keyed values, for a test whose signature ends
+    in ``dtype`` while the row does not name one.
+    """
+
+    def build(w: dict, dtype: torch.dtype) -> tuple:
+        values = tuple(getattr(torch, w[k]) if k.endswith("dtype") else w[k] for k in keys)
+        return (*values, dtype) if dtype_last else values
+
+    return build
+
+
+def then_dtype(
+    row_args: "Callable[[dict], tuple]",
+    *,
+    tune: bool | None = None,
+) -> "Callable[[dict, torch.dtype], tuple]":
+    """Append the case's dtype to what *row_args* returns, and *tune* after it
+    when the test takes one. *row_args* is a family's row-to-args function; it
+    reads the row only, since the dtype is the axis this adds."""
+
+    def build(w: dict, dtype: torch.dtype) -> tuple:
+        tail = (dtype,) if tune is None else (dtype, tune)
+        return (*row_args(w), *tail)
+
+    return build
+
+
 def workloads_to_params(op_name: str, include_extra: bool = False) -> list:
     """Convert manifest workload dicts for *op_name* to pytest params.
 
-    Each entry becomes ``pytest.param(shape, dtype, id=...)``; with
-    ``include_extra=True`` a third element carries the op-call params
-    declared on the workload entry (e.g. ``{"dim": 0}``).
+    Single-tensor-input convenience wrapper over :func:`workload_params`: it
+    reads the manifest, checks each row against the signature, and yields
+    ``pytest.param(shape, dtype)``; with ``include_extra=True`` a third element
+    carries the op-call params declared on the row (e.g. ``{"dim": 0}``).
     """
     workloads = load_workloads(op_name)  # canonical not-found error
     shape_key, allowed = _workload_contract(op_name)
-    params = []
     for w in workloads:
         if shape_key not in w:
             raise KeyError(
@@ -232,38 +322,22 @@ def workloads_to_params(op_name: str, include_extra: bool = False) -> list:
                 f"workload {w.get('label', w)!r} of {op_name!r} has unknown "
                 f"keys {unknown}; allowed: {sorted(allowed)}."
             )
+
+    def build(w: dict, dtype: torch.dtype) -> tuple:
         shape = tuple(w[shape_key])
-        label = w.get("label", "x".join(str(s) for s in shape))
-        extra = _workload_extra_params(w, shape_key) if include_extra else {}
-        for dtype_str in w["dtypes"]:
-            dtype = getattr(torch, dtype_str)
-            # Copy ``extra`` per parametrization so mutation in one test case
-            # cannot leak into later cases sharing the workload entry.
-            param_args = (shape, dtype, dict(extra)) if include_extra else (shape, dtype)
-            params.append(pytest.param(*param_args, id=f"{label}-{dtype_str}"))
-    return params
+        if not include_extra:
+            return (shape, dtype)
+        # Copy the extras per case so mutation in one cannot leak into a later
+        # case sharing the row.
+        return (shape, dtype, dict(_workload_extra_params(w, shape_key)))
 
-
-def workload_field_params(workloads: list, keys: tuple) -> list:
-    """Turn manifest workload dicts into pytest params.
-
-    First workload is marked ``smoke``, the rest ``full``. Keys ending in
-    ``dtype`` are resolved to ``torch.dtype`` values, and the case id ends with
-    the dtype it runs, so a label never has to spell one.
-    """
-    params = []
-    for i, w in enumerate(workloads):
-        args = [getattr(torch, w[k]) if k.endswith("dtype") else w[k] for k in keys]
-        dtype_keys = [k for k in keys if k.endswith("dtype")]
-        suffix = "".join(f"-{w[k]}" for k in dtype_keys)
-        params.append(
-            pytest.param(
-                *args,
-                marks=pytest.mark.smoke if i == 0 else pytest.mark.full,
-                id=f"{w['label']}{suffix}",
-            )
-        )
-    return params
+    # A row with no label is named by its shape, as the reports did before. The
+    # rows are the manifest's own dicts, so name a copy rather than writing to them.
+    rows = [
+        w if "label" in w else {**w, "label": "x".join(str(s) for s in w[shape_key])}
+        for w in workloads
+    ]
+    return workload_params(rows, build)
 
 
 class ManifestBenchmark(BenchmarkBase[Any]):

--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -214,7 +214,6 @@ def workload_params(
     build_args: "Callable[[dict, torch.dtype], tuple]",
     *,
     smoke_first: bool = False,
-    dedupe_on: "tuple[str, ...] | None" = None,
     marks: "Callable[[dict, torch.dtype, int], tuple] | None" = None,
 ) -> list:
     """The one place a manifest workload becomes a pytest case.
@@ -229,31 +228,19 @@ def workload_params(
         build_args: ``(row, dtype) -> positional args`` for one case.
         smoke_first: Mark the first row's cases ``smoke`` and the rest ``full``.
         marks: ``(row, dtype, row_index) -> marks`` when a case's marks depend on
-            its dtype; it replaces *smoke_first* for the rows it is given.
-        dedupe_on: Row keys that identify a measurement. A row repeating an
-            earlier row's values under these keys is dropped, for a bench whose
-            workload generator makes the dtype rows one measurement.
+            its dtype. A row carrying ``bench_skip_reason`` is skipped either way.
     """
     params: list = []
-    seen: set = set()
-    rows = 0
-    for w in workloads:
-        if dedupe_on is not None:
-            identity = tuple(str(w.get(k)) for k in dedupe_on)
-            if identity in seen:
-                continue
-            seen.add(identity)
-        row_marks: tuple = ()
-        if reason := w.get("bench_skip_reason"):
-            row_marks = (pytest.mark.skip(reason=reason),)
-        elif smoke_first:
-            row_marks = (pytest.mark.smoke if rows == 0 else pytest.mark.full,)
-        index = rows
-        rows += 1
+    for index, w in enumerate(workloads):
+        # A row the manifest says to skip is skipped whatever else decides marks.
+        skip = (
+            (pytest.mark.skip(reason=w["bench_skip_reason"]),) if w.get("bench_skip_reason") else ()
+        )
+        smoke = (pytest.mark.smoke if index == 0 else pytest.mark.full,) if smoke_first else ()
         label = w.get("label", "manifest")
         for dtype_str in w["dtypes"]:
             dtype = getattr(torch, dtype_str)
-            case_marks = row_marks if marks is None else tuple(marks(w, dtype, index))
+            case_marks = skip or (tuple(marks(w, dtype, index)) if marks else smoke)
             params.append(
                 pytest.param(
                     *build_args(w, dtype),

--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -248,16 +248,19 @@ def workload_field_params(workloads: list, keys: tuple) -> list:
     """Turn manifest workload dicts into pytest params.
 
     First workload is marked ``smoke``, the rest ``full``. Keys ending in
-    ``dtype`` are resolved to ``torch.dtype`` values.
+    ``dtype`` are resolved to ``torch.dtype`` values, and the case id ends with
+    the dtype it runs, so a label never has to spell one.
     """
     params = []
     for i, w in enumerate(workloads):
         args = [getattr(torch, w[k]) if k.endswith("dtype") else w[k] for k in keys]
+        dtype_keys = [k for k in keys if k.endswith("dtype")]
+        suffix = "".join(f"-{w[k]}" for k in dtype_keys)
         params.append(
             pytest.param(
                 *args,
                 marks=pytest.mark.smoke if i == 0 else pytest.mark.full,
-                id=w["label"],
+                id=f"{w['label']}{suffix}",
             )
         )
     return params

--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -216,23 +216,18 @@ def workload_params(
     smoke_first: bool = False,
     marks: "Callable[[dict, torch.dtype, int], tuple] | None" = None,
 ) -> list:
-    """The one place a manifest workload becomes a pytest case.
+    """The one place a manifest workload row becomes a pytest case.
 
-    One case per (row, dtype in that row's ``dtypes``), with the id
-    ``f"{label}-{dtype}"`` — so a label never has to spell a dtype. What varies
-    per family is only how a row becomes positional args, which is *build_args*;
-    compose it with :func:`fields` and :func:`then_dtype`.
-
-    Args:
-        workloads: Rows from ``load_workloads``.
-        build_args: ``(row, dtype) -> positional args`` for one case.
-        smoke_first: Mark the first row's cases ``smoke`` and the rest ``full``.
-        marks: ``(row, dtype, row_index) -> marks`` when a case's marks depend on
-            its dtype. A row carrying ``bench_skip_reason`` is skipped either way.
+    One case per (row, dtype in its ``dtypes``), ided ``f"{label}-{dtype}"`` so a
+    label never has to spell a dtype. *build_args* maps a row and that dtype to
+    the case's positional args — the one thing that differs per family; compose
+    it with :func:`fields` and :func:`then_dtype`. *marks* takes
+    ``(row, dtype, row_index)`` for marks that depend on the dtype, and
+    *smoke_first* marks the first row ``smoke`` and the rest ``full``.
     """
     params: list = []
     for index, w in enumerate(workloads):
-        # A row the manifest says to skip is skipped whatever else decides marks.
+        # A row the manifest says to skip is skipped whichever else applies.
         skip = (
             (pytest.mark.skip(reason=w["bench_skip_reason"]),) if w.get("bench_skip_reason") else ()
         )
@@ -252,13 +247,9 @@ def workload_params(
 
 
 def fields(*keys: str, dtype_last: bool = False) -> "Callable[[dict, torch.dtype], tuple]":
-    """Row values under *keys*, positionally.
-
-    A key ending in ``dtype`` resolves to the ``torch.dtype`` it names, so a row
-    declaring an input and an output dtype keeps them apart. With *dtype_last*
-    the case's dtype follows the keyed values, for a test whose signature ends
-    in ``dtype`` while the row does not name one.
-    """
+    """Row values under *keys*, positionally; a key ending in ``dtype`` resolves to
+    the ``torch.dtype`` it names, and *dtype_last* appends the case's dtype for a
+    test whose signature ends in one the row does not name."""
 
     def build(w: dict, dtype: torch.dtype) -> tuple:
         values = tuple(getattr(torch, w[k]) if k.endswith("dtype") else w[k] for k in keys)
@@ -272,9 +263,8 @@ def then_dtype(
     *,
     tune: bool | None = None,
 ) -> "Callable[[dict, torch.dtype], tuple]":
-    """Append the case's dtype to what *row_args* returns, and *tune* after it
-    when the test takes one. *row_args* is a family's row-to-args function; it
-    reads the row only, since the dtype is the axis this adds."""
+    """Append the case's dtype to what *row_args* returns, and *tune* after it when
+    the test takes one. *row_args* reads the row only."""
 
     def build(w: dict, dtype: torch.dtype) -> tuple:
         tail = (dtype,) if tune is None else (dtype, tune)
@@ -284,13 +274,10 @@ def then_dtype(
 
 
 def workloads_to_params(op_name: str, include_extra: bool = False) -> list:
-    """Convert manifest workload dicts for *op_name* to pytest params.
-
-    Single-tensor-input convenience wrapper over :func:`workload_params`: it
-    reads the manifest, checks each row against the signature, and yields
-    ``pytest.param(shape, dtype)``; with ``include_extra=True`` a third element
-    carries the op-call params declared on the row (e.g. ``{"dim": 0}``).
-    """
+    """Single-tensor-input wrapper over :func:`workload_params`: reads the manifest,
+    checks each row against the signature, and yields ``pytest.param(shape,
+    dtype)``; with *include_extra* a third element carries the row's op-call
+    params (e.g. ``{"dim": 0}``)."""
     workloads = load_workloads(op_name)  # canonical not-found error
     shape_key, allowed = _workload_contract(op_name)
     for w in workloads:
@@ -318,8 +305,8 @@ def workloads_to_params(op_name: str, include_extra: bool = False) -> list:
         # case sharing the row.
         return (shape, dtype, dict(_workload_extra_params(w, shape_key)))
 
-    # A row with no label is named by its shape, as the reports did before. The
-    # rows are the manifest's own dicts, so name a copy rather than writing to them.
+    # Name a copy: an unlabelled row is named by its shape, as the reports did
+    # before, and the rows are the manifest's own dicts.
     rows = [
         w if "label" in w else {**w, "label": "x".join(str(s) for s in w[shape_key])}
         for w in workloads

--- a/benchmarks/ops/attention/bench_deepseek_dsa_decode.py
+++ b/benchmarks/ops/attention/bench_deepseek_dsa_decode.py
@@ -7,7 +7,7 @@ from benchmarks.benchmark_base import (
     then_dtype,
     workload_params,
 )
-from benchmarks.ops.attention.manifest_params import dsa_decode_args
+from benchmarks.ops.attention.workload_args import dsa_decode_args
 from tileops.manifest import load_workloads
 from tileops.ops import DeepSeekSparseAttentionDecodeWithKVCacheFwdOp
 from workloads.attention.deepseek import DsaDecodeWorkload

--- a/benchmarks/ops/attention/bench_deepseek_dsa_decode.py
+++ b/benchmarks/ops/attention/bench_deepseek_dsa_decode.py
@@ -2,8 +2,12 @@ import pytest
 import torch
 
 from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
-from benchmarks.benchmark_base import ManifestBenchmark
-from benchmarks.ops.attention.manifest_params import dsa_decode_args, manifest_params
+from benchmarks.benchmark_base import (
+    ManifestBenchmark,
+    then_dtype,
+    workload_params,
+)
+from benchmarks.ops.attention.manifest_params import dsa_decode_args
 from tileops.manifest import load_workloads
 from tileops.ops import DeepSeekSparseAttentionDecodeWithKVCacheFwdOp
 from workloads.attention.deepseek import DsaDecodeWorkload
@@ -11,10 +15,12 @@ from workloads.attention.deepseek import DsaDecodeWorkload
 _OP_NAME = "DeepSeekSparseAttentionDecodeWithKVCacheFwdOp"
 
 
-_DSA_DECODE_BENCH_PARAMS = manifest_params(
+_DSA_DECODE_BENCH_PARAMS = workload_params(
     load_workloads(_OP_NAME),
-    dsa_decode_args,
-    tune=False,
+    then_dtype(
+        dsa_decode_args,
+        tune=False,
+    ),
 )
 
 

--- a/benchmarks/ops/attention/bench_deepseek_mla_decode.py
+++ b/benchmarks/ops/attention/bench_deepseek_mla_decode.py
@@ -2,8 +2,12 @@ import pytest
 import torch
 
 from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
-from benchmarks.benchmark_base import ManifestBenchmark
-from benchmarks.ops.attention.manifest_params import manifest_params, mla_decode_args
+from benchmarks.benchmark_base import (
+    ManifestBenchmark,
+    then_dtype,
+    workload_params,
+)
+from benchmarks.ops.attention.manifest_params import mla_decode_args
 from tileops.manifest import load_workloads
 from tileops.ops import MultiHeadLatentAttentionDecodeWithKVCacheFwdOp
 from workloads.attention.deepseek import MlaDecodeWorkload
@@ -11,7 +15,9 @@ from workloads.attention.deepseek import MlaDecodeWorkload
 _OP_NAME = "MultiHeadLatentAttentionDecodeWithKVCacheFwdOp"
 
 
-_MLA_DECODE_BENCH_PARAMS = manifest_params(load_workloads(_OP_NAME), mla_decode_args)
+_MLA_DECODE_BENCH_PARAMS = workload_params(
+    load_workloads(_OP_NAME), then_dtype(mla_decode_args, tune=True)
+)
 
 
 @pytest.mark.parametrize(

--- a/benchmarks/ops/attention/bench_deepseek_mla_decode.py
+++ b/benchmarks/ops/attention/bench_deepseek_mla_decode.py
@@ -7,7 +7,7 @@ from benchmarks.benchmark_base import (
     then_dtype,
     workload_params,
 )
-from benchmarks.ops.attention.manifest_params import mla_decode_args
+from benchmarks.ops.attention.workload_args import mla_decode_args
 from tileops.manifest import load_workloads
 from tileops.ops import MultiHeadLatentAttentionDecodeWithKVCacheFwdOp
 from workloads.attention.deepseek import MlaDecodeWorkload

--- a/benchmarks/ops/attention/bench_gqa.py
+++ b/benchmarks/ops/attention/bench_gqa.py
@@ -9,12 +9,13 @@ from benchmarks.benchmark_base import (
     BenchmarkReport,
     ManifestBenchmark,
     backward_of,
+    then_dtype,
+    workload_params,
 )
 from benchmarks.ops.attention.manifest_params import (
     gqa_prefill_args,
     gqa_prefill_paged_args,
     gqa_qkv_args,
-    manifest_params,
 )
 from tileops.kernels.attention import (
     GQAFwdWgmmaPipelinedKernel,
@@ -262,7 +263,9 @@ def _tileops_gqa_variant(op: GroupedQueryAttentionFwdOp, dtype: torch.dtype) -> 
 # Training (bf16): seq_len 2K-8K covers SFT (2K) and pretraining (4K-8K).
 # B=1-2 reflects typical micro-batch sizes.  No long-context training configs
 # since >90% of pretraining compute is at 4K-8K.
-_GQA_FWD_BENCH_PARAMS = manifest_params(load_workloads(_GQA_FWD_OP), gqa_qkv_args)
+_GQA_FWD_BENCH_PARAMS = workload_params(
+    load_workloads(_GQA_FWD_OP), then_dtype(gqa_qkv_args, tune=True)
+)
 
 
 @pytest.mark.parametrize(
@@ -304,7 +307,9 @@ def test_gqa_fwd_bench(
 # GQA backward benchmark parameters (training only).
 # Backward is only used during training — extract the training subset from
 # _GQA_FWD_BENCH_PARAMS by ID prefix to avoid manual duplication.
-_GQA_BWD_BENCH_PARAMS = manifest_params(load_workloads(_GQA_BWD_OP), gqa_qkv_args)
+_GQA_BWD_BENCH_PARAMS = workload_params(
+    load_workloads(_GQA_BWD_OP), then_dtype(gqa_qkv_args, tune=True)
+)
 
 
 @pytest.mark.parametrize(
@@ -338,14 +343,16 @@ def test_gqa_bwd_bench(
     # No FlashInfer baseline for bwd (FlashInfer has no backward API)
 
 
-_GQA_PREFILL_FWD_BENCH_PARAMS = manifest_params(
+_GQA_PREFILL_FWD_BENCH_PARAMS = workload_params(
     [
         workload
         for workload in load_workloads(_GQA_PREFILL_FWD_OP)
         if workload.get("backend") != "fp8"
     ],
-    gqa_prefill_args,
-    tune=False,
+    then_dtype(
+        gqa_prefill_args,
+        tune=False,
+    ),
 )
 
 
@@ -499,10 +506,12 @@ def _fp8_paged_cache_inputs(
     )
 
 
-_GQA_PREFILL_PAGED_WITH_KV_CACHE_FWD_BENCH_PARAMS = manifest_params(
+_GQA_PREFILL_PAGED_WITH_KV_CACHE_FWD_BENCH_PARAMS = workload_params(
     load_workloads(_GQA_PREFILL_PAGED_WITH_KV_CACHE_FWD_OP),
-    gqa_prefill_paged_args,
-    tune=False,
+    then_dtype(
+        gqa_prefill_paged_args,
+        tune=False,
+    ),
 )
 
 

--- a/benchmarks/ops/attention/bench_gqa.py
+++ b/benchmarks/ops/attention/bench_gqa.py
@@ -12,7 +12,7 @@ from benchmarks.benchmark_base import (
     then_dtype,
     workload_params,
 )
-from benchmarks.ops.attention.manifest_params import (
+from benchmarks.ops.attention.workload_args import (
     gqa_prefill_args,
     gqa_prefill_paged_args,
     gqa_qkv_args,

--- a/benchmarks/ops/attention/bench_gqa.py
+++ b/benchmarks/ops/attention/bench_gqa.py
@@ -413,7 +413,7 @@ _GQA_PREFILL_VARLEN_FWD_BENCH_PARAMS = [
         True,
         torch.float16,
         False,
-        id="llama-3.1-8b-prefill-varlen-uniform-fp16",
+        id="llama-8b-prefill-varlen-uniform-fp16",
     ),
     pytest.param(
         4,
@@ -425,7 +425,7 @@ _GQA_PREFILL_VARLEN_FWD_BENCH_PARAMS = [
         True,
         torch.float16,
         False,
-        id="llama-3.1-8b-prefill-varlen-mixed-fp16",
+        id="llama-8b-prefill-varlen-mixed-fp16",
     ),
     pytest.param(
         2,
@@ -437,7 +437,7 @@ _GQA_PREFILL_VARLEN_FWD_BENCH_PARAMS = [
         True,
         torch.bfloat16,
         False,
-        id="llama-3.1-70b-prefill-varlen-q-lt-kv-bf16",
+        id="llama-70b-prefill-varlen-q-lt-kv-bf16",
     ),
 ]
 

--- a/benchmarks/ops/attention/bench_gqa_decode.py
+++ b/benchmarks/ops/attention/bench_gqa_decode.py
@@ -6,7 +6,7 @@ from benchmarks.benchmark_base import (
     then_dtype,
     workload_params,
 )
-from benchmarks.ops.attention.manifest_params import gqa_decode_args
+from benchmarks.ops.attention.workload_args import gqa_decode_args
 from tileops.manifest import load_workloads
 from tileops.ops import GroupedQueryAttentionDecodeWithKVCacheFwdOp
 from workloads.attention.gqa import GroupedQueryAttentionDecodeWorkload

--- a/benchmarks/ops/attention/bench_gqa_decode.py
+++ b/benchmarks/ops/attention/bench_gqa_decode.py
@@ -1,8 +1,12 @@
 import pytest
 import torch
 
-from benchmarks.benchmark_base import ManifestBenchmark
-from benchmarks.ops.attention.manifest_params import gqa_decode_args, manifest_params
+from benchmarks.benchmark_base import (
+    ManifestBenchmark,
+    then_dtype,
+    workload_params,
+)
+from benchmarks.ops.attention.manifest_params import gqa_decode_args
 from tileops.manifest import load_workloads
 from tileops.ops import GroupedQueryAttentionDecodeWithKVCacheFwdOp
 from workloads.attention.gqa import GroupedQueryAttentionDecodeWorkload
@@ -115,7 +119,9 @@ def _flashinfer_gqa_decode_fwd(test, q, k, v):
     return run_fn
 
 
-_GQA_DECODE_BENCH_PARAMS = manifest_params(load_workloads(_OP_NAME), gqa_decode_args)
+_GQA_DECODE_BENCH_PARAMS = workload_params(
+    load_workloads(_OP_NAME), then_dtype(gqa_decode_args, tune=True)
+)
 
 
 @pytest.mark.parametrize(

--- a/benchmarks/ops/attention/bench_gqa_decode_paged.py
+++ b/benchmarks/ops/attention/bench_gqa_decode_paged.py
@@ -10,7 +10,7 @@ from benchmarks.benchmark_base import (
     then_dtype,
     workload_params,
 )
-from benchmarks.ops.attention.manifest_params import gqa_decode_paged_args
+from benchmarks.ops.attention.workload_args import gqa_decode_paged_args
 from tileops.manifest import load_workloads
 from tileops.ops import GroupedQueryAttentionDecodePagedWithKVCacheFwdOp
 from workloads.attention.gqa import GroupedQueryAttentionDecodePagedWorkload

--- a/benchmarks/ops/attention/bench_gqa_decode_paged.py
+++ b/benchmarks/ops/attention/bench_gqa_decode_paged.py
@@ -5,8 +5,12 @@ import torch
 import torch.nn.functional as F
 from torch.nn.attention import SDPBackend, sdpa_kernel
 
-from benchmarks.benchmark_base import ManifestBenchmark
-from benchmarks.ops.attention.manifest_params import gqa_decode_paged_args, manifest_params
+from benchmarks.benchmark_base import (
+    ManifestBenchmark,
+    then_dtype,
+    workload_params,
+)
+from benchmarks.ops.attention.manifest_params import gqa_decode_paged_args
 from tileops.manifest import load_workloads
 from tileops.ops import GroupedQueryAttentionDecodePagedWithKVCacheFwdOp
 from workloads.attention.gqa import GroupedQueryAttentionDecodePagedWorkload
@@ -144,10 +148,12 @@ def _flashinfer_gqa_decode_paged(test, q, k, v, real_seqlen_kv, block_table):
     return run_fn
 
 
-_GQA_DECODE_PAGED_BENCH_PARAMS = manifest_params(
+_GQA_DECODE_PAGED_BENCH_PARAMS = workload_params(
     load_workloads(_OP_NAME),
-    gqa_decode_paged_args,
-    tune=False,
+    then_dtype(
+        gqa_decode_paged_args,
+        tune=False,
+    ),
 )
 
 

--- a/benchmarks/ops/attention/bench_gqa_fp8.py
+++ b/benchmarks/ops/attention/bench_gqa_fp8.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 import pytest
 import torch
 
-from benchmarks.benchmark_base import ManifestBenchmark
+from benchmarks.benchmark_base import ManifestBenchmark, workload_params
 from tileops.manifest import load_workloads
 from tileops.ops import GroupedQueryAttentionPrefillFwdOp
 from workloads.gqa_fp8_utils import (
@@ -23,34 +23,21 @@ class GQAFp8TensorCoreBenchCase:
     dim: int
     validate_uniform_cu_seqlens: bool
     out_dtype: torch.dtype
-    label: str
 
 
-def _manifest_cases() -> list[GQAFp8TensorCoreBenchCase]:
-    cases: list[GQAFp8TensorCoreBenchCase] = []
-    for workload in load_workloads(_OP_NAME):
-        if workload.get("backend") != "fp8":
-            continue
-        batch = workload["batch"]
-        seq_len = workload["max_seqlen_q"]
-        heads = workload["heads"]
-        heads_kv = workload["heads_kv"]
-        dim = workload["dim"]
-        for dtype_name in workload["dtypes"]:
-            out_dtype = getattr(torch, dtype_name)
-            cases.append(
-                GQAFp8TensorCoreBenchCase(
-                    batch=batch,
-                    seq_len=seq_len,
-                    heads=heads,
-                    heads_kv=heads_kv,
-                    dim=dim,
-                    validate_uniform_cu_seqlens=workload.get("validate_uniform_cu_seqlens", True),
-                    out_dtype=out_dtype,
-                    label=f"{workload['label']}-{dtype_name}",
-                )
-            )
-    return cases
+def _fp8_case_args(workload: dict, dtype: torch.dtype) -> tuple:
+    """One case object; the fp8 tensor-core path is the only one this bench runs."""
+    return (
+        GQAFp8TensorCoreBenchCase(
+            batch=workload["batch"],
+            seq_len=workload["max_seqlen_q"],
+            heads=workload["heads"],
+            heads_kv=workload["heads_kv"],
+            dim=workload["dim"],
+            validate_uniform_cu_seqlens=workload.get("validate_uniform_cu_seqlens", True),
+            out_dtype=dtype,
+        ),
+    )
 
 
 def _make_inputs(case: GQAFp8TensorCoreBenchCase) -> tuple[torch.Tensor, ...]:
@@ -110,7 +97,13 @@ def _fa3_gqa_fp8_fwd(case: GQAFp8TensorCoreBenchCase):
     return _run
 
 
-@pytest.mark.parametrize("case", [pytest.param(c, id=c.label) for c in _manifest_cases()])
+@pytest.mark.parametrize(
+    "case",
+    workload_params(
+        [w for w in load_workloads(_OP_NAME) if w.get("backend") == "fp8"],
+        _fp8_case_args,
+    ),
+)
 def test_gqa_prefill_fp8_tensor_core_bench(case: GQAFp8TensorCoreBenchCase) -> None:
     if not hasattr(torch, "float8_e4m3fn"):
         pytest.skip("torch fp8 is unavailable")
@@ -139,4 +132,16 @@ def test_gqa_prefill_fp8_tensor_core_bench(case: GQAFp8TensorCoreBenchCase) -> N
     if fa3_fn is not None:
         functors["fa3"] = fa3_fn
 
-    bm.compare(functors, *inputs, record_as=op, params={"case": case.label})
+    bm.compare(
+        functors,
+        *inputs,
+        record_as=op,
+        params={
+            "batch": case.batch,
+            "seq_len": case.seq_len,
+            "heads": case.heads,
+            "heads_kv": case.heads_kv,
+            "dim": case.dim,
+            "dtype": case.out_dtype,
+        },
+    )

--- a/benchmarks/ops/attention/bench_gqa_sliding_window.py
+++ b/benchmarks/ops/attention/bench_gqa_sliding_window.py
@@ -9,7 +9,7 @@ from benchmarks.benchmark_base import (
     then_dtype,
     workload_params,
 )
-from benchmarks.ops.attention.manifest_params import (
+from benchmarks.ops.attention.workload_args import (
     gqa_sliding_window_args,
 )
 from tileops.manifest import load_workloads

--- a/benchmarks/ops/attention/bench_gqa_sliding_window.py
+++ b/benchmarks/ops/attention/bench_gqa_sliding_window.py
@@ -4,10 +4,13 @@ import pytest
 import torch
 from torch.nn import functional as F
 
-from benchmarks.benchmark_base import ManifestBenchmark
+from benchmarks.benchmark_base import (
+    ManifestBenchmark,
+    then_dtype,
+    workload_params,
+)
 from benchmarks.ops.attention.manifest_params import (
     gqa_sliding_window_args,
-    manifest_params,
 )
 from tileops.manifest import load_workloads
 from tileops.ops import GroupedQueryAttentionSlidingWindowFwdOp
@@ -97,9 +100,12 @@ def _flashinfer_sliding_window_fwd(test, q, k, v):
     return run_fn
 
 
-_GQA_SLIDING_WINDOW_FWD_BENCH_PARAMS = manifest_params(
+_GQA_SLIDING_WINDOW_FWD_BENCH_PARAMS = workload_params(
     load_workloads(_OP_NAME),
-    gqa_sliding_window_args,
+    then_dtype(
+        gqa_sliding_window_args,
+        tune=True,
+    ),
 )
 
 

--- a/benchmarks/ops/attention/bench_gqa_sliding_window_varlen.py
+++ b/benchmarks/ops/attention/bench_gqa_sliding_window_varlen.py
@@ -9,7 +9,7 @@ from benchmarks.benchmark_base import (
     then_dtype,
     workload_params,
 )
-from benchmarks.ops.attention.manifest_params import (
+from benchmarks.ops.attention.workload_args import (
     gqa_sliding_window_varlen_args,
 )
 from tileops.manifest import load_workloads

--- a/benchmarks/ops/attention/bench_gqa_sliding_window_varlen.py
+++ b/benchmarks/ops/attention/bench_gqa_sliding_window_varlen.py
@@ -4,10 +4,13 @@ import pytest
 import torch
 from torch.nn import functional as F
 
-from benchmarks.benchmark_base import ManifestBenchmark
+from benchmarks.benchmark_base import (
+    ManifestBenchmark,
+    then_dtype,
+    workload_params,
+)
 from benchmarks.ops.attention.manifest_params import (
     gqa_sliding_window_varlen_args,
-    manifest_params,
 )
 from tileops.manifest import load_workloads
 from tileops.ops import GroupedQueryAttentionSlidingWindowVarlenFwdOp
@@ -17,10 +20,12 @@ from workloads.attention.gqa import (
 
 _OP_NAME = "GroupedQueryAttentionSlidingWindowVarlenFwdOp"
 
-_GQA_SLIDING_WINDOW_VARLEN_FWD_BENCH_PARAMS = manifest_params(
+_GQA_SLIDING_WINDOW_VARLEN_FWD_BENCH_PARAMS = workload_params(
     load_workloads(_OP_NAME),
-    gqa_sliding_window_varlen_args,
-    tune=False,
+    then_dtype(
+        gqa_sliding_window_varlen_args,
+        tune=False,
+    ),
 )
 
 

--- a/benchmarks/ops/attention/bench_mha.py
+++ b/benchmarks/ops/attention/bench_mha.py
@@ -2,8 +2,13 @@ import pytest
 import torch
 from torch.nn import functional as F
 
-from benchmarks.benchmark_base import ManifestBenchmark, backward_of
-from benchmarks.ops.attention.manifest_params import manifest_params, mha_qkv_args
+from benchmarks.benchmark_base import (
+    ManifestBenchmark,
+    backward_of,
+    then_dtype,
+    workload_params,
+)
+from benchmarks.ops.attention.manifest_params import mha_qkv_args
 from tileops.manifest import load_workloads
 from tileops.ops import MultiHeadAttentionBwdOp, MultiHeadAttentionFwdOp
 from workloads.attention.mha import (
@@ -110,7 +115,9 @@ def _torch_mha_bwd(test):
     return fn
 
 
-_MHA_FWD_BENCH_PARAMS = manifest_params(load_workloads(_MHA_FWD_OP), mha_qkv_args)
+_MHA_FWD_BENCH_PARAMS = workload_params(
+    load_workloads(_MHA_FWD_OP), then_dtype(mha_qkv_args, tune=True)
+)
 
 
 @pytest.mark.parametrize("batch, seq_len, heads, dim, causal, dtype, tune", _MHA_FWD_BENCH_PARAMS)
@@ -138,7 +145,9 @@ def test_mha_fwd_bench(
     bm.compare(functors, *inputs, record_as=op, params=locals())
 
 
-_MHA_BWD_BENCH_PARAMS = manifest_params(load_workloads(_MHA_BWD_OP), mha_qkv_args)
+_MHA_BWD_BENCH_PARAMS = workload_params(
+    load_workloads(_MHA_BWD_OP), then_dtype(mha_qkv_args, tune=True)
+)
 
 
 @pytest.mark.parametrize("batch, seq_len, heads, dim, causal, dtype, tune", _MHA_BWD_BENCH_PARAMS)

--- a/benchmarks/ops/attention/bench_mha.py
+++ b/benchmarks/ops/attention/bench_mha.py
@@ -8,7 +8,7 @@ from benchmarks.benchmark_base import (
     then_dtype,
     workload_params,
 )
-from benchmarks.ops.attention.manifest_params import mha_qkv_args
+from benchmarks.ops.attention.workload_args import mha_qkv_args
 from tileops.manifest import load_workloads
 from tileops.ops import MultiHeadAttentionBwdOp, MultiHeadAttentionFwdOp
 from workloads.attention.mha import (

--- a/benchmarks/ops/attention/bench_mha_decode.py
+++ b/benchmarks/ops/attention/bench_mha_decode.py
@@ -6,7 +6,7 @@ from benchmarks.benchmark_base import (
     then_dtype,
     workload_params,
 )
-from benchmarks.ops.attention.manifest_params import mha_decode_args
+from benchmarks.ops.attention.workload_args import mha_decode_args
 from tileops.manifest import load_workloads
 from tileops.ops import MultiHeadAttentionDecodeWithKVCacheFwdOp
 from workloads.attention.mha import MhaDecodeWorkload

--- a/benchmarks/ops/attention/bench_mha_decode.py
+++ b/benchmarks/ops/attention/bench_mha_decode.py
@@ -1,8 +1,12 @@
 import pytest
 import torch
 
-from benchmarks.benchmark_base import ManifestBenchmark
-from benchmarks.ops.attention.manifest_params import manifest_params, mha_decode_args
+from benchmarks.benchmark_base import (
+    ManifestBenchmark,
+    then_dtype,
+    workload_params,
+)
+from benchmarks.ops.attention.manifest_params import mha_decode_args
 from tileops.manifest import load_workloads
 from tileops.ops import MultiHeadAttentionDecodeWithKVCacheFwdOp
 from workloads.attention.mha import MhaDecodeWorkload
@@ -57,7 +61,9 @@ def _flashinfer_mha_decode_fwd(test, q, k, v):
     return run_fn
 
 
-_MHA_DECODE_BENCH_PARAMS = manifest_params(load_workloads(_OP_NAME), mha_decode_args)
+_MHA_DECODE_BENCH_PARAMS = workload_params(
+    load_workloads(_OP_NAME), then_dtype(mha_decode_args, tune=True)
+)
 
 
 @pytest.mark.parametrize("b, h, s_q, s_kv, d, dtype, tune", _MHA_DECODE_BENCH_PARAMS)

--- a/benchmarks/ops/attention/bench_mha_decode_paged.py
+++ b/benchmarks/ops/attention/bench_mha_decode_paged.py
@@ -6,7 +6,7 @@ from benchmarks.benchmark_base import (
     then_dtype,
     workload_params,
 )
-from benchmarks.ops.attention.manifest_params import mha_decode_paged_args
+from benchmarks.ops.attention.workload_args import mha_decode_paged_args
 from tileops.manifest import load_workloads
 from tileops.ops import MultiHeadAttentionDecodePagedWithKVCacheFwdOp
 from workloads.attention.mha import MhaDecodePagedWorkload

--- a/benchmarks/ops/attention/bench_mha_decode_paged.py
+++ b/benchmarks/ops/attention/bench_mha_decode_paged.py
@@ -1,8 +1,12 @@
 import pytest
 import torch
 
-from benchmarks.benchmark_base import ManifestBenchmark
-from benchmarks.ops.attention.manifest_params import manifest_params, mha_decode_paged_args
+from benchmarks.benchmark_base import (
+    ManifestBenchmark,
+    then_dtype,
+    workload_params,
+)
+from benchmarks.ops.attention.manifest_params import mha_decode_paged_args
 from tileops.manifest import load_workloads
 from tileops.ops import MultiHeadAttentionDecodePagedWithKVCacheFwdOp
 from workloads.attention.mha import MhaDecodePagedWorkload
@@ -79,7 +83,9 @@ def _flashinfer_mha_decode_paged(test, q, k, v, real_seqlen_kv, block_table):
     return run_fn
 
 
-_MHA_DECODE_PAGED_BENCH_PARAMS = manifest_params(load_workloads(_OP_NAME), mha_decode_paged_args)
+_MHA_DECODE_PAGED_BENCH_PARAMS = workload_params(
+    load_workloads(_OP_NAME), then_dtype(mha_decode_paged_args, tune=True)
+)
 
 
 @pytest.mark.parametrize(

--- a/benchmarks/ops/attention/manifest_params.py
+++ b/benchmarks/ops/attention/manifest_params.py
@@ -1,38 +1,10 @@
-from collections.abc import Callable, Iterable
 from typing import Any
 
-import pytest
 import torch
 
 
 def torch_dtype(dtype_name: str) -> torch.dtype:
     return getattr(torch, dtype_name)
-
-
-def manifest_params(
-    workloads: Iterable[dict[str, Any]],
-    build_args: Callable[[dict[str, Any]], tuple[Any, ...]],
-    *,
-    tune: bool = True,
-) -> list:
-    params = []
-    for workload in workloads:
-        label = workload.get("label", "manifest")
-        marks = ()
-        if reason := workload.get("bench_skip_reason"):
-            marks = (pytest.mark.skip(reason=reason),)
-        for dtype_name in workload["dtypes"]:
-            dtype = torch_dtype(dtype_name)
-            params.append(
-                pytest.param(
-                    *build_args(workload),
-                    dtype,
-                    tune,
-                    id=f"{label}-{dtype_name}",
-                    marks=marks,
-                )
-            )
-    return params
 
 
 def mha_qkv_args(workload: dict[str, Any]) -> tuple[int, int, int, int, bool]:

--- a/benchmarks/ops/attention/workload_args.py
+++ b/benchmarks/ops/attention/workload_args.py
@@ -3,10 +3,6 @@ from typing import Any
 import torch
 
 
-def torch_dtype(dtype_name: str) -> torch.dtype:
-    return getattr(torch, dtype_name)
-
-
 def mha_qkv_args(workload: dict[str, Any]) -> tuple[int, int, int, int, bool]:
     batch, seq_len, heads, dim = workload["q_shape"]
     return batch, seq_len, heads, dim, workload.get("is_causal", True)
@@ -99,7 +95,7 @@ def gqa_prefill_paged_args(
         workload.get("fuse_rope", False),
         workload.get("rotary_dim"),
         workload.get("softcap"),
-        torch_dtype(workload["cache_dtype"]) if workload.get("cache_dtype") else None,
+        getattr(torch, workload["cache_dtype"]) if workload.get("cache_dtype") else None,
     )
 
 

--- a/benchmarks/ops/bench_ada_layer_norm.py
+++ b/benchmarks/ops/bench_ada_layer_norm.py
@@ -3,7 +3,7 @@ import torch
 import torch.nn.functional as F
 
 from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
-from benchmarks.benchmark_base import ManifestBenchmark
+from benchmarks.benchmark_base import ManifestBenchmark, workload_params
 from tileops.manifest import load_workloads
 from tileops.ops.norm.ada_layer_norm import AdaLayerNormFwdOp
 from tileops.ops.norm.ada_layer_norm_zero import AdaLayerNormZeroFwdOp
@@ -13,18 +13,13 @@ _ADA_OP_NAME = "AdaLayerNormFwdOp"
 _ADA_ZERO_OP_NAME = "AdaLayerNormZeroFwdOp"
 
 
-def _to_params(workloads):
-    params = []
-    for w in workloads:
-        m, n = w["x_shape"]
-        label = w.get("label", f"{m}x{n}")
-        for dtype_str in w["dtypes"]:
-            dtype = getattr(torch, dtype_str)
-            params.append(pytest.param(m, n, dtype, id=f"{label}-{dtype_str}"))
-    return params
+def _ada_args(w: dict, dtype: torch.dtype) -> tuple:
+    """``(m, n, dtype)`` for one case."""
+    m, n = w["x_shape"]
+    return (m, n, dtype)
 
 
-@pytest.mark.parametrize("m, n, dtype", _to_params(load_workloads(_ADA_OP_NAME)))
+@pytest.mark.parametrize("m, n, dtype", workload_params(load_workloads(_ADA_OP_NAME), _ada_args))
 def test_ada_layer_norm_bench(m: int, n: int, dtype: torch.dtype) -> None:
     test = AdaLayerNormWorkload(m, n, dtype)
     inputs = test.gen_inputs()
@@ -49,7 +44,9 @@ def test_ada_layer_norm_bench(m: int, n: int, dtype: torch.dtype) -> None:
     )
 
 
-@pytest.mark.parametrize("m, n, dtype", _to_params(load_workloads(_ADA_ZERO_OP_NAME)))
+@pytest.mark.parametrize(
+    "m, n, dtype", workload_params(load_workloads(_ADA_ZERO_OP_NAME), _ada_args)
+)
 def test_ada_layer_norm_zero_bench(m: int, n: int, dtype: torch.dtype) -> None:
     test = AdaLayerNormZeroWorkload(m, n, dtype)
     inputs = test.gen_inputs()

--- a/benchmarks/ops/bench_ada_layer_norm.py
+++ b/benchmarks/ops/bench_ada_layer_norm.py
@@ -14,7 +14,6 @@ _ADA_ZERO_OP_NAME = "AdaLayerNormZeroFwdOp"
 
 
 def _ada_args(w: dict, dtype: torch.dtype) -> tuple:
-    """``(m, n, dtype)`` for one case."""
     m, n = w["x_shape"]
     return (m, n, dtype)
 

--- a/benchmarks/ops/bench_batch_norm.py
+++ b/benchmarks/ops/bench_batch_norm.py
@@ -95,13 +95,11 @@ def _torch_bn_bwd(grad_out, x, weight, mean, rstd):
 
 
 def _fwd_args(w: dict, dtype: torch.dtype) -> tuple:
-    """``(N, C, spatial, dtype, tune, training)``."""
     n, c, *spatial = w["x_shape"]
     return (n, c, tuple(spatial), dtype, True, False)
 
 
 def _bwd_args(w: dict, dtype: torch.dtype) -> tuple:
-    """``(N, C, spatial, dtype)``."""
     n, c, *spatial = w["x_shape"]
     return (n, c, tuple(spatial), dtype)
 

--- a/benchmarks/ops/bench_batch_norm.py
+++ b/benchmarks/ops/bench_batch_norm.py
@@ -18,7 +18,7 @@ from benchmarks.baselines import (
     compiled_reference,
     flaggems_op,
 )
-from benchmarks.benchmark_base import ManifestBenchmark, backward_of
+from benchmarks.benchmark_base import ManifestBenchmark, backward_of, workload_params
 from tileops.manifest import load_workloads
 from tileops.ops.norm.batch_norm import BatchNormBwdOp, BatchNormFwdOp
 from workloads.normalization import BatchNormBwdWorkload, BatchNormFwdWorkload
@@ -94,36 +94,24 @@ def _torch_bn_bwd(grad_out, x, weight, mean, rstd):
 # Manifest-driven params
 
 
-def _manifest_fwd_params():
-    params = []
-    for w in load_workloads(_FWD_OP_NAME):
-        shape = w["x_shape"]
-        N, C, spatial = shape[0], shape[1], tuple(shape[2:])
-        label = w.get("label", f"{N}x{C}")
-        for dtype_str in w["dtypes"]:
-            dtype = getattr(torch, dtype_str)
-            params.append(
-                pytest.param(N, C, spatial, dtype, True, False, id=f"{label}-{dtype_str}")
-            )
-    return params
+def _fwd_args(w: dict, dtype: torch.dtype) -> tuple:
+    """``(N, C, spatial, dtype, tune, training)``."""
+    n, c, *spatial = w["x_shape"]
+    return (n, c, tuple(spatial), dtype, True, False)
 
 
-def _manifest_bwd_params():
-    params = []
-    for w in load_workloads(_BWD_OP_NAME):
-        shape = w["x_shape"]
-        N, C, spatial = shape[0], shape[1], tuple(shape[2:])
-        label = w.get("label", f"{N}x{C}")
-        for dtype_str in w["dtypes"]:
-            dtype = getattr(torch, dtype_str)
-            params.append(pytest.param(N, C, spatial, dtype, id=f"{label}-{dtype_str}"))
-    return params
+def _bwd_args(w: dict, dtype: torch.dtype) -> tuple:
+    """``(N, C, spatial, dtype)``."""
+    n, c, *spatial = w["x_shape"]
+    return (n, c, tuple(spatial), dtype)
 
 
 # Benchmark tests
 
 
-@pytest.mark.parametrize("N, C, spatial, dtype, training, tune", _manifest_fwd_params())
+@pytest.mark.parametrize(
+    "N, C, spatial, dtype, training, tune", workload_params(load_workloads(_FWD_OP_NAME), _fwd_args)
+)
 def test_batch_norm_fwd_bench(N, C, spatial, dtype, training, tune):
     x, weight, bias, running_mean, running_var = _make_inputs(N, C, spatial, dtype)
     # Manifest input order: (x, running_mean, running_var, weight, bias).
@@ -156,7 +144,9 @@ def test_batch_norm_fwd_bench(N, C, spatial, dtype, training, tune):
     )
 
 
-@pytest.mark.parametrize("N, C, spatial, dtype", _manifest_bwd_params())
+@pytest.mark.parametrize(
+    "N, C, spatial, dtype", workload_params(load_workloads(_BWD_OP_NAME), _bwd_args)
+)
 def test_batch_norm_bwd_bench(N, C, spatial, dtype):
     inputs = _make_bwd_inputs(N, C, spatial, dtype)
 

--- a/benchmarks/ops/bench_binary_elementwise.py
+++ b/benchmarks/ops/bench_binary_elementwise.py
@@ -25,6 +25,7 @@ from benchmarks.baselines import (
 from benchmarks.benchmark_base import (
     BenchmarkBase,
     ManifestBenchmark,
+    workload_params,
 )
 from tileops.kernels.elementwise import (
     GeluAndMulFwdKernel,
@@ -577,35 +578,41 @@ _GELU_AND_MUL_OP = "GeluAndMulFwdOp"
 _GELU_TANH_AND_MUL_OP = "GeluTanhAndMulFwdOp"
 
 
-def _fused_gated_params(workloads: list) -> list:
-    """Manifest workloads -> (M, N, dtype) params; x_shape trailing axis is 2*N."""
-    params = []
-    for i, w in enumerate(workloads):
-        m, two_n = w["x_shape"]
-        for dtype_name in w["dtypes"]:
-            mark = pytest.mark.smoke if i == 0 else pytest.mark.full
-            params.append(
-                pytest.param(
-                    m,
-                    two_n // 2,
-                    getattr(torch, dtype_name),
-                    marks=mark,
-                    id=f"{w.get('label', f'w{i}')}-{dtype_name}",
-                )
-            )
-    return params
+def _fused_gated_args(w: dict, dtype: torch.dtype) -> tuple:
+    """``(M, N, dtype)``; the x_shape trailing axis is 2*N."""
+    m, two_n = w["x_shape"]
+    return (m, two_n // 2, dtype)
 
 
 class SiluAndMulBenchFixture(FixtureBase):
-    PARAMS = [("M, N, dtype", _fused_gated_params(load_workloads(_SILU_AND_MUL_OP)))]
+    PARAMS = [
+        (
+            "M, N, dtype",
+            workload_params(load_workloads(_SILU_AND_MUL_OP), _fused_gated_args, smoke_first=True),
+        )
+    ]
 
 
 class GeluAndMulBenchFixture(FixtureBase):
-    PARAMS = [("M, N, dtype", _fused_gated_params(load_workloads(_GELU_AND_MUL_OP)))]
+    PARAMS = [
+        (
+            "M, N, dtype",
+            workload_params(load_workloads(_GELU_AND_MUL_OP), _fused_gated_args, smoke_first=True),
+        )
+    ]
 
 
 class GeluTanhAndMulBenchFixture(FixtureBase):
-    PARAMS = [("M, N, dtype", _fused_gated_params(load_workloads(_GELU_TANH_AND_MUL_OP)))]
+    PARAMS = [
+        (
+            "M, N, dtype",
+            workload_params(
+                load_workloads(_GELU_TANH_AND_MUL_OP),
+                _fused_gated_args,
+                smoke_first=True,
+            ),
+        )
+    ]
 
 
 def _silu_and_mul_baseline(x: torch.Tensor) -> torch.Tensor:

--- a/benchmarks/ops/bench_bmm.py
+++ b/benchmarks/ops/bench_bmm.py
@@ -7,7 +7,7 @@ from benchmarks.baselines import (
     flaggems_op,
     reference_tolerance,
 )
-from benchmarks.benchmark_base import ManifestBenchmark
+from benchmarks.benchmark_base import ManifestBenchmark, fields, workload_params
 from tileops.manifest import load_workloads
 from tileops.ops import BmmFp8KNFwdOp, BmmFp8NKFwdOp, BmmFwdOp
 from workloads.bmm import BmmFp8Workload, BmmWorkload
@@ -15,13 +15,6 @@ from workloads.bmm import BmmFp8Workload, BmmWorkload
 _OP_NAME = "BmmFwdOp"
 _FP8_KN_OP_NAME = "BmmFp8KNFwdOp"
 _FP8_NK_OP_NAME = "BmmFp8NKFwdOp"
-
-_DTYPE_MAP = {
-    "bfloat16": torch.bfloat16,
-    "float16": torch.float16,
-    "float8_e4m3fn": torch.float8_e4m3fn,
-    "float8_e5m2": torch.float8_e5m2,
-}
 
 
 class BmmFp8BenchmarkWorkload(BmmFp8Workload):
@@ -65,46 +58,11 @@ def _flashinfer_bmm_fp8_per_tensor_ref(
     )
 
 
-def _manifest_params() -> list:
-    """Convert manifest workloads to pytest params (batch, m, n, k, dtype)."""
-    params = []
-    for w in load_workloads(_OP_NAME):
-        label = w.get("label", "unlabeled")
-        for dtype_str in w["dtypes"]:
-            params.append(
-                pytest.param(
-                    w["b"],
-                    w["m"],
-                    w["n"],
-                    w["k"],
-                    dtype_str,
-                    id=f"{label}-{dtype_str}",
-                )
-            )
-    return params
-
-
-def _fp8_params(workloads) -> list:
-    params = []
-    for w in workloads:
-        label = w.get("label", "unlabeled")
-        for dtype_str in w["dtypes"]:
-            params.append(
-                pytest.param(
-                    w["b"],
-                    w["m"],
-                    w["n"],
-                    w["k"],
-                    dtype_str,
-                    id=f"{label}-{dtype_str}",
-                )
-            )
-    return params
-
-
-@pytest.mark.parametrize("batch, m, n, k, dtype_str", _manifest_params())
-def test_bmm_bench(batch: int, m: int, n: int, k: int, dtype_str: str) -> None:
-    dtype = _DTYPE_MAP[dtype_str]
+@pytest.mark.parametrize(
+    "batch, m, n, k, dtype",
+    workload_params(load_workloads(_OP_NAME), fields("b", "m", "n", "k", dtype_last=True)),
+)
+def test_bmm_bench(batch: int, m: int, n: int, k: int, dtype: torch.dtype) -> None:
     workload = BmmWorkload(batch, m, n, k, dtype)
     a, b = workload.gen_inputs()
 
@@ -130,16 +88,18 @@ def test_bmm_bench(batch: int, m: int, n: int, k: int, dtype_str: str) -> None:
     )
 
 
-@pytest.mark.parametrize("batch, m, n, k, dtype_str", _fp8_params(load_workloads(_FP8_KN_OP_NAME)))
+@pytest.mark.parametrize(
+    "batch, m, n, k, dtype",
+    workload_params(load_workloads(_FP8_KN_OP_NAME), fields("b", "m", "n", "k", dtype_last=True)),
+)
 def test_bmm_fp8_kn_bench(
     batch: int,
     m: int,
     n: int,
     k: int,
-    dtype_str: str,
+    dtype: torch.dtype,
 ) -> None:
     """The [B, K, N] order, which the kernel reaches through a transpose."""
-    dtype = _DTYPE_MAP[dtype_str]
     out_dtype = torch.bfloat16
     workload = BmmFp8BenchmarkWorkload(batch, m, n, k, dtype, out_dtype=out_dtype)
     a, b_kn, scale_a, scale_b = workload.gen_inputs()
@@ -153,15 +113,17 @@ def test_bmm_fp8_kn_bench(
     )
 
 
-@pytest.mark.parametrize("batch, m, n, k, dtype_str", _fp8_params(load_workloads(_FP8_NK_OP_NAME)))
+@pytest.mark.parametrize(
+    "batch, m, n, k, dtype",
+    workload_params(load_workloads(_FP8_NK_OP_NAME), fields("b", "m", "n", "k", dtype_last=True)),
+)
 def test_bmm_fp8_nk_bench(
     batch: int,
     m: int,
     n: int,
     k: int,
-    dtype_str: str,
+    dtype: torch.dtype,
 ) -> None:
-    dtype = _DTYPE_MAP[dtype_str]
     out_dtype = torch.bfloat16
     workload = BmmFp8BenchmarkWorkload(batch, m, n, k, dtype, out_dtype=out_dtype)
     a, b_kn, scale_a, scale_b = workload.gen_inputs()

--- a/benchmarks/ops/bench_convolution.py
+++ b/benchmarks/ops/bench_convolution.py
@@ -76,11 +76,6 @@ class ConvCase:
         return asdict(self)
 
 
-def _mark(w: dict, dtype: torch.dtype, index: int) -> tuple:
-    """First manifest workload of an op is the smoke case; the rest are full."""
-    return (pytest.mark.smoke if index == 0 else pytest.mark.full,)
-
-
 def _conv_args(w: dict, dtype: torch.dtype, kernel_keys: tuple[str, ...]) -> tuple:
     """One :class:`ConvCase` for this row and dtype.
 
@@ -303,7 +298,7 @@ _CONV1D_KERNEL_KEYS = ("kW",)
     workload_params(
         load_workloads(_CONV1D_OP),
         functools.partial(_conv_args, kernel_keys=_CONV1D_KERNEL_KEYS),
-        marks=_mark,
+        smoke_first=True,
     ),
 )
 def test_conv1d_bench(case: ConvCase) -> None:
@@ -329,7 +324,7 @@ _CONV2D_KERNEL_KEYS = ("kH", "kW")
     workload_params(
         load_workloads(_CONV2D_OP),
         functools.partial(_conv_args, kernel_keys=_CONV2D_KERNEL_KEYS),
-        marks=_mark,
+        smoke_first=True,
     ),
 )
 def test_conv2d_bench(case: ConvCase) -> None:
@@ -355,7 +350,7 @@ _CONV3D_KERNEL_KEYS = ("kD", "kH", "kW")
     workload_params(
         load_workloads(_CONV3D_OP),
         functools.partial(_conv_args, kernel_keys=_CONV3D_KERNEL_KEYS),
-        marks=_mark,
+        smoke_first=True,
     ),
 )
 def test_conv3d_bench(case: ConvCase) -> None:

--- a/benchmarks/ops/bench_convolution.py
+++ b/benchmarks/ops/bench_convolution.py
@@ -14,6 +14,7 @@ Every row is timed against flag_gems' Triton convolutions, ``F.convNd`` eager
 inductor.
 """
 
+import functools
 from dataclasses import asdict, dataclass
 from typing import Callable, Optional
 
@@ -28,7 +29,7 @@ from benchmarks.baselines import (
     compiled_reference,
     flaggems_op,
 )
-from benchmarks.benchmark_base import ManifestBenchmark
+from benchmarks.benchmark_base import ManifestBenchmark, workload_params
 from tileops.manifest import load_workloads
 from tileops.ops import Conv1dFwdOp, Conv2dFwdOp, Conv3dFwdOp
 
@@ -75,54 +76,39 @@ class ConvCase:
         return asdict(self)
 
 
-def _mark(idx: int):
+def _mark(w: dict, dtype: torch.dtype, index: int) -> tuple:
     """First manifest workload of an op is the smoke case; the rest are full."""
-    return pytest.mark.smoke if idx == 0 else pytest.mark.full
+    return (pytest.mark.smoke if index == 0 else pytest.mark.full,)
 
 
-def _conv_params(workloads: list[dict], kernel_keys: tuple[str, ...]) -> list:
-    """Build one :class:`ConvCase` parameter per manifest workload row and dtype.
+def _conv_args(w: dict, dtype: torch.dtype, kernel_keys: tuple[str, ...]) -> tuple:
+    """One :class:`ConvCase` for this row and dtype.
 
     ``kernel_keys`` names the manifest spatial-extent keys in order, e.g.
-    ``("kD", "kH", "kW")`` for 3d. Workload entries omitting ``stride`` /
-    ``padding`` fall back to the manifest signature defaults; scalar entries
-    are broadcast across the spatial dims the way PyTorch broadcasts them.
+    ``("kD", "kH", "kW")`` for 3d. Rows omitting ``stride`` / ``padding`` fall
+    back to the manifest signature defaults; a scalar entry is broadcast across
+    the spatial dims the way PyTorch broadcasts it.
     """
     n_spatial = len(kernel_keys)
 
-    def _spatial(value) -> tuple[int, ...]:
+    def spatial(value) -> tuple[int, ...]:
         if isinstance(value, (list, tuple)):
             return tuple(value)
         return (value,) * n_spatial
 
-    params = []
-    for idx, w in enumerate(workloads):
-        input_shape = tuple(w["input_shape"])
-        kernel_size = tuple(w[key] for key in kernel_keys)
-        stride = _spatial(w.get("stride", 1))
-        padding = _spatial(w.get("padding", 0))
-        dilation = _spatial(w.get("dilation", 1))
-        groups = w.get("groups", 1)
-        with_bias = "bias_shape" in w
-        for dtype_name in w["dtypes"]:
-            params.append(
-                pytest.param(
-                    ConvCase(
-                        input_shape,
-                        w["C_out"],
-                        kernel_size,
-                        stride,
-                        padding,
-                        dilation,
-                        groups,
-                        getattr(torch, dtype_name),
-                        with_bias,
-                    ),
-                    id=f"{w['label']}-{dtype_name}",
-                    marks=_mark(idx),
-                )
-            )
-    return params
+    return (
+        ConvCase(
+            tuple(w["input_shape"]),
+            w["C_out"],
+            tuple(w[key] for key in kernel_keys),
+            spatial(w.get("stride", 1)),
+            spatial(w.get("padding", 0)),
+            spatial(w.get("dilation", 1)),
+            w.get("groups", 1),
+            dtype,
+            "bias_shape" in w,
+        ),
+    )
 
 
 def _conv_inputs(
@@ -314,7 +300,11 @@ _CONV1D_KERNEL_KEYS = ("kW",)
 
 @pytest.mark.parametrize(
     "case",
-    _conv_params(load_workloads(_CONV1D_OP), _CONV1D_KERNEL_KEYS),
+    workload_params(
+        load_workloads(_CONV1D_OP),
+        functools.partial(_conv_args, kernel_keys=_CONV1D_KERNEL_KEYS),
+        marks=_mark,
+    ),
 )
 def test_conv1d_bench(case: ConvCase) -> None:
     op = Conv1dFwdOp(
@@ -336,7 +326,11 @@ _CONV2D_KERNEL_KEYS = ("kH", "kW")
 
 @pytest.mark.parametrize(
     "case",
-    _conv_params(load_workloads(_CONV2D_OP), _CONV2D_KERNEL_KEYS),
+    workload_params(
+        load_workloads(_CONV2D_OP),
+        functools.partial(_conv_args, kernel_keys=_CONV2D_KERNEL_KEYS),
+        marks=_mark,
+    ),
 )
 def test_conv2d_bench(case: ConvCase) -> None:
     op = Conv2dFwdOp(
@@ -358,7 +352,11 @@ _CONV3D_KERNEL_KEYS = ("kD", "kH", "kW")
 
 @pytest.mark.parametrize(
     "case",
-    _conv_params(load_workloads(_CONV3D_OP), _CONV3D_KERNEL_KEYS),
+    workload_params(
+        load_workloads(_CONV3D_OP),
+        functools.partial(_conv_args, kernel_keys=_CONV3D_KERNEL_KEYS),
+        marks=_mark,
+    ),
 )
 def test_conv3d_bench(case: ConvCase) -> None:
     op = Conv3dFwdOp(

--- a/benchmarks/ops/bench_deltanet.py
+++ b/benchmarks/ops/bench_deltanet.py
@@ -16,8 +16,12 @@ import pytest
 import torch
 from fla.ops.delta_rule import chunk_delta_rule
 
-from benchmarks.benchmark_base import ManifestBenchmark, backward_of
-from benchmarks.ops.attention.manifest_params import manifest_params
+from benchmarks.benchmark_base import (
+    ManifestBenchmark,
+    backward_of,
+    then_dtype,
+    workload_params,
+)
 from tileops.manifest import load_workloads
 from tileops.ops import DeltaNetBwdOp, DeltaNetFwdOp
 from workloads.linear_attention import DeltaNetFwdWorkload
@@ -48,7 +52,7 @@ def _deltanet_args(workload: dict) -> tuple[int, int, int, int, int, int]:
 
 @pytest.mark.parametrize(
     "batch, seq_len, heads, dim_k, dim_v, chunk_size, dtype, tune",
-    manifest_params(load_workloads(_FWD_OP_NAME), _deltanet_args, tune=False),
+    workload_params(load_workloads(_FWD_OP_NAME), then_dtype(_deltanet_args, tune=False)),
 )
 def test_deltanet_vs_fla_fwd(
     batch: int,
@@ -86,7 +90,7 @@ def test_deltanet_vs_fla_fwd(
 
 @pytest.mark.parametrize(
     "batch, seq_len, heads, dim_k, dim_v, chunk_size, dtype, tune",
-    manifest_params(load_workloads(_BWD_OP_NAME), _deltanet_args, tune=False),
+    workload_params(load_workloads(_BWD_OP_NAME), then_dtype(_deltanet_args, tune=False)),
 )
 def test_deltanet_vs_fla_bwd(
     batch: int,

--- a/benchmarks/ops/bench_deltanet_recurrence.py
+++ b/benchmarks/ops/bench_deltanet_recurrence.py
@@ -3,8 +3,12 @@ from typing import Optional
 import torch
 
 from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
-from benchmarks.benchmark_base import BenchmarkBase, ManifestBenchmark
-from benchmarks.ops.attention.manifest_params import manifest_params
+from benchmarks.benchmark_base import (
+    BenchmarkBase,
+    ManifestBenchmark,
+    then_dtype,
+    workload_params,
+)
 from tileops.manifest import load_workloads
 from tileops.ops import DeltaNetDecodeFwdOp
 from workloads.linear_attention import DeltaNetDecodeWorkload
@@ -61,10 +65,12 @@ class DeltaNetDecodeBenchFixture(FixtureBase):
     PARAMS = [
         (
             "batch, heads, dim_k, dim_v, dtype, tune",
-            manifest_params(
+            workload_params(
                 load_workloads(_OP_NAME),
-                lambda w: (w["q_shape"][0], w["q_shape"][1], w["q_shape"][2], w["v_shape"][2]),
-                tune=False,
+                then_dtype(
+                    lambda w: (w["q_shape"][0], w["q_shape"][1], w["q_shape"][2], w["v_shape"][2]),
+                    tune=False,
+                ),
             ),
         ),
     ]

--- a/benchmarks/ops/bench_elementwise_manifest.py
+++ b/benchmarks/ops/bench_elementwise_manifest.py
@@ -7,6 +7,7 @@ implemented elementwise manifest entry a benchmark path that is sourced from
 Each row is timed against torch eager and the same reference through inductor.
 """
 
+import functools
 from math import prod
 from typing import Callable
 
@@ -15,7 +16,7 @@ import torch
 import torch.nn.functional as F
 
 from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
-from benchmarks.benchmark_base import ManifestBenchmark
+from benchmarks.benchmark_base import ManifestBenchmark, workload_params
 from tileops.manifest import load_workloads
 from tileops.ops.elementwise import (
     AddFwdOp,
@@ -71,87 +72,25 @@ from workloads.elementwise import (
 )
 
 
-def _dtype(name: str) -> torch.dtype:
-    return getattr(torch, name)
+def _mark(w: dict, dtype: torch.dtype, index: int) -> tuple:
+    """The first row's fp16 case is the smoke case; every other case is full."""
+    return (pytest.mark.smoke if index == 0 and dtype is torch.float16 else pytest.mark.full,)
 
 
-def _mark(idx: int, dtype: torch.dtype):
-    return pytest.mark.smoke if idx == 0 and dtype is torch.float16 else pytest.mark.full
+def _shape_args(w: dict, dtype: torch.dtype) -> tuple:
+    return (tuple(w["input_shape"]), dtype)
 
 
-def _shape_dtype_params(workloads: list[dict]) -> list:
-    params = []
-    for idx, w in enumerate(workloads):
-        shape = tuple(w["input_shape"])
-        label = w.get("label", "x".join(str(dim) for dim in shape))
-        for dtype_name in w["dtypes"]:
-            dtype = _dtype(dtype_name)
-            params.append(
-                pytest.param(shape, dtype, id=f"{label}-{dtype_name}", marks=_mark(idx, dtype))
-            )
-    return params
+def _binary_args(w: dict, dtype: torch.dtype, rhs_key: str = "other_shape") -> tuple:
+    return (tuple(w["input_shape"]), tuple(w[rhs_key]), dtype)
 
 
-def _binary_params(workloads: list[dict], rhs_key: str = "other_shape") -> list:
-    params = []
-    for idx, w in enumerate(workloads):
-        input_shape = tuple(w["input_shape"])
-        other_shape = tuple(w[rhs_key])
-        label = w.get("label", "x".join(str(dim) for dim in input_shape))
-        for dtype_name in w["dtypes"]:
-            dtype = _dtype(dtype_name)
-            params.append(
-                pytest.param(
-                    input_shape,
-                    other_shape,
-                    dtype,
-                    id=f"{label}-{dtype_name}",
-                    marks=_mark(idx, dtype),
-                )
-            )
-    return params
+def _prelu_args(w: dict, dtype: torch.dtype) -> tuple:
+    return (tuple(w["input_shape"]), tuple(w["weight_shape"]), dtype)
 
 
-def _prelu_params(workloads: list[dict]) -> list:
-    params = []
-    for idx, w in enumerate(workloads):
-        input_shape = tuple(w["input_shape"])
-        weight_shape = tuple(w["weight_shape"])
-        label = w.get("label", "prelu")
-        for dtype_name in w["dtypes"]:
-            dtype = _dtype(dtype_name)
-            params.append(
-                pytest.param(
-                    input_shape,
-                    weight_shape,
-                    dtype,
-                    id=f"{label}-{dtype_name}",
-                    marks=_mark(idx, dtype),
-                )
-            )
-    return params
-
-
-def _masked_fill_tensor_params(workloads: list[dict]) -> list:
-    params = []
-    for idx, w in enumerate(workloads):
-        input_shape = tuple(w["input_shape"])
-        mask_shape = tuple(w["mask_shape"])
-        value_shape = tuple(w["value_shape"])
-        label = w.get("label", "masked-fill")
-        for dtype_name in w["dtypes"]:
-            dtype = _dtype(dtype_name)
-            params.append(
-                pytest.param(
-                    input_shape,
-                    mask_shape,
-                    value_shape,
-                    dtype,
-                    id=f"{label}-{dtype_name}",
-                    marks=_mark(idx, dtype),
-                )
-            )
-    return params
+def _masked_fill_tensor_args(w: dict, dtype: torch.dtype) -> tuple:
+    return (tuple(w["input_shape"]), tuple(w["mask_shape"]), tuple(w["value_shape"]), dtype)
 
 
 def _numel(shape: tuple[int, ...]) -> int:
@@ -283,7 +222,9 @@ _CLAMP_SCALAR_OP = "ClampScalarFwdOp"
 _NAN_TO_NUM_OP = "NanToNumFwdOp"
 
 
-@pytest.mark.parametrize("shape, dtype", _shape_dtype_params(load_workloads(_RELU_OP)))
+@pytest.mark.parametrize(
+    "shape, dtype", workload_params(load_workloads(_RELU_OP), _shape_args, marks=_mark)
+)
 def test_relu_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> None:
     test = ShapedRandnWorkload(shape, dtype)
     inputs = test.gen_inputs()
@@ -292,7 +233,9 @@ def test_relu_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> None
     _record_unary(op, bm, inputs, F.relu)
 
 
-@pytest.mark.parametrize("shape, dtype", _shape_dtype_params(load_workloads(_GELU_OP)))
+@pytest.mark.parametrize(
+    "shape, dtype", workload_params(load_workloads(_GELU_OP), _shape_args, marks=_mark)
+)
 def test_gelu_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> None:
     test = ShapedRandnWorkload(shape, dtype)
     inputs = test.gen_inputs()
@@ -301,7 +244,9 @@ def test_gelu_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> None
     _record_unary(op, bm, inputs, lambda x: F.gelu(x, approximate="none"))
 
 
-@pytest.mark.parametrize("shape, dtype", _shape_dtype_params(load_workloads(_SILU_OP)))
+@pytest.mark.parametrize(
+    "shape, dtype", workload_params(load_workloads(_SILU_OP), _shape_args, marks=_mark)
+)
 def test_silu_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> None:
     test = ShapedRandnWorkload(shape, dtype)
     inputs = test.gen_inputs()
@@ -310,7 +255,9 @@ def test_silu_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> None
     _record_unary(op, bm, inputs, F.silu)
 
 
-@pytest.mark.parametrize("shape, dtype", _shape_dtype_params(load_workloads(_HARDSWISH_OP)))
+@pytest.mark.parametrize(
+    "shape, dtype", workload_params(load_workloads(_HARDSWISH_OP), _shape_args, marks=_mark)
+)
 def test_hardswish_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> None:
     test = ShapedRandnWorkload(shape, dtype)
     inputs = test.gen_inputs()
@@ -319,7 +266,9 @@ def test_hardswish_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) ->
     _record_unary(op, bm, inputs, F.hardswish)
 
 
-@pytest.mark.parametrize("shape, dtype", _shape_dtype_params(load_workloads(_HARDSIGMOID_OP)))
+@pytest.mark.parametrize(
+    "shape, dtype", workload_params(load_workloads(_HARDSIGMOID_OP), _shape_args, marks=_mark)
+)
 def test_hardsigmoid_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> None:
     test = ShapedRandnWorkload(shape, dtype)
     inputs = test.gen_inputs()
@@ -328,7 +277,9 @@ def test_hardsigmoid_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) 
     _record_unary(op, bm, inputs, F.hardsigmoid)
 
 
-@pytest.mark.parametrize("shape, dtype", _shape_dtype_params(load_workloads(_MISH_OP)))
+@pytest.mark.parametrize(
+    "shape, dtype", workload_params(load_workloads(_MISH_OP), _shape_args, marks=_mark)
+)
 def test_mish_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> None:
     test = ShapedRandnWorkload(shape, dtype)
     inputs = test.gen_inputs()
@@ -337,7 +288,9 @@ def test_mish_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> None
     _record_unary(op, bm, inputs, F.mish)
 
 
-@pytest.mark.parametrize("shape, dtype", _shape_dtype_params(load_workloads(_SELU_OP)))
+@pytest.mark.parametrize(
+    "shape, dtype", workload_params(load_workloads(_SELU_OP), _shape_args, marks=_mark)
+)
 def test_selu_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> None:
     test = ShapedRandnWorkload(shape, dtype)
     inputs = test.gen_inputs()
@@ -346,7 +299,9 @@ def test_selu_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> None
     _record_unary(op, bm, inputs, F.selu)
 
 
-@pytest.mark.parametrize("shape, dtype", _shape_dtype_params(load_workloads(_LEAKY_RELU_OP)))
+@pytest.mark.parametrize(
+    "shape, dtype", workload_params(load_workloads(_LEAKY_RELU_OP), _shape_args, marks=_mark)
+)
 def test_leaky_relu_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> None:
     test = ShapedRandnWorkload(shape, dtype)
     inputs = test.gen_inputs()
@@ -355,7 +310,9 @@ def test_leaky_relu_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -
     _record_unary(op, bm, inputs, lambda x: F.leaky_relu(x, 0.01))
 
 
-@pytest.mark.parametrize("shape, dtype", _shape_dtype_params(load_workloads(_ELU_OP)))
+@pytest.mark.parametrize(
+    "shape, dtype", workload_params(load_workloads(_ELU_OP), _shape_args, marks=_mark)
+)
 def test_elu_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> None:
     test = ShapedRandnWorkload(shape, dtype)
     inputs = test.gen_inputs()
@@ -364,7 +321,9 @@ def test_elu_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> None:
     _record_unary(op, bm, inputs, lambda x: F.elu(x, 1.0))
 
 
-@pytest.mark.parametrize("shape, dtype", _shape_dtype_params(load_workloads(_HARDTANH_OP)))
+@pytest.mark.parametrize(
+    "shape, dtype", workload_params(load_workloads(_HARDTANH_OP), _shape_args, marks=_mark)
+)
 def test_hardtanh_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> None:
     test = ShapedRandnWorkload(shape, dtype)
     inputs = test.gen_inputs()
@@ -373,7 +332,9 @@ def test_hardtanh_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> 
     _record_unary(op, bm, inputs, lambda x: F.hardtanh(x, -1.0, 1.0))
 
 
-@pytest.mark.parametrize("shape, dtype", _shape_dtype_params(load_workloads(_SOFTPLUS_OP)))
+@pytest.mark.parametrize(
+    "shape, dtype", workload_params(load_workloads(_SOFTPLUS_OP), _shape_args, marks=_mark)
+)
 def test_softplus_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> None:
     test = ShapedRandnWorkload(shape, dtype)
     inputs = test.gen_inputs()
@@ -382,7 +343,9 @@ def test_softplus_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> 
     _record_unary(op, bm, inputs, lambda x: F.softplus(x, 1.0, 20.0))
 
 
-@pytest.mark.parametrize("shape, dtype", _shape_dtype_params(load_workloads(_SIGMOID_OP)))
+@pytest.mark.parametrize(
+    "shape, dtype", workload_params(load_workloads(_SIGMOID_OP), _shape_args, marks=_mark)
+)
 def test_sigmoid_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> None:
     test = ShapedRandnWorkload(shape, dtype)
     inputs = test.gen_inputs()
@@ -391,7 +354,9 @@ def test_sigmoid_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> N
     _record_unary(op, bm, inputs, torch.sigmoid)
 
 
-@pytest.mark.parametrize("shape, dtype", _shape_dtype_params(load_workloads(_TANH_OP)))
+@pytest.mark.parametrize(
+    "shape, dtype", workload_params(load_workloads(_TANH_OP), _shape_args, marks=_mark)
+)
 def test_tanh_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> None:
     test = ShapedRandnWorkload(shape, dtype)
     inputs = test.gen_inputs()
@@ -400,7 +365,9 @@ def test_tanh_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> None
     _record_unary(op, bm, inputs, torch.tanh)
 
 
-@pytest.mark.parametrize("shape, dtype", _shape_dtype_params(load_workloads(_CLAMP_SCALAR_OP)))
+@pytest.mark.parametrize(
+    "shape, dtype", workload_params(load_workloads(_CLAMP_SCALAR_OP), _shape_args, marks=_mark)
+)
 def test_clamp_scalar_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> None:
     test = ShapedRandnWorkload(shape, dtype)
     inputs = test.gen_inputs()
@@ -409,7 +376,9 @@ def test_clamp_scalar_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype)
     _record_unary(op, bm, inputs, lambda x: torch.clamp(x, -0.5, 0.5))
 
 
-@pytest.mark.parametrize("shape, dtype", _shape_dtype_params(load_workloads(_NAN_TO_NUM_OP)))
+@pytest.mark.parametrize(
+    "shape, dtype", workload_params(load_workloads(_NAN_TO_NUM_OP), _shape_args, marks=_mark)
+)
 def test_nan_to_num_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> None:
     test = ShapedRandnWorkload(shape, dtype)
     inputs = test.gen_inputs()
@@ -423,7 +392,7 @@ _PRELU_OP = "PreluFwdOp"
 
 @pytest.mark.parametrize(
     "input_shape, weight_shape, dtype",
-    _prelu_params(load_workloads(_PRELU_OP)),
+    workload_params(load_workloads(_PRELU_OP), _prelu_args, marks=_mark),
 )
 def test_prelu_manifest_bench(
     input_shape: tuple[int, ...],
@@ -453,7 +422,7 @@ _MASKED_FILL_SCALAR_OP = "MaskedFillScalarFwdOp"
 
 @pytest.mark.parametrize(
     "input_shape, mask_shape, value_shape, dtype",
-    _masked_fill_tensor_params(load_workloads(_MASKED_FILL_OP)),
+    workload_params(load_workloads(_MASKED_FILL_OP), _masked_fill_tensor_args, marks=_mark),
 )
 def test_masked_fill_tensor_manifest_bench(
     input_shape: tuple[int, ...],
@@ -485,7 +454,7 @@ def test_masked_fill_tensor_manifest_bench(
 
 @pytest.mark.parametrize(
     "shape, dtype",
-    _shape_dtype_params(load_workloads(_MASKED_FILL_SCALAR_OP)),
+    workload_params(load_workloads(_MASKED_FILL_SCALAR_OP), _shape_args, marks=_mark),
 )
 def test_masked_fill_scalar_manifest_bench(
     shape: tuple[int, ...],
@@ -524,7 +493,10 @@ _MAXIMUM_OP = "MaximumFwdOp"
 _MINIMUM_OP = "MinimumFwdOp"
 
 
-@pytest.mark.parametrize("input_shape, other_shape, dtype", _binary_params(load_workloads(_ADD_OP)))
+@pytest.mark.parametrize(
+    "input_shape, other_shape, dtype",
+    workload_params(load_workloads(_ADD_OP), _binary_args, marks=_mark),
+)
 def test_add_manifest_bench(input_shape: tuple, other_shape: tuple, dtype: torch.dtype) -> None:
     test = BinaryManifestWorkload(input_shape, other_shape, dtype)
     inputs = test.gen_inputs()
@@ -533,7 +505,10 @@ def test_add_manifest_bench(input_shape: tuple, other_shape: tuple, dtype: torch
     _record_binary(op, bm, inputs, torch.add)
 
 
-@pytest.mark.parametrize("input_shape, other_shape, dtype", _binary_params(load_workloads(_SUB_OP)))
+@pytest.mark.parametrize(
+    "input_shape, other_shape, dtype",
+    workload_params(load_workloads(_SUB_OP), _binary_args, marks=_mark),
+)
 def test_sub_manifest_bench(input_shape: tuple, other_shape: tuple, dtype: torch.dtype) -> None:
     test = BinaryManifestWorkload(input_shape, other_shape, dtype)
     inputs = test.gen_inputs()
@@ -542,7 +517,10 @@ def test_sub_manifest_bench(input_shape: tuple, other_shape: tuple, dtype: torch
     _record_binary(op, bm, inputs, torch.sub)
 
 
-@pytest.mark.parametrize("input_shape, other_shape, dtype", _binary_params(load_workloads(_MUL_OP)))
+@pytest.mark.parametrize(
+    "input_shape, other_shape, dtype",
+    workload_params(load_workloads(_MUL_OP), _binary_args, marks=_mark),
+)
 def test_mul_manifest_bench(input_shape: tuple, other_shape: tuple, dtype: torch.dtype) -> None:
     test = BinaryManifestWorkload(input_shape, other_shape, dtype)
     inputs = test.gen_inputs()
@@ -551,7 +529,10 @@ def test_mul_manifest_bench(input_shape: tuple, other_shape: tuple, dtype: torch
     _record_binary(op, bm, inputs, torch.mul)
 
 
-@pytest.mark.parametrize("input_shape, other_shape, dtype", _binary_params(load_workloads(_DIV_OP)))
+@pytest.mark.parametrize(
+    "input_shape, other_shape, dtype",
+    workload_params(load_workloads(_DIV_OP), _binary_args, marks=_mark),
+)
 def test_div_manifest_bench(input_shape: tuple, other_shape: tuple, dtype: torch.dtype) -> None:
     test = BinaryManifestWorkload(input_shape, other_shape, dtype, positive=True)
     inputs = test.gen_inputs()
@@ -562,7 +543,7 @@ def test_div_manifest_bench(input_shape: tuple, other_shape: tuple, dtype: torch
 
 @pytest.mark.parametrize(
     "input_shape, other_shape, dtype",
-    _binary_params(load_workloads(_REMAINDER_OP)),
+    workload_params(load_workloads(_REMAINDER_OP), _binary_args, marks=_mark),
 )
 def test_remainder_manifest_bench(
     input_shape: tuple,
@@ -578,7 +559,11 @@ def test_remainder_manifest_bench(
 
 @pytest.mark.parametrize(
     "input_shape, exponent_shape, dtype",
-    _binary_params(load_workloads(_POW_OP), "exponent_shape"),
+    workload_params(
+        load_workloads(_POW_OP),
+        functools.partial(_binary_args, rhs_key="exponent_shape"),
+        marks=_mark,
+    ),
 )
 def test_pow_manifest_bench(
     input_shape: tuple,
@@ -594,7 +579,7 @@ def test_pow_manifest_bench(
 
 @pytest.mark.parametrize(
     "input_shape, other_shape, dtype",
-    _binary_params(load_workloads(_FLOOR_DIVIDE_OP)),
+    workload_params(load_workloads(_FLOOR_DIVIDE_OP), _binary_args, marks=_mark),
 )
 def test_floor_divide_manifest_bench(
     input_shape: tuple,
@@ -609,7 +594,12 @@ def test_floor_divide_manifest_bench(
 
 
 @pytest.mark.parametrize(
-    "input_shape, end_shape, dtype", _binary_params(load_workloads(_LERP_OP), "end_shape")
+    "input_shape, end_shape, dtype",
+    workload_params(
+        load_workloads(_LERP_OP),
+        functools.partial(_binary_args, rhs_key="end_shape"),
+        marks=_mark,
+    ),
 )
 def test_lerp_manifest_bench(input_shape: tuple, end_shape: tuple, dtype: torch.dtype) -> None:
     test = BinaryManifestWorkload(input_shape, end_shape, dtype)
@@ -620,7 +610,8 @@ def test_lerp_manifest_bench(input_shape: tuple, end_shape: tuple, dtype: torch.
 
 
 @pytest.mark.parametrize(
-    "input_shape, other_shape, dtype", _binary_params(load_workloads(_MAXIMUM_OP))
+    "input_shape, other_shape, dtype",
+    workload_params(load_workloads(_MAXIMUM_OP), _binary_args, marks=_mark),
 )
 def test_maximum_manifest_bench(input_shape: tuple, other_shape: tuple, dtype: torch.dtype) -> None:
     test = BinaryManifestWorkload(input_shape, other_shape, dtype)
@@ -631,7 +622,8 @@ def test_maximum_manifest_bench(input_shape: tuple, other_shape: tuple, dtype: t
 
 
 @pytest.mark.parametrize(
-    "input_shape, other_shape, dtype", _binary_params(load_workloads(_MINIMUM_OP))
+    "input_shape, other_shape, dtype",
+    workload_params(load_workloads(_MINIMUM_OP), _binary_args, marks=_mark),
 )
 def test_minimum_manifest_bench(input_shape: tuple, other_shape: tuple, dtype: torch.dtype) -> None:
     test = BinaryManifestWorkload(input_shape, other_shape, dtype)
@@ -654,7 +646,10 @@ _BITWISE_OR_OP = "BitwiseOrFwdOp"
 _BITWISE_XOR_OP = "BitwiseXorFwdOp"
 
 
-@pytest.mark.parametrize("input_shape, other_shape, dtype", _binary_params(load_workloads(_EQ_OP)))
+@pytest.mark.parametrize(
+    "input_shape, other_shape, dtype",
+    workload_params(load_workloads(_EQ_OP), _binary_args, marks=_mark),
+)
 def test_eq_manifest_bench(input_shape: tuple, other_shape: tuple, dtype: torch.dtype) -> None:
     test = BinaryManifestWorkload(input_shape, other_shape, dtype)
     inputs = test.gen_inputs()
@@ -663,7 +658,10 @@ def test_eq_manifest_bench(input_shape: tuple, other_shape: tuple, dtype: torch.
     _record_binary(op, bm, inputs, torch.eq)
 
 
-@pytest.mark.parametrize("input_shape, other_shape, dtype", _binary_params(load_workloads(_NE_OP)))
+@pytest.mark.parametrize(
+    "input_shape, other_shape, dtype",
+    workload_params(load_workloads(_NE_OP), _binary_args, marks=_mark),
+)
 def test_ne_manifest_bench(input_shape: tuple, other_shape: tuple, dtype: torch.dtype) -> None:
     test = BinaryManifestWorkload(input_shape, other_shape, dtype)
     inputs = test.gen_inputs()
@@ -672,7 +670,10 @@ def test_ne_manifest_bench(input_shape: tuple, other_shape: tuple, dtype: torch.
     _record_binary(op, bm, inputs, torch.ne)
 
 
-@pytest.mark.parametrize("input_shape, other_shape, dtype", _binary_params(load_workloads(_GT_OP)))
+@pytest.mark.parametrize(
+    "input_shape, other_shape, dtype",
+    workload_params(load_workloads(_GT_OP), _binary_args, marks=_mark),
+)
 def test_gt_manifest_bench(input_shape: tuple, other_shape: tuple, dtype: torch.dtype) -> None:
     test = BinaryManifestWorkload(input_shape, other_shape, dtype)
     inputs = test.gen_inputs()
@@ -681,7 +682,10 @@ def test_gt_manifest_bench(input_shape: tuple, other_shape: tuple, dtype: torch.
     _record_binary(op, bm, inputs, torch.gt)
 
 
-@pytest.mark.parametrize("input_shape, other_shape, dtype", _binary_params(load_workloads(_LT_OP)))
+@pytest.mark.parametrize(
+    "input_shape, other_shape, dtype",
+    workload_params(load_workloads(_LT_OP), _binary_args, marks=_mark),
+)
 def test_lt_manifest_bench(input_shape: tuple, other_shape: tuple, dtype: torch.dtype) -> None:
     test = BinaryManifestWorkload(input_shape, other_shape, dtype)
     inputs = test.gen_inputs()
@@ -690,7 +694,10 @@ def test_lt_manifest_bench(input_shape: tuple, other_shape: tuple, dtype: torch.
     _record_binary(op, bm, inputs, torch.lt)
 
 
-@pytest.mark.parametrize("input_shape, other_shape, dtype", _binary_params(load_workloads(_GE_OP)))
+@pytest.mark.parametrize(
+    "input_shape, other_shape, dtype",
+    workload_params(load_workloads(_GE_OP), _binary_args, marks=_mark),
+)
 def test_ge_manifest_bench(input_shape: tuple, other_shape: tuple, dtype: torch.dtype) -> None:
     test = BinaryManifestWorkload(input_shape, other_shape, dtype)
     inputs = test.gen_inputs()
@@ -699,7 +706,10 @@ def test_ge_manifest_bench(input_shape: tuple, other_shape: tuple, dtype: torch.
     _record_binary(op, bm, inputs, torch.ge)
 
 
-@pytest.mark.parametrize("input_shape, other_shape, dtype", _binary_params(load_workloads(_LE_OP)))
+@pytest.mark.parametrize(
+    "input_shape, other_shape, dtype",
+    workload_params(load_workloads(_LE_OP), _binary_args, marks=_mark),
+)
 def test_le_manifest_bench(input_shape: tuple, other_shape: tuple, dtype: torch.dtype) -> None:
     test = BinaryManifestWorkload(input_shape, other_shape, dtype)
     inputs = test.gen_inputs()
@@ -709,7 +719,8 @@ def test_le_manifest_bench(input_shape: tuple, other_shape: tuple, dtype: torch.
 
 
 @pytest.mark.parametrize(
-    "input_shape, other_shape, dtype", _binary_params(load_workloads(_LOGICAL_AND_OP))
+    "input_shape, other_shape, dtype",
+    workload_params(load_workloads(_LOGICAL_AND_OP), _binary_args, marks=_mark),
 )
 def test_logical_and_manifest_bench(
     input_shape: tuple, other_shape: tuple, dtype: torch.dtype
@@ -722,7 +733,8 @@ def test_logical_and_manifest_bench(
 
 
 @pytest.mark.parametrize(
-    "input_shape, other_shape, dtype", _binary_params(load_workloads(_LOGICAL_OR_OP))
+    "input_shape, other_shape, dtype",
+    workload_params(load_workloads(_LOGICAL_OR_OP), _binary_args, marks=_mark),
 )
 def test_logical_or_manifest_bench(
     input_shape: tuple, other_shape: tuple, dtype: torch.dtype
@@ -735,7 +747,8 @@ def test_logical_or_manifest_bench(
 
 
 @pytest.mark.parametrize(
-    "input_shape, other_shape, dtype", _binary_params(load_workloads(_BITWISE_AND_OP))
+    "input_shape, other_shape, dtype",
+    workload_params(load_workloads(_BITWISE_AND_OP), _binary_args, marks=_mark),
 )
 def test_bitwise_and_manifest_bench(
     input_shape: tuple, other_shape: tuple, dtype: torch.dtype
@@ -748,7 +761,8 @@ def test_bitwise_and_manifest_bench(
 
 
 @pytest.mark.parametrize(
-    "input_shape, other_shape, dtype", _binary_params(load_workloads(_BITWISE_OR_OP))
+    "input_shape, other_shape, dtype",
+    workload_params(load_workloads(_BITWISE_OR_OP), _binary_args, marks=_mark),
 )
 def test_bitwise_or_manifest_bench(
     input_shape: tuple, other_shape: tuple, dtype: torch.dtype
@@ -761,7 +775,8 @@ def test_bitwise_or_manifest_bench(
 
 
 @pytest.mark.parametrize(
-    "input_shape, other_shape, dtype", _binary_params(load_workloads(_BITWISE_XOR_OP))
+    "input_shape, other_shape, dtype",
+    workload_params(load_workloads(_BITWISE_XOR_OP), _binary_args, marks=_mark),
 )
 def test_bitwise_xor_manifest_bench(
     input_shape: tuple, other_shape: tuple, dtype: torch.dtype
@@ -777,7 +792,9 @@ _WHERE_OP = "WhereFwdOp"
 _LERP_TENSOR_OP = "LerpTensorFwdOp"
 
 
-@pytest.mark.parametrize("shape, dtype", _shape_dtype_params(load_workloads(_WHERE_OP)))
+@pytest.mark.parametrize(
+    "shape, dtype", workload_params(load_workloads(_WHERE_OP), _shape_args, marks=_mark)
+)
 def test_where_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> None:
     test = WhereManifestWorkload(shape, dtype)
     cond, x, other = test.gen_inputs()
@@ -797,7 +814,9 @@ def test_where_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> Non
     )
 
 
-@pytest.mark.parametrize("shape, dtype", _shape_dtype_params(load_workloads(_LERP_TENSOR_OP)))
+@pytest.mark.parametrize(
+    "shape, dtype", workload_params(load_workloads(_LERP_TENSOR_OP), _shape_args, marks=_mark)
+)
 def test_lerp_tensor_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> None:
     test = LerpTensorManifestWorkload(shape, dtype)
     x, end, weight = test.gen_inputs()

--- a/benchmarks/ops/bench_engram.py
+++ b/benchmarks/ops/bench_engram.py
@@ -14,7 +14,8 @@ import torch
 from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
 from benchmarks.benchmark_base import (
     ManifestBenchmark,
-    workload_field_params,
+    fields,
+    workload_params,
 )
 from tileops.manifest import load_workloads
 from tileops.ops.sequence_modeling.engram import EngramGateConvBwdOp, EngramGateConvFwdOp
@@ -31,9 +32,10 @@ _TUNE = True
 
 
 _ENGRAM_GATE_CONV_FWD_OP = "EngramGateConvFwdOp"
-_ENGRAM_GATE_CONV_FWD_PARAMS = workload_field_params(
+_ENGRAM_GATE_CONV_FWD_PARAMS = workload_params(
     load_workloads(_ENGRAM_GATE_CONV_FWD_OP),
-    ("M", "seq_len", "d", "dtype"),
+    fields("M", "seq_len", "d", "dtype"),
+    smoke_first=True,
 )
 
 
@@ -58,9 +60,10 @@ def test_engram_gate_conv_fwd_bench(M, seq_len, d, dtype):
 
 
 _ENGRAM_GATE_CONV_BWD_OP = "EngramGateConvBwdOp"
-_ENGRAM_GATE_CONV_BWD_PARAMS = workload_field_params(
+_ENGRAM_GATE_CONV_BWD_PARAMS = workload_params(
     load_workloads(_ENGRAM_GATE_CONV_BWD_OP),
-    ("M", "seq_len", "d", "dtype"),
+    fields("M", "seq_len", "d", "dtype"),
+    smoke_first=True,
 )
 
 
@@ -89,9 +92,10 @@ def test_engram_gate_conv_bwd_bench(M, seq_len, d, dtype):
 
 
 _ENGRAM_DECODE_OP = "EngramDecodeFwdOp"
-_ENGRAM_DECODE_PARAMS = workload_field_params(
+_ENGRAM_DECODE_PARAMS = workload_params(
     load_workloads(_ENGRAM_DECODE_OP),
-    ("batch", "d_mem", "d", "max_conv_len", "conv_kernel_size", "dilation", "dtype"),
+    fields("batch", "d_mem", "d", "max_conv_len", "conv_kernel_size", "dilation", "dtype"),
+    smoke_first=True,
 )
 
 

--- a/benchmarks/ops/bench_fp8_lightning_indexer.py
+++ b/benchmarks/ops/bench_fp8_lightning_indexer.py
@@ -7,7 +7,7 @@ come from the op's ``eval_roofline()`` via :class:`ManifestBenchmark`.
 import pytest
 
 from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
-from benchmarks.benchmark_base import ManifestBenchmark
+from benchmarks.benchmark_base import ManifestBenchmark, fields, workload_params
 from tileops.manifest import load_workloads
 from tileops.ops import FP8LightningIndexerFwdOp
 from workloads.fp8_lightning_indexer import FP8LightningIndexerWorkload
@@ -31,29 +31,16 @@ _SHAPE_KEYS = (
 )
 
 
-def _indexer_params() -> list:
-    """Params from manifest workloads, deduped on shape.
-
-    ``FP8LightningIndexerWorkload.gen_inputs`` emits bf16 and quantizes inside
-    the op, so workloads differing only in ``dtypes`` are one measurement.
-    """
-    seen, params = set(), []
-    for w in load_workloads(_FP8_LIGHTNING_INDEXER_OP):
-        args = tuple(w[k] for k in _SHAPE_KEYS)
-        if args in seen:
-            continue
-        seen.add(args)
-        params.append(
-            pytest.param(
-                *args, id=w["label"], marks=pytest.mark.smoke if not params else pytest.mark.full
-            )
-        )
-    return params
-
-
 @pytest.mark.parametrize(
     "batch, seq_len, heads, index_dim, seq_len_kv, kv_group, clean_logits",
-    _indexer_params(),
+    workload_params(
+        load_workloads(_FP8_LIGHTNING_INDEXER_OP),
+        fields(*_SHAPE_KEYS),
+        smoke_first=True,
+        # gen_inputs emits bf16 and the op quantizes inside, so the dtype rows
+        # of one shape are one measurement.
+        dedupe_on=_SHAPE_KEYS,
+    ),
 )
 def test_fp8_lightning_indexer_bench(
     batch: int,

--- a/benchmarks/ops/bench_fp8_lightning_indexer.py
+++ b/benchmarks/ops/bench_fp8_lightning_indexer.py
@@ -31,15 +31,28 @@ _SHAPE_KEYS = (
 )
 
 
+def _one_row_per_shape(workloads: list[dict]) -> list[dict]:
+    """The rows this bench measures: one per shape.
+
+    ``FP8LightningIndexerWorkload.gen_inputs`` emits bf16 and the op quantizes
+    inside, so two rows differing only in ``dtypes`` are one measurement.
+    """
+    seen, rows = set(), []
+    for w in workloads:
+        shape = tuple(str(w[key]) for key in _SHAPE_KEYS)
+        if shape in seen:
+            continue
+        seen.add(shape)
+        rows.append(w)
+    return rows
+
+
 @pytest.mark.parametrize(
     "batch, seq_len, heads, index_dim, seq_len_kv, kv_group, clean_logits",
     workload_params(
-        load_workloads(_FP8_LIGHTNING_INDEXER_OP),
+        _one_row_per_shape(load_workloads(_FP8_LIGHTNING_INDEXER_OP)),
         fields(*_SHAPE_KEYS),
         smoke_first=True,
-        # gen_inputs emits bf16 and the op quantizes inside, so the dtype rows
-        # of one shape are one measurement.
-        dedupe_on=_SHAPE_KEYS,
     ),
 )
 def test_fp8_lightning_indexer_bench(

--- a/benchmarks/ops/bench_fp8_quant.py
+++ b/benchmarks/ops/bench_fp8_quant.py
@@ -11,7 +11,8 @@ import torch
 from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
 from benchmarks.benchmark_base import (
     ManifestBenchmark,
-    workload_field_params,
+    fields,
+    workload_params,
 )
 from tileops.manifest import load_workloads
 from tileops.ops import FP8QuantFwdOp
@@ -23,9 +24,10 @@ _TUNE = True
 
 
 _FP8_QUANT_OP = "FP8QuantFwdOp"
-_FP8_QUANT_PARAMS = workload_field_params(
+_FP8_QUANT_PARAMS = workload_params(
     load_workloads(_FP8_QUANT_OP),
-    ("batch", "seq_len_kv", "kv_group", "index_dim", "in_dtype"),
+    fields("batch", "seq_len_kv", "kv_group", "index_dim", "in_dtype"),
+    smoke_first=True,
 )
 
 

--- a/benchmarks/ops/bench_fused_moe_experts.py
+++ b/benchmarks/ops/bench_fused_moe_experts.py
@@ -56,7 +56,7 @@ except ImportError:
             stacklevel=2,
         )
 
-from benchmarks.benchmark_base import ManifestBenchmark
+from benchmarks.benchmark_base import ManifestBenchmark, fields, workload_params
 from tileops.manifest import load_workloads
 from tileops.ops.moe import FusedMoEExpertsNopadPersistent3WGFwdOp
 from workloads.moe import MoeExpertsWorkload
@@ -73,33 +73,23 @@ _OP_NAME = "FusedMoEExpertsNopadPersistent3WGFwdOp"  # manifest entry name
 # Manifest-driven parametrize
 
 
-def _manifest_params():
-    params = []
-    for w in load_workloads(_OP_NAME):
-        label = w.get("label", "unlabeled")
-        for dtype_str in w["dtypes"]:
-            dtype = getattr(torch, dtype_str)
-            params.append(
-                pytest.param(
-                    w["num_tokens"],
-                    w["num_experts"],
-                    w["num_experts_local"],
-                    w["top_k"],
-                    w["hidden_size"],
-                    w["ffn_size"],
-                    dtype,
-                    id=f"{label}-{dtype_str}",
-                )
-            )
-    return params
-
-
 # Benchmark test
 
 
 @pytest.mark.parametrize(
     "num_tokens, num_experts, num_experts_local, top_k, hidden_size, ffn_size, dtype",
-    _manifest_params(),
+    workload_params(
+        load_workloads(_OP_NAME),
+        fields(
+            "num_tokens",
+            "num_experts",
+            "num_experts_local",
+            "top_k",
+            "hidden_size",
+            "ffn_size",
+            dtype_last=True,
+        ),
+    ),
 )
 def test_moe_experts_nopad_bench(
     num_tokens: int,

--- a/benchmarks/ops/bench_gated_deltanet.py
+++ b/benchmarks/ops/bench_gated_deltanet.py
@@ -19,8 +19,9 @@ from fla.ops.gated_delta_rule import chunk_gated_delta_rule
 from benchmarks.benchmark_base import (
     ManifestBenchmark,
     backward_of,
+    then_dtype,
+    workload_params,
 )
-from benchmarks.ops.attention.manifest_params import manifest_params
 from tileops.manifest import load_workloads
 from tileops.ops import GatedDeltaNetBHTDFwdOp, GatedDeltaNetBTHDFwdOp, GatedDeltaNetBwdOp
 from workloads.linear_attention import GatedDeltaNetFwdWorkload
@@ -61,7 +62,7 @@ def _gdn_bthd_args(workload: dict) -> tuple[int, int, int, int, int, int]:
 
 @pytest.mark.parametrize(
     "batch, heads, seq_len, dim_k, dim_v, chunk_size, dtype, tune",
-    manifest_params(load_workloads(_FWD_OP_NAME), _gdn_bthd_args, tune=False),
+    workload_params(load_workloads(_FWD_OP_NAME), then_dtype(_gdn_bthd_args, tune=False)),
 )
 def test_gated_deltanet_vs_fla_fwd(
     batch: int,
@@ -90,7 +91,7 @@ def test_gated_deltanet_vs_fla_fwd(
 
 @pytest.mark.parametrize(
     "batch, heads, seq_len, dim_k, dim_v, chunk_size, dtype, tune",
-    manifest_params(load_workloads(_BHTD_FWD_OP_NAME), _gdn_bhtd_args, tune=False),
+    workload_params(load_workloads(_BHTD_FWD_OP_NAME), then_dtype(_gdn_bhtd_args, tune=False)),
 )
 def test_gated_deltanet_bhtd_vs_fla_fwd(
     batch: int,
@@ -121,7 +122,7 @@ def test_gated_deltanet_bhtd_vs_fla_fwd(
 
 @pytest.mark.parametrize(
     "batch, heads, seq_len, dim_k, dim_v, chunk_size, dtype, tune",
-    manifest_params(load_workloads(_BWD_OP_NAME), _gdn_bhtd_args, tune=False),
+    workload_params(load_workloads(_BWD_OP_NAME), then_dtype(_gdn_bhtd_args, tune=False)),
 )
 def test_gated_deltanet_vs_fla_bwd(
     batch: int,

--- a/benchmarks/ops/bench_gated_deltanet_prefill.py
+++ b/benchmarks/ops/bench_gated_deltanet_prefill.py
@@ -16,8 +16,12 @@ import pytest
 import torch
 from fla.ops.gated_delta_rule import chunk_gated_delta_rule
 
-from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark
-from benchmarks.ops.attention.manifest_params import manifest_params
+from benchmarks.benchmark_base import (
+    BenchmarkReport,
+    ManifestBenchmark,
+    then_dtype,
+    workload_params,
+)
 from tileops.manifest import load_workloads
 from tileops.ops import GatedDeltaNetPrefillBHTDFwdOp, GatedDeltaNetPrefillBTHDFwdOp
 from workloads.linear_attention import GatedDeltaNetPrefillFwdWorkload
@@ -105,11 +109,13 @@ def _gdn_prefill_args(
     )
 
 
-_BENCH_PARAMS = manifest_params(load_workloads(_OP_NAME), _gdn_prefill_args, tune=False)
-_BHTD_BENCH_PARAMS = manifest_params(
+_BENCH_PARAMS = workload_params(load_workloads(_OP_NAME), then_dtype(_gdn_prefill_args, tune=False))
+_BHTD_BENCH_PARAMS = workload_params(
     load_workloads(_BHTD_OP_NAME),
-    functools.partial(_gdn_prefill_args, layout="bhtd"),
-    tune=False,
+    then_dtype(
+        functools.partial(_gdn_prefill_args, layout="bhtd"),
+        tune=False,
+    ),
 )
 
 

--- a/benchmarks/ops/bench_gated_deltanet_recurrence.py
+++ b/benchmarks/ops/bench_gated_deltanet_recurrence.py
@@ -2,8 +2,12 @@ from typing import Optional
 
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, ManifestBenchmark
-from benchmarks.ops.attention.manifest_params import manifest_params
+from benchmarks.benchmark_base import (
+    BenchmarkBase,
+    ManifestBenchmark,
+    then_dtype,
+    workload_params,
+)
 from tileops.manifest import load_workloads
 from tileops.ops import GatedDeltaNetDecodeFwdOp
 from workloads.linear_attention import GatedDeltaNetDecodeWorkload
@@ -70,10 +74,12 @@ class GatedDeltaNetDecodeBenchFixture(FixtureBase):
     PARAMS = [
         (
             "batch, heads, dim_k, dim_v, dtype, tune",
-            manifest_params(
+            workload_params(
                 load_workloads(_OP_NAME),
-                lambda w: (w["q_shape"][0], w["q_shape"][1], w["q_shape"][2], w["v_shape"][2]),
-                tune=False,
+                then_dtype(
+                    lambda w: (w["q_shape"][0], w["q_shape"][1], w["q_shape"][2], w["v_shape"][2]),
+                    tune=False,
+                ),
             ),
         ),
     ]

--- a/benchmarks/ops/bench_gemm.py
+++ b/benchmarks/ops/bench_gemm.py
@@ -226,12 +226,10 @@ def _gemm_args(w: dict, dtype: torch.dtype) -> tuple:
 
 
 def _gemm_fp8_args(w: dict, dtype: torch.dtype) -> tuple:
-    """``(m, n, k, scale_mode, dtype)``."""
     return (w["m"], w["n"], w["k"], w["scale_mode"], dtype)
 
 
 def _gemm_w4a16_args(w: dict, dtype: torch.dtype) -> tuple:
-    """``(m, n, k, group_size, dtype)``."""
     return (w["m"], w["n"], w["k"], int(w.get("group_size", 128)), dtype)
 
 

--- a/benchmarks/ops/bench_gemm.py
+++ b/benchmarks/ops/bench_gemm.py
@@ -9,7 +9,7 @@ from benchmarks.baselines import (
     flaggems_op,
     reference_tolerance,
 )
-from benchmarks.benchmark_base import ManifestBenchmark
+from benchmarks.benchmark_base import ManifestBenchmark, workload_params
 from tileops.manifest import load_workloads
 from tileops.ops import GemmFp8FwdOp, GemmFwdOp, GemmW4A16FwdOp
 from workloads.gemm import GemmFp8Workload, GemmW4A16Workload, GemmWorkload
@@ -18,13 +18,6 @@ _OP_NAME = "GemmFwdOp"
 _FP8_OP_NAME = "GemmFp8FwdOp"
 _W4A16_OP_NAME = "GemmW4A16FwdOp"
 _W4A16_GROUP_SIZE = 128
-
-_DTYPE_MAP = {
-    "bfloat16": torch.bfloat16,
-    "float16": torch.float16,
-    "float8_e4m3fn": torch.float8_e4m3fn,
-    "float8_e5m2": torch.float8_e5m2,
-}
 
 
 class GemmBenchmarkWorkload(GemmWorkload):
@@ -220,75 +213,40 @@ def _prepare_marlin_w4a16_baseline(
     return _run_marlin, (activation, qweight, scales, zeros, workspace)
 
 
-def _manifest_params() -> list:
-    """Convert manifest workloads to pytest params (m, n, k, trans_a, trans_b, dtype)."""
-    params = []
-    for w in load_workloads(_OP_NAME):
-        label = w.get("label", "unlabeled")
-        trans_a = bool(w.get("trans_a", False))
-        trans_b = bool(w.get("trans_b", True))
-        for dtype_str in w["dtypes"]:
-            params.append(
-                pytest.param(
-                    w["m"],
-                    w["n"],
-                    w["k"],
-                    trans_a,
-                    trans_b,
-                    dtype_str,
-                    id=f"{label}-{dtype_str}",
-                )
-            )
-    return params
+def _gemm_args(w: dict, dtype: torch.dtype) -> tuple:
+    """``(m, n, k, trans_a, trans_b, dtype)``; the transposes default to N-T."""
+    return (
+        w["m"],
+        w["n"],
+        w["k"],
+        bool(w.get("trans_a", False)),
+        bool(w.get("trans_b", True)),
+        dtype,
+    )
 
 
-def _manifest_fp8_params() -> list:
-    params = []
-    for w in load_workloads(_FP8_OP_NAME):
-        label = w.get("label", "unlabeled")
-        for dtype_str in w["dtypes"]:
-            params.append(
-                pytest.param(
-                    w["m"],
-                    w["n"],
-                    w["k"],
-                    w["scale_mode"],
-                    dtype_str,
-                    id=f"{label}-{dtype_str}",
-                )
-            )
-    return params
+def _gemm_fp8_args(w: dict, dtype: torch.dtype) -> tuple:
+    """``(m, n, k, scale_mode, dtype)``."""
+    return (w["m"], w["n"], w["k"], w["scale_mode"], dtype)
 
 
-def _manifest_w4a16_params() -> list:
-    params = []
-    for w in load_workloads(_W4A16_OP_NAME):
-        label = w.get("label", "unlabeled")
-        group_size = int(w.get("group_size", 128))
-        for dtype_str in w["dtypes"]:
-            params.append(
-                pytest.param(
-                    w["m"],
-                    w["n"],
-                    w["k"],
-                    group_size,
-                    dtype_str,
-                    id=f"{label}-{dtype_str}",
-                )
-            )
-    return params
+def _gemm_w4a16_args(w: dict, dtype: torch.dtype) -> tuple:
+    """``(m, n, k, group_size, dtype)``."""
+    return (w["m"], w["n"], w["k"], int(w.get("group_size", 128)), dtype)
 
 
-@pytest.mark.parametrize("m, n, k, trans_a, trans_b, dtype_str", _manifest_params())
+@pytest.mark.parametrize(
+    "m, n, k, trans_a, trans_b, dtype",
+    workload_params(load_workloads(_OP_NAME), _gemm_args),
+)
 def test_gemm_bench(
     m: int,
     n: int,
     k: int,
     trans_a: bool,
     trans_b: bool,
-    dtype_str: str,
+    dtype: torch.dtype,
 ) -> None:
-    dtype = _DTYPE_MAP[dtype_str]
     workload = GemmBenchmarkWorkload(m, n, k, dtype, trans_a, trans_b)
     a, b = workload.gen_inputs()
 
@@ -311,15 +269,16 @@ def test_gemm_bench(
     bm.compare(functors, a, b, record_as=op, params=locals())
 
 
-@pytest.mark.parametrize("m, n, k, scale_mode, dtype_str", _manifest_fp8_params())
+@pytest.mark.parametrize(
+    "m, n, k, scale_mode, dtype", workload_params(load_workloads(_FP8_OP_NAME), _gemm_fp8_args)
+)
 def test_gemm_fp8_bench(
     m: int,
     n: int,
     k: int,
     scale_mode: str,
-    dtype_str: str,
+    dtype: torch.dtype,
 ) -> None:
-    dtype = _DTYPE_MAP[dtype_str]
     out_dtype = torch.bfloat16
     workload = GemmFp8BenchmarkWorkload(m, n, k, dtype, scale_mode, out_dtype=out_dtype)
     inputs = workload.gen_inputs()
@@ -366,15 +325,16 @@ def test_gemm_fp8_bench(
     bm.compare(functors, *inputs, record_as=op, params=locals())
 
 
-@pytest.mark.parametrize("m, n, k, group_size, dtype_str", _manifest_w4a16_params())
+@pytest.mark.parametrize(
+    "m, n, k, group_size, dtype", workload_params(load_workloads(_W4A16_OP_NAME), _gemm_w4a16_args)
+)
 def test_gemm_w4a16_bench(
     m: int,
     n: int,
     k: int,
     group_size: int,
-    dtype_str: str,
+    dtype: torch.dtype,
 ) -> None:
-    dtype = _DTYPE_MAP[dtype_str]
     workload = GemmW4A16BenchmarkWorkload(m, n, k, dtype, group_size=group_size)
     inputs = workload.gen_inputs()
 

--- a/benchmarks/ops/bench_gla_chunkwise.py
+++ b/benchmarks/ops/bench_gla_chunkwise.py
@@ -13,8 +13,12 @@ import pytest
 import torch
 from fla.ops.gla import chunk_gla
 
-from benchmarks.benchmark_base import ManifestBenchmark, backward_of
-from benchmarks.ops.attention.manifest_params import manifest_params
+from benchmarks.benchmark_base import (
+    ManifestBenchmark,
+    backward_of,
+    then_dtype,
+    workload_params,
+)
 from tileops.manifest import load_workloads
 from tileops.ops import GLABwdOp, GLAFwdOp
 from workloads.linear_attention import GLAChunkwiseWorkload
@@ -53,7 +57,7 @@ def _gla_bwd_args(workload: dict) -> tuple[int, int, int, int, int, int]:
 
 @pytest.mark.parametrize(
     "batch, seq_len, heads, dim_k, dim_v, chunk_size, has_initial_state, dtype, tune",
-    manifest_params(load_workloads(_FWD_OP_NAME), _gla_args, tune=False),
+    workload_params(load_workloads(_FWD_OP_NAME), then_dtype(_gla_args, tune=False)),
 )
 def test_gla_fwd_bench(
     batch: int,
@@ -98,7 +102,7 @@ def test_gla_fwd_bench(
 )
 @pytest.mark.parametrize(
     "batch, seq_len, heads, dim_k, dim_v, chunk_size, dtype, tune",
-    manifest_params(load_workloads(_BWD_OP_NAME), _gla_bwd_args, tune=False),
+    workload_params(load_workloads(_BWD_OP_NAME), then_dtype(_gla_bwd_args, tune=False)),
 )
 def test_gla_bwd_bench(
     batch: int,

--- a/benchmarks/ops/bench_gla_recurrence.py
+++ b/benchmarks/ops/bench_gla_recurrence.py
@@ -11,8 +11,12 @@ from typing import Optional
 import torch
 
 from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
-from benchmarks.benchmark_base import BenchmarkBase, ManifestBenchmark
-from benchmarks.ops.attention.manifest_params import manifest_params
+from benchmarks.benchmark_base import (
+    BenchmarkBase,
+    ManifestBenchmark,
+    then_dtype,
+    workload_params,
+)
 from tileops.manifest import load_workloads
 from tileops.ops import GLADecodeFwdOp
 from workloads.linear_attention import GLADecodeWorkload
@@ -73,16 +77,18 @@ class GLADecodeBenchFixture(FixtureBase):
     PARAMS = [
         (
             "batch, heads, dim_k, dim_v, scale, dtype, tune",
-            manifest_params(
+            workload_params(
                 load_workloads(_OP_NAME),
-                lambda w: (
-                    w["q_shape"][0],
-                    w["q_shape"][1],
-                    w["q_shape"][2],
-                    w["v_shape"][2],
-                    w.get("scale", w["q_shape"][2] ** -0.5),
+                then_dtype(
+                    lambda w: (
+                        w["q_shape"][0],
+                        w["q_shape"][1],
+                        w["q_shape"][2],
+                        w["v_shape"][2],
+                        w.get("scale", w["q_shape"][2] ** -0.5),
+                    ),
+                    tune=False,
                 ),
-                tune=False,
             ),
         ),
     ]

--- a/benchmarks/ops/bench_group_norm.py
+++ b/benchmarks/ops/bench_group_norm.py
@@ -14,7 +14,7 @@ from benchmarks.baselines import (
     flaggems_group_norm,
     reference_tolerance,
 )
-from benchmarks.benchmark_base import ManifestBenchmark
+from benchmarks.benchmark_base import ManifestBenchmark, workload_params
 from tileops.manifest import load_workloads
 from tileops.ops.norm.group_norm import GroupNormFwdOp
 from workloads.normalization import GroupNormWorkload
@@ -22,26 +22,19 @@ from workloads.normalization import GroupNormWorkload
 _OP_NAME = "GroupNormFwdOp"
 
 
-def _build_params(workloads):
-    params = []
-    for w in workloads:
-        shape = w["x_shape"]
-        n, c, spatial = shape[0], shape[1], tuple(shape[2:])
-        num_groups = w.get("num_groups")
-        if num_groups is None:
-            raise KeyError("Workload manifest must contain 'num_groups'")
-        label = w.get("label", f"{n}x{c}x{'x'.join(map(str, spatial))}")
-        for dtype_str in w["dtypes"]:
-            dtype = getattr(torch, dtype_str)
-            params.append(
-                pytest.param(n, c, spatial, num_groups, dtype, False, id=f"{label}-{dtype_str}")
-            )
-    return params
+def _group_norm_args(w: dict, dtype: torch.dtype) -> tuple:
+    """``(n, c, spatial, num_groups, dtype, tune)``."""
+    n, c, *spatial = w["x_shape"]
+    if "num_groups" not in w:
+        raise KeyError("Workload manifest must contain 'num_groups'")
+    return (n, c, tuple(spatial), w["num_groups"], dtype, False)
 
 
 _WORKLOADS = load_workloads(_OP_NAME)
-_AFFINE_PARAMS = _build_params([w for w in _WORKLOADS if "weight_shape" in w])
-_NO_AFFINE_PARAMS = _build_params([w for w in _WORKLOADS if "weight_shape" not in w])
+_AFFINE_PARAMS = workload_params([w for w in _WORKLOADS if "weight_shape" in w], _group_norm_args)
+_NO_AFFINE_PARAMS = workload_params(
+    [w for w in _WORKLOADS if "weight_shape" not in w], _group_norm_args
+)
 
 
 @pytest.mark.parametrize("n, c, spatial, num_groups, dtype, tune", _AFFINE_PARAMS)

--- a/benchmarks/ops/bench_group_norm.py
+++ b/benchmarks/ops/bench_group_norm.py
@@ -23,7 +23,6 @@ _OP_NAME = "GroupNormFwdOp"
 
 
 def _group_norm_args(w: dict, dtype: torch.dtype) -> tuple:
-    """``(n, c, spatial, num_groups, dtype, tune)``."""
     n, c, *spatial = w["x_shape"]
     if "num_groups" not in w:
         raise KeyError("Workload manifest must contain 'num_groups'")

--- a/benchmarks/ops/bench_grouped_gemm.py
+++ b/benchmarks/ops/bench_grouped_gemm.py
@@ -13,7 +13,8 @@ import torch
 from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
 from benchmarks.benchmark_base import (
     ManifestBenchmark,
-    workload_field_params,
+    fields,
+    workload_params,
 )
 from tileops.manifest import load_workloads
 from tileops.ops import GroupedGemmFwdOp
@@ -29,9 +30,10 @@ _TUNE = True
 # Test functions
 
 _GROUPED_GEMM_OP = "GroupedGemmFwdOp"
-_GROUPED_GEMM_PARAMS = workload_field_params(
+_GROUPED_GEMM_PARAMS = workload_params(
     load_workloads(_GROUPED_GEMM_OP),
-    ("batch_sum", "batch_count", "n", "k", "dtype", "transpose_a", "transpose_b"),
+    fields("batch_sum", "batch_count", "n", "k", "dtype", "transpose_a", "transpose_b"),
+    smoke_first=True,
 )
 
 

--- a/benchmarks/ops/bench_independent_elementwise.py
+++ b/benchmarks/ops/bench_independent_elementwise.py
@@ -135,13 +135,21 @@ _SINUSOIDAL_OP = "SinusoidalFwdOp"
 
 
 def _generative_params(workloads: list, keys: tuple) -> list:
-    """Manifest workloads -> params; first workload smoke, rest full."""
+    """Manifest workloads -> params; first workload smoke, rest full.
+
+    The id ends with the dtype the case runs, so a label never has to spell one.
+    """
     params = []
     for i, w in enumerate(workloads):
         values = [w[k] for k in keys]
-        dtype = getattr(torch, w["dtypes"][0])
+        dtype_name = w["dtypes"][0]
         mark = pytest.mark.smoke if i == 0 else pytest.mark.full
-        params.append(pytest.param(*values, dtype, marks=mark, id=w.get("label", f"w{i}")))
+        label = w.get("label", f"w{i}")
+        params.append(
+            pytest.param(
+                *values, getattr(torch, dtype_name), marks=mark, id=f"{label}-{dtype_name}"
+            )
+        )
     return params
 
 

--- a/benchmarks/ops/bench_independent_elementwise.py
+++ b/benchmarks/ops/bench_independent_elementwise.py
@@ -15,7 +15,13 @@ import torch
 import torch.nn.functional as F
 
 from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, ManifestBenchmark
+from benchmarks.benchmark_base import (
+    BenchmarkBase,
+    BenchmarkReport,
+    ManifestBenchmark,
+    fields,
+    workload_params,
+)
 from tileops.manifest import load_workloads
 from tileops.ops.elementwise import (
     AlibiFwdOp,
@@ -59,37 +65,25 @@ class UnaryBenchmark(BenchmarkBase[ShapedRandnWorkload]):
 _CLAMP_FWD_OP = "ClampFwdOp"
 
 
-def _workloads_to_clamp_params(workloads: list) -> list:
-    """Convert manifest workload dicts to clamp-bench pytest params.
+def _clamp_args(w: dict, dtype: torch.dtype) -> tuple:
+    """``(input_shape, min_shape, max_shape, dtype)``; a row passes a bound
+    exactly when it declares that bound's shape."""
+    return (
+        tuple(w["input_shape"]),
+        tuple(w["min_shape"]) if "min_shape" in w else None,
+        tuple(w["max_shape"]) if "max_shape" in w else None,
+        dtype,
+    )
 
-    A row passes a bound exactly when it declares that bound's shape.
-    """
-    params = []
-    for idx, w in enumerate(workloads):
-        input_shape = tuple(w["input_shape"])
-        min_shape = tuple(w["min_shape"]) if "min_shape" in w else None
-        max_shape = tuple(w["max_shape"]) if "max_shape" in w else None
-        label = w.get("label", "x".join(str(s) for s in input_shape))
-        for dtype_str in w["dtypes"]:
-            dtype = getattr(torch, dtype_str)
-            # Smoke = first workload + fp16; everything else is full-mode.
-            mark = pytest.mark.smoke if (idx == 0 and dtype is torch.float16) else pytest.mark.full
-            params.append(
-                pytest.param(
-                    input_shape,
-                    min_shape,
-                    max_shape,
-                    dtype,
-                    marks=mark,
-                    id=f"{label}-{dtype_str}",
-                )
-            )
-    return params
+
+def _clamp_marks(w: dict, dtype: torch.dtype, index: int) -> tuple:
+    """The first row's fp16 case is the smoke case; every other case is full."""
+    return (pytest.mark.smoke if index == 0 and dtype is torch.float16 else pytest.mark.full,)
 
 
 @pytest.mark.parametrize(
     "input_shape, min_shape, max_shape, dtype",
-    _workloads_to_clamp_params(load_workloads(_CLAMP_FWD_OP)),
+    workload_params(load_workloads(_CLAMP_FWD_OP), _clamp_args, marks=_clamp_marks),
 )
 def test_clamp_tensor_bench(
     input_shape: tuple,
@@ -134,30 +128,15 @@ _ALIBI_OP = "AlibiFwdOp"
 _SINUSOIDAL_OP = "SinusoidalFwdOp"
 
 
-def _generative_params(workloads: list, keys: tuple) -> list:
-    """Manifest workloads -> params; first workload smoke, rest full.
-
-    The id ends with the dtype the case runs, so a label never has to spell one.
-    """
-    params = []
-    for i, w in enumerate(workloads):
-        values = [w[k] for k in keys]
-        dtype_name = w["dtypes"][0]
-        mark = pytest.mark.smoke if i == 0 else pytest.mark.full
-        label = w.get("label", f"w{i}")
-        params.append(
-            pytest.param(
-                *values, getattr(torch, dtype_name), marks=mark, id=f"{label}-{dtype_name}"
-            )
-        )
-    return params
-
-
 class AlibiBenchFixture(FixtureBase):
     PARAMS = [
         (
             "seq_len, num_heads, dtype",
-            _generative_params(load_workloads(_ALIBI_OP), ("seq_len", "num_heads")),
+            workload_params(
+                load_workloads(_ALIBI_OP),
+                fields("seq_len", "num_heads", dtype_last=True),
+                smoke_first=True,
+            ),
         )
     ]
 
@@ -166,7 +145,11 @@ class SinusoidalBenchFixture(FixtureBase):
     PARAMS = [
         (
             "seq_len, d_model, dtype",
-            _generative_params(load_workloads(_SINUSOIDAL_OP), ("seq_len", "d_model")),
+            workload_params(
+                load_workloads(_SINUSOIDAL_OP),
+                fields("seq_len", "d_model", dtype_last=True),
+                smoke_first=True,
+            ),
         )
     ]
 

--- a/benchmarks/ops/bench_instance_norm.py
+++ b/benchmarks/ops/bench_instance_norm.py
@@ -19,7 +19,7 @@ from benchmarks.baselines import (
     flaggems_group_norm,
     reference_tolerance,
 )
-from benchmarks.benchmark_base import ManifestBenchmark
+from benchmarks.benchmark_base import ManifestBenchmark, workload_params
 from tileops.manifest import load_workloads
 from tileops.ops.norm.instance_norm import InstanceNormFwdOp
 from workloads.normalization import InstanceNormWorkload
@@ -27,27 +27,16 @@ from workloads.normalization import InstanceNormWorkload
 _OP_NAME = "InstanceNormFwdOp"
 
 
-def _build_params(workloads):
-    """One param per workload row and dtype.
-
-    A row applies the affine exactly when it declares ``weight_shape``.
-    """
-    params = []
-    for w in workloads:
-        shape = w["x_shape"]
-        n, c, spatial = shape[0], shape[1], tuple(shape[2:])
-        label = w.get("label", f"{n}x{c}x{'x'.join(map(str, spatial))}")
-        affine = "weight_shape" in w
-        for dtype_str in w["dtypes"]:
-            dtype = getattr(torch, dtype_str)
-            params.append(
-                pytest.param(n, c, spatial, dtype, True, affine, id=f"{label}-{dtype_str}")
-            )
-    return params
+def _instance_norm_args(w: dict, dtype: torch.dtype) -> tuple:
+    """``(n, c, spatial, dtype, tune, affine)``; a row is affine exactly when it
+    declares ``weight_shape``."""
+    n, c, *spatial = w["x_shape"]
+    return (n, c, tuple(spatial), dtype, True, "weight_shape" in w)
 
 
 @pytest.mark.parametrize(
-    "n, c, spatial, dtype, tune, affine", _build_params(load_workloads(_OP_NAME))
+    "n, c, spatial, dtype, tune, affine",
+    workload_params(load_workloads(_OP_NAME), _instance_norm_args),
 )
 def test_instance_norm_bench(
     n: int, c: int, spatial: tuple, dtype: torch.dtype, tune: bool, affine: bool

--- a/benchmarks/ops/bench_mamba.py
+++ b/benchmarks/ops/bench_mamba.py
@@ -3,8 +3,11 @@ import torch
 import torch.nn.functional as F
 
 from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
-from benchmarks.benchmark_base import ManifestBenchmark
-from benchmarks.ops.attention.manifest_params import manifest_params
+from benchmarks.benchmark_base import (
+    ManifestBenchmark,
+    then_dtype,
+    workload_params,
+)
 from tileops.manifest import load_workloads
 from tileops.ops.mamba.cb_producer import CBProducerFwdOp
 from tileops.ops.mamba.da_cumsum import DaCumsumFwdOp
@@ -37,7 +40,9 @@ def _cb_producer_args(w: dict) -> tuple:
 
 @pytest.mark.parametrize(
     "batch, num_chunks, n_groups, chunk_len, d_state, dtype, tune",
-    manifest_params(load_workloads(_CB_PRODUCER_OP_NAME), _cb_producer_args, tune=False),
+    workload_params(
+        load_workloads(_CB_PRODUCER_OP_NAME), then_dtype(_cb_producer_args, tune=False)
+    ),
 )
 def test_cb_producer_fwd_bench(
     batch: int,
@@ -163,7 +168,7 @@ def da_cumsum_fwd_ref(
 
 @pytest.mark.parametrize(
     "batch, num_chunks, chunk_len, n_heads, has_dt_bias, dt_softplus, dtype, tune",
-    manifest_params(load_workloads(_DA_CUMSUM_OP_NAME), _da_cumsum_args, tune=False),
+    workload_params(load_workloads(_DA_CUMSUM_OP_NAME), then_dtype(_da_cumsum_args, tune=False)),
 )
 def test_da_cumsum_fwd_bench(
     batch, num_chunks, chunk_len, n_heads, has_dt_bias, dt_softplus, dtype, tune
@@ -296,7 +301,7 @@ def ssd_chunk_scan_fwd_ref(x, cb, dA_cumsum, C, prev_states, dt, n_groups):
 # Schema: (batch, num_chunks, chunk_len, n_heads, d_head, d_state, n_groups, dtype, tune)
 @pytest.mark.parametrize(
     "batch, num_chunks, chunk_len, n_heads, d_head, d_state, n_groups, dtype, tune",
-    manifest_params(load_workloads(_CHUNK_SCAN_OP_NAME), _chunk_scan_args, tune=False),
+    workload_params(load_workloads(_CHUNK_SCAN_OP_NAME), then_dtype(_chunk_scan_args, tune=False)),
 )
 def test_ssd_chunk_scan_fwd_bench(
     batch: int,
@@ -385,7 +390,9 @@ def ssd_chunk_state_fwd_ref(
 
 @pytest.mark.parametrize(
     "batch, num_chunks, chunk_len, n_heads, d_head, d_state, n_groups, has_seq_idx, dtype, tune",
-    manifest_params(load_workloads(_CHUNK_STATE_OP_NAME), _chunk_state_args, tune=False),
+    workload_params(
+        load_workloads(_CHUNK_STATE_OP_NAME), then_dtype(_chunk_state_args, tune=False)
+    ),
 )
 def test_ssd_chunk_state_fwd_bench(
     batch: int,
@@ -453,7 +460,9 @@ def test_ssd_chunk_state_fwd_bench(
 # Schema: (batch, num_chunks, n_heads, d_state, dtype, tune)
 @pytest.mark.parametrize(
     "batch, num_chunks, n_heads, d_state, has_initial_states, dtype, tune",
-    manifest_params(load_workloads(_STATE_PASSING_OP_NAME), _state_passing_args, tune=False),
+    workload_params(
+        load_workloads(_STATE_PASSING_OP_NAME), then_dtype(_state_passing_args, tune=False)
+    ),
 )
 def test_ssd_state_passing_fwd_bench(
     batch: int,
@@ -546,7 +555,7 @@ def ssd_decode_ref(
 # Schema: (batch, n_heads, d_head, d_state, n_groups, dtype, tune)
 @pytest.mark.parametrize(
     "batch, n_heads, d_head, d_state, n_groups, dtype, tune",
-    manifest_params(load_workloads(_DECODE_OP_NAME), _decode_args, tune=False),
+    workload_params(load_workloads(_DECODE_OP_NAME), then_dtype(_decode_args, tune=False)),
 )
 def test_ssd_decode_bench(
     batch: int,

--- a/benchmarks/ops/bench_mamba2_e2e.py
+++ b/benchmarks/ops/bench_mamba2_e2e.py
@@ -14,8 +14,11 @@ import torch
 import torch.nn.functional as F
 
 from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
-from benchmarks.benchmark_base import ManifestBenchmark
-from benchmarks.ops.attention.manifest_params import manifest_params
+from benchmarks.benchmark_base import (
+    ManifestBenchmark,
+    then_dtype,
+    workload_params,
+)
 from tileops.manifest import load_workloads
 from tileops.ops.mamba.mamba2_fwd import Mamba2FwdOp
 from workloads.mamba2_e2e import Mamba2FwdWorkload
@@ -155,7 +158,7 @@ def _mamba2_args(workload: dict) -> tuple:
 @pytest.mark.parametrize(
     "batch, seqlen, n_heads, d_head, d_state, n_groups, chunk_size, dt_softplus,"
     " has_dt_bias, has_initial_states, dtype, tune",
-    manifest_params(load_workloads("Mamba2FwdOp"), _mamba2_args, tune=False),
+    workload_params(load_workloads("Mamba2FwdOp"), then_dtype(_mamba2_args, tune=False)),
 )
 def test_mamba2_fwd_bench(
     batch,

--- a/benchmarks/ops/bench_mhc.py
+++ b/benchmarks/ops/bench_mhc.py
@@ -11,7 +11,8 @@ import torch
 from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
 from benchmarks.benchmark_base import (
     ManifestBenchmark,
-    workload_field_params,
+    fields,
+    workload_params,
 )
 from tileops.manifest import load_workloads
 from tileops.ops import MHCPostFwdOp, MHCPreFwdOp
@@ -27,9 +28,9 @@ _SINKHORN_EPS = 0.02
 
 
 _MHC_PRE_OP = "MHCPreFwdOp"
-_MHC_PRE_PARAMS = workload_field_params(
+_MHC_PRE_PARAMS = workload_params(
     load_workloads(_MHC_PRE_OP),
-    (
+    fields(
         "batch",
         "n_expand",
         "c_x",
@@ -39,6 +40,7 @@ _MHC_PRE_PARAMS = workload_field_params(
         "alpha_res",
         "sinkhorn_repeat",
     ),
+    smoke_first=True,
 )
 
 
@@ -78,9 +80,10 @@ def test_mhc_pre_bench(
 
 
 _MHC_POST_OP = "MHCPostFwdOp"
-_MHC_POST_PARAMS = workload_field_params(
+_MHC_POST_PARAMS = workload_params(
     load_workloads(_MHC_POST_OP),
-    ("batch", "n_expand", "c_x", "dtype"),
+    fields("batch", "n_expand", "c_x", "dtype"),
+    smoke_first=True,
 )
 
 

--- a/benchmarks/ops/bench_moe_fused_moe.py
+++ b/benchmarks/ops/bench_moe_fused_moe.py
@@ -30,17 +30,12 @@ try:
 except ImportError:
     _VLLM_AVAILABLE = False
 
-from benchmarks.benchmark_base import BenchmarkBase
+from benchmarks.benchmark_base import BenchmarkBase, workload_params
 from tileops.manifest import load_workloads
 from tileops.ops.moe import FusedMoeFwdOp, FusedTopKOp
 from workloads.moe import FusedMoeWorkload
 
 _OP_NAME = "FusedMoeFwdOp"
-
-_DTYPE_MAP = {
-    "bfloat16": torch.bfloat16,
-    "float16": torch.float16,
-}
 
 
 class FusedMoeBenchmark(BenchmarkBase[FusedMoeWorkload]):
@@ -73,35 +68,24 @@ def _renormalize(w: dict) -> bool:
     return bool(w.get("renormalize", False))
 
 
-def _to_params(workloads):
-    """Convert the manifest entry's workloads to pytest params.
-
-    A row passes the correction bias exactly when it declares
-    ``correction_bias_shape``.
-    """
-    params = []
-    for w in workloads:
-        label = w.get("label", "unlabeled")
-        for dtype_str in w["dtypes"]:
-            params.append(
-                pytest.param(
-                    w["num_tokens"],
-                    w["num_experts"],
-                    w["top_k"],
-                    w["hidden_size"],
-                    w["ffn_size"],
-                    w["scoring_func"],
-                    _renormalize(w),
-                    "correction_bias_shape" in w,
-                    _routed_scaling_factor(w),
-                    dtype_str,
-                    id=f"{label}-{dtype_str}",
-                )
-            )
-    return params
+def _fused_moe_args(w: dict, dtype: torch.dtype) -> tuple:
+    """Positional args for one fused-MoE case; a row passes the correction bias
+    exactly when it declares ``correction_bias_shape``."""
+    return (
+        w["num_tokens"],
+        w["num_experts"],
+        w["top_k"],
+        w["hidden_size"],
+        w["ffn_size"],
+        w["scoring_func"],
+        _renormalize(w),
+        "correction_bias_shape" in w,
+        _routed_scaling_factor(w),
+        dtype,
+    )
 
 
-_FWD_PARAMS = _to_params(load_workloads(_OP_NAME))
+_FWD_PARAMS = workload_params(load_workloads(_OP_NAME), _fused_moe_args)
 
 
 def _run_bench(
@@ -238,7 +222,7 @@ def _run_bench(
 @pytest.mark.parametrize(
     "num_tokens, num_experts, top_k, hidden_size, ffn_size,"
     " scoring_func, renormalize, with_correction_bias,"
-    " routed_scaling_factor, dtype_str",
+    " routed_scaling_factor, dtype",
     _FWD_PARAMS,
 )
 def test_fused_moe_fwd_bench(
@@ -251,9 +235,8 @@ def test_fused_moe_fwd_bench(
     renormalize,
     with_correction_bias,
     routed_scaling_factor,
-    dtype_str,
+    dtype: torch.dtype,
 ) -> None:
-    dtype = _DTYPE_MAP[dtype_str]
     _run_bench(
         num_tokens,
         num_experts,

--- a/benchmarks/ops/bench_moe_gate_up.py
+++ b/benchmarks/ops/bench_moe_gate_up.py
@@ -16,7 +16,7 @@ import torch
 import torch.nn.functional as F
 
 from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
-from benchmarks.benchmark_base import ManifestBenchmark
+from benchmarks.benchmark_base import ManifestBenchmark, fields, workload_params
 from tileops.kernels.moe import (
     MoeGroupedGemmPersistent3WGFusedActKernel,
     MoeGroupedGemmSeparateActKernel,
@@ -27,47 +27,24 @@ from workloads.moe import MoeGroupedGemmNopadWorkload
 
 _OP_NAME = "MoeGateUpFwdOp"
 
-_DTYPE_MAP = {
-    "bfloat16": torch.bfloat16,
-    "float16": torch.float16,
-}
-
-
-def _manifest_params():
-    """Convert manifest workloads to pytest params (numel, E, ffn, K, dtype)."""
-    params = []
-    for w in load_workloads(_OP_NAME):
-        label = w.get("label", "unlabeled")
-        for dtype_str in w["dtypes"]:
-            params.append(
-                pytest.param(
-                    w["numel"],
-                    w["num_experts"],
-                    w["ffn"],
-                    w["k"],
-                    dtype_str,
-                    id=f"{label}-{dtype_str}",
-                )
-            )
-    return params
-
 
 @pytest.mark.parametrize(
-    "numel, num_experts, ffn, k, dtype_str",
-    _manifest_params(),
+    "numel, num_experts, ffn, k, dtype",
+    workload_params(
+        load_workloads(_OP_NAME), fields("numel", "num_experts", "ffn", "k", dtype_last=True)
+    ),
 )
 def test_moe_gate_up_bench(
     numel: int,
     num_experts: int,
     ffn: int,
     k: int,
-    dtype_str: str,
+    dtype: torch.dtype,
 ) -> None:
     cap = torch.cuda.get_device_capability()
     if cap[0] < 9:
         pytest.skip(f"SM90 required for the 3WG fused-activation kernel; got SM{cap[0]}{cap[1]}.")
 
-    dtype = _DTYPE_MAP[dtype_str]
     workload = MoeGroupedGemmNopadWorkload(numel, num_experts, 2 * ffn, k, dtype)
     a, b, true_sizes, true_offsets = workload.gen_inputs()
 

--- a/benchmarks/ops/bench_moe_grouped_gemm_nopad.py
+++ b/benchmarks/ops/bench_moe_grouped_gemm_nopad.py
@@ -12,7 +12,7 @@ import pytest
 import torch
 
 from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
-from benchmarks.benchmark_base import ManifestBenchmark
+from benchmarks.benchmark_base import ManifestBenchmark, fields, workload_params
 from tileops.manifest import load_workloads
 from tileops.ops.moe import MoeGroupedGemmNopadFwdOp
 from workloads.moe import MoeGroupedGemmNopadWorkload
@@ -20,43 +20,19 @@ from workloads.moe import MoeGroupedGemmNopadWorkload
 _OP_NAME = "MoeGroupedGemmNopadFwdOp"
 
 
-_DTYPE_MAP = {
-    "bfloat16": torch.bfloat16,
-    "float16": torch.float16,
-}
-
-
-def _manifest_params():
-    """Convert manifest workloads to pytest params (numel, E, N, K, dtype)."""
-    params = []
-    for w in load_workloads(_OP_NAME):
-        label = w.get("label", "unlabeled")
-        for dtype_str in w["dtypes"]:
-            params.append(
-                pytest.param(
-                    w["numel"],
-                    w["num_experts"],
-                    w["n"],
-                    w["k"],
-                    dtype_str,
-                    id=f"{label}-{dtype_str}",
-                )
-            )
-    return params
-
-
 @pytest.mark.parametrize(
-    "numel, num_experts, n, k, dtype_str",
-    _manifest_params(),
+    "numel, num_experts, n, k, dtype",
+    workload_params(
+        load_workloads(_OP_NAME), fields("numel", "num_experts", "n", "k", dtype_last=True)
+    ),
 )
 def test_moe_grouped_gemm_nopad_bench(
     numel: int,
     num_experts: int,
     n: int,
     k: int,
-    dtype_str: str,
+    dtype: torch.dtype,
 ) -> None:
-    dtype = _DTYPE_MAP[dtype_str]
     workload = MoeGroupedGemmNopadWorkload(numel, num_experts, n, k, dtype)
     a, b, true_sizes, true_offsets = workload.gen_inputs()
 

--- a/benchmarks/ops/bench_moe_permute_align.py
+++ b/benchmarks/ops/bench_moe_permute_align.py
@@ -21,7 +21,7 @@ try:
 except ImportError:
     _SGL_KERNEL_AVAILABLE = False
 
-from benchmarks.benchmark_base import ManifestBenchmark
+from benchmarks.benchmark_base import ManifestBenchmark, fields, workload_params
 from tileops.manifest import load_workloads
 from tileops.ops.moe import MoePermuteAlignFwdOp
 from workloads.moe import MoePermuteAlignWorkload
@@ -147,30 +147,12 @@ def _triton_permute_align(
 # Manifest-driven parametrize
 
 
-def _manifest_params():
-    """Convert manifest workloads to pytest params."""
-    params = []
-    for w in load_workloads(_OP_NAME):
-        label = w.get("label", "unlabeled")
-        for dtype_str in w["dtypes"]:
-            params.append(
-                pytest.param(
-                    w["total_tokens"],
-                    w["top_k"],
-                    w["num_experts"],
-                    w["block_size"],
-                    id=f"{label}-{dtype_str}",
-                )
-            )
-    return params
-
-
-# Benchmark test
-
-
 @pytest.mark.parametrize(
     "total_tokens, top_k, num_experts, block_size",
-    _manifest_params(),
+    workload_params(
+        load_workloads(_OP_NAME),
+        fields("total_tokens", "top_k", "num_experts", "block_size"),
+    ),
 )
 def test_permute_align_bench(
     total_tokens: int, top_k: int, num_experts: int, block_size: int

--- a/benchmarks/ops/bench_moe_permute_nopad.py
+++ b/benchmarks/ops/bench_moe_permute_nopad.py
@@ -22,7 +22,7 @@ try:
 except ImportError:
     _VLLM_AVAILABLE = False
 
-from benchmarks.benchmark_base import ManifestBenchmark
+from benchmarks.benchmark_base import ManifestBenchmark, workload_params
 from tileops.manifest import load_workloads
 from tileops.ops.moe import MoePermuteNopadFwdOp
 from workloads.moe import MoePermuteWorkload
@@ -35,34 +35,17 @@ _OP_NAME = "MoePermuteNopadFwdOp"
 # Manifest-driven parametrize
 
 
-def _manifest_params():
-    """Convert manifest workloads to pytest params."""
-    params = []
-    for w in load_workloads(_OP_NAME):
-        label = w.get("label", "unlabeled")
-        total_tokens, hidden_size = w["hidden_states_shape"]
-        topk_tokens, top_k = w["topk_ids_shape"]
-        assert topk_tokens == total_tokens
-        for dtype_str in w["dtypes"]:
-            params.append(
-                pytest.param(
-                    total_tokens,
-                    top_k,
-                    w["num_experts"],
-                    w["num_experts_local"],
-                    hidden_size,
-                    id=f"{label}-{dtype_str}",
-                )
-            )
-    return params
-
-
-# Benchmark test
+def _permute_nopad_args(w: dict, _dtype) -> tuple:
+    """(total_tokens, top_k, num_experts, num_experts_local, hidden_size)."""
+    total_tokens, hidden_size = w["hidden_states_shape"]
+    topk_tokens, top_k = w["topk_ids_shape"]
+    assert topk_tokens == total_tokens
+    return (total_tokens, top_k, w["num_experts"], w["num_experts_local"], hidden_size)
 
 
 @pytest.mark.parametrize(
     "total_tokens, top_k, num_experts, num_experts_local, hidden_size",
-    _manifest_params(),
+    workload_params(load_workloads(_OP_NAME), _permute_nopad_args),
 )
 def test_moe_permute_nopad_bench(
     total_tokens: int,

--- a/benchmarks/ops/bench_moe_unpermute.py
+++ b/benchmarks/ops/bench_moe_unpermute.py
@@ -25,7 +25,7 @@ try:
 except ImportError:
     _VLLM_AVAILABLE = False
 
-from benchmarks.benchmark_base import ManifestBenchmark
+from benchmarks.benchmark_base import ManifestBenchmark, fields, workload_params
 from tileops.manifest import load_workloads
 from tileops.ops.moe import MoeUnpermuteFwdOp
 from workloads.moe import MoeUnpermuteWorkload
@@ -38,29 +38,15 @@ _OP_NAME = "MoeUnpermuteFwdOp"
 # Manifest-driven parametrize
 
 
-def _manifest_params():
-    """Convert manifest workloads to pytest params."""
-    params = []
-    for w in load_workloads(_OP_NAME):
-        label = w.get("label", "unlabeled")
-        for dtype_str in w["dtypes"]:
-            params.append(
-                pytest.param(
-                    w["total_tokens"],
-                    w["top_k"],
-                    w["hidden_size"],
-                    id=f"{label}-{dtype_str}",
-                )
-            )
-    return params
-
-
 # Benchmark test
 
 
 @pytest.mark.parametrize(
     "total_tokens, top_k, hidden_size",
-    _manifest_params(),
+    workload_params(
+        load_workloads(_OP_NAME),
+        fields("total_tokens", "top_k", "hidden_size"),
+    ),
 )
 def test_moe_unpermute_bench(total_tokens: int, top_k: int, hidden_size: int) -> None:
     dtype = torch.bfloat16

--- a/benchmarks/ops/bench_norm.py
+++ b/benchmarks/ops/bench_norm.py
@@ -103,7 +103,6 @@ def _assert_fused_add_matches(fn, reference, x, residual, weight, eps, **toleran
 
 
 def _norm_args(w: dict, dtype: torch.dtype) -> tuple:
-    """``(m, n, dtype, tune)`` for one case."""
     m, n = w["x_shape"]
     return (m, n, dtype, True)
 

--- a/benchmarks/ops/bench_norm.py
+++ b/benchmarks/ops/bench_norm.py
@@ -23,7 +23,7 @@ from benchmarks.baselines import (
     reference_tolerance,
     vllm_op,
 )
-from benchmarks.benchmark_base import ManifestBenchmark
+from benchmarks.benchmark_base import ManifestBenchmark, workload_params
 from tileops.manifest import load_workloads
 from tileops.ops.norm.fused_add_layer_norm import FusedAddLayerNormFwdOp
 from tileops.ops.norm.fused_add_rms_norm import FusedAddRMSNormFwdOp
@@ -102,26 +102,18 @@ def _assert_fused_add_matches(fn, reference, x, residual, weight, eps, **toleran
     torch.testing.assert_close(residual_copy, expected_add, **tolerance)
 
 
-def _norm_params(workloads: list[dict]) -> list:
-    """One param per manifest row and dtype: ``(m, n, dtype, tune)``.
-
-    Takes rows, not an op name, so each call site keeps the literal
-    ``load_workloads(<OpName>)`` the manifest validator matches.
-    """
-    params = []
-    for w in workloads:
-        m, n = w["x_shape"]
-        label = w.get("label", f"{m}x{n}")
-        for dtype_str in w["dtypes"]:
-            dtype = getattr(torch, dtype_str)
-            params.append(pytest.param(m, n, dtype, True, id=f"{label}-{dtype_str}"))
-    return params
+def _norm_args(w: dict, dtype: torch.dtype) -> tuple:
+    """``(m, n, dtype, tune)`` for one case."""
+    m, n = w["x_shape"]
+    return (m, n, dtype, True)
 
 
 _RMS_OP_NAME = "RMSNormFwdOp"
 
 
-@pytest.mark.parametrize("m, n, dtype, tune", _norm_params(load_workloads(_RMS_OP_NAME)))
+@pytest.mark.parametrize(
+    "m, n, dtype, tune", workload_params(load_workloads(_RMS_OP_NAME), _norm_args)
+)
 def test_rms_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
     test = RMSNormWorkload(m, n, dtype)
     inputs = test.gen_inputs()
@@ -154,7 +146,9 @@ def test_rms_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
 _FUSED_RMS_OP_NAME = "FusedAddRMSNormFwdOp"
 
 
-@pytest.mark.parametrize("m, n, dtype, tune", _norm_params(load_workloads(_FUSED_RMS_OP_NAME)))
+@pytest.mark.parametrize(
+    "m, n, dtype, tune", workload_params(load_workloads(_FUSED_RMS_OP_NAME), _norm_args)
+)
 def test_fused_add_rms_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
     test = FusedAddRMSNormWorkload(m, n, dtype)
     inputs = test.gen_inputs()
@@ -187,7 +181,9 @@ def test_fused_add_rms_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool
 _LN_OP_NAME = "LayerNormFwdOp"
 
 
-@pytest.mark.parametrize("m, n, dtype, tune", _norm_params(load_workloads(_LN_OP_NAME)))
+@pytest.mark.parametrize(
+    "m, n, dtype, tune", workload_params(load_workloads(_LN_OP_NAME), _norm_args)
+)
 def test_layer_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
     test = LayerNormWorkload(m, n, dtype)
     inputs = test.gen_inputs()
@@ -230,7 +226,9 @@ def test_layer_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool) -> Non
 _FUSED_LN_OP_NAME = "FusedAddLayerNormFwdOp"
 
 
-@pytest.mark.parametrize("m, n, dtype, tune", _norm_params(load_workloads(_FUSED_LN_OP_NAME)))
+@pytest.mark.parametrize(
+    "m, n, dtype, tune", workload_params(load_workloads(_FUSED_LN_OP_NAME), _norm_args)
+)
 def test_fused_add_layer_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
     test = FusedAddLayerNormWorkload(m, n, dtype)
     inputs = test.gen_inputs()

--- a/benchmarks/ops/bench_pool.py
+++ b/benchmarks/ops/bench_pool.py
@@ -15,7 +15,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import ManifestBenchmark
+from benchmarks.benchmark_base import ManifestBenchmark, workload_params
 from tileops.kernels.pool.common import pool_output_dim
 from tileops.manifest import load_workloads
 from tileops.ops import (
@@ -613,34 +613,26 @@ _MAX_POOL3D_OP_NAME = "MaxPool3dFwdOp"
 _MAX_POOL3D_INDICES_OP_NAME = "MaxPool3dIndicesFwdOp"
 
 
-def _avg_pool1d_bench_params() -> list:
-    params = []
-    for workload in load_workloads(_AVG_POOL1D_OP_NAME):
-        n, c_in, l_in = workload["input_shape"]
-        kernel_size = workload["kernel_size"]
-        stride = workload.get("stride")
-        padding = workload.get("padding", 0)
-        ceil_mode = workload.get("ceil_mode", False)
-        count_include_pad = workload.get("count_include_pad", True)
-        label = workload.get("label", f"{n}x{c_in}x{l_in}")
-        for dtype_str in workload["dtypes"]:
-            dtype = getattr(torch, dtype_str)
-            params.append(
-                pytest.param(
-                    n,
-                    c_in,
-                    l_in,
-                    kernel_size,
-                    stride,
-                    padding,
-                    ceil_mode,
-                    count_include_pad,
-                    dtype,
-                    True,
-                    id=f"{label}-{dtype_str}",
-                )
-            )
-    return params
+def _avg_pool1d_args(workload: dict, dtype: torch.dtype) -> tuple:
+    """Positional args for one avg_pool1d case."""
+    n, c_in, l_in = workload["input_shape"]
+    kernel_size = workload["kernel_size"]
+    stride = workload.get("stride")
+    padding = workload.get("padding", 0)
+    ceil_mode = workload.get("ceil_mode", False)
+    count_include_pad = workload.get("count_include_pad", True)
+    return (
+        n,
+        c_in,
+        l_in,
+        kernel_size,
+        stride,
+        padding,
+        ceil_mode,
+        count_include_pad,
+        dtype,
+        True,
+    )
 
 
 class AvgPool1dBenchmarkWorkload(AvgPool1dBenchCase):
@@ -722,7 +714,7 @@ class MaxPool3dBenchmarkWorkload(MaxPool3dBenchCase):
 
 @pytest.mark.parametrize(
     "n, c_in, l_in, kernel_size, stride, padding, ceil_mode, count_include_pad, dtype, tune",
-    _avg_pool1d_bench_params(),
+    workload_params(load_workloads(_AVG_POOL1D_OP_NAME), _avg_pool1d_args),
 )
 def test_avg_pool1d_bench(
     n: int,
@@ -767,44 +759,36 @@ def test_avg_pool1d_bench(
     )
 
 
-def _avg_pool2d_bench_params() -> list:
-    params = []
-    for workload in load_workloads(_AVG_POOL2D_OP_NAME):
-        n, c_in, h_in, w_in = workload["input_shape"]
-        kernel_size = tuple(workload["kernel_size"])
-        stride = workload.get("stride")
-        if stride is not None:
-            stride = tuple(stride)
-        padding = tuple(workload.get("padding", (0, 0)))
-        ceil_mode = workload.get("ceil_mode", False)
-        count_include_pad = workload.get("count_include_pad", True)
-        divisor_override = workload.get("divisor_override")
-        label = workload.get("label", f"{n}x{c_in}x{h_in}x{w_in}")
-        for dtype_str in workload["dtypes"]:
-            dtype = getattr(torch, dtype_str)
-            params.append(
-                pytest.param(
-                    n,
-                    c_in,
-                    h_in,
-                    w_in,
-                    kernel_size,
-                    stride,
-                    padding,
-                    ceil_mode,
-                    count_include_pad,
-                    divisor_override,
-                    dtype,
-                    True,
-                    id=f"{label}-{dtype_str}",
-                )
-            )
-    return params
+def _avg_pool2d_args(workload: dict, dtype: torch.dtype) -> tuple:
+    """Positional args for one avg_pool2d case."""
+    n, c_in, h_in, w_in = workload["input_shape"]
+    kernel_size = tuple(workload["kernel_size"])
+    stride = workload.get("stride")
+    if stride is not None:
+        stride = tuple(stride)
+    padding = tuple(workload.get("padding", (0, 0)))
+    ceil_mode = workload.get("ceil_mode", False)
+    count_include_pad = workload.get("count_include_pad", True)
+    divisor_override = workload.get("divisor_override")
+    return (
+        n,
+        c_in,
+        h_in,
+        w_in,
+        kernel_size,
+        stride,
+        padding,
+        ceil_mode,
+        count_include_pad,
+        divisor_override,
+        dtype,
+        True,
+    )
 
 
 @pytest.mark.parametrize(
     "n, c_in, h_in, w_in, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override, dtype, tune",
-    _avg_pool2d_bench_params(),
+    workload_params(load_workloads(_AVG_POOL2D_OP_NAME), _avg_pool2d_args),
 )
 def test_avg_pool2d_bench(
     n: int,
@@ -860,45 +844,37 @@ def test_avg_pool2d_bench(
     )
 
 
-def _avg_pool3d_bench_params() -> list:
-    params = []
-    for workload in load_workloads(_AVG_POOL3D_OP_NAME):
-        n, c_in, d_in, h_in, w_in = workload["input_shape"]
-        kernel_size = tuple(workload["kernel_size"])
-        stride = workload.get("stride")
-        if stride is not None:
-            stride = tuple(stride)
-        padding = tuple(workload.get("padding", (0, 0, 0)))
-        ceil_mode = workload.get("ceil_mode", False)
-        count_include_pad = workload.get("count_include_pad", True)
-        divisor_override = workload.get("divisor_override")
-        label = workload.get("label", f"{n}x{c_in}x{d_in}x{h_in}x{w_in}")
-        for dtype_str in workload["dtypes"]:
-            dtype = getattr(torch, dtype_str)
-            params.append(
-                pytest.param(
-                    n,
-                    c_in,
-                    d_in,
-                    h_in,
-                    w_in,
-                    kernel_size,
-                    stride,
-                    padding,
-                    ceil_mode,
-                    count_include_pad,
-                    divisor_override,
-                    dtype,
-                    True,
-                    id=f"{label}-{dtype_str}",
-                )
-            )
-    return params
+def _avg_pool3d_args(workload: dict, dtype: torch.dtype) -> tuple:
+    """Positional args for one avg_pool3d case."""
+    n, c_in, d_in, h_in, w_in = workload["input_shape"]
+    kernel_size = tuple(workload["kernel_size"])
+    stride = workload.get("stride")
+    if stride is not None:
+        stride = tuple(stride)
+    padding = tuple(workload.get("padding", (0, 0, 0)))
+    ceil_mode = workload.get("ceil_mode", False)
+    count_include_pad = workload.get("count_include_pad", True)
+    divisor_override = workload.get("divisor_override")
+    return (
+        n,
+        c_in,
+        d_in,
+        h_in,
+        w_in,
+        kernel_size,
+        stride,
+        padding,
+        ceil_mode,
+        count_include_pad,
+        divisor_override,
+        dtype,
+        True,
+    )
 
 
 @pytest.mark.parametrize(
     "n, c_in, d_in, h_in, w_in, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override, dtype, tune",
-    _avg_pool3d_bench_params(),
+    workload_params(load_workloads(_AVG_POOL3D_OP_NAME), _avg_pool3d_args),
 )
 def test_avg_pool3d_bench(
     n: int,
@@ -956,45 +932,37 @@ def test_avg_pool3d_bench(
     )
 
 
-def _max_pool2d_bench_params_from_workloads(workloads: list[dict]) -> list:
-    params = []
-    for workload in workloads:
-        n, c_in, h_in, w_in = workload["input_shape"]
-        kernel_size = tuple(workload["kernel_size"])
-        stride = workload.get("stride")
-        if stride is not None:
-            stride = tuple(stride)
-        padding = tuple(workload.get("padding", (0, 0)))
-        dilation = tuple(workload.get("dilation", (1, 1)))
-        ceil_mode = workload.get("ceil_mode", False)
-        label = workload.get("label", f"{n}x{c_in}x{h_in}x{w_in}")
-        for dtype_str in workload["dtypes"]:
-            dtype = getattr(torch, dtype_str)
-            params.append(
-                pytest.param(
-                    n,
-                    c_in,
-                    h_in,
-                    w_in,
-                    kernel_size,
-                    stride,
-                    padding,
-                    dilation,
-                    ceil_mode,
-                    dtype,
-                    True,
-                    id=f"{label}-{dtype_str}",
-                )
-            )
-    return params
+def _max_pool2d_args(workload: dict, dtype: torch.dtype) -> tuple:
+    """Positional args for one max_pool2d case."""
+    n, c_in, h_in, w_in = workload["input_shape"]
+    kernel_size = tuple(workload["kernel_size"])
+    stride = workload.get("stride")
+    if stride is not None:
+        stride = tuple(stride)
+    padding = tuple(workload.get("padding", (0, 0)))
+    dilation = tuple(workload.get("dilation", (1, 1)))
+    ceil_mode = workload.get("ceil_mode", False)
+    return (
+        n,
+        c_in,
+        h_in,
+        w_in,
+        kernel_size,
+        stride,
+        padding,
+        dilation,
+        ceil_mode,
+        dtype,
+        True,
+    )
 
 
 def _max_pool2d_bench_params() -> list:
-    return _max_pool2d_bench_params_from_workloads(load_workloads(_MAX_POOL2D_OP_NAME))
+    return workload_params(load_workloads(_MAX_POOL2D_OP_NAME), _max_pool2d_args)
 
 
 def _max_pool2d_indices_bench_params() -> list:
-    return _max_pool2d_bench_params_from_workloads(load_workloads(_MAX_POOL2D_INDICES_OP_NAME))
+    return workload_params(load_workloads(_MAX_POOL2D_INDICES_OP_NAME), _max_pool2d_args)
 
 
 @pytest.mark.parametrize(
@@ -1108,47 +1076,39 @@ def test_max_pool2d_indices_bench(
     )
 
 
-def _max_pool1d_bench_params_from_workloads(workloads: list[dict]) -> list:
-    params = []
-    for workload in workloads:
-        n, c_in, l_in = workload["input_shape"]
-        kernel_size = workload["kernel_size"]
-        kernel_size = tuple(kernel_size) if isinstance(kernel_size, list) else (kernel_size,)
-        stride = workload.get("stride")
-        if stride is not None:
-            stride = tuple(stride) if isinstance(stride, list) else (stride,)
-        padding = workload.get("padding", 0)
-        padding = tuple(padding) if isinstance(padding, list) else (padding,)
-        dilation = workload.get("dilation", 1)
-        dilation = tuple(dilation) if isinstance(dilation, list) else (dilation,)
-        ceil_mode = workload.get("ceil_mode", False)
-        label = workload.get("label", f"{n}x{c_in}x{l_in}")
-        for dtype_str in workload["dtypes"]:
-            dtype = getattr(torch, dtype_str)
-            params.append(
-                pytest.param(
-                    n,
-                    c_in,
-                    l_in,
-                    kernel_size,
-                    stride,
-                    padding,
-                    dilation,
-                    ceil_mode,
-                    dtype,
-                    True,
-                    id=f"{label}-{dtype_str}",
-                )
-            )
-    return params
+def _max_pool1d_args(workload: dict, dtype: torch.dtype) -> tuple:
+    """Positional args for one max_pool1d case."""
+    n, c_in, l_in = workload["input_shape"]
+    kernel_size = workload["kernel_size"]
+    kernel_size = tuple(kernel_size) if isinstance(kernel_size, list) else (kernel_size,)
+    stride = workload.get("stride")
+    if stride is not None:
+        stride = tuple(stride) if isinstance(stride, list) else (stride,)
+    padding = workload.get("padding", 0)
+    padding = tuple(padding) if isinstance(padding, list) else (padding,)
+    dilation = workload.get("dilation", 1)
+    dilation = tuple(dilation) if isinstance(dilation, list) else (dilation,)
+    ceil_mode = workload.get("ceil_mode", False)
+    return (
+        n,
+        c_in,
+        l_in,
+        kernel_size,
+        stride,
+        padding,
+        dilation,
+        ceil_mode,
+        dtype,
+        True,
+    )
 
 
 def _max_pool1d_bench_params() -> list:
-    return _max_pool1d_bench_params_from_workloads(load_workloads(_MAX_POOL1D_OP_NAME))
+    return workload_params(load_workloads(_MAX_POOL1D_OP_NAME), _max_pool1d_args)
 
 
 def _max_pool1d_indices_bench_params() -> list:
-    return _max_pool1d_bench_params_from_workloads(load_workloads(_MAX_POOL1D_INDICES_OP_NAME))
+    return workload_params(load_workloads(_MAX_POOL1D_INDICES_OP_NAME), _max_pool1d_args)
 
 
 @pytest.mark.parametrize(
@@ -1258,49 +1218,41 @@ def test_max_pool1d_indices_bench(
     )
 
 
-def _max_pool3d_bench_params_from_workloads(workloads: list[dict]) -> list:
-    params = []
-    for workload in workloads:
-        n, c_in, d_in, h_in, w_in = workload["input_shape"]
-        kernel_size = workload["kernel_size"]
-        kernel_size = tuple(kernel_size) if isinstance(kernel_size, list) else (kernel_size,) * 3
-        stride = workload.get("stride")
-        if stride is not None:
-            stride = tuple(stride) if isinstance(stride, list) else (stride,) * 3
-        padding = workload.get("padding", 0)
-        padding = tuple(padding) if isinstance(padding, list) else (padding,) * 3
-        dilation = workload.get("dilation", 1)
-        dilation = tuple(dilation) if isinstance(dilation, list) else (dilation,) * 3
-        ceil_mode = workload.get("ceil_mode", False)
-        label = workload.get("label", f"{n}x{c_in}x{d_in}x{h_in}x{w_in}")
-        for dtype_str in workload["dtypes"]:
-            dtype = getattr(torch, dtype_str)
-            params.append(
-                pytest.param(
-                    n,
-                    c_in,
-                    d_in,
-                    h_in,
-                    w_in,
-                    kernel_size,
-                    stride,
-                    padding,
-                    dilation,
-                    ceil_mode,
-                    dtype,
-                    True,
-                    id=f"{label}-{dtype_str}",
-                )
-            )
-    return params
+def _max_pool3d_args(workload: dict, dtype: torch.dtype) -> tuple:
+    """Positional args for one max_pool3d case."""
+    n, c_in, d_in, h_in, w_in = workload["input_shape"]
+    kernel_size = workload["kernel_size"]
+    kernel_size = tuple(kernel_size) if isinstance(kernel_size, list) else (kernel_size,) * 3
+    stride = workload.get("stride")
+    if stride is not None:
+        stride = tuple(stride) if isinstance(stride, list) else (stride,) * 3
+    padding = workload.get("padding", 0)
+    padding = tuple(padding) if isinstance(padding, list) else (padding,) * 3
+    dilation = workload.get("dilation", 1)
+    dilation = tuple(dilation) if isinstance(dilation, list) else (dilation,) * 3
+    ceil_mode = workload.get("ceil_mode", False)
+    return (
+        n,
+        c_in,
+        d_in,
+        h_in,
+        w_in,
+        kernel_size,
+        stride,
+        padding,
+        dilation,
+        ceil_mode,
+        dtype,
+        True,
+    )
 
 
 def _max_pool3d_bench_params() -> list:
-    return _max_pool3d_bench_params_from_workloads(load_workloads(_MAX_POOL3D_OP_NAME))
+    return workload_params(load_workloads(_MAX_POOL3D_OP_NAME), _max_pool3d_args)
 
 
 def _max_pool3d_indices_bench_params() -> list:
-    return _max_pool3d_bench_params_from_workloads(load_workloads(_MAX_POOL3D_INDICES_OP_NAME))
+    return workload_params(load_workloads(_MAX_POOL3D_INDICES_OP_NAME), _max_pool3d_args)
 
 
 @pytest.mark.parametrize(
@@ -1436,32 +1388,24 @@ class AdaptiveMaxPool2dBenchmarkWorkload(AdaptivePool2dWorkload):
         return F.adaptive_max_pool2d(x, size, return_indices=self.return_indices)
 
 
-def _adaptive_pool2d_bench_params_from_workloads(workloads) -> list:
-    params = []
-    for workload in workloads:
-        n, c_in, h_in, w_in = workload["input_shape"]
-        output_size = tuple(workload["output_size"])
-        label = workload.get("label", f"{n}x{c_in}x{h_in}x{w_in}")
-        for dtype_str in workload["dtypes"]:
-            dtype = getattr(torch, dtype_str)
-            params.append(
-                pytest.param(
-                    n,
-                    c_in,
-                    h_in,
-                    w_in,
-                    output_size,
-                    dtype,
-                    True,
-                    id=f"{label}-{dtype_str}",
-                )
-            )
-    return params
+def _adaptive_pool2d_args(workload: dict, dtype: torch.dtype) -> tuple:
+    """Positional args for one adaptive_pool2d case."""
+    n, c_in, h_in, w_in = workload["input_shape"]
+    output_size = tuple(workload["output_size"])
+    return (
+        n,
+        c_in,
+        h_in,
+        w_in,
+        output_size,
+        dtype,
+        True,
+    )
 
 
 @pytest.mark.parametrize(
     "n, c_in, h_in, w_in, output_size, dtype, tune",
-    _adaptive_pool2d_bench_params_from_workloads(load_workloads(_ADAPTIVE_AVG_POOL2D_OP_NAME)),
+    workload_params(load_workloads(_ADAPTIVE_AVG_POOL2D_OP_NAME), _adaptive_pool2d_args),
 )
 def test_adaptive_avg_pool2d_bench(
     n: int,
@@ -1494,7 +1438,7 @@ def test_adaptive_avg_pool2d_bench(
 
 @pytest.mark.parametrize(
     "n, c_in, h_in, w_in, output_size, dtype, tune",
-    _adaptive_pool2d_bench_params_from_workloads(load_workloads(_ADAPTIVE_MAX_POOL2D_OP_NAME)),
+    workload_params(load_workloads(_ADAPTIVE_MAX_POOL2D_OP_NAME), _adaptive_pool2d_args),
 )
 def test_adaptive_max_pool2d_bench(
     n: int,
@@ -1527,9 +1471,7 @@ def test_adaptive_max_pool2d_bench(
 
 @pytest.mark.parametrize(
     "n, c_in, h_in, w_in, output_size, dtype, tune",
-    _adaptive_pool2d_bench_params_from_workloads(
-        load_workloads(_ADAPTIVE_MAX_POOL2D_INDICES_OP_NAME)
-    ),
+    workload_params(load_workloads(_ADAPTIVE_MAX_POOL2D_INDICES_OP_NAME), _adaptive_pool2d_args),
 )
 def test_adaptive_max_pool2d_indices_bench(
     n: int,

--- a/benchmarks/ops/bench_pool.py
+++ b/benchmarks/ops/bench_pool.py
@@ -614,7 +614,6 @@ _MAX_POOL3D_INDICES_OP_NAME = "MaxPool3dIndicesFwdOp"
 
 
 def _avg_pool1d_args(workload: dict, dtype: torch.dtype) -> tuple:
-    """Positional args for one avg_pool1d case."""
     n, c_in, l_in = workload["input_shape"]
     kernel_size = workload["kernel_size"]
     stride = workload.get("stride")
@@ -760,7 +759,6 @@ def test_avg_pool1d_bench(
 
 
 def _avg_pool2d_args(workload: dict, dtype: torch.dtype) -> tuple:
-    """Positional args for one avg_pool2d case."""
     n, c_in, h_in, w_in = workload["input_shape"]
     kernel_size = tuple(workload["kernel_size"])
     stride = workload.get("stride")
@@ -845,7 +843,6 @@ def test_avg_pool2d_bench(
 
 
 def _avg_pool3d_args(workload: dict, dtype: torch.dtype) -> tuple:
-    """Positional args for one avg_pool3d case."""
     n, c_in, d_in, h_in, w_in = workload["input_shape"]
     kernel_size = tuple(workload["kernel_size"])
     stride = workload.get("stride")
@@ -933,7 +930,6 @@ def test_avg_pool3d_bench(
 
 
 def _max_pool2d_args(workload: dict, dtype: torch.dtype) -> tuple:
-    """Positional args for one max_pool2d case."""
     n, c_in, h_in, w_in = workload["input_shape"]
     kernel_size = tuple(workload["kernel_size"])
     stride = workload.get("stride")
@@ -1077,7 +1073,6 @@ def test_max_pool2d_indices_bench(
 
 
 def _max_pool1d_args(workload: dict, dtype: torch.dtype) -> tuple:
-    """Positional args for one max_pool1d case."""
     n, c_in, l_in = workload["input_shape"]
     kernel_size = workload["kernel_size"]
     kernel_size = tuple(kernel_size) if isinstance(kernel_size, list) else (kernel_size,)
@@ -1219,7 +1214,6 @@ def test_max_pool1d_indices_bench(
 
 
 def _max_pool3d_args(workload: dict, dtype: torch.dtype) -> tuple:
-    """Positional args for one max_pool3d case."""
     n, c_in, d_in, h_in, w_in = workload["input_shape"]
     kernel_size = workload["kernel_size"]
     kernel_size = tuple(kernel_size) if isinstance(kernel_size, list) else (kernel_size,) * 3
@@ -1389,7 +1383,6 @@ class AdaptiveMaxPool2dBenchmarkWorkload(AdaptivePool2dWorkload):
 
 
 def _adaptive_pool2d_args(workload: dict, dtype: torch.dtype) -> tuple:
-    """Positional args for one adaptive_pool2d case."""
     n, c_in, h_in, w_in = workload["input_shape"]
     output_size = tuple(workload["output_size"])
     return (

--- a/benchmarks/ops/bench_rope.py
+++ b/benchmarks/ops/bench_rope.py
@@ -20,7 +20,7 @@ from benchmarks.baselines import (
     compiled_reference,
     vllm_op,
 )
-from benchmarks.benchmark_base import ManifestBenchmark
+from benchmarks.benchmark_base import ManifestBenchmark, workload_params
 from tileops.manifest import load_workloads
 from tileops.ops.rope import (
     RopeLlama31FwdOp,
@@ -48,49 +48,23 @@ class RopeWorkload:
         self.dtype = dtype
 
 
-def _mark(idx: int):
+def _mark(w: dict, dtype: torch.dtype, index: int) -> tuple:
     """First manifest workload of an op is the smoke case; the rest are full."""
-    return pytest.mark.smoke if idx == 0 else pytest.mark.full
+    return (pytest.mark.smoke if index == 0 else pytest.mark.full,)
 
 
-def _layout_params(workloads: list[dict]) -> list:
-    """Build ``(shape, dtype, layout)`` params for the 1d/2d RoPE variants."""
-    params = []
-    for idx, w in enumerate(workloads):
-        layout = w["layout"]
-        if layout == "1d":
-            shape = (w["seq_len"], w["head_dim"])
-        else:
-            shape = (w["batch"], w["seq_len"], w["num_heads"], w["head_dim"])
-        for dtype_name in w["dtypes"]:
-            params.append(
-                pytest.param(
-                    shape,
-                    getattr(torch, dtype_name),
-                    layout,
-                    id=f"{w['label']}-{dtype_name}",
-                    marks=_mark(idx),
-                )
-            )
-    return params
+def _layout_args(w: dict, dtype: torch.dtype) -> tuple:
+    """``(shape, dtype, layout)`` for the 1d/2d RoPE variants."""
+    if w["layout"] == "1d":
+        shape = (w["seq_len"], w["head_dim"])
+    else:
+        shape = (w["batch"], w["seq_len"], w["num_heads"], w["head_dim"])
+    return (shape, dtype, w["layout"])
 
 
-def _position_ids_params(workloads: list[dict]) -> list:
-    """Build ``(shape, dtype, max_position)`` params for the THD variant."""
-    params = []
-    for idx, w in enumerate(workloads):
-        shape = (w["num_tokens"], w["num_heads"], w["head_dim"])
-        for dtype_name in w["dtypes"]:
-            params.append(
-                pytest.param(
-                    shape,
-                    getattr(torch, dtype_name),
-                    w["max_position"],
-                    id=f"{w['label']}-{dtype_name}",
-                    marks=_mark(idx),
-                )
-            )
-    return params
+def _position_ids_args(w: dict, dtype: torch.dtype) -> tuple:
+    """``(shape, dtype, max_position)`` for the THD variant."""
+    return ((w["num_tokens"], w["num_heads"], w["head_dim"]), dtype, w["max_position"])
 
 
 # Bench-local PyTorch baselines
@@ -183,7 +157,7 @@ _NEOX_OP = "RopeNeoxFwdOp"
 
 @pytest.mark.parametrize(
     "shape, dtype, layout",
-    _layout_params(load_workloads(_NEOX_OP)),
+    workload_params(load_workloads(_NEOX_OP), _layout_args, marks=_mark),
 )
 def test_rope_neox_bench(
     shape: tuple[int, ...],
@@ -200,7 +174,7 @@ _NON_NEOX_OP = "RopeNonNeoxFwdOp"
 
 @pytest.mark.parametrize(
     "shape, dtype, layout",
-    _layout_params(load_workloads(_NON_NEOX_OP)),
+    workload_params(load_workloads(_NON_NEOX_OP), _layout_args, marks=_mark),
 )
 def test_rope_non_neox_bench(
     shape: tuple[int, ...],
@@ -217,7 +191,7 @@ _LLAMA31_OP = "RopeLlama31FwdOp"
 
 @pytest.mark.parametrize(
     "shape, dtype, layout",
-    _layout_params(load_workloads(_LLAMA31_OP)),
+    workload_params(load_workloads(_LLAMA31_OP), _layout_args, marks=_mark),
 )
 def test_rope_llama31_bench(
     shape: tuple[int, ...],
@@ -234,7 +208,7 @@ _YARN_OP = "RopeYarnFwdOp"
 
 @pytest.mark.parametrize(
     "shape, dtype, layout",
-    _layout_params(load_workloads(_YARN_OP)),
+    workload_params(load_workloads(_YARN_OP), _layout_args, marks=_mark),
 )
 def test_rope_yarn_bench(
     shape: tuple[int, ...],
@@ -251,7 +225,7 @@ _LONGROPE_OP = "RopeLongRopeFwdOp"
 
 @pytest.mark.parametrize(
     "shape, dtype, layout",
-    _layout_params(load_workloads(_LONGROPE_OP)),
+    workload_params(load_workloads(_LONGROPE_OP), _layout_args, marks=_mark),
 )
 def test_rope_longrope_bench(
     shape: tuple[int, ...],
@@ -268,7 +242,7 @@ _POSITION_IDS_OP = "RopeNeoxPositionIdsFwdOp"
 
 @pytest.mark.parametrize(
     "shape, dtype, max_position",
-    _position_ids_params(load_workloads(_POSITION_IDS_OP)),
+    workload_params(load_workloads(_POSITION_IDS_OP), _position_ids_args, marks=_mark),
 )
 def test_rope_neox_position_ids_bench(
     shape: tuple[int, int, int],

--- a/benchmarks/ops/bench_rope.py
+++ b/benchmarks/ops/bench_rope.py
@@ -48,11 +48,6 @@ class RopeWorkload:
         self.dtype = dtype
 
 
-def _mark(w: dict, dtype: torch.dtype, index: int) -> tuple:
-    """First manifest workload of an op is the smoke case; the rest are full."""
-    return (pytest.mark.smoke if index == 0 else pytest.mark.full,)
-
-
 def _layout_args(w: dict, dtype: torch.dtype) -> tuple:
     """``(shape, dtype, layout)`` for the 1d/2d RoPE variants."""
     if w["layout"] == "1d":
@@ -63,7 +58,6 @@ def _layout_args(w: dict, dtype: torch.dtype) -> tuple:
 
 
 def _position_ids_args(w: dict, dtype: torch.dtype) -> tuple:
-    """``(shape, dtype, max_position)`` for the THD variant."""
     return ((w["num_tokens"], w["num_heads"], w["head_dim"]), dtype, w["max_position"])
 
 
@@ -157,7 +151,7 @@ _NEOX_OP = "RopeNeoxFwdOp"
 
 @pytest.mark.parametrize(
     "shape, dtype, layout",
-    workload_params(load_workloads(_NEOX_OP), _layout_args, marks=_mark),
+    workload_params(load_workloads(_NEOX_OP), _layout_args, smoke_first=True),
 )
 def test_rope_neox_bench(
     shape: tuple[int, ...],
@@ -174,7 +168,7 @@ _NON_NEOX_OP = "RopeNonNeoxFwdOp"
 
 @pytest.mark.parametrize(
     "shape, dtype, layout",
-    workload_params(load_workloads(_NON_NEOX_OP), _layout_args, marks=_mark),
+    workload_params(load_workloads(_NON_NEOX_OP), _layout_args, smoke_first=True),
 )
 def test_rope_non_neox_bench(
     shape: tuple[int, ...],
@@ -191,7 +185,7 @@ _LLAMA31_OP = "RopeLlama31FwdOp"
 
 @pytest.mark.parametrize(
     "shape, dtype, layout",
-    workload_params(load_workloads(_LLAMA31_OP), _layout_args, marks=_mark),
+    workload_params(load_workloads(_LLAMA31_OP), _layout_args, smoke_first=True),
 )
 def test_rope_llama31_bench(
     shape: tuple[int, ...],
@@ -208,7 +202,7 @@ _YARN_OP = "RopeYarnFwdOp"
 
 @pytest.mark.parametrize(
     "shape, dtype, layout",
-    workload_params(load_workloads(_YARN_OP), _layout_args, marks=_mark),
+    workload_params(load_workloads(_YARN_OP), _layout_args, smoke_first=True),
 )
 def test_rope_yarn_bench(
     shape: tuple[int, ...],
@@ -225,7 +219,7 @@ _LONGROPE_OP = "RopeLongRopeFwdOp"
 
 @pytest.mark.parametrize(
     "shape, dtype, layout",
-    workload_params(load_workloads(_LONGROPE_OP), _layout_args, marks=_mark),
+    workload_params(load_workloads(_LONGROPE_OP), _layout_args, smoke_first=True),
 )
 def test_rope_longrope_bench(
     shape: tuple[int, ...],
@@ -242,7 +236,7 @@ _POSITION_IDS_OP = "RopeNeoxPositionIdsFwdOp"
 
 @pytest.mark.parametrize(
     "shape, dtype, max_position",
-    workload_params(load_workloads(_POSITION_IDS_OP), _position_ids_args, marks=_mark),
+    workload_params(load_workloads(_POSITION_IDS_OP), _position_ids_args, smoke_first=True),
 )
 def test_rope_neox_position_ids_bench(
     shape: tuple[int, int, int],

--- a/benchmarks/ops/bench_topk_selector.py
+++ b/benchmarks/ops/bench_topk_selector.py
@@ -15,7 +15,8 @@ import torch
 from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
 from benchmarks.benchmark_base import (
     ManifestBenchmark,
-    workload_field_params,
+    fields,
+    workload_params,
 )
 from tileops.manifest import load_workloads
 from tileops.ops import TopkSelectorFwdOp
@@ -27,9 +28,10 @@ _TUNE = True
 
 
 _TOPK_SELECTOR_OP = "TopkSelectorFwdOp"
-_TOPK_SELECTOR_PARAMS = workload_field_params(
+_TOPK_SELECTOR_PARAMS = workload_params(
     load_workloads(_TOPK_SELECTOR_OP),
-    ("batch", "seq_len", "seq_len_kv", "kv_group", "topk", "in_dtype", "out_dtype"),
+    fields("batch", "seq_len", "seq_len_kv", "kv_group", "topk", "in_dtype", "out_dtype"),
+    smoke_first=True,
 )
 
 

--- a/docs/design/manifest.md
+++ b/docs/design/manifest.md
@@ -410,7 +410,7 @@ where a reader sees they come from one implementation.
 Shape keys use `<tensor_name>_shape`. Op-specific parameters can be added per entry.
 
 ```yaml
-- {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b"}
+- {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "llama-8b"}
 ```
 
 `workloads` are for benchmark parametrization only, not unit-test coverage.
@@ -536,8 +536,8 @@ RMSNormFwdOp:
       - "output.shape == x.shape"
 
   workloads:
-    - {x_shape: [2048, 4096], normalized_shape: [4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill"}
-    - {x_shape: [1, 4096], normalized_shape: [4096], dtypes: [bfloat16], label: "llama-3.1-8b-decode"}
+    - {x_shape: [2048, 4096], normalized_shape: [4096], dtypes: [float16, bfloat16], label: "llama-8b-prefill"}
+    - {x_shape: [1, 4096], normalized_shape: [4096], dtypes: [bfloat16], label: "llama-8b-decode"}
 
   roofline:
     vars:
@@ -566,12 +566,12 @@ consumption.
 Each entry under `workloads:` is a mapping. `dtypes` and `label` are
 reserved. Key rules: R21.
 
-| Key             | Required | Meaning                                                                                                                                                                                |
-| --------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `{input}_shape` | yes\*    | Shape for the single tensor input (list of ints), named per R21. \*Multi-input families define their own aggregate shape keys (e.g. `q_shape`/`kv_shape`) in their family bench files. |
-| `dtypes`        | yes      | List of dtype strings (`["float16", "bfloat16"]`).                                                                                                                                     |
-| `label`         | no       | Human-readable id used in the pytest param id and report tables.                                                                                                                       |
-| *any other key* | no       | Op param value (`dim`, `keepdim`, …). MUST be a declared `signature.params` name (R21); overrides its default.                                                                         |
+| Key             | Required | Meaning                                                                                                                                                                                               |
+| --------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `{input}_shape` | yes\*    | Shape for the single tensor input (list of ints), named per R21. \*Multi-input families define their own aggregate shape keys (e.g. `q_shape`/`kv_shape`) in their family bench files.                |
+| `dtypes`        | yes      | List of dtype strings (`["float16", "bfloat16"]`).                                                                                                                                                    |
+| `label`         | no       | Human-readable id used in the pytest param id and report tables. MUST NOT name a dtype the row's `dtypes` already lists: the case id ends with the dtype it runs, so the label would render it twice. |
+| *any other key* | no       | Op param value (`dim`, `keepdim`, …). MUST be a declared `signature.params` name (R21); overrides its default.                                                                                        |
 
 Example — parametrizing a reduction workload over a non-last `dim`:
 

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -453,6 +453,32 @@ def _l0_signature(op_name: str, entry: dict, sig: dict) -> list[str]:
     return errors
 
 
+# A case id ends with the dtype the case runs, so a label spelling one renders it
+# twice. Both spellings of each dtype are listed, since labels use the short one.
+_DTYPE_LABEL_TOKENS = {
+    "float16": ("fp16", "f16", "float16"),
+    "bfloat16": ("bf16", "bfloat16"),
+    "float32": ("fp32", "f32", "float32"),
+    "float64": ("fp64", "f64", "float64"),
+    "float8_e4m3fn": ("fp8", "e4m3"),
+    "float8_e5m2": ("e5m2",),
+    "int8": ("int8",),
+    "int32": ("int32",),
+    "int64": ("int64",),
+}
+
+
+def _label_names_its_own_dtype(label: str, dtypes: list) -> str | None:
+    """The dtype token a label repeats from its own ``dtypes``, if any."""
+    for dtype in dtypes:
+        if not isinstance(dtype, str):
+            continue
+        for token in _DTYPE_LABEL_TOKENS.get(dtype, ()):
+            if re.search(rf"(?<![a-z0-9]){token}(?![a-z0-9])", label):
+                return token
+    return None
+
+
 def _l0_workloads(op_name: str, entry: dict, workloads: list) -> list[str]:
     """Workload policy: count, dtypes, required-param pinning, R21 keys."""
     errors: list[str] = []
@@ -484,6 +510,15 @@ def _l0_workloads(op_name: str, entry: dict, workloads: list) -> list[str]:
         missing_params = required_params - set(w.keys())
         if missing_params:
             err(f"workloads[{i}] missing required param(s): {sorted(missing_params)}")
+        label = w.get("label")
+        dtypes = w.get("dtypes")
+        if isinstance(label, str) and isinstance(dtypes, list):
+            repeated = _label_names_its_own_dtype(label, dtypes)
+            if repeated is not None:
+                err(
+                    f"workloads[{i}] label {label!r} names {repeated!r}, a dtype the "
+                    f"row already lists in 'dtypes'; the case id appends it"
+                )
     if isinstance(entry.get("signature"), dict):
         errors.extend(_check_single_input_workload_keys(op_name, entry["signature"], workloads))
     return errors

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -453,28 +453,38 @@ def _l0_signature(op_name: str, entry: dict, sig: dict) -> list[str]:
     return errors
 
 
-# A case id ends with the dtype the case runs, so a label spelling one renders it
-# twice. Both spellings of each dtype are listed, since labels use the short one.
-_DTYPE_LABEL_TOKENS = {
-    "float16": ("fp16", "f16", "float16"),
-    "bfloat16": ("bf16", "bfloat16"),
-    "float32": ("fp32", "f32", "float32"),
-    "float64": ("fp64", "f64", "float64"),
-    "float8_e4m3fn": ("fp8", "e4m3"),
-    "float8_e5m2": ("e5m2",),
-    "int8": ("int8",),
-    "int32": ("int32",),
-    "int64": ("int64",),
-}
+def _dtype_label_tokens(dtype: str) -> set[str]:
+    """How a label could spell *dtype*: the name itself and its short forms.
+
+    Derived rather than tabulated, so a dtype the manifest gains later is covered
+    without editing this: ``bfloat16`` yields ``bf16`` / ``f16`` / ``bfloat16``,
+    and ``float8_e4m3fn`` also yields its sub-format ``e4m3fn`` and ``e4m3``.
+    """
+    tokens = {dtype}
+    m = re.fullmatch(r"(b?float)(\d+)(?:_(\w+))?", dtype)
+    if m:
+        kind, bits, sub = m.groups()
+        tokens |= {f"{'bf' if kind == 'bfloat' else 'fp'}{bits}", f"f{bits}", f"{kind}{bits}"}
+        if sub:
+            tokens |= {sub, sub.removesuffix("fn")}
+    m = re.fullmatch(r"(u?int)(\d+)", dtype)
+    if m:
+        tokens.add(f"{'u' if dtype.startswith('u') else ''}i{m.group(2)}")
+    return {tok for tok in tokens if tok}
 
 
 def _label_names_its_own_dtype(label: str, dtypes: list) -> str | None:
-    """The dtype token a label repeats from its own ``dtypes``, if any."""
+    """The dtype token a label repeats from its own ``dtypes``, if any.
+
+    A case id ends with the dtype the case runs, so a label spelling one renders
+    it twice. Labels use the short spelling, the manifest the long one, and both
+    are checked.
+    """
     for dtype in dtypes:
         if not isinstance(dtype, str):
             continue
-        for token in _DTYPE_LABEL_TOKENS.get(dtype, ()):
-            if re.search(rf"(?<![a-z0-9]){token}(?![a-z0-9])", label):
+        for token in sorted(_dtype_label_tokens(dtype), key=len, reverse=True):
+            if re.search(rf"(?<![a-z0-9]){re.escape(token)}(?![a-z0-9])", label):
                 return token
     return None
 

--- a/src/tileops/manifest/__init__.py
+++ b/src/tileops/manifest/__init__.py
@@ -83,7 +83,7 @@ def load_workloads(op_name: str) -> list[dict[str, Any]]:
 
     >>> workloads = load_workloads("RMSNormFwdOp")
     >>> workloads[0]
-    {'x_shape': [2048, 4096], 'dtypes': ['float16', 'bfloat16'], 'label': 'llama-3.1-8b-prefill'}
+    {'x_shape': [2048, 4096], 'dtypes': ['float16', 'bfloat16'], 'label': 'llama-8b-prefill'}
     """
     ops = load_manifest()
     if op_name not in ops:

--- a/src/tileops/manifest/attention.yaml
+++ b/src/tileops/manifest/attention.yaml
@@ -27,11 +27,11 @@ MultiHeadAttentionFwdOp:
 
   workloads:
     # Llama-3.1-8B (H=32, D=128)
-    - {q_shape: [4, 512, 32, 128], kv_shape: [4, 512, 32, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-8b-short"}
-    - {q_shape: [2, 2048, 32, 128], kv_shape: [2, 2048, 32, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-8b-long"}
+    - {q_shape: [4, 512, 32, 128], kv_shape: [4, 512, 32, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-8b-short"}
+    - {q_shape: [2, 2048, 32, 128], kv_shape: [2, 2048, 32, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-8b-long"}
     # Llama-3.1-70B (H=64, D=128)
-    - {q_shape: [2, 512, 64, 128], kv_shape: [2, 512, 64, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-70b-short"}
-    - {q_shape: [1, 2048, 64, 128], kv_shape: [1, 2048, 64, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-70b-long"}
+    - {q_shape: [2, 512, 64, 128], kv_shape: [2, 512, 64, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-70b-short"}
+    - {q_shape: [1, 2048, 64, 128], kv_shape: [1, 2048, 64, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-70b-long"}
 
   roofline:
     func: "tileops.perf.formulas.mha_fwd_roofline"
@@ -79,11 +79,11 @@ MultiHeadAttentionBwdOp:
 
   workloads:
     # Llama-3.1-8B (H=32, D=128)
-    - {q_shape: [4, 512, 32, 128], kv_shape: [4, 512, 32, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-8b-short"}
-    - {q_shape: [2, 2048, 32, 128], kv_shape: [2, 2048, 32, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-8b-long"}
+    - {q_shape: [4, 512, 32, 128], kv_shape: [4, 512, 32, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-8b-short"}
+    - {q_shape: [2, 2048, 32, 128], kv_shape: [2, 2048, 32, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-8b-long"}
     # Llama-3.1-70B (H=64, D=128)
-    - {q_shape: [2, 512, 64, 128], kv_shape: [2, 512, 64, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-70b-short"}
-    - {q_shape: [1, 2048, 64, 128], kv_shape: [1, 2048, 64, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-70b-long"}
+    - {q_shape: [2, 512, 64, 128], kv_shape: [2, 512, 64, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-70b-short"}
+    - {q_shape: [1, 2048, 64, 128], kv_shape: [1, 2048, 64, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-70b-long"}
 
   roofline:
     func: "tileops.perf.formulas.mha_bwd_roofline"
@@ -121,11 +121,11 @@ GroupedQueryAttentionFwdOp:
 
   workloads:
     # Llama-3.1-8B (H=32, H_kv=8, D=128)
-    - {q_shape: [4, 512, 32, 128], kv_shape: [4, 512, 8, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-8b-short"}
-    - {q_shape: [2, 2048, 32, 128], kv_shape: [2, 2048, 8, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-8b-long"}
+    - {q_shape: [4, 512, 32, 128], kv_shape: [4, 512, 8, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-8b-short"}
+    - {q_shape: [2, 2048, 32, 128], kv_shape: [2, 2048, 8, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-8b-long"}
     # Llama-3.1-70B (H=64, H_kv=8, D=128)
-    - {q_shape: [2, 512, 64, 128], kv_shape: [2, 512, 8, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-70b-short"}
-    - {q_shape: [1, 2048, 64, 128], kv_shape: [1, 2048, 8, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-70b-long"}
+    - {q_shape: [2, 512, 64, 128], kv_shape: [2, 512, 8, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-70b-short"}
+    - {q_shape: [1, 2048, 64, 128], kv_shape: [1, 2048, 8, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-70b-long"}
 
   roofline:
     func: "tileops.perf.formulas.gqa_fwd_roofline"
@@ -191,17 +191,17 @@ GroupedQueryAttentionPrefillFwdOp:
 
   workloads:
     # Llama-3.1-8B (H=32, H_kv=8, D=128)
-    - {total_q: 2048, total_kv: 2048, batch: 4, q_lens: [512, 512, 512, 512], kv_lens: [512, 512, 512, 512], heads: 32, heads_kv: 8, dim: 128, max_seqlen_q: 512, max_seqlen_kv: 512, is_causal: true, backend: "dense", validate_uniform_cu_seqlens: false, dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill-dense"}
-    - {total_q: 2048, total_kv: 2048, batch: 4, q_lens: [512, 512, 512, 512], kv_lens: [512, 512, 512, 512], heads: 32, heads_kv: 8, dim: 128, max_seqlen_q: 512, max_seqlen_kv: 512, is_causal: true, backend: "dense", validate_uniform_cu_seqlens: false, sm_scale: 0.125, dtypes: [float16], label: "llama-3.1-8b-prefill-dense-sm-scale-0.125"}
-    - {total_q: 2048, total_kv: 2048, batch: 4, q_lens: [512, 512, 512, 512], kv_lens: [512, 512, 512, 512], heads: 32, heads_kv: 8, dim: 128, max_seqlen_q: 512, max_seqlen_kv: 512, is_causal: true, backend: "dense", validate_uniform_cu_seqlens: false, softcap: 50.0, dtypes: [float16], label: "llama-3.1-8b-prefill-dense-softcap50"}
-    - {total_q: 1024, total_kv: 8192, batch: 2, q_lens: [512, 512], kv_lens: [4096, 4096], heads: 32, heads_kv: 8, dim: 128, max_seqlen_q: 512, max_seqlen_kv: 4096, is_causal: true, backend: "dense", validate_uniform_cu_seqlens: false, dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill-dense-q-lt-kv"}
+    - {total_q: 2048, total_kv: 2048, batch: 4, q_lens: [512, 512, 512, 512], kv_lens: [512, 512, 512, 512], heads: 32, heads_kv: 8, dim: 128, max_seqlen_q: 512, max_seqlen_kv: 512, is_causal: true, backend: "dense", validate_uniform_cu_seqlens: false, dtypes: [float16, bfloat16], label: "llama-8b-prefill-dense"}
+    - {total_q: 2048, total_kv: 2048, batch: 4, q_lens: [512, 512, 512, 512], kv_lens: [512, 512, 512, 512], heads: 32, heads_kv: 8, dim: 128, max_seqlen_q: 512, max_seqlen_kv: 512, is_causal: true, backend: "dense", validate_uniform_cu_seqlens: false, sm_scale: 0.125, dtypes: [float16], label: "llama-8b-prefill-dense-sm-scale-0.125"}
+    - {total_q: 2048, total_kv: 2048, batch: 4, q_lens: [512, 512, 512, 512], kv_lens: [512, 512, 512, 512], heads: 32, heads_kv: 8, dim: 128, max_seqlen_q: 512, max_seqlen_kv: 512, is_causal: true, backend: "dense", validate_uniform_cu_seqlens: false, softcap: 50.0, dtypes: [float16], label: "llama-8b-prefill-dense-softcap50"}
+    - {total_q: 1024, total_kv: 8192, batch: 2, q_lens: [512, 512], kv_lens: [4096, 4096], heads: 32, heads_kv: 8, dim: 128, max_seqlen_q: 512, max_seqlen_kv: 4096, is_causal: true, backend: "dense", validate_uniform_cu_seqlens: false, dtypes: [float16, bfloat16], label: "llama-8b-prefill-dense-q-lt-kv"}
     # Llama-3.1-70B (H=64, H_kv=8, D=128)
-    - {total_q: 512, total_kv: 4096, batch: 1, q_lens: [512], kv_lens: [4096], heads: 64, heads_kv: 8, dim: 128, max_seqlen_q: 512, max_seqlen_kv: 4096, is_causal: true, backend: "dense", validate_uniform_cu_seqlens: false, dtypes: [float16, bfloat16], label: "llama-3.1-70b-prefill-dense-q-lt-kv"}
+    - {total_q: 512, total_kv: 4096, batch: 1, q_lens: [512], kv_lens: [4096], heads: 64, heads_kv: 8, dim: 128, max_seqlen_q: 512, max_seqlen_kv: 4096, is_causal: true, backend: "dense", validate_uniform_cu_seqlens: false, dtypes: [float16, bfloat16], label: "llama-70b-prefill-dense-q-lt-kv"}
     # FP8 Tensor Core prefill through the canonical packed prefill surface.
-    - {total_q: 896, total_kv: 896, batch: 1, q_lens: [896], kv_lens: [896], heads: 32, heads_kv: 8, dim: 128, max_seqlen_q: 896, max_seqlen_kv: 896, is_causal: false, backend: "fp8", validate_uniform_cu_seqlens: false, dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill-fp8tc-bn224-s896"}
-    - {total_q: 1792, total_kv: 1792, batch: 1, q_lens: [1792], kv_lens: [1792], heads: 32, heads_kv: 8, dim: 128, max_seqlen_q: 1792, max_seqlen_kv: 1792, is_causal: false, backend: "fp8", validate_uniform_cu_seqlens: false, dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill-fp8tc-bn224-s1792"}
-    - {total_q: 3584, total_kv: 3584, batch: 1, q_lens: [3584], kv_lens: [3584], heads: 64, heads_kv: 8, dim: 128, max_seqlen_q: 3584, max_seqlen_kv: 3584, is_causal: false, backend: "fp8", validate_uniform_cu_seqlens: false, dtypes: [float16, bfloat16], label: "llama-3.1-70b-prefill-fp8tc-bn224-s3584"}
-    - {total_q: 7168, total_kv: 7168, batch: 1, q_lens: [7168], kv_lens: [7168], heads: 64, heads_kv: 8, dim: 128, max_seqlen_q: 7168, max_seqlen_kv: 7168, is_causal: false, backend: "fp8", validate_uniform_cu_seqlens: false, dtypes: [float16, bfloat16], label: "llama-3.1-70b-prefill-fp8tc-bn224-s7168"}
+    - {total_q: 896, total_kv: 896, batch: 1, q_lens: [896], kv_lens: [896], heads: 32, heads_kv: 8, dim: 128, max_seqlen_q: 896, max_seqlen_kv: 896, is_causal: false, backend: "fp8", validate_uniform_cu_seqlens: false, dtypes: [float16, bfloat16], label: "llama-8b-prefill-fp8tc-bn224-s896"}
+    - {total_q: 1792, total_kv: 1792, batch: 1, q_lens: [1792], kv_lens: [1792], heads: 32, heads_kv: 8, dim: 128, max_seqlen_q: 1792, max_seqlen_kv: 1792, is_causal: false, backend: "fp8", validate_uniform_cu_seqlens: false, dtypes: [float16, bfloat16], label: "llama-8b-prefill-fp8tc-bn224-s1792"}
+    - {total_q: 3584, total_kv: 3584, batch: 1, q_lens: [3584], kv_lens: [3584], heads: 64, heads_kv: 8, dim: 128, max_seqlen_q: 3584, max_seqlen_kv: 3584, is_causal: false, backend: "fp8", validate_uniform_cu_seqlens: false, dtypes: [float16, bfloat16], label: "llama-70b-prefill-fp8tc-bn224-s3584"}
+    - {total_q: 7168, total_kv: 7168, batch: 1, q_lens: [7168], kv_lens: [7168], heads: 64, heads_kv: 8, dim: 128, max_seqlen_q: 7168, max_seqlen_kv: 7168, is_causal: false, backend: "fp8", validate_uniform_cu_seqlens: false, dtypes: [float16, bfloat16], label: "llama-70b-prefill-fp8tc-bn224-s7168"}
 
   roofline:
     func: "tileops.perf.formulas.gqa_prefill_varlen_fwd_roofline"
@@ -279,13 +279,13 @@ GroupedQueryAttentionPrefillPagedWithKVCacheFwdOp:
   workloads:
     - {total_q: 8192, batch: 8, q_lens: [1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024], cache_lens: [32768, 32768, 32768, 32768, 32768, 32768, 32768, 32768], heads: 32, heads_kv: 8, dim: 256, page_size: 64, max_pages_per_req: 528, max_seqlen_q: 1024, physical_tokens: 270336, is_causal: true, fuse_rope: true, max_position: 33792, rotary_dim: 64, dtypes: [float16], label: "qwen35-9b-prefill-paged-fullattn-b8-prefix32k-chunk1k-p64-partial-rope64"}
     - {total_q: 4608, batch: 8, q_lens: [256, 512, 768, 1024, 384, 640, 896, 128], cache_lens: [4096, 8192, 16384, 32768, 12288, 24576, 30720, 2048], heads: 32, heads_kv: 8, dim: 256, page_size: 64, max_pages_per_req: 528, max_seqlen_q: 1024, physical_tokens: 270336, is_causal: true, fuse_rope: true, max_position: 33792, rotary_dim: 64, dtypes: [float16], label: "qwen35-9b-prefill-paged-fullattn-mixed-b8-p64-partial-rope64"}
-    - {total_q: 4096, batch: 8, q_lens: [512, 512, 512, 512, 512, 512, 512, 512], cache_lens: [4096, 4096, 4096, 4096, 4096, 4096, 4096, 4096], heads: 32, heads_kv: 8, dim: 128, page_size: 64, max_pages_per_req: 72, max_seqlen_q: 512, physical_tokens: 36864, is_causal: true, fuse_rope: true, max_position: 4608, rotary_dim: null, dtypes: [float16], label: "llama31-8b-prefill-paged-b8-prefix4k-chunk512-p64-full-rope"}
+    - {total_q: 4096, batch: 8, q_lens: [512, 512, 512, 512, 512, 512, 512, 512], cache_lens: [4096, 4096, 4096, 4096, 4096, 4096, 4096, 4096], heads: 32, heads_kv: 8, dim: 128, page_size: 64, max_pages_per_req: 72, max_seqlen_q: 512, physical_tokens: 36864, is_causal: true, fuse_rope: true, max_position: 4608, rotary_dim: null, dtypes: [float16], label: "llama-8b-prefill-paged-b8-prefix4k-chunk512-p64-full-rope"}
     - {total_q: 2048, batch: 4, q_lens: [512, 512, 512, 512], cache_lens: [4096, 4096, 4096, 4096], heads: 8, heads_kv: 2, dim: 64, page_size: 64, max_pages_per_req: 72, max_seqlen_q: 512, physical_tokens: 18432, is_causal: true, softcap: 50.0, dtypes: [float16], label: "gqa-prefill-paged-softcap50-b4-prefix4k-chunk512-p64"}
     # Storage-only FP8 cache variants: q/k_new/v_new participate in attention
     # as same_as(q); old cache pages are dequantized online with scalar
     # k_scale/v_scale. Fused RoPE + FP8 append remains a follow-up kernel variant.
     - {total_q: 8192, batch: 8, heads: 32, heads_kv: 8, dim: 256, page_size: 64, max_pages_per_req: 528, max_seqlen_q: 1024, physical_tokens: 270336, is_causal: true, dtypes: [float16], cache_dtype: float8_e4m3fn, label: "qwen35-9b-prefill-paged-fp8-cache-b8-prefix32k-chunk1k-p64"}
-    - {total_q: 4096, batch: 8, heads: 32, heads_kv: 8, dim: 128, page_size: 64, max_pages_per_req: 72, max_seqlen_q: 512, physical_tokens: 36864, is_causal: true, dtypes: [float16], cache_dtype: float8_e4m3fn, label: "llama31-8b-prefill-paged-fp8-cache-b8-prefix4k-chunk512-p64"}
+    - {total_q: 4096, batch: 8, heads: 32, heads_kv: 8, dim: 128, page_size: 64, max_pages_per_req: 72, max_seqlen_q: 512, physical_tokens: 36864, is_causal: true, dtypes: [float16], cache_dtype: float8_e4m3fn, label: "llama-8b-prefill-paged-fp8-cache-b8-prefix4k-chunk512-p64"}
     - {total_q: 2048, batch: 4, heads: 8, heads_kv: 2, dim: 64, page_size: 64, max_pages_per_req: 72, max_seqlen_q: 512, physical_tokens: 18432, is_causal: true, softcap: 50.0, dtypes: [float16], cache_dtype: float8_e4m3fn, label: "gqa-prefill-paged-fp8-cache-softcap50-b4-prefix4k-chunk512-p64"}
 
   roofline:
@@ -336,11 +336,11 @@ GroupedQueryAttentionBwdOp:
 
   workloads:
     # Llama-3.1-8B (H=32, H_kv=8, D=128)
-    - {q_shape: [4, 512, 32, 128], kv_shape: [4, 512, 8, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-8b-short"}
-    - {q_shape: [2, 2048, 32, 128], kv_shape: [2, 2048, 8, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-8b-long"}
+    - {q_shape: [4, 512, 32, 128], kv_shape: [4, 512, 8, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-8b-short"}
+    - {q_shape: [2, 2048, 32, 128], kv_shape: [2, 2048, 8, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-8b-long"}
     # Llama-3.1-70B (H=64, H_kv=8, D=128)
-    - {q_shape: [2, 512, 64, 128], kv_shape: [2, 512, 8, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-70b-short"}
-    - {q_shape: [1, 2048, 64, 128], kv_shape: [1, 2048, 8, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-70b-long"}
+    - {q_shape: [2, 512, 64, 128], kv_shape: [2, 512, 8, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-70b-short"}
+    - {q_shape: [1, 2048, 64, 128], kv_shape: [1, 2048, 8, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-70b-long"}
 
   roofline:
     func: "tileops.perf.formulas.gqa_bwd_roofline"
@@ -379,13 +379,13 @@ MultiHeadAttentionDecodeWithKVCacheFwdOp:
 
   workloads:
     # Llama-3.1-8B (H=32, D=128), short KV
-    - {q_shape: [32, 1, 32, 128], kv_shape: [32, 4096, 32, 128], dtypes: [float16, bfloat16], label: "llama-3.1-8b-4k"}
+    - {q_shape: [32, 1, 32, 128], kv_shape: [32, 4096, 32, 128], dtypes: [float16, bfloat16], label: "llama-8b-4k"}
     # Llama-3.1-8B, long KV
-    - {q_shape: [8, 1, 32, 128], kv_shape: [8, 32768, 32, 128], dtypes: [float16, bfloat16], label: "llama-3.1-8b-32k"}
+    - {q_shape: [8, 1, 32, 128], kv_shape: [8, 32768, 32, 128], dtypes: [float16, bfloat16], label: "llama-8b-32k"}
     # Llama-3.1-70B (H=64, D=128), short KV
-    - {q_shape: [16, 1, 64, 128], kv_shape: [16, 4096, 64, 128], dtypes: [float16, bfloat16], label: "llama-3.1-70b-4k"}
+    - {q_shape: [16, 1, 64, 128], kv_shape: [16, 4096, 64, 128], dtypes: [float16, bfloat16], label: "llama-70b-4k"}
     # Llama-3.1-70B, long KV
-    - {q_shape: [4, 1, 64, 128], kv_shape: [4, 32768, 64, 128], dtypes: [float16, bfloat16], label: "llama-3.1-70b-32k"}
+    - {q_shape: [4, 1, 64, 128], kv_shape: [4, 32768, 64, 128], dtypes: [float16, bfloat16], label: "llama-70b-32k"}
 
   roofline:
     func: "tileops.perf.formulas.mha_decode_roofline"
@@ -464,14 +464,14 @@ GroupedQueryAttentionDecodeWithKVCacheFwdOp:
 
   workloads:
     # Llama-3.1-8B (H=32, H_kv=8, D=128), short KV
-    - {q_shape: [32, 32, 128], kv_shape: [32, 4096, 8, 128], dtypes: [float16, bfloat16], label: "llama-3.1-8b-4k"}
+    - {q_shape: [32, 32, 128], kv_shape: [32, 4096, 8, 128], dtypes: [float16, bfloat16], label: "llama-8b-4k"}
     # Llama-3.1-8B, long KV
-    - {q_shape: [8, 32, 128], kv_shape: [8, 32768, 8, 128], dtypes: [float16, bfloat16], label: "llama-3.1-8b-32k"}
+    - {q_shape: [8, 32, 128], kv_shape: [8, 32768, 8, 128], dtypes: [float16, bfloat16], label: "llama-8b-32k"}
     # Llama-3.1-70B (H=64, H_kv=8, D=128), short KV
-    - {q_shape: [16, 64, 128], kv_shape: [16, 4096, 8, 128], dtypes: [float16, bfloat16], label: "llama-3.1-70b-4k"}
+    - {q_shape: [16, 64, 128], kv_shape: [16, 4096, 8, 128], dtypes: [float16, bfloat16], label: "llama-70b-4k"}
     # Llama-3.1-70B, long KV
-    - {q_shape: [4, 64, 128], kv_shape: [4, 32768, 8, 128], dtypes: [float16, bfloat16], label: "llama-3.1-70b-32k"}
-    - {q_shape: [32, 32, 128], kv_shape: [32, 4096, 8, 128], softcap: 50.0, dtypes: [float16], label: "llama-3.1-8b-4k-softcap50"}
+    - {q_shape: [4, 64, 128], kv_shape: [4, 32768, 8, 128], dtypes: [float16, bfloat16], label: "llama-70b-32k"}
+    - {q_shape: [32, 32, 128], kv_shape: [32, 4096, 8, 128], softcap: 50.0, dtypes: [float16], label: "llama-8b-4k-softcap50"}
     # Qwen3-30B-A3B (H=32, H_kv=4, D=128), batch=1 single-request decode, KV 1K..256K
     - {q_shape: [1, 32, 128], kv_shape: [1, 1024, 4, 128], dtypes: [float16], label: "qwen3-30b-a3b-bs1-1k"}
     - {q_shape: [1, 32, 128], kv_shape: [1, 4096, 4, 128], dtypes: [float16], label: "qwen3-30b-a3b-bs1-4k"}
@@ -577,11 +577,11 @@ GroupedQueryAttentionSlidingWindowFwdOp:
 
   workloads:
     # Llama-3.1-8B (H=32, H_kv=8, D=128), short seq
-    - {q_shape: [4, 512, 32, 128], kv_shape: [4, 512, 8, 128], is_causal: true, window_size_left: 256, dtypes: [float16, bfloat16], label: "llama-3.1-8b-short-w256"}
-    - {q_shape: [2, 2048, 32, 128], kv_shape: [2, 2048, 8, 128], is_causal: true, window_size_left: 1024, dtypes: [float16, bfloat16], label: "llama-3.1-8b-long-w1024"}
+    - {q_shape: [4, 512, 32, 128], kv_shape: [4, 512, 8, 128], is_causal: true, window_size_left: 256, dtypes: [float16, bfloat16], label: "llama-8b-short-w256"}
+    - {q_shape: [2, 2048, 32, 128], kv_shape: [2, 2048, 8, 128], is_causal: true, window_size_left: 1024, dtypes: [float16, bfloat16], label: "llama-8b-long-w1024"}
     # Llama-3.1-70B (H=64, H_kv=8, D=128)
-    - {q_shape: [2, 512, 64, 128], kv_shape: [2, 512, 8, 128], is_causal: true, window_size_left: 256, dtypes: [float16, bfloat16], label: "llama-3.1-70b-short-w256"}
-    - {q_shape: [1, 2048, 64, 128], kv_shape: [1, 2048, 8, 128], is_causal: true, window_size_left: 1024, dtypes: [float16, bfloat16], label: "llama-3.1-70b-long-w1024"}
+    - {q_shape: [2, 512, 64, 128], kv_shape: [2, 512, 8, 128], is_causal: true, window_size_left: 256, dtypes: [float16, bfloat16], label: "llama-70b-short-w256"}
+    - {q_shape: [1, 2048, 64, 128], kv_shape: [1, 2048, 8, 128], is_causal: true, window_size_left: 1024, dtypes: [float16, bfloat16], label: "llama-70b-long-w1024"}
 
   roofline:
     func: "tileops.perf.formulas.gqa_sliding_window_fwd_roofline"
@@ -625,11 +625,11 @@ GroupedQueryAttentionSlidingWindowVarlenFwdOp:
 
   workloads:
     # Llama-3.1-8B (H=32, H_kv=8, D=128), short seq
-    - {total_q: 2048, total_k: 2048, batch: 4, heads: 32, heads_kv: 8, dim: 128, is_causal: true, window_size_left: 256, max_seqlen_q: 512, dtypes: [float16, bfloat16], label: "llama-3.1-8b-short-w256"}
-    - {total_q: 8192, total_k: 8192, batch: 4, heads: 32, heads_kv: 8, dim: 128, is_causal: true, window_size_left: 1024, max_seqlen_q: 2048, dtypes: [float16, bfloat16], label: "llama-3.1-8b-long-w1024"}
+    - {total_q: 2048, total_k: 2048, batch: 4, heads: 32, heads_kv: 8, dim: 128, is_causal: true, window_size_left: 256, max_seqlen_q: 512, dtypes: [float16, bfloat16], label: "llama-8b-short-w256"}
+    - {total_q: 8192, total_k: 8192, batch: 4, heads: 32, heads_kv: 8, dim: 128, is_causal: true, window_size_left: 1024, max_seqlen_q: 2048, dtypes: [float16, bfloat16], label: "llama-8b-long-w1024"}
     # Llama-3.1-70B (H=64, H_kv=8, D=128)
-    - {total_q: 2048, total_k: 2048, batch: 4, heads: 64, heads_kv: 8, dim: 128, is_causal: true, window_size_left: 256, max_seqlen_q: 512, dtypes: [float16, bfloat16], label: "llama-3.1-70b-short-w256"}
-    - {total_q: 8192, total_k: 8192, batch: 4, heads: 64, heads_kv: 8, dim: 128, is_causal: true, window_size_left: 1024, max_seqlen_q: 2048, dtypes: [float16, bfloat16], label: "llama-3.1-70b-long-w1024"}
+    - {total_q: 2048, total_k: 2048, batch: 4, heads: 64, heads_kv: 8, dim: 128, is_causal: true, window_size_left: 256, max_seqlen_q: 512, dtypes: [float16, bfloat16], label: "llama-70b-short-w256"}
+    - {total_q: 8192, total_k: 8192, batch: 4, heads: 64, heads_kv: 8, dim: 128, is_causal: true, window_size_left: 1024, max_seqlen_q: 2048, dtypes: [float16, bfloat16], label: "llama-70b-long-w1024"}
 
   roofline:
     func: "tileops.perf.formulas.gqa_sliding_window_varlen_fwd_roofline"

--- a/src/tileops/manifest/attention_indexing.yaml
+++ b/src/tileops/manifest/attention_indexing.yaml
@@ -31,8 +31,7 @@ FP8LightningIndexerFwdOp:
     - "index_k_scale is None or index_k_scale.shape == (index_q.shape[0], index_k.shape[1], index_k.shape[2])"
 
   workloads:
-  - {batch: 1, seq_len: 8192, heads: 32, index_dim: 64, seq_len_kv: 8192, kv_group: 1, clean_logits: true, dtypes: [bfloat16], label: "lightning-indexer-bf16-s8k-h32-d64"}
-  - {batch: 1, seq_len: 8192, heads: 32, index_dim: 64, seq_len_kv: 8192, kv_group: 1, clean_logits: true, dtypes: [float8_e4m3fn], label: "lightning-indexer-fp8-s8k-h32-d64"}
+  - {batch: 1, seq_len: 8192, heads: 32, index_dim: 64, seq_len_kv: 8192, kv_group: 1, clean_logits: true, dtypes: [bfloat16, float8_e4m3fn], label: "lightning-indexer-s8k-h32-d64"}
   - {batch: 1, seq_len: 8192, heads: 32, index_dim: 64, seq_len_kv: 8192, kv_group: 1, clean_logits: true, dtypes: [float8_e4m3fn], index_k_scale_shape: [1, 8192, 1], label: "lightning-indexer-s8k-h32-d64-kscale"}
 
   roofline:

--- a/src/tileops/manifest/attention_indexing.yaml
+++ b/src/tileops/manifest/attention_indexing.yaml
@@ -31,7 +31,8 @@ FP8LightningIndexerFwdOp:
     - "index_k_scale is None or index_k_scale.shape == (index_q.shape[0], index_k.shape[1], index_k.shape[2])"
 
   workloads:
-  - {batch: 1, seq_len: 8192, heads: 32, index_dim: 64, seq_len_kv: 8192, kv_group: 1, clean_logits: true, dtypes: [bfloat16, float8_e4m3fn], label: "lightning-indexer-s8k-h32-d64"}
+  - {batch: 1, seq_len: 8192, heads: 32, index_dim: 64, seq_len_kv: 8192, kv_group: 1, clean_logits: true, dtypes: [bfloat16], label: "lightning-indexer-s8k-h32-d64"}
+  - {batch: 1, seq_len: 8192, heads: 32, index_dim: 64, seq_len_kv: 8192, kv_group: 1, clean_logits: true, dtypes: [float8_e4m3fn], label: "lightning-indexer-s8k-h32-d64"}
   - {batch: 1, seq_len: 8192, heads: 32, index_dim: 64, seq_len_kv: 8192, kv_group: 1, clean_logits: true, dtypes: [float8_e4m3fn], index_k_scale_shape: [1, 8192, 1], label: "lightning-indexer-s8k-h32-d64-kscale"}
 
   roofline:

--- a/src/tileops/manifest/elementwise_fused_gated.yaml
+++ b/src/tileops/manifest/elementwise_fused_gated.yaml
@@ -28,8 +28,8 @@ SiluAndMulFwdOp:
 
   workloads:
     # SwiGLU FFN intermediate (Llama-3.1-8B, hidden_dim=14336)
-    - {x_shape: [2048, 28672], dtypes: [float16, bfloat16], label: "llama-3.1-8b-swiglu-prefill"}
-    - {x_shape: [1, 28672], dtypes: [bfloat16], label: "llama-3.1-8b-swiglu-decode"}
+    - {x_shape: [2048, 28672], dtypes: [float16, bfloat16], label: "llama-8b-swiglu-prefill"}
+    - {x_shape: [1, 28672], dtypes: [bfloat16], label: "llama-8b-swiglu-decode"}
 
   roofline:
     vars:

--- a/src/tileops/manifest/elementwise_generative.yaml
+++ b/src/tileops/manifest/elementwise_generative.yaml
@@ -21,10 +21,10 @@ AlibiFwdOp:
 
   workloads:
     # Llama-style attention bias dimensions
-    - {seq_len: 2048, num_heads: 32, dtype: float16, dtypes: [float16], label: "llama-prefill-2k-fp16"}
-    - {seq_len: 2048, num_heads: 32, dtype: bfloat16, dtypes: [bfloat16], label: "llama-prefill-2k-bf16"}
-    - {seq_len: 4096, num_heads: 32, dtype: float16, dtypes: [float16], label: "llama-prefill-4k-fp16"}
-    - {seq_len: 4096, num_heads: 32, dtype: bfloat16, dtypes: [bfloat16], label: "llama-prefill-4k-bf16"}
+    - {seq_len: 2048, num_heads: 32, dtype: float16, dtypes: [float16], label: "llama-prefill-2k"}
+    - {seq_len: 2048, num_heads: 32, dtype: bfloat16, dtypes: [bfloat16], label: "llama-prefill-2k"}
+    - {seq_len: 4096, num_heads: 32, dtype: float16, dtypes: [float16], label: "llama-prefill-4k"}
+    - {seq_len: 4096, num_heads: 32, dtype: bfloat16, dtypes: [bfloat16], label: "llama-prefill-4k"}
 
   roofline:
     vars:
@@ -71,10 +71,10 @@ SinusoidalFwdOp:
 
   workloads:
     # Transformer-style positional encodings
-    - {seq_len: 2048, d_model: 4096, dtype: float16, dtypes: [float16], label: "transformer-2k-4k-fp16"}
-    - {seq_len: 2048, d_model: 4096, dtype: bfloat16, dtypes: [bfloat16], label: "transformer-2k-4k-bf16"}
-    - {seq_len: 4096, d_model: 4096, dtype: float16, dtypes: [float16], label: "transformer-4k-4k-fp16"}
-    - {seq_len: 4096, d_model: 4096, dtype: bfloat16, dtypes: [bfloat16], label: "transformer-4k-4k-bf16"}
+    - {seq_len: 2048, d_model: 4096, dtype: float16, dtypes: [float16], label: "transformer-2k-4k"}
+    - {seq_len: 2048, d_model: 4096, dtype: bfloat16, dtypes: [bfloat16], label: "transformer-2k-4k"}
+    - {seq_len: 4096, d_model: 4096, dtype: float16, dtypes: [float16], label: "transformer-4k-4k"}
+    - {seq_len: 4096, d_model: 4096, dtype: bfloat16, dtypes: [bfloat16], label: "transformer-4k-4k"}
 
   roofline:
     vars:

--- a/src/tileops/manifest/elementwise_unary_activation.yaml
+++ b/src/tileops/manifest/elementwise_unary_activation.yaml
@@ -65,8 +65,8 @@ GeluFwdOp:
 
   workloads:
     # Llama-3.1-8B FFN intermediate (hidden_dim=14336)
-    - {input_shape: [2048, 14336], dtypes: [float16, bfloat16], label: "llama-3.1-8b-ffn-prefill"}
-    - {input_shape: [1, 14336], dtypes: [bfloat16], label: "llama-3.1-8b-ffn-decode"}
+    - {input_shape: [2048, 14336], dtypes: [float16, bfloat16], label: "llama-8b-ffn-prefill"}
+    - {input_shape: [1, 14336], dtypes: [bfloat16], label: "llama-8b-ffn-decode"}
 
   roofline:
     vars:
@@ -102,8 +102,8 @@ SiluFwdOp:
 
   workloads:
     # Llama-3.1-8B SwiGLU FFN intermediate
-    - {input_shape: [2048, 14336], dtypes: [float16, bfloat16], label: "llama-3.1-8b-ffn-prefill"}
-    - {input_shape: [1, 14336], dtypes: [bfloat16], label: "llama-3.1-8b-ffn-decode"}
+    - {input_shape: [2048, 14336], dtypes: [float16, bfloat16], label: "llama-8b-ffn-prefill"}
+    - {input_shape: [1, 14336], dtypes: [bfloat16], label: "llama-8b-ffn-decode"}
 
   roofline:
     vars:

--- a/src/tileops/manifest/gemm.yaml
+++ b/src/tileops/manifest/gemm.yaml
@@ -187,8 +187,8 @@ GroupedGemmFwdOp:
     - "not transpose_a or output.shape == (batch_sizes.shape[0], a.shape[1], b.shape[0 if transpose_b else 1])"
 
   workloads:
-  - {batch_sum: 4096, batch_count: 16, n: 4096, k: 4096, dtype: float16, transpose_a: false, transpose_b: true, dtypes: [float16], label: "nt-batch16-m4096-n4096-k4096-fp16"}
-  - {batch_sum: 4096, batch_count: 16, n: 4096, k: 4096, dtype: bfloat16, transpose_a: false, transpose_b: true, dtypes: [bfloat16], label: "nt-batch16-m4096-n4096-k4096-bf16"}
+  - {batch_sum: 4096, batch_count: 16, n: 4096, k: 4096, dtype: float16, transpose_a: false, transpose_b: true, dtypes: [float16], label: "nt-batch16-m4096-n4096-k4096"}
+  - {batch_sum: 4096, batch_count: 16, n: 4096, k: 4096, dtype: bfloat16, transpose_a: false, transpose_b: true, dtypes: [bfloat16], label: "nt-batch16-m4096-n4096-k4096"}
   - {batch_sum: 4096, batch_count: 16, n: 4096, k: 4096, dtype: float16, transpose_a: false, transpose_b: false, dtypes: [float16], label: "nn-batch16-m4096-n4096-k4096"}
   - {batch_sum: 4096, batch_count: 16, n: 4096, k: 4096, dtype: float16, transpose_a: true, transpose_b: false, dtypes: [float16], label: "tn-batch16-m4096-n4096-k4096"}
 

--- a/src/tileops/manifest/quantization.yaml
+++ b/src/tileops/manifest/quantization.yaml
@@ -19,8 +19,8 @@ FP8QuantFwdOp:
     - "input_tensor.shape[3] > 0"
 
   workloads:
-  - {batch: 1, seq_len_kv: 8192, kv_group: 1, index_dim: 64, in_dtype: float16, dtypes: [float16], label: "kv-index-8k-d64-fp16"}
-  - {batch: 1, seq_len_kv: 8192, kv_group: 1, index_dim: 64, in_dtype: bfloat16, dtypes: [bfloat16], label: "kv-index-8k-d64-bf16"}
+  - {batch: 1, seq_len_kv: 8192, kv_group: 1, index_dim: 64, in_dtype: float16, dtypes: [float16], label: "kv-index-8k-d64"}
+  - {batch: 1, seq_len_kv: 8192, kv_group: 1, index_dim: 64, in_dtype: bfloat16, dtypes: [bfloat16], label: "kv-index-8k-d64"}
   - {batch: 1, seq_len_kv: 4096, kv_group: 1, index_dim: 128, in_dtype: float32, dtypes: [float32], label: "kv-index-4k-d128"}
 
   roofline:

--- a/src/tileops/manifest/reduction.yaml
+++ b/src/tileops/manifest/reduction.yaml
@@ -27,11 +27,11 @@ SoftmaxFwdOp:
   workloads:
     # Attention weight matrices (batch * heads, seq, seq)
   - {x_shape: [32, 32, 4096], dtypes: [float16, bfloat16], label: "attn-weights-4k"}
-  - {x_shape: [32, 32, 4096], dtypes: [float32], label: "attn-weights-4k-fp32"}
+  - {x_shape: [32, 32, 4096], dtypes: [float32], label: "attn-weights-4k"}
   - {x_shape: [32, 32, 32768], dtypes: [bfloat16], label: "attn-weights-32k"}
     # LM head logits (batch, vocab_size)
   - {x_shape: [4, 102400], dtypes: [float16, bfloat16], label: "lm-head-logits"}
-  - {x_shape: [4, 102400], dtypes: [float32], label: "lm-head-logits-fp32"}
+  - {x_shape: [4, 102400], dtypes: [float32], label: "lm-head-logits"}
 
   roofline:
     vars:
@@ -76,11 +76,11 @@ LogSoftmaxFwdOp:
   workloads:
     # Attention weight matrices
   - {x_shape: [32, 32, 4096], dtypes: [float16, bfloat16], label: "attn-weights-4k"}
-  - {x_shape: [32, 32, 4096], dtypes: [float32], label: "attn-weights-4k-fp32"}
+  - {x_shape: [32, 32, 4096], dtypes: [float32], label: "attn-weights-4k"}
   - {x_shape: [32, 32, 32768], dtypes: [bfloat16], label: "attn-weights-32k"}
     # LM head logits
   - {x_shape: [4, 102400], dtypes: [float16, bfloat16], label: "lm-head-logits"}
-  - {x_shape: [4, 102400], dtypes: [float32], label: "lm-head-logits-fp32"}
+  - {x_shape: [4, 102400], dtypes: [float32], label: "lm-head-logits"}
 
   roofline:
     vars:

--- a/src/tileops/manifest/regularization.yaml
+++ b/src/tileops/manifest/regularization.yaml
@@ -21,9 +21,8 @@ DropoutFwdOp:
   workloads:
   # Normal kernel path. p=0, p=1, and training=false are short-circuit paths
   # and should be tested separately from release-facing roofline workloads.
-  - {input_shape: [1024, 4096], p: 0.5, training: true, dtypes: [float16], label: "tokens-1k-hidden-4k-fp16"}
+  - {input_shape: [1024, 4096], p: 0.5, training: true, dtypes: [float16, float32], label: "tokens-1k-hidden-4k"}
   - {input_shape: [1024, 10240], p: 0.5, training: true, dtypes: [bfloat16], label: "tokens-1k-hidden-10k"}
-  - {input_shape: [1024, 4096], p: 0.5, training: true, dtypes: [float32], label: "tokens-1k-hidden-4k-fp32"}
 
   roofline:
     func: "tileops.perf.formulas.dropout_roofline"

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -540,6 +540,23 @@ class TestWorkloadPolicy:
         assert any("workloads[0]" in e and "'fp16'" in e for e in errors), errors
         assert not any("workloads[1]" in e for e in errors), errors
 
+    def test_label_dtype_check_covers_exact_and_short_spellings(self, validator):
+        """The long name and the short forms of one dtype are caught alike."""
+        fp8 = str(torch.float8_e4m3fn).rsplit(".", 1)[-1]
+        for label_suffix, dtype in (
+            (fp8, fp8),
+            ("e4m3", fp8),
+            ("f8", fp8),
+            ("bfloat16", "bfloat16"),
+        ):
+            entry = _make_entry()
+            entry["workloads"] = [
+                {"x_shape": [1, 4096], "dtypes": [dtype], "label": f"tokens-1k-{label_suffix}"},
+                {"x_shape": [8, 8192], "dtypes": [dtype], "label": "tokens-8k"},
+            ]
+            errors = validator.check_l0("test_op", entry)
+            assert any("workloads[0]" in e for e in errors), (label_suffix, errors)
+
     def test_label_may_name_a_dtype_the_row_does_not_run(self, validator):
         """``fp8`` in a bf16 row names the kernel path, not the case's dtype."""
         entry = _make_entry()

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -529,6 +529,26 @@ class TestWorkloadPolicy:
         entry = _make_entry(params={"dim": {"type": "int", "default": -1}})
         assert validator.check_l0("test_op", entry) == []
 
+    def test_label_repeating_its_own_dtype_fails(self, validator):
+        """A label may not spell a dtype the case id already appends."""
+        entry = _make_entry()
+        entry["workloads"] = [
+            {"x_shape": [1, 4096], "dtypes": ["float16"], "label": "tokens-1k-fp16"},
+            {"x_shape": [8, 8192], "dtypes": ["bfloat16"], "label": "tokens-8k"},
+        ]
+        errors = validator.check_l0("test_op", entry)
+        assert any("workloads[0]" in e and "'fp16'" in e for e in errors), errors
+        assert not any("workloads[1]" in e for e in errors), errors
+
+    def test_label_may_name_a_dtype_the_row_does_not_run(self, validator):
+        """``fp8`` in a bf16 row names the kernel path, not the case's dtype."""
+        entry = _make_entry()
+        entry["workloads"] = [
+            {"x_shape": [1, 4096], "dtypes": ["bfloat16"], "label": "prefill-fp8-cache"},
+            {"x_shape": [8, 8192], "dtypes": ["bfloat16"], "label": "decode-fp8-cache"},
+        ]
+        assert validator.check_l0("test_op", entry) == []
+
 
 class TestOutputShapeDeclaration:
     """Every output declares a shape, or the signature has shape_rules."""


### PR DESCRIPTION
## problems

- 48 labels still carry `llama-3.1-` / `llama31-`, and 20 spell a dtype their own row lists. #1955 fixed the norm family only.
- Nine places turned a manifest row into a pytest case: two in `benchmark_base.py`, one under `ops/attention/`, six inside single bench files (`bench_pool.py` had seven functions). They disagreed on the id — two appended the dtype, the rest left it to the label, so dropping the token collided with the sibling row.
- Three benches carried a local dtype-name-to-`torch.dtype` map to undo the string their own builder passed.
- Nothing stopped the next label from spelling a dtype: `docs/design/manifest.md` said only "human-readable id".

## changes

- `workload_params(workloads, build_args)` in `benchmark_base.py` is the only builder: it iterates `row["dtypes"]` and ids each case `f"{label}-{dtype}"`. Marks come from `smoke_first` or a `marks` callable; `bench_skip_reason` wins over both. Per family only `_*_args(row, dtype)` remains, composed with `fields()` / `then_dtype()`.
- The builder hands over `torch.dtype`; the three local maps and the `dtype_str` parameters are gone.
- 20 labels dropped the dtype token; one pair of rows differing only in `dtypes` became one row.
- 48 labels lost the Llama point release (3.1 and 3.3 of one size share every shape a row measures), as did three hand-written ids in `bench_gqa.py`. `RopeLlama31FwdOp` keeps `llama31-`: there it names the rope variant, like `neox` and `yarn`.
- `fp8` stays in `…-fp8tc-bn224-…` and `…-paged-fp8-cache-…`: those rows run fp16/bf16, and the token names the kernel path and the cache dtype.
- Validator: a label may not name a dtype its own `dtypes` lists. Tokens are derived from the dtype name, so `fp16`, `float16`, `e4m3` and `f8` are caught alike. Rule in the `workloads` key table; check in `_l0_workloads`; three tests in `TestWorkloadPolicy`.

Left alone: 38 labels whose first token repeats a word of their op name (`neox-1d-2k-d64`). Renaming breaks 38 more nightly histories for no reader gain, and no rule would hold them.

Follow-up: the indexer bench measures one row per shape, so `FP8LightningIndexerFwdOp`'s `index_k_scale` row has never been benchmarked.