### PR TITLE
[BugFix][GatedDeltaNet] Write the first partition's initial state in the CP prefill

### DIFF
--- a/src/tileops/kernels/attention/gqa_bwd.py
+++ b/src/tileops/kernels/attention/gqa_bwd.py
@@ -14,6 +14,7 @@ __all__ = ["FlashAttnBwdPreprocessKernel", "GQABwdWgmmaPipelinedKernel"]
 # preprocess for gqa bwd
 
 
+@functools.lru_cache(maxsize=32)
 @tilelang.jit(out_idx=[2])
 def _flashattn_bwd_preprocess_kernel(
     batch: int, heads: int, seq_len: int, dim: int, dtype: str

--- a/src/tileops/kernels/fp8_lightning_indexer.py
+++ b/src/tileops/kernels/fp8_lightning_indexer.py
@@ -159,6 +159,7 @@ def _fp8_lightning_indexer_kernel(
     return _fp8_lightning_indexer_func
 
 
+@functools.lru_cache(maxsize=32)
 @tilelang.jit
 def clean_logits_(
     threads: int = 512,

--- a/src/tileops/kernels/gated_deltanet/gated_deltanet_prefill.py
+++ b/src/tileops/kernels/gated_deltanet/gated_deltanet_prefill.py
@@ -85,7 +85,7 @@ def _prefill_partition_metadata(
     )
 
 
-def _prefill_auto_cp_local_chunks(num_chunks: int, num_heads: int) -> int:
+def _prefill_auto_cp_local_chunks(num_chunks: int, num_heads: int, device_index: int) -> int:
     env_max_local_chunks = os.environ.get(
         "TILEOPS_GDN_PREFILL_MAX_LOCAL_CHUNKS",
         os.environ.get("TILEOPS_GDN_PREFILL_CP_MAX_LOCAL_CHUNKS"),
@@ -93,7 +93,8 @@ def _prefill_auto_cp_local_chunks(num_chunks: int, num_heads: int) -> int:
     if env_max_local_chunks:
         max_local_chunks = int(env_max_local_chunks)
     else:
-        sm_count = torch.cuda.get_device_properties().multi_processor_count
+        # Without an argument this reads the current device, not the tensors'.
+        sm_count = torch.cuda.get_device_properties(device_index).multi_processor_count
         max_local_chunks = 2 ** round(math.log2(math.sqrt(num_heads * num_chunks / sm_count) * 3))
         if num_heads >= 64 and num_chunks >= 512:
             max_local_chunks = max(max_local_chunks, 256)
@@ -125,7 +126,7 @@ def _prefill_partitioned_initial_state_bthd(
     if sum(raw_sequence_lengths) != num_tokens:
         raise ValueError("raw sequence lengths must sum to the flattened token count")
     num_chunks = tilelang.cdiv(num_tokens, chunk_size)
-    max_local_chunks = _prefill_auto_cp_local_chunks(num_chunks, num_heads)
+    max_local_chunks = _prefill_auto_cp_local_chunks(num_chunks, num_heads, k.device.index)
 
     has_partition = num_chunks > max_local_chunks
     force_partition = (

--- a/src/tileops/kernels/gated_deltanet/gdn_prefill/cp_fwd.py
+++ b/src/tileops/kernels/gated_deltanet/gdn_prefill/cp_fwd.py
@@ -135,11 +135,6 @@ def _build_correct_h0_kernel(
         hd_shared = T.alloc_shared((DK, block_DV), dtype=buffer_dtype)
         m_shared = T.alloc_shared((DK, DK), dtype=buffer_dtype)
 
-        T.copy(
-            h_fragment,
-            cp_h0[seq_start_idx, bh, 0:DK, bv * block_DV : (bv + 1) * block_DV],
-        )
-
         for i_s in T.Pipelined(num_iters - 1, num_stages=2):
             if fallback_mask[seq_start_idx + i_s, bh]:
                 T.copy(h_fragment, hd_shared)
@@ -188,6 +183,13 @@ def _build_correct_h0_kernel(
                     raw_h0[bb, bh, 0:DK, bv * block_DV : (bv + 1) * block_DV],
                     h_fragment,
                 )
+                # The loop never writes the partition a sequence starts on, and a
+                # fragment-to-global T.copy before it is dropped — the fragment's
+                # layout comes from how the loop consumes it. Hence a plain store.
+                for ik, iv in T.Parallel(DK, block_DV):
+                    cp_h0[seq_start_idx, bh, ik, bv * block_DV + iv] = raw_h0[
+                        bb, bh, ik, bv * block_DV + iv
+                    ]
 
                 kernel_body(
                     bb,
@@ -227,6 +229,9 @@ def _build_correct_h0_kernel(
 
                 h_fragment = T.alloc_fragment((DK, block_DV), dtype=accum_dtype)
                 T.clear(h_fragment)
+                # See the raw_h0 branch.
+                for ik, iv in T.Parallel(DK, block_DV):
+                    cp_h0[seq_start_idx, bh, ik, bv * block_DV + iv] = 0.0
 
                 kernel_body(
                     bb,

--- a/src/tileops/kernels/gated_deltanet/gdn_prefill/cp_fwd.py
+++ b/src/tileops/kernels/gated_deltanet/gdn_prefill/cp_fwd.py
@@ -2,11 +2,14 @@
 # Licensed under the MIT License.
 # Adapted and modified for TileOps GatedDeltaNet prefill integration.
 
+import functools
+
 import tilelang
 import tilelang.language as T
 import torch
 
 
+@functools.lru_cache(maxsize=32)
 @tilelang.jit()
 def _build_warmup_chunks_kernel(
     num_heads,
@@ -100,6 +103,7 @@ def get_warmup_chunks(
     return num_warmup_chunks, fallback_mask
 
 
+@functools.lru_cache(maxsize=32)
 @tilelang.jit()
 def _build_correct_h0_kernel(
     H,

--- a/src/tileops/kernels/gated_deltanet/gdn_prefill/fused_fwd.py
+++ b/src/tileops/kernels/gated_deltanet/gdn_prefill/fused_fwd.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 # Adapted and modified for TileOps GatedDeltaNet prefill integration.
 
+import functools
 import os
 
 import tilelang
@@ -14,6 +15,7 @@ MULTI_PROCESSOR_COUNT = torch.cuda.get_device_properties().multi_processor_count
 TARGET_NUM_CTAS = int(MULTI_PROCESSOR_COUNT * 0.7)
 
 
+@functools.lru_cache(maxsize=32)
 @tilelang.jit(
     # out_idx=[-3, -2, -1],
     pass_configs={

--- a/src/tileops/kernels/gated_deltanet/gdn_prefill/prepare_h.py
+++ b/src/tileops/kernels/gated_deltanet/gdn_prefill/prepare_h.py
@@ -2,6 +2,8 @@
 # Licensed under the MIT License.
 # Adapted and modified for TileOps GatedDeltaNet prefill integration.
 
+import functools
+
 import tilelang
 import tilelang.language as T
 import torch
@@ -9,6 +11,7 @@ import torch
 from .utils import prepare_chunk_offsets
 
 
+@functools.lru_cache(maxsize=32)
 @tilelang.jit(
     pass_configs={
         tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,

--- a/src/tileops/kernels/gated_deltanet/gdn_prefill/utils.py
+++ b/src/tileops/kernels/gated_deltanet/gdn_prefill/utils.py
@@ -82,6 +82,7 @@ def prepare_chunk_indices(
     return torch.stack([indices.eq(0).cumsum(0) - 1, indices], 1).to(cu_seqlens)
 
 
+@functools.lru_cache(maxsize=32)
 @tilelang.jit()
 def _build_prepare_chunk_offsets_kernel(
     chunk_size,

--- a/tests/ops/test_gated_deltanet_fwd.py
+++ b/tests/ops/test_gated_deltanet_fwd.py
@@ -126,22 +126,7 @@ def test_bthd_forward_names_the_requirement_a_call_missed() -> None:
         pytest.param(128, 64, torch.float16, marks=pytest.mark.smoke),
         pytest.param(128, 64, torch.bfloat16, marks=pytest.mark.smoke),
         pytest.param(128, 128, torch.float16, marks=pytest.mark.smoke),
-        pytest.param(
-            32768,
-            64,
-            torch.float16,
-            marks=[
-                pytest.mark.full,
-                # xfail, not skip: `hopper` tests that skip on a Hopper device fail
-                # the run by policy, and the disagreement is worth still measuring.
-                pytest.mark.xfail(
-                    reason="BTHD and BHTD disagree at this sequence length: ~2300 of "
-                    "16.7M elements exceed the 0.05 tolerance, some by an infinite "
-                    "relative difference. The three shorter cases still run.",
-                    strict=False,
-                ),
-            ],
-        ),
+        pytest.param(32768, 64, torch.float16, marks=pytest.mark.full),
     ],
 )
 @pytest.mark.hopper

--- a/tests/ops/test_gated_deltanet_prefill.py
+++ b/tests/ops/test_gated_deltanet_prefill.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 
 from tests.test_base import FixtureBase, TestBase
+from tileops.kernels.gated_deltanet.gdn_prefill import cp_fwd
 from tileops.ops import GatedDeltaNetPrefillBHTDFwdOp, GatedDeltaNetPrefillBTHDFwdOp
 from tileops.perf.formulas import gated_deltanet_prefill_fwd_roofline
 from workloads.linear_attention import (
@@ -391,3 +392,90 @@ def test_gated_deltanet_prefill_roofline_layout_equivalence() -> None:
     )
     assert bthd == bhtd
     assert bthd[0] > 0 and bthd[1] > 0
+
+
+# ----------------------------------------------------------------------
+# Initial state of every partition on the CP path.
+#
+# At the kernel entry, not through the op: an unwritten partition reads as zero on
+# a clean allocator, so the op only disagrees on a dirty one — not a state a test
+# can ask for.
+# ----------------------------------------------------------------------
+
+
+CP_H, CP_DK, CP_DV = 4, 64, 64
+PARTITIONS_PER_SEQUENCE = 2
+RAW_BATCH = 2
+
+
+@pytest.fixture
+def poisoned_empty(monkeypatch):
+    """Hand `correct_initial_states` an output full of NaN instead of a fresh block."""
+    real_empty = torch.empty
+
+    def _empty(*args, **kwargs):
+        out = real_empty(*args, **kwargs)
+        if out.is_cuda and out.is_floating_point():
+            out.fill_(float("nan"))
+        return out
+
+    monkeypatch.setattr(cp_fwd.torch, "empty", _empty)
+    yield
+    # Without this the NaN returns to the allocator and reaches whatever runs next.
+    torch.cuda.empty_cache()
+
+
+def _inputs(fallback: bool):
+    cp_batch = RAW_BATCH * PARTITIONS_PER_SEQUENCE
+    ht = torch.randn(cp_batch, CP_H, CP_DK, CP_DV, dtype=torch.float16, device="cuda")
+    mt = torch.randn(cp_batch, CP_H, CP_DK, CP_DK, dtype=torch.float16, device="cuda")
+    mask = torch.full((cp_batch, CP_H), fallback, dtype=torch.bool, device="cuda")
+    seq_map_r2c = torch.tensor(
+        [i * PARTITIONS_PER_SEQUENCE for i in range(RAW_BATCH + 1)],
+        dtype=torch.int32,
+        device="cuda",
+    )
+    return ht, mt, mask, seq_map_r2c
+
+
+@pytest.mark.parametrize(
+    "fallback",
+    [
+        pytest.param(False, marks=pytest.mark.smoke),
+        pytest.param(True, marks=pytest.mark.full),
+    ],
+)
+@pytest.mark.hopper
+def test_every_partition_is_written_without_a_raw_initial_state(poisoned_empty, fallback):
+    """The loop writes `seq_start_idx + i_s + 1` only, so the first partition is the
+    one at risk; with no incoming state it must be zero."""
+    ht, mt, mask, seq_map_r2c = _inputs(fallback)
+    cp_h0 = cp_fwd.correct_initial_states(None, ht, mt, mask, seq_map_r2c)
+
+    unwritten = torch.isnan(cp_h0).flatten(1).any(dim=1).nonzero().flatten().tolist()
+    assert not unwritten, f"partitions left as allocated: {unwritten}"
+
+    first_of_each = seq_map_r2c[:-1].tolist()
+    for partition in first_of_each:
+        assert torch.equal(cp_h0[partition], torch.zeros_like(cp_h0[partition]))
+
+
+@pytest.mark.parametrize(
+    "fallback",
+    [
+        pytest.param(False, marks=pytest.mark.smoke),
+        pytest.param(True, marks=pytest.mark.full),
+    ],
+)
+@pytest.mark.hopper
+def test_every_partition_is_written_with_a_raw_initial_state(poisoned_empty, fallback):
+    """With an incoming state, each sequence's first partition carries it verbatim."""
+    ht, mt, mask, seq_map_r2c = _inputs(fallback)
+    raw_h0 = torch.randn(RAW_BATCH, CP_H, CP_DK, CP_DV, dtype=torch.float32, device="cuda")
+    cp_h0 = cp_fwd.correct_initial_states(raw_h0, ht, mt, mask, seq_map_r2c)
+
+    unwritten = torch.isnan(cp_h0).flatten(1).any(dim=1).nonzero().flatten().tolist()
+    assert not unwritten, f"partitions left as allocated: {unwritten}"
+
+    for raw_index, partition in enumerate(seq_map_r2c[:-1].tolist()):
+        torch.testing.assert_close(cp_h0[partition], raw_h0[raw_index])


### PR DESCRIPTION
Fixes #1962.

## problems

- `correct_h0_kernel` wrote the first partition of each raw sequence with a fragment-to-global `T.copy` placed before the pipelined loop, and the warp specialization pass dropped that statement. The emitted CUDA carried one store to `cp_h0` — the in-loop one, covering `seq_start_idx + 1` onward — so that slot was never written.
- Its correct value is zero for a sequence with no incoming state, and a fresh allocation usually reads as zero. Hence #1962: agrees with the reference on a clean allocator, disagrees once earlier work dirtied the block. `seq_len=32768` is the smallest case that partitions, the threshold being 512 chunks per sequence.
- `_prefill_auto_cp_local_chunks` called `torch.cuda.get_device_properties()` with no argument, so the SM count deciding the partition layout came from the current device, not the tensors'.
- Seven module-level builders carried `@tilelang.jit` without the `functools.lru_cache` the style rule requires, re-tracing and re-compiling on every call.

## changes

- Both branches write the first partition with a plain elementwise store, sourced from `raw_h0` or zero rather than through the fragment — the fragment's own initialization is eliminated by the same pass.
- `_prefill_auto_cp_local_chunks` takes a device index.
- `lru_cache(maxsize=32)` on the seven builders: six in the Gated DeltaNet prefill package, one each in GQA backward and the FP8 lightning indexer. All parameters hashable.
- Two tests in `tests/ops/test_gated_deltanet_prefill.py` poison the output allocation and assert every partition is written and each sequence's first one is zero or `raw_h0`. They cover `fallback_mask` both ways, and the fixture calls `empty_cache()` so a failing run leaves no NaN for the next test.
- `test_gated_deltanet_bthd_matches_the_head_major_op[32768-64-dtype3]` is no longer xfailed.

## verification

Dev runner image `cu132-torch2.13-tl-afcebed1-dev`, one H200.

| check | before | after |
| --- | --- | --- |
| stores to `cp_h0` in the emitted CUDA | 1 | 2 |
| partitions unwritten, output allocation poisoned | `[0, 32]` | `[]` |
| `seq_len=32768` BTHD vs BHTD, poisoned | 524288 NaN | 0 outside tolerance, max abs diff 1.9e-3 |
| new tests | 4 failed, naming `[0, 2]` | 4 passed |
| gated_deltanet fwd / prefill / recurrence suites | — | 49 passed |

Disabling `TL_DISABLE_WARP_SPECIALIZED` makes the missing store reappear, which is what identifies elimination rather than a mis-addressed write.

## left out

- `warmup_chunks_kernel` does not write `fallback_mask` on its `ht_mask` branch. The one-line store does not survive the compiler either, and nothing reads that slot: `kernel_body` loops `num_iters - 1`, reaching `seq_end_idx - 2`, while `ht_mask` marks the last partition.
- `maxsize` stays at the rule's default. `_build_fused_chunk_gdr_fwd_kernel` has the widest key of the seven and is the one to revisit if eviction shows up as repeated compilation.
- One earlier run showed seven failures in this file under a poisoned allocator. It does not reproduce — global poisoning gives 10 passed, re-running the combination gives 14 — most likely because the worktree was edited while a run had it mounted.
