### PR TITLE
[Refactor][Ops] Register every operator under the tileops namespace

### DIFF
--- a/src/tileops/kernels/attention/deepseek_dsa_decode.py
+++ b/src/tileops/kernels/attention/deepseek_dsa_decode.py
@@ -439,7 +439,7 @@ def _sparse_mla_kernel(
     return _sparse_mla_fwd_func
 
 
-@torch.library.custom_op("top::sparse_mla_fwd_wrapped_kernel", mutates_args=())
+@torch.library.custom_op("tileops::sparse_mla_fwd_wrapped_kernel", mutates_args=())
 def _sparse_mla_wrapped_kernel(
     batch: int,
     seq_len: int,

--- a/src/tileops/kernels/attention/deepseek_mla_decode.py
+++ b/src/tileops/kernels/attention/deepseek_mla_decode.py
@@ -643,7 +643,7 @@ def _mla_decode_ws_kernel(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, dty
     return _mla_decode_ws_func
 
 
-@torch.library.custom_op("top::mla_decode_ws_wrapped_kernel", mutates_args=())
+@torch.library.custom_op("tileops::mla_decode_ws_wrapped_kernel", mutates_args=())
 def _mla_decode_ws_wrapped_kernel(
     batch: int,
     heads: int,

--- a/src/tileops/kernels/attention/deepseek_nsa_cmp_fwd.py
+++ b/src/tileops/kernels/attention/deepseek_nsa_cmp_fwd.py
@@ -159,7 +159,7 @@ def _nsa_cmp_fwd_varlen_kernel(
     return _nsa_cmp_fwd_varlen_func
 
 
-@torch.library.custom_op("top::nsa_cmp_fwd_varlen_wrapped_kernel", mutates_args=())
+@torch.library.custom_op("tileops::nsa_cmp_fwd_varlen_wrapped_kernel", mutates_args=())
 def _nsa_cmp_fwd_varlen_wrapped_kernel(
     seq_num: int,
     c_seq_len: int,

--- a/src/tileops/kernels/attention/deepseek_nsa_fwd.py
+++ b/src/tileops/kernels/attention/deepseek_nsa_fwd.py
@@ -157,7 +157,7 @@ def _nsa_fwd_varlen_kernel(
     return _nsa_fwd_varlen_func
 
 
-@torch.library.custom_op("top::nsa_fwd_varlen_wrapped_kernel", mutates_args=())
+@torch.library.custom_op("tileops::nsa_fwd_varlen_wrapped_kernel", mutates_args=())
 def _nsa_fwd_varlen_wrapped_kernel(
     batch: int,
     heads: int,

--- a/src/tileops/kernels/attention/deepseek_nsa_topk.py
+++ b/src/tileops/kernels/attention/deepseek_nsa_topk.py
@@ -225,7 +225,7 @@ def _nsa_topk_varlen_kernel(
     return _nsa_topk_varlen_func
 
 
-@torch.library.custom_op("top::nsa_topk_varlen_wrapped_kernel", mutates_args=())
+@torch.library.custom_op("tileops::nsa_topk_varlen_wrapped_kernel", mutates_args=())
 def _nsa_topk_varlen_wrapped_kernel(
     seq_num: int,
     c_seq_len: int,

--- a/src/tileops/kernels/attention/gqa_decode.py
+++ b/src/tileops/kernels/attention/gqa_decode.py
@@ -309,7 +309,7 @@ def _gqa_decode_split_kernel(batch, heads, groups, seqlen_kv, dim, sm_scale, sof
 # Custom ops (torch.compile compatible wrappers)
 
 
-@torch.library.custom_op("top::gqa_decode_no_split_op", mutates_args=())
+@torch.library.custom_op("tileops::gqa_decode_no_split_op", mutates_args=())
 def _gqa_decode_no_split_op(
     batch: int,
     heads: int,
@@ -355,7 +355,7 @@ def _(
     return torch.empty_like(Q)
 
 
-@torch.library.custom_op("top::gqa_decode_split_op", mutates_args=())
+@torch.library.custom_op("tileops::gqa_decode_split_op", mutates_args=())
 def _gqa_decode_split_op(
     batch: int,
     heads: int,

--- a/src/tileops/kernels/attention/gqa_decode_bs1.py
+++ b/src/tileops/kernels/attention/gqa_decode_bs1.py
@@ -106,7 +106,7 @@ def _gqa_decode_bs1_ctx_kernel(batch, heads, groups, seqlen_kv, dim, sm_scale, s
     return _func
 
 
-@torch.library.custom_op("top::gqa_decode_bs1_ctx_op", mutates_args=())
+@torch.library.custom_op("tileops::gqa_decode_bs1_ctx_op", mutates_args=())
 def _gqa_decode_bs1_ctx_op(
     batch: int,
     heads: int,

--- a/src/tileops/kernels/attention/gqa_decode_bs1_paged.py
+++ b/src/tileops/kernels/attention/gqa_decode_bs1_paged.py
@@ -118,7 +118,7 @@ def _gqa_decode_paged_bs1_ctx_kernel(
     return _func
 
 
-@torch.library.custom_op("top::gqa_decode_paged_bs1_ctx_op", mutates_args=())
+@torch.library.custom_op("tileops::gqa_decode_paged_bs1_ctx_op", mutates_args=())
 def _gqa_decode_paged_bs1_ctx_op(
     batch: int,
     heads: int,

--- a/src/tileops/kernels/attention/gqa_decode_paged.py
+++ b/src/tileops/kernels/attention/gqa_decode_paged.py
@@ -398,7 +398,7 @@ def _gqa_decode_split_paged_kernel(
 # Custom ops (torch.compile compatible wrappers)
 
 
-@torch.library.custom_op("top::gqa_decode_paged_no_split_op", mutates_args=())
+@torch.library.custom_op("tileops::gqa_decode_paged_no_split_op", mutates_args=())
 def _gqa_decode_paged_no_split_op(
     batch: int,
     heads: int,
@@ -448,7 +448,7 @@ def _(
     return torch.empty_like(Q)
 
 
-@torch.library.custom_op("top::gqa_decode_paged_split_op", mutates_args=())
+@torch.library.custom_op("tileops::gqa_decode_paged_split_op", mutates_args=())
 def _gqa_decode_paged_split_op(
     batch: int,
     heads: int,

--- a/src/tileops/kernels/attention/gqa_fwd.py
+++ b/src/tileops/kernels/attention/gqa_fwd.py
@@ -194,7 +194,7 @@ def _gqa_fwd_wgmma_pipelined_kernel(
     return _gqa_fwd_wgmma_pipelined_func
 
 
-@torch.library.custom_op("top::gqa_fwd_wgmma_pipelined_wrapped_kernel", mutates_args=())
+@torch.library.custom_op("tileops::gqa_fwd_wgmma_pipelined_wrapped_kernel", mutates_args=())
 def _gqa_fwd_wgmma_pipelined_wrapped_kernel(
     batch: int,
     heads: int,
@@ -468,7 +468,7 @@ def _gqa_prefill_fwd_kernel(
     return _gqa_prefill_fwd_func
 
 
-@torch.library.custom_op("top::gqa_prefill_fwd_wrapped_kernel", mutates_args=())
+@torch.library.custom_op("tileops::gqa_prefill_fwd_wrapped_kernel", mutates_args=())
 def _gqa_prefill_fwd_wrapped_kernel(
     batch: int,
     heads: int,
@@ -862,7 +862,7 @@ def _gqa_prefill_paged_with_kv_cache_fwd_kernel(
 
 
 @torch.library.custom_op(
-    "top::gqa_prefill_paged_with_kv_cache_fwd_wrapped_kernel",
+    "tileops::gqa_prefill_paged_with_kv_cache_fwd_wrapped_kernel",
     mutates_args=("k_pages", "v_pages"),
 )
 def _gqa_prefill_paged_with_kv_cache_fwd_wrapped_kernel(
@@ -1306,7 +1306,7 @@ def _gqa_prefill_paged_with_fp8_kv_cache_fwd_kernel(
 
 
 @torch.library.custom_op(
-    "top::gqa_prefill_paged_with_fp8_kv_cache_fwd_wrapped_kernel",
+    "tileops::gqa_prefill_paged_with_fp8_kv_cache_fwd_wrapped_kernel",
     mutates_args=("k_pages", "v_pages"),
 )
 def _gqa_prefill_paged_with_fp8_kv_cache_fwd_wrapped_kernel(
@@ -1918,7 +1918,7 @@ def _gqa_prefill_paged_with_kv_cache_rope_fwd_kernel(
 
 
 @torch.library.custom_op(
-    "top::gqa_prefill_paged_with_kv_cache_rope_fwd_wrapped_kernel",
+    "tileops::gqa_prefill_paged_with_kv_cache_rope_fwd_wrapped_kernel",
     mutates_args=(),
 )
 def _gqa_prefill_paged_with_kv_cache_rope_fwd_wrapped_kernel(

--- a/src/tileops/kernels/attention/gqa_fwd_fp8.py
+++ b/src/tileops/kernels/attention/gqa_fwd_fp8.py
@@ -607,7 +607,7 @@ def _gqa_fwd_fp8_bn224_tma_v_kernel(
     return func
 
 
-@torch.library.custom_op("top::gqa_fwd_fp8_bn224_tma_v_wrapped_kernel", mutates_args=())
+@torch.library.custom_op("tileops::gqa_fwd_fp8_bn224_tma_v_wrapped_kernel", mutates_args=())
 def _gqa_fwd_fp8_bn224_tma_v_wrapped_kernel(
     batch: int,
     heads: int,

--- a/src/tileops/kernels/attention/gqa_prefill_varlen_fwd.py
+++ b/src/tileops/kernels/attention/gqa_prefill_varlen_fwd.py
@@ -225,7 +225,7 @@ def _gqa_prefill_varlen_fwd_kernel(
     return _gqa_prefill_varlen_fwd_func
 
 
-@torch.library.custom_op("top::gqa_prefill_varlen_fwd_wrapped_kernel", mutates_args=())
+@torch.library.custom_op("tileops::gqa_prefill_varlen_fwd_wrapped_kernel", mutates_args=())
 def _gqa_prefill_varlen_fwd_wrapped_kernel(
     batch: int,
     heads: int,

--- a/src/tileops/kernels/attention/gqa_sliding_window_fwd.py
+++ b/src/tileops/kernels/attention/gqa_sliding_window_fwd.py
@@ -190,7 +190,7 @@ def _gqa_sw_fwd_wgmma_pipelined_kernel(
     return _gqa_sw_fwd_wgmma_pipelined_func
 
 
-@torch.library.custom_op("top::gqa_sw_fwd_wgmma_pipelined_wrapped_kernel", mutates_args=())
+@torch.library.custom_op("tileops::gqa_sw_fwd_wgmma_pipelined_wrapped_kernel", mutates_args=())
 def _gqa_sw_fwd_wgmma_pipelined_wrapped_kernel(
     batch: int,
     heads: int,

--- a/src/tileops/kernels/attention/gqa_sliding_window_varlen_fwd.py
+++ b/src/tileops/kernels/attention/gqa_sliding_window_varlen_fwd.py
@@ -317,7 +317,9 @@ def _gqa_sw_fwd_varlen_wgmma_pipelined_kernel(
     return _gqa_sw_fwd_varlen_wgmma_pipelined_func
 
 
-@torch.library.custom_op("top::gqa_sw_fwd_varlen_wgmma_pipelined_wrapped_kernel", mutates_args=())
+@torch.library.custom_op(
+    "tileops::gqa_sw_fwd_varlen_wgmma_pipelined_wrapped_kernel", mutates_args=()
+)
 def _gqa_sw_fwd_varlen_wgmma_pipelined_wrapped_kernel(
     batch: int,
     heads: int,

--- a/src/tileops/kernels/attention/mha_decode.py
+++ b/src/tileops/kernels/attention/mha_decode.py
@@ -359,7 +359,7 @@ def _mha_decode_split_kernel(batch, heads, seqlen_q, seqlen_kv, dim, is_causal, 
 # Custom ops (torch.compile compatible wrappers)
 
 
-@torch.library.custom_op("top::mha_decode_no_split_op", mutates_args=())
+@torch.library.custom_op("tileops::mha_decode_no_split_op", mutates_args=())
 def _mha_decode_no_split_op(
     batch: int,
     heads: int,
@@ -403,7 +403,7 @@ def _(
     return torch.empty_like(Q)
 
 
-@torch.library.custom_op("top::mha_decode_split_op", mutates_args=())
+@torch.library.custom_op("tileops::mha_decode_split_op", mutates_args=())
 def _mha_decode_split_op(
     batch: int,
     heads: int,

--- a/src/tileops/kernels/attention/mha_decode_paged.py
+++ b/src/tileops/kernels/attention/mha_decode_paged.py
@@ -439,7 +439,7 @@ def _mha_decode_split_kernel(batch, heads, seqlen_q, seqlen_kv, dim, page_size, 
 # Use distinct op names so paged and non-paged (mha_decode.py) do not overwrite
 # each other in torch.library; otherwise the first-registered impl "changes" the
 # registry and later parametrized tests can hit the wrong implementation.
-@torch.library.custom_op("top::mha_decode_paged_no_split_op", mutates_args=())
+@torch.library.custom_op("tileops::mha_decode_paged_no_split_op", mutates_args=())
 def _mha_decode_paged_no_split_op(
     batch: int,
     heads: int,
@@ -487,7 +487,7 @@ def _(
     return torch.empty_like(Q)
 
 
-@torch.library.custom_op("top::mha_decode_paged_split_op", mutates_args=())
+@torch.library.custom_op("tileops::mha_decode_paged_split_op", mutates_args=())
 def _mha_decode_paged_split_op(
     batch: int,
     heads: int,

--- a/src/tileops/kernels/attention/mha_decode_paged_ws.py
+++ b/src/tileops/kernels/attention/mha_decode_paged_ws.py
@@ -311,7 +311,7 @@ def _mha_decode_paged_ws_kernel(
 # Custom op (torch.compile compatible wrapper)
 
 
-@torch.library.custom_op("top::mha_decode_paged_ws_op", mutates_args=())
+@torch.library.custom_op("tileops::mha_decode_paged_ws_op", mutates_args=())
 def _mha_decode_paged_ws_op(
     batch: int,
     heads: int,

--- a/src/tileops/kernels/engram/engram_bwd.py
+++ b/src/tileops/kernels/engram/engram_bwd.py
@@ -347,7 +347,7 @@ def _engram_gate_conv_bwd_kernel(M, seq_len, d, eps, dtype):
     return _func
 
 
-@torch.library.custom_op("top::engram_gate_conv_bwd", mutates_args=())
+@torch.library.custom_op("tileops::engram_gate_conv_bwd", mutates_args=())
 def _engram_gate_conv_bwd_wrapped(
     M: int,
     seq_len: int,

--- a/src/tileops/kernels/engram/engram_decode.py
+++ b/src/tileops/kernels/engram/engram_decode.py
@@ -234,7 +234,7 @@ def _engram_decode_kernel(batch, d_mem, d, max_conv_len, conv_kernel_size, dilat
     return _func
 
 
-@torch.library.custom_op("top::engram_decode", mutates_args=())
+@torch.library.custom_op("tileops::engram_decode", mutates_args=())
 def _engram_decode_wrapped(
     batch: int,
     d_mem: int,

--- a/src/tileops/kernels/engram/engram_fwd.py
+++ b/src/tileops/kernels/engram/engram_fwd.py
@@ -193,7 +193,7 @@ def _engram_gate_conv_fwd_kernel(M, seq_len, d, eps, dtype):
     return _func
 
 
-@torch.library.custom_op("top::engram_gate_conv_fwd", mutates_args=())
+@torch.library.custom_op("tileops::engram_gate_conv_fwd", mutates_args=())
 def _engram_gate_conv_fwd_wrapped(
     M: int,
     seq_len: int,

--- a/src/tileops/kernels/fft.py
+++ b/src/tileops/kernels/fft.py
@@ -605,7 +605,7 @@ def _fft_c2c_kernel(n: int, batch_size: int = 1, dtype: str = "complex64") -> Ca
     return _fft_lut_func
 
 
-@torch.library.custom_op("top::fft_c2c_wrapped_kernel", mutates_args=())
+@torch.library.custom_op("tileops::fft_c2c_wrapped_kernel", mutates_args=())
 def _fft_c2c_wrapped_kernel(
     n: int,
     batch_size: int,

--- a/src/tileops/kernels/fp8_lightning_indexer.py
+++ b/src/tileops/kernels/fp8_lightning_indexer.py
@@ -197,7 +197,7 @@ def clean_logits_(
     return clean_logits_kernel
 
 
-@torch.library.custom_op("top::fp8_lightning_indexer_wrapped_kernel", mutates_args=("Logits",))
+@torch.library.custom_op("tileops::fp8_lightning_indexer_wrapped_kernel", mutates_args=("Logits",))
 def fp8_lightning_indexer_wrapped_kernel(
     batch: int,
     seq_len: int,

--- a/src/tileops/kernels/fp8_quant.py
+++ b/src/tileops/kernels/fp8_quant.py
@@ -64,7 +64,7 @@ def _fp8_quant_kernel(batch, seq_len_kv, kv_group, index_dim, in_dtype: str):
     return _fp8_quant_fwd_func
 
 
-@torch.library.custom_op("top::fp8_quant_wrapped_kernel", mutates_args=())
+@torch.library.custom_op("tileops::fp8_quant_wrapped_kernel", mutates_args=())
 def _fp8_quant_wrapped_kernel(
     batch: int,
     seq_len_kv: int,

--- a/src/tileops/kernels/gemm/bmm.py
+++ b/src/tileops/kernels/gemm/bmm.py
@@ -579,7 +579,7 @@ def _bmm_fp8_persistent_ws_kernel(
     return _bmm_fp8_persistent_ws_func
 
 
-@torch.library.custom_op("top::bmm_wrapped_kernel", mutates_args=())
+@torch.library.custom_op("tileops::bmm_wrapped_kernel", mutates_args=())
 def _bmm_wrapped_kernel(
     batch: int,
     m: int,

--- a/src/tileops/kernels/gemm/dense.py
+++ b/src/tileops/kernels/gemm/dense.py
@@ -560,7 +560,7 @@ def _gemm_kernel(
     return _gemm_func
 
 
-@torch.library.custom_op("top::gemm_wrapped_kernel", mutates_args=())
+@torch.library.custom_op("tileops::gemm_wrapped_kernel", mutates_args=())
 def _gemm_wrapped_kernel(
     m: int,
     n: int,
@@ -740,7 +740,7 @@ def _gemv_kernel(n: int, k: int, dtype: str = "float16") -> Callable:
     return _gemv_func
 
 
-@torch.library.custom_op("top::gemv_wrapped_kernel", mutates_args=())
+@torch.library.custom_op("tileops::gemv_wrapped_kernel", mutates_args=())
 def _gemv_wrapped_kernel(
     n: int,
     k: int,

--- a/src/tileops/kernels/linear_attention/gated_deltanet/prefill/__init__.py
+++ b/src/tileops/kernels/linear_attention/gated_deltanet/prefill/__init__.py
@@ -2,9 +2,9 @@
 # Licensed under the MIT License.
 # Adapted and modified for TileOps GatedDeltaNet prefill integration.
 
-from .tilelang_compat import install_gemm_v1_compat
+from .gemm_lowering import install_gemm_v1
 
-install_gemm_v1_compat()
+install_gemm_v1()
 
 from .cp_fwd import correct_initial_states, get_warmup_chunks  # noqa: E402
 from .fused_fwd import fused_gdr_fwd  # noqa: E402

--- a/src/tileops/kernels/linear_attention/gated_deltanet/prefill/gemm_lowering.py
+++ b/src/tileops/kernels/linear_attention/gated_deltanet/prefill/gemm_lowering.py
@@ -1,6 +1,11 @@
 # Copyright (c) 2026 The Qwen team, Alibaba Group.
 # Licensed under the MIT License.
 # Adapted and modified for TileOps GatedDeltaNet prefill integration.
+"""Which lowering the prefill GEMMs get, installed as ``T.gemm_v1``.
+
+The kernels call ``T.gemm_v1`` rather than ``T.gemm`` so that
+``TILEOPS_GDN_PREFILL_GEMM_V1_MODE`` can pick among the lowerings below.
+"""
 
 from __future__ import annotations
 
@@ -49,7 +54,7 @@ def _read_ptr(buf: Any):
 
 
 @T.macro
-def _gemm_ss_compat(
+def _gemm_ss_extern(
     a,
     b,
     c,
@@ -78,7 +83,7 @@ def _gemm_ss_compat(
 
 
 @T.macro
-def _wgmma_gemm_sync_compat(
+def _wgmma_gemm_sync(
     a,
     b,
     c,
@@ -104,10 +109,10 @@ def _wgmma_gemm_sync_compat(
     T.warpgroup_fence_operand(c, num_regs=num_regs)
 
 
-def install_gemm_v1_compat() -> None:
+def install_gemm_v1() -> None:
     original_gemm = T.gemm
 
-    def gemm_v1_compat(
+    def _gemm_v1(
         a,
         b,
         c,
@@ -129,7 +134,7 @@ def install_gemm_v1_compat() -> None:
             os.environ.get("FLASHQLA_TL019_GEMM_V1_MODE", "default"),
         )
         if mode == "wgmma" and a_dtype in ("float16", "bfloat16") and a_dtype == b_dtype:
-            return _wgmma_gemm_sync_compat(
+            return _wgmma_gemm_sync(
                 a,
                 b,
                 c,
@@ -148,7 +153,7 @@ def install_gemm_v1_compat() -> None:
             and k >= 16
             and k % 16 == 0
         ):
-            return _gemm_ss_compat(
+            return _gemm_ss_extern(
                 a,
                 b,
                 c,
@@ -168,4 +173,4 @@ def install_gemm_v1_compat() -> None:
             clear_accum=clear_accum,
         )
 
-    T.gemm_v1 = gemm_v1_compat  # type: ignore[attr-defined]
+    T.gemm_v1 = _gemm_v1  # type: ignore[attr-defined]

--- a/src/tileops/kernels/linear_attention/gla/gla_fwd.py
+++ b/src/tileops/kernels/linear_attention/gla/gla_fwd.py
@@ -353,7 +353,7 @@ def _gla_fwd_o_kernel(
 # Custom op wrappers (kept for torch.compile compatibility)
 
 
-@torch.library.custom_op("top::gla_fwd_wrapped_kernel", mutates_args=("h_out",))
+@torch.library.custom_op("tileops::gla_fwd_wrapped_kernel", mutates_args=("h_out",))
 def _gla_fwd_wrapped_kernel(
     batch: int,
     seq_len: int,

--- a/src/tileops/kernels/mamba/cb_producer.py
+++ b/src/tileops/kernels/mamba/cb_producer.py
@@ -174,7 +174,7 @@ def _cb_producer_kernel(
 # PyTorch custom op registration
 
 
-@torch.library.custom_op("top::cb_producer", mutates_args=())
+@torch.library.custom_op("tileops::cb_producer", mutates_args=())
 def _cb_producer_wrapped(
     batch: int,
     num_chunks: int,

--- a/src/tileops/kernels/mamba/da_cumsum.py
+++ b/src/tileops/kernels/mamba/da_cumsum.py
@@ -154,7 +154,7 @@ def _da_cumsum_fwd_kernel(
     return kernel_func
 
 
-@torch.library.custom_op("top::da_cumsum_fwd", mutates_args=())
+@torch.library.custom_op("tileops::da_cumsum_fwd", mutates_args=())
 def _da_cumsum_fwd_wrapped(
     batch: int,
     num_chunks: int,

--- a/src/tileops/kernels/mamba/ssd_chunk_scan.py
+++ b/src/tileops/kernels/mamba/ssd_chunk_scan.py
@@ -473,7 +473,7 @@ def _ssd_chunk_scan_fwd_kernel(
     return kernel_func
 
 
-@torch.library.custom_op("top::ssd_chunk_scan_fwd", mutates_args=())
+@torch.library.custom_op("tileops::ssd_chunk_scan_fwd", mutates_args=())
 def _ssd_chunk_scan_fwd_wrapped(
     batch: int,
     num_chunks: int,

--- a/src/tileops/kernels/mamba/ssd_chunk_state.py
+++ b/src/tileops/kernels/mamba/ssd_chunk_state.py
@@ -259,7 +259,7 @@ def _ssd_chunk_state_fwd_kernel(
     return kernel_func
 
 
-@torch.library.custom_op("top::ssd_chunk_state_fwd", mutates_args=())
+@torch.library.custom_op("tileops::ssd_chunk_state_fwd", mutates_args=())
 def _ssd_chunk_state_fwd_wrapped(
     batch: int,
     num_chunks: int,

--- a/src/tileops/kernels/mamba/ssd_decode.py
+++ b/src/tileops/kernels/mamba/ssd_decode.py
@@ -268,7 +268,7 @@ def _ssd_decode_kernel(
     return kernel_func
 
 
-@torch.library.custom_op("top::ssd_decode", mutates_args=("state",))
+@torch.library.custom_op("tileops::ssd_decode", mutates_args=("state",))
 def _ssd_decode_wrapped(
     batch: int,
     n_heads: int,

--- a/src/tileops/kernels/mamba/ssd_state_passing.py
+++ b/src/tileops/kernels/mamba/ssd_state_passing.py
@@ -228,7 +228,7 @@ def _ssd_state_passing_fwd_kernel(
     return kernel_func
 
 
-@torch.library.custom_op("top::ssd_state_passing_fwd", mutates_args=())
+@torch.library.custom_op("tileops::ssd_state_passing_fwd", mutates_args=())
 def _ssd_state_passing_fwd_wrapped(
     batch: int,
     num_chunks: int,

--- a/src/tileops/kernels/mhc/mhc_post.py
+++ b/src/tileops/kernels/mhc/mhc_post.py
@@ -66,7 +66,7 @@ def _mhc_post_kernel(batch: int, n_expand: int, c_x: int, x_dtype: str = "bfloat
     return _mhc_func
 
 
-@torch.library.custom_op("top::mhc_post_wrapped_kernel", mutates_args=())
+@torch.library.custom_op("tileops::mhc_post_wrapped_kernel", mutates_args=())
 def _mhc_post_wrapped_kernel(
     batch: int,
     n_expand: int,

--- a/src/tileops/kernels/mhc/mhc_pre.py
+++ b/src/tileops/kernels/mhc/mhc_pre.py
@@ -258,7 +258,7 @@ def _mhc_pre_kernel(batch: int, n_expand: int, c_x: int, x_dtype: str = "bfloat1
     return _mhc_func
 
 
-@torch.library.custom_op("top::mhc_pre_wrapped_kernel", mutates_args=())
+@torch.library.custom_op("tileops::mhc_pre_wrapped_kernel", mutates_args=())
 def _mhc_pre_wrapped_kernel(
     batch: int,
     n_expand: int,

--- a/src/tileops/kernels/pool/mean_pooling.py
+++ b/src/tileops/kernels/pool/mean_pooling.py
@@ -79,7 +79,7 @@ def _mean_pooling_kernel(
     return _mean_pooling_func
 
 
-@torch.library.custom_op("top::mean_pooling_fwd_wrapped_kernel", mutates_args=())
+@torch.library.custom_op("tileops::mean_pooling_fwd_wrapped_kernel", mutates_args=())
 def _mean_pooling_wrapped_kernel(
     batch_size: int,
     seq_len: int,

--- a/src/tileops/kernels/topk_selector.py
+++ b/src/tileops/kernels/topk_selector.py
@@ -246,7 +246,7 @@ def _topk_selector_kernel(batch, seq_len, seq_len_kv, kv_group, topk, in_dtype, 
     return topk_selector_fwd_func
 
 
-@torch.library.custom_op("top::topk_selector_wrapped_kernel", mutates_args=())
+@torch.library.custom_op("tileops::topk_selector_wrapped_kernel", mutates_args=())
 def _topk_selector_wrapped_kernel(
     batch: int,
     seq_len: int,

--- a/src/tileops/ops/attention/mha.py
+++ b/src/tileops/ops/attention/mha.py
@@ -36,7 +36,7 @@ class MultiHeadAttentionFwdOp(Op):
     """
 
     #: The operator this op registers; a test asserts the graph holds nothing else.
-    compile_op_names: ClassVar[Tuple[str, ...]] = ("top::mha_fwd",)
+    compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::mha_fwd",)
 
     def __init__(
         self,
@@ -358,7 +358,7 @@ class MultiHeadAttentionDecodePagedWithKVCacheFwdOp(Op):
 # torch.compile dispatch boundary (see src/tileops/ops/compile_boundary.py)
 
 
-@torch.library.custom_op("top::mha_fwd", mutates_args=())
+@torch.library.custom_op("tileops::mha_fwd", mutates_args=())
 def _mha_fwd(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, instance_key: str) -> torch.Tensor:
     return get_instance(instance_key)._eager_forward(q, k, v)
 

--- a/src/tileops/ops/compile_boundary.py
+++ b/src/tileops/ops/compile_boundary.py
@@ -7,7 +7,7 @@ The op passes its key instead, and the operator body trades the key back for the
         def forward(self, x):
             return _foo(x, self._instance_key)
 
-    @torch.library.custom_op("top::foo", mutates_args=())
+    @torch.library.custom_op("tileops::foo", mutates_args=())
     def _foo(x: torch.Tensor, instance_key: str) -> torch.Tensor:
         return get_instance(instance_key)._eager_forward(x)
 

--- a/src/tileops/ops/convolution.py
+++ b/src/tileops/ops/convolution.py
@@ -229,7 +229,7 @@ def _conv1d_l_out(
 
 class Conv1dFwdOp(Op):
     #: The operator this op registers; a test asserts the graph holds nothing else.
-    compile_op_names: ClassVar[Tuple[str, ...]] = ("top::conv_conv1d_fwd",)
+    compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::conv_conv1d_fwd",)
 
     def __init__(
         self,
@@ -561,7 +561,7 @@ def _conv_out_dim(
 
 class Conv2dFwdOp(Op):
     #: The operator this op registers; a test asserts the graph holds nothing else.
-    compile_op_names: ClassVar[Tuple[str, ...]] = ("top::conv_conv2d_fwd",)
+    compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::conv_conv2d_fwd",)
 
     def __init__(
         self,
@@ -963,7 +963,7 @@ def _triple(value: int | Tuple[int, int, int]) -> Tuple[int, int, int]:
 
 class Conv3dFwdOp(Op):
     #: The operator this op registers; a test asserts the graph holds nothing else.
-    compile_op_names: ClassVar[Tuple[str, ...]] = ("top::conv_conv3d_fwd",)
+    compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::conv_conv3d_fwd",)
 
     def __init__(
         self,
@@ -1355,7 +1355,7 @@ class Conv3dFwdOp(Op):
 # ``new_empty``, not ``empty_like``: a non-contiguous input's strides must not reach the fake.
 
 
-@torch.library.custom_op("top::conv_conv1d_fwd", mutates_args=())
+@torch.library.custom_op("tileops::conv_conv1d_fwd", mutates_args=())
 def _conv1d_fwd(
     input: torch.Tensor,
     weight: torch.Tensor,
@@ -1381,7 +1381,7 @@ def _conv1d_fwd_fake(
     return input.new_empty(shapes["output"])
 
 
-@torch.library.custom_op("top::conv_conv2d_fwd", mutates_args=())
+@torch.library.custom_op("tileops::conv_conv2d_fwd", mutates_args=())
 def _conv2d_fwd(
     input: torch.Tensor,
     weight: torch.Tensor,
@@ -1407,7 +1407,7 @@ def _conv2d_fwd_fake(
     return input.new_empty(shapes["output"])
 
 
-@torch.library.custom_op("top::conv_conv3d_fwd", mutates_args=())
+@torch.library.custom_op("tileops::conv_conv3d_fwd", mutates_args=())
 def _conv3d_fwd(
     input: torch.Tensor,
     weight: torch.Tensor,

--- a/src/tileops/ops/dropout.py
+++ b/src/tileops/ops/dropout.py
@@ -141,7 +141,7 @@ class DropoutFwdOp(Op):
 # torch.compile registration
 
 
-@torch.library.custom_op("top::dropout", mutates_args=())
+@torch.library.custom_op("tileops::dropout", mutates_args=())
 def _wrapped_dropout(x: torch.Tensor, instance_key: str) -> torch.Tensor:
     instance = get_instance(instance_key)
     return instance._eager_forward(x)

--- a/src/tileops/ops/elementwise/_base.py
+++ b/src/tileops/ops/elementwise/_base.py
@@ -163,7 +163,7 @@ def _register_unary_custom_op(op_cls):
         op_cls: The Op subclass to register (must have ``_op_name``).
     """
     _require_shape_inference(op_cls)
-    op_name = f"top::elementwise_unary_{op_cls._op_name}"
+    op_name = f"tileops::elementwise_unary_{op_cls._op_name}"
 
     @torch.library.custom_op(op_name, mutates_args=())
     def _wrapped(x: torch.Tensor, instance_key: str) -> torch.Tensor:
@@ -197,7 +197,7 @@ def _register_unary_inplace_custom_op(op_cls):
     correctly. Sets ``op_cls._wrapped_inplace`` for ``forward()`` to
     dispatch through.
     """
-    op_name = f"top::elementwise_unary_{op_cls._op_name}_inplace"
+    op_name = f"tileops::elementwise_unary_{op_cls._op_name}_inplace"
 
     @torch.library.custom_op(op_name, mutates_args=("x",))
     def _wrapped_inplace(x: torch.Tensor, instance_key: str) -> None:
@@ -218,7 +218,7 @@ def _register_binary_custom_op(op_cls):
         op_cls: The Op subclass to register.
     """
     _require_shape_inference(op_cls)
-    op_name = f"top::elementwise_binary_{op_cls._op_name}"
+    op_name = f"tileops::elementwise_binary_{op_cls._op_name}"
 
     @torch.library.custom_op(op_name, mutates_args=())
     def _wrapped(a: torch.Tensor, b: torch.Tensor, instance_key: str) -> torch.Tensor:
@@ -242,7 +242,7 @@ def _register_fused_gated_custom_op(op_cls):
         op_cls: The Op subclass to register.
     """
     _require_shape_inference(op_cls)
-    op_name = f"top::elementwise_fused_gated_{op_cls._op_name}"
+    op_name = f"tileops::elementwise_fused_gated_{op_cls._op_name}"
 
     @torch.library.custom_op(op_name, mutates_args=())
     def _wrapped(x: torch.Tensor, instance_key: str) -> torch.Tensor:

--- a/src/tileops/ops/elementwise/arithmetic.py
+++ b/src/tileops/ops/elementwise/arithmetic.py
@@ -314,7 +314,7 @@ class LerpTensorFwdOp(_PerDtypeKernels, Op):
 _require_shape_inference(LerpTensorFwdOp)
 
 
-@torch.library.custom_op("top::elementwise_lerp_tensor", mutates_args=())
+@torch.library.custom_op("tileops::elementwise_lerp_tensor", mutates_args=())
 def _lerp_tensor_fwd(
     input: torch.Tensor,
     end: torch.Tensor,
@@ -339,4 +339,4 @@ def _lerp_tensor_fwd_fake(
 
 
 LerpTensorFwdOp._wrapped = _lerp_tensor_fwd
-LerpTensorFwdOp.compile_op_names = ("top::elementwise_lerp_tensor",)
+LerpTensorFwdOp.compile_op_names = ("tileops::elementwise_lerp_tensor",)

--- a/src/tileops/ops/elementwise/clamp.py
+++ b/src/tileops/ops/elementwise/clamp.py
@@ -240,7 +240,7 @@ class ClampScalarFwdOp(_PerDtypeKernels, Op):
 _require_shape_inference(ClampFwdOp)
 
 
-@torch.library.custom_op("top::elementwise_clamp_tensor", mutates_args=())
+@torch.library.custom_op("tileops::elementwise_clamp_tensor", mutates_args=())
 def _clamp_tensor_fwd(
     input: torch.Tensor,
     min: Optional[torch.Tensor],
@@ -269,4 +269,4 @@ def _clamp_tensor_fwd_fake(
 
 
 ClampFwdOp._wrapped = _clamp_tensor_fwd
-ClampFwdOp.compile_op_names = ("top::elementwise_clamp_tensor",)
+ClampFwdOp.compile_op_names = ("tileops::elementwise_clamp_tensor",)

--- a/src/tileops/ops/elementwise/masked_fill.py
+++ b/src/tileops/ops/elementwise/masked_fill.py
@@ -242,7 +242,7 @@ _require_shape_inference(MaskedFillFwdOp)
 _require_shape_inference(MaskedFillScalarFwdOp)
 
 
-@torch.library.custom_op("top::elementwise_masked_fill_tensor_value", mutates_args=())
+@torch.library.custom_op("tileops::elementwise_masked_fill_tensor_value", mutates_args=())
 def _masked_fill_tensor_value_fwd(
     input: torch.Tensor,
     mask: torch.Tensor,
@@ -266,7 +266,7 @@ def _masked_fill_tensor_value_fwd_fake(
     )
 
 
-@torch.library.custom_op("top::elementwise_masked_fill", mutates_args=())
+@torch.library.custom_op("tileops::elementwise_masked_fill", mutates_args=())
 def _masked_fill_fwd(
     input: torch.Tensor,
     mask: torch.Tensor,
@@ -289,6 +289,6 @@ def _masked_fill_fwd_fake(
 
 
 MaskedFillFwdOp._wrapped = _masked_fill_tensor_value_fwd
-MaskedFillFwdOp.compile_op_names = ("top::elementwise_masked_fill_tensor_value",)
+MaskedFillFwdOp.compile_op_names = ("tileops::elementwise_masked_fill_tensor_value",)
 MaskedFillScalarFwdOp._wrapped = _masked_fill_fwd
-MaskedFillScalarFwdOp.compile_op_names = ("top::elementwise_masked_fill",)
+MaskedFillScalarFwdOp.compile_op_names = ("tileops::elementwise_masked_fill",)

--- a/src/tileops/ops/elementwise/prelu.py
+++ b/src/tileops/ops/elementwise/prelu.py
@@ -137,7 +137,7 @@ class PreluFwdOp(_PerDtypeKernels, Op):
 _require_shape_inference(PreluFwdOp)
 
 
-@torch.library.custom_op("top::elementwise_prelu", mutates_args=())
+@torch.library.custom_op("tileops::elementwise_prelu", mutates_args=())
 def _prelu_fwd(x: torch.Tensor, weight: torch.Tensor, instance_key: str) -> torch.Tensor:
     return get_instance(instance_key)._eager_forward(x, weight)
 
@@ -150,4 +150,4 @@ def _prelu_fwd_fake(x: torch.Tensor, weight: torch.Tensor, instance_key: str) ->
 
 
 PreluFwdOp._wrapped = _prelu_fwd
-PreluFwdOp.compile_op_names = ("top::elementwise_prelu",)
+PreluFwdOp.compile_op_names = ("tileops::elementwise_prelu",)

--- a/src/tileops/ops/elementwise/where.py
+++ b/src/tileops/ops/elementwise/where.py
@@ -157,7 +157,7 @@ class WhereFwdOp(_PerDtypeKernels, Op):
 _require_shape_inference(WhereFwdOp)
 
 
-@torch.library.custom_op("top::elementwise_where", mutates_args=())
+@torch.library.custom_op("tileops::elementwise_where", mutates_args=())
 def _where_fwd(
     condition: torch.Tensor,
     input: torch.Tensor,
@@ -182,4 +182,4 @@ def _where_fwd_fake(
 
 
 WhereFwdOp._wrapped = _where_fwd
-WhereFwdOp.compile_op_names = ("top::elementwise_where",)
+WhereFwdOp.compile_op_names = ("tileops::elementwise_where",)

--- a/src/tileops/ops/moe/permute_align.py
+++ b/src/tileops/ops/moe/permute_align.py
@@ -34,7 +34,7 @@ class MoePermuteAlignFwdOp(Op):
     """
 
     #: The operator this op registers; a test asserts the graph holds nothing else.
-    compile_op_names: ClassVar[Tuple[str, ...]] = ("top::moe_permute_align_fwd",)
+    compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::moe_permute_align_fwd",)
 
     def __init__(
         self,
@@ -112,7 +112,7 @@ class MoePermuteAlignFwdOp(Op):
         return self.kernel(topk_ids)
 
 
-@torch.library.custom_op("top::moe_permute_align_fwd", mutates_args=())
+@torch.library.custom_op("tileops::moe_permute_align_fwd", mutates_args=())
 def _moe_permute_align_fwd(
     topk_ids: torch.Tensor,
     instance_key: str,

--- a/src/tileops/ops/moe/routed_expert/gate_up.py
+++ b/src/tileops/ops/moe/routed_expert/gate_up.py
@@ -46,7 +46,7 @@ class MoeGateUpFwdOp(GroupedOperandEagerForward, Op):
     """
 
     #: The operator this op registers; a test asserts the graph holds nothing else.
-    compile_op_names: ClassVar[Tuple[str, ...]] = ("top::moe_gate_up_fwd",)
+    compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::moe_gate_up_fwd",)
 
     def __init__(
         self,
@@ -142,7 +142,7 @@ class MoeGateUpFwdOp(GroupedOperandEagerForward, Op):
         return _moe_gate_up_fwd(a, b, true_sizes, true_offsets, self._instance_key)
 
 
-@torch.library.custom_op("top::moe_gate_up_fwd", mutates_args=())
+@torch.library.custom_op("tileops::moe_gate_up_fwd", mutates_args=())
 def _moe_gate_up_fwd(
     a: torch.Tensor,
     b: torch.Tensor,

--- a/src/tileops/ops/moe/routed_expert/moe_grouped_gemm_nopad.py
+++ b/src/tileops/ops/moe/routed_expert/moe_grouped_gemm_nopad.py
@@ -42,7 +42,7 @@ class MoeGroupedGemmNopadFwdOp(GroupedOperandEagerForward, Op):
     """
 
     #: The operator this op registers; a test asserts the graph holds nothing else.
-    compile_op_names: ClassVar[Tuple[str, ...]] = ("top::moe_grouped_gemm_nopad_fwd",)
+    compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::moe_grouped_gemm_nopad_fwd",)
 
     def __init__(
         self,
@@ -122,7 +122,7 @@ class MoeGroupedGemmNopadFwdOp(GroupedOperandEagerForward, Op):
         return _moe_grouped_gemm_nopad_fwd(a, b, true_sizes, true_offsets, self._instance_key)
 
 
-@torch.library.custom_op("top::moe_grouped_gemm_nopad_fwd", mutates_args=())
+@torch.library.custom_op("tileops::moe_grouped_gemm_nopad_fwd", mutates_args=())
 def _moe_grouped_gemm_nopad_fwd(
     a: torch.Tensor,
     b: torch.Tensor,

--- a/src/tileops/ops/moe/routed_expert/permute_nopad.py
+++ b/src/tileops/ops/moe/routed_expert/permute_nopad.py
@@ -47,7 +47,7 @@ class MoePermuteNopadFwdOp(Op):
     """
 
     #: The operator this op registers; a test asserts the graph holds nothing else.
-    compile_op_names: ClassVar[Tuple[str, ...]] = ("top::moe_permute_nopad_fwd",)
+    compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::moe_permute_nopad_fwd",)
 
     def __init__(
         self,
@@ -312,7 +312,7 @@ class MoePermuteNopadFwdOp(Op):
         return kernel(hidden_states, topk_ids, expert_map)
 
 
-@torch.library.custom_op("top::moe_permute_nopad_fwd", mutates_args=())
+@torch.library.custom_op("tileops::moe_permute_nopad_fwd", mutates_args=())
 def _moe_permute_nopad_fwd(
     hidden_states: torch.Tensor,
     topk_ids: torch.Tensor,

--- a/src/tileops/ops/moe/routed_expert/unpermute.py
+++ b/src/tileops/ops/moe/routed_expert/unpermute.py
@@ -40,8 +40,8 @@ class MoeUnpermuteFwdOp(Op):
     #: ``relu`` / ``relu_``: ``forward`` picks one, and a test asserts the graph holds
     #: nothing else.
     compile_op_names: ClassVar[Tuple[str, ...]] = (
-        "top::moe_unpermute_fwd",
-        "top::moe_unpermute_fwd_inplace",
+        "tileops::moe_unpermute_fwd",
+        "tileops::moe_unpermute_fwd_inplace",
     )
 
     def __init__(
@@ -136,7 +136,7 @@ class MoeUnpermuteFwdOp(Op):
         )
 
 
-@torch.library.custom_op("top::moe_unpermute_fwd", mutates_args=())
+@torch.library.custom_op("tileops::moe_unpermute_fwd", mutates_args=())
 def _moe_unpermute_fwd(
     mm2_pad: torch.Tensor,
     fwd_idx: torch.Tensor,
@@ -161,7 +161,7 @@ def _moe_unpermute_fwd_fake(
     return mm2_pad.new_empty(shapes["output"])
 
 
-@torch.library.custom_op("top::moe_unpermute_fwd_inplace", mutates_args=("out",))
+@torch.library.custom_op("tileops::moe_unpermute_fwd_inplace", mutates_args=("out",))
 def _moe_unpermute_fwd_inplace(
     mm2_pad: torch.Tensor,
     fwd_idx: torch.Tensor,

--- a/src/tileops/ops/norm/ada_layer_norm.py
+++ b/src/tileops/ops/norm/ada_layer_norm.py
@@ -43,7 +43,7 @@ class AdaLayerNormFwdOp(Op):
     """
 
     #: The operator this op registers; a test asserts the graph holds nothing else.
-    compile_op_names: ClassVar[Tuple[str, ...]] = ("top::norm_ada_layer_norm_fwd",)
+    compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::norm_ada_layer_norm_fwd",)
 
     def __init__(
         self,
@@ -138,7 +138,7 @@ class AdaLayerNormFwdOp(Op):
         return kernel(x, scale, shift)
 
 
-@torch.library.custom_op("top::norm_ada_layer_norm_fwd", mutates_args=())
+@torch.library.custom_op("tileops::norm_ada_layer_norm_fwd", mutates_args=())
 def _norm_ada_layer_norm_fwd(
     x: torch.Tensor,
     scale: torch.Tensor,

--- a/src/tileops/ops/norm/ada_layer_norm_zero.py
+++ b/src/tileops/ops/norm/ada_layer_norm_zero.py
@@ -44,7 +44,7 @@ class AdaLayerNormZeroFwdOp(Op):
     """
 
     #: The operator this op registers; a test asserts the graph holds nothing else.
-    compile_op_names: ClassVar[Tuple[str, ...]] = ("top::norm_ada_layer_norm_zero_fwd",)
+    compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::norm_ada_layer_norm_zero_fwd",)
 
     def __init__(
         self,
@@ -148,7 +148,7 @@ class AdaLayerNormZeroFwdOp(Op):
         return kernel(x, scale, shift, gate)
 
 
-@torch.library.custom_op("top::norm_ada_layer_norm_zero_fwd", mutates_args=())
+@torch.library.custom_op("tileops::norm_ada_layer_norm_zero_fwd", mutates_args=())
 def _norm_ada_layer_norm_zero_fwd(
     x: torch.Tensor,
     scale: torch.Tensor,

--- a/src/tileops/ops/norm/batch_norm.py
+++ b/src/tileops/ops/norm/batch_norm.py
@@ -73,7 +73,7 @@ class BatchNormFwdOp(Op):
     """
 
     #: The operator this op registers; a test asserts the graph holds nothing else.
-    compile_op_names: ClassVar[Tuple[str, ...]] = ("top::norm_batch_norm_fwd",)
+    compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::norm_batch_norm_fwd",)
 
     def __init__(
         self,
@@ -256,7 +256,7 @@ class BatchNormBwdOp(Op):
     """
 
     #: The operator this op registers; a test asserts the graph holds nothing else.
-    compile_op_names: ClassVar[Tuple[str, ...]] = ("top::norm_batch_norm_bwd",)
+    compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::norm_batch_norm_bwd",)
 
     def __init__(
         self,
@@ -405,7 +405,7 @@ class BatchNormBwdOp(Op):
 
 
 @torch.library.custom_op(
-    "top::norm_batch_norm_fwd",
+    "tileops::norm_batch_norm_fwd",
     mutates_args=("running_mean", "running_var"),
 )
 def _batch_norm_fwd_wrapped(
@@ -440,7 +440,7 @@ def _batch_norm_fwd_fake(
     return x.new_empty(shapes["output"])
 
 
-@torch.library.custom_op("top::norm_batch_norm_bwd", mutates_args=())
+@torch.library.custom_op("tileops::norm_batch_norm_bwd", mutates_args=())
 def _batch_norm_bwd_wrapped(
     grad_out: torch.Tensor,
     x: torch.Tensor,

--- a/src/tileops/ops/norm/fused_add_layer_norm.py
+++ b/src/tileops/ops/norm/fused_add_layer_norm.py
@@ -46,7 +46,7 @@ class FusedAddLayerNormFwdOp(Op):
     """
 
     #: The operator this op registers; a test asserts the graph holds nothing else.
-    compile_op_names: ClassVar[Tuple[str, ...]] = ("top::norm_fused_add_layer_norm_fwd",)
+    compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::norm_fused_add_layer_norm_fwd",)
 
     def __init__(
         self,
@@ -157,7 +157,7 @@ class FusedAddLayerNormFwdOp(Op):
         return y, residual_out
 
 
-@torch.library.custom_op("top::norm_fused_add_layer_norm_fwd", mutates_args=())
+@torch.library.custom_op("tileops::norm_fused_add_layer_norm_fwd", mutates_args=())
 def _norm_fused_add_layer_norm_fwd(
     x: torch.Tensor,
     residual: torch.Tensor,

--- a/src/tileops/ops/norm/fused_add_rms_norm.py
+++ b/src/tileops/ops/norm/fused_add_rms_norm.py
@@ -45,7 +45,7 @@ class FusedAddRMSNormFwdOp(Op):
     """
 
     #: The operator this op registers; a test asserts the graph holds nothing else.
-    compile_op_names: ClassVar[Tuple[str, ...]] = ("top::norm_fused_add_rms_norm_fwd",)
+    compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::norm_fused_add_rms_norm_fwd",)
 
     def __init__(
         self,
@@ -150,7 +150,7 @@ class FusedAddRMSNormFwdOp(Op):
         return y, residual_out
 
 
-@torch.library.custom_op("top::norm_fused_add_rms_norm_fwd", mutates_args=())
+@torch.library.custom_op("tileops::norm_fused_add_rms_norm_fwd", mutates_args=())
 def _norm_fused_add_rms_norm_fwd(
     x: torch.Tensor,
     residual: torch.Tensor,

--- a/src/tileops/ops/norm/group_norm.py
+++ b/src/tileops/ops/norm/group_norm.py
@@ -64,7 +64,7 @@ class GroupNormFwdOp(Op):
     """
 
     #: The operator this op registers; a test asserts the graph holds nothing else.
-    compile_op_names: ClassVar[Tuple[str, ...]] = ("top::norm_group_norm_fwd",)
+    compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::norm_group_norm_fwd",)
 
     def __init__(
         self,
@@ -214,7 +214,7 @@ class GroupNormFwdOp(Op):
         return kernel(x, weight, bias)
 
 
-@torch.library.custom_op("top::norm_group_norm_fwd", mutates_args=())
+@torch.library.custom_op("tileops::norm_group_norm_fwd", mutates_args=())
 def _norm_group_norm_fwd(
     x: torch.Tensor,
     weight: Optional[torch.Tensor],

--- a/src/tileops/ops/norm/instance_norm.py
+++ b/src/tileops/ops/norm/instance_norm.py
@@ -72,7 +72,7 @@ class InstanceNormFwdOp(Op):
     """
 
     #: The operator this op registers; a test asserts the graph holds nothing else.
-    compile_op_names: ClassVar[Tuple[str, ...]] = ("top::norm_instance_norm_fwd",)
+    compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::norm_instance_norm_fwd",)
 
     def __init__(
         self,
@@ -347,7 +347,7 @@ class InstanceNormFwdOp(Op):
         return kernel(x, running_mean, running_var, weight, bias)
 
 
-@torch.library.custom_op("top::norm_instance_norm_fwd", mutates_args=())
+@torch.library.custom_op("tileops::norm_instance_norm_fwd", mutates_args=())
 def _norm_instance_norm_fwd(
     x: torch.Tensor,
     running_mean: Optional[torch.Tensor],

--- a/src/tileops/ops/norm/layer_norm.py
+++ b/src/tileops/ops/norm/layer_norm.py
@@ -46,7 +46,7 @@ class LayerNormFwdOp(Op):
     DEFAULT_EPS = 1e-5
 
     #: The operator this op registers; a test asserts the graph holds nothing else.
-    compile_op_names: ClassVar[Tuple[str, ...]] = ("top::norm_layer_norm_fwd",)
+    compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::norm_layer_norm_fwd",)
 
     def __init__(
         self,
@@ -166,7 +166,7 @@ class LayerNormFwdOp(Op):
         return kernel(x, weight, bias)
 
 
-@torch.library.custom_op("top::norm_layer_norm_fwd", mutates_args=())
+@torch.library.custom_op("tileops::norm_layer_norm_fwd", mutates_args=())
 def _layer_norm_fwd(
     x: torch.Tensor,
     weight: torch.Tensor,

--- a/src/tileops/ops/norm/rms_norm.py
+++ b/src/tileops/ops/norm/rms_norm.py
@@ -63,7 +63,7 @@ class RMSNormFwdOp(Op):
     DEFAULT_EPS = 1.0e-6
 
     #: The operator this op registers; a test asserts the graph holds nothing else.
-    compile_op_names: ClassVar[Tuple[str, ...]] = ("top::norm_rms_norm_fwd",)
+    compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::norm_rms_norm_fwd",)
 
     def __init__(
         self,
@@ -170,7 +170,7 @@ class RMSNormFwdOp(Op):
 # src/tileops/ops/compile_boundary.py.
 
 
-@torch.library.custom_op("top::norm_rms_norm_fwd", mutates_args=())
+@torch.library.custom_op("tileops::norm_rms_norm_fwd", mutates_args=())
 def _rms_norm_fwd(
     x: torch.Tensor,
     weight: torch.Tensor,

--- a/src/tileops/ops/pool.py
+++ b/src/tileops/ops/pool.py
@@ -1354,17 +1354,17 @@ def _register_pool_operator(op_cls: type, name: str) -> None:
 
 
 for _op_cls, _op_name in (
-    (AvgPool1dFwdOp, "top::pool_avg_pool1d_fwd"),
-    (AvgPool2dFwdOp, "top::pool_avg_pool2d_fwd"),
-    (AvgPool3dFwdOp, "top::pool_avg_pool3d_fwd"),
-    (MaxPool1dFwdOp, "top::pool_max_pool1d_fwd"),
-    (MaxPool2dFwdOp, "top::pool_max_pool2d_fwd"),
-    (MaxPool3dFwdOp, "top::pool_max_pool3d_fwd"),
-    (MaxPool1dIndicesFwdOp, "top::pool_max_pool1d_indices_fwd"),
-    (MaxPool2dIndicesFwdOp, "top::pool_max_pool2d_indices_fwd"),
-    (MaxPool3dIndicesFwdOp, "top::pool_max_pool3d_indices_fwd"),
-    (AdaptiveAvgPool2dFwdOp, "top::pool_adaptive_avg_pool2d_fwd"),
-    (AdaptiveMaxPool2dFwdOp, "top::pool_adaptive_max_pool2d_fwd"),
-    (AdaptiveMaxPool2dIndicesFwdOp, "top::pool_adaptive_max_pool2d_indices_fwd"),
+    (AvgPool1dFwdOp, "tileops::pool_avg_pool1d_fwd"),
+    (AvgPool2dFwdOp, "tileops::pool_avg_pool2d_fwd"),
+    (AvgPool3dFwdOp, "tileops::pool_avg_pool3d_fwd"),
+    (MaxPool1dFwdOp, "tileops::pool_max_pool1d_fwd"),
+    (MaxPool2dFwdOp, "tileops::pool_max_pool2d_fwd"),
+    (MaxPool3dFwdOp, "tileops::pool_max_pool3d_fwd"),
+    (MaxPool1dIndicesFwdOp, "tileops::pool_max_pool1d_indices_fwd"),
+    (MaxPool2dIndicesFwdOp, "tileops::pool_max_pool2d_indices_fwd"),
+    (MaxPool3dIndicesFwdOp, "tileops::pool_max_pool3d_indices_fwd"),
+    (AdaptiveAvgPool2dFwdOp, "tileops::pool_adaptive_avg_pool2d_fwd"),
+    (AdaptiveMaxPool2dFwdOp, "tileops::pool_adaptive_max_pool2d_fwd"),
+    (AdaptiveMaxPool2dIndicesFwdOp, "tileops::pool_adaptive_max_pool2d_indices_fwd"),
 ):
     _register_pool_operator(_op_cls, _op_name)

--- a/src/tileops/ops/reduction/_boundary.py
+++ b/src/tileops/ops/reduction/_boundary.py
@@ -45,7 +45,7 @@ def register_reduction_op(op_cls) -> None:
             f"{op_cls.__name__} registers a compile boundary but has no manifest entry; "
             "the operator name, the output names and their dtypes all come from it"
         )
-    op_name = f"top::{entry['family']}_{_snake(op_cls.__name__)}"
+    op_name = f"tileops::{entry['family']}_{_snake(op_cls.__name__)}"
     outputs = tuple(entry["signature"]["outputs"])
     if len(outputs) == 1:
         _register_single(op_cls, op_name, outputs[0])

--- a/src/tileops/ops/rope.py
+++ b/src/tileops/ops/rope.py
@@ -52,7 +52,7 @@ def _register_rope_custom_op(op_cls):
     """
     op_name = op_cls._op_name
 
-    @torch.library.custom_op(f"top::rope_{op_name}", mutates_args=())
+    @torch.library.custom_op(f"tileops::rope_{op_name}", mutates_args=())
     def _wrapped(x: torch.Tensor, instance_key: str) -> torch.Tensor:
         instance = get_instance(instance_key)
         return instance._eager_forward(x)
@@ -68,7 +68,7 @@ def _register_rope_position_ids_custom_op(op_cls):
     """Register a RoPE op that consumes explicit packed position ids."""
     op_name = op_cls._op_name
 
-    @torch.library.custom_op(f"top::rope_{op_name}", mutates_args=())
+    @torch.library.custom_op(f"tileops::rope_{op_name}", mutates_args=())
     def _wrapped(x: torch.Tensor, position_ids: torch.Tensor, instance_key: str) -> torch.Tensor:
         instance = get_instance(instance_key)
         return instance._eager_forward(x, position_ids)

--- a/tests/compile_contract.py
+++ b/tests/compile_contract.py
@@ -50,7 +50,7 @@ def register_compile_contract(op_cls: type) -> None:
 
 
 def operator_overload(name: str):
-    """``"top::foo"`` as the overload object a graph node carries."""
+    """``"tileops::foo"`` as the overload object a graph node carries."""
     namespace, _, opname = name.partition("::")
     return getattr(getattr(torch.ops, namespace), opname).default
 


### PR DESCRIPTION
## Problems

- Registrations split across two namespaces: 74 `top::`, 10 `tileops::`. `top` dates to 2025-10, `tileops` to 2026-03 — the split is migration leftover, not a distinction.
- `prefill/tilelang_compat.py` named nothing: every kernel here is written on TileLang, and the file is no compatibility shim.

## Changes

- Every registration, the `compile_op_names` declaring them, and two docstring examples move to `tileops::` — 119 lines across 64 files, each the namespace and nothing else. One line wraps because the longer name crosses the limit.
- `tilelang_compat.py` → `gemm_lowering.py`: it installs `T.gemm_v1` and picks among three lowerings. `install_gemm_v1_compat` → `install_gemm_v1`, `_gemm_ss_compat` → `_gemm_ss_extern`, `_wgmma_gemm_sync_compat` → `_wgmma_gemm_sync`. `T.gemm_v1` keeps its name — 16 call sites invoke it.

Normalising the namespace away leaves the 83 operator names identical. After import the dispatcher holds no `top::` registration; `T.gemm_v1` still installs. 93 compile-contract and 10 prefill tests pass on an H200.

Anything outside this repo referencing `top::…` or a graph carrying those names moves with it. Nothing inside does.
