### PR TITLE
[Bench] Give the fp8 KN bmm row its baselines, and guard the ones that have none

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,6 +69,12 @@ repos:
         language: python
         files: ^benchmarks/ops/.*\.py$
 
+      - id: bench-baseline-lint
+        name: benchmark baseline lint
+        entry: python scripts/lint/bench_baseline_lint.py
+        language: python
+        files: ^benchmarks/.*\.py$
+
   - repo: https://github.com/executablebooks/mdformat
     rev: 0.7.22
     hooks:

--- a/benchmarks/ops/bench_bmm.py
+++ b/benchmarks/ops/bench_bmm.py
@@ -106,11 +106,23 @@ def test_bmm_fp8_kn_bench(
 
     op = BmmFp8KNFwdOp(out_dtype=out_dtype, tune=True)
     bm = ManifestBenchmark(_FP8_KN_OP_NAME, op, workload)
-    bm.compare(
-        {"tileops": (op, (a, b_kn, scale_a, scale_b))},
-        record_as=op,
-        params=locals(),
-    )
+    functors = {
+        "tileops": (op, (a, b_kn, scale_a, scale_b)),
+        "torch-fp32-ref": (workload.torch_fp32_bmm_ref, (a, b_kn, scale_a, scale_b)),
+    }
+
+    def flashinfer_fn(a_, b_, sa_, sb_):
+        return _flashinfer_bmm_fp8_per_tensor_ref(workload, a_, b_, sa_, sb_)
+
+    # b_kn is already [B, K, N], the order flashinfer's bmm_fp8 reads.
+    try:
+        flashinfer_fn(a, b_kn, scale_a, scale_b)
+    except (ImportError, RuntimeError) as exc:
+        print(f"  [skip] flashinfer-bmm-fp8: {exc}")
+    else:
+        functors["flashinfer-bmm-fp8"] = (flashinfer_fn, (a, b_kn, scale_a, scale_b))
+
+    bm.compare(functors, record_as=op, params=locals())
 
 
 @pytest.mark.parametrize(

--- a/benchmarks/ops/bench_moe_permute_nopad.py
+++ b/benchmarks/ops/bench_moe_permute_nopad.py
@@ -77,8 +77,13 @@ def test_moe_permute_nopad_bench(
     functors = {"tileops": op}
 
     if expert_map is not None:
-        # No vLLM or torch column: their permute takes the whole expert table, so
-        # the two would not measure the same work.
+        # FIXME(staged-rollout): this row records no baseline.
+        #
+        # Broken invariant: every benchmark records >=1 non-tileops baseline.
+        # Why: under expert parallelism this rank owns a slice of the expert
+        #   table, and vLLM's and torch's permute both take the whole table, so
+        #   either column would time a different amount of work.
+        # Cleanup: a baseline that permutes against the local expert slice.
         bm.compare(
             functors,
             hidden_states,

--- a/scripts/lint/bench_baseline_lint.py
+++ b/scripts/lint/bench_baseline_lint.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Lint benchmark files for a comparison that names no baseline.
+
+A benchmark timing only tileops reports a number with nothing to read it against,
+and the rendered page shows that row with an empty comparison. A row that has no
+baseline yet says why with ``FIXME(staged-rollout)`` above the comparison.
+
+Reads the tags a call site passes, not which survive at runtime: a baseline behind
+an optional import still counts, because dropping its row where the library is
+missing is what the bench is meant to do. A dict built by ``**`` unpacking or
+returned by a helper is decided elsewhere and left alone.
+
+Usage: ``bench_baseline_lint.py [FILE ...]``. With no arguments, scans
+``benchmarks/``. Exits 1 for a comparison with no baseline and no marker.
+"""
+
+import ast
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BENCH_DIR = REPO_ROOT / "benchmarks"
+
+OURS = "tileops"
+MARKER = "FIXME(staged-rollout)"
+
+
+def _literal_keys(node: ast.AST) -> set[str]:
+    """String keys of a dict display."""
+    if not isinstance(node, ast.Dict):
+        return set()
+    return {k.value for k in node.keys if isinstance(k, ast.Constant) and isinstance(k.value, str)}
+
+
+def _unreadable(node: ast.AST) -> bool:
+    """Whether a dict display holds a key this cannot name.
+
+    ``ast.Dict`` writes ``**expr`` as a ``None`` key; a computed key is an
+    expression. Either way the tags come from somewhere else.
+    """
+    return isinstance(node, ast.Dict) and any(
+        k is None or not (isinstance(k, ast.Constant) and isinstance(k.value, str))
+        for k in node.keys
+    )
+
+
+def _tags_of(name: str, func: ast.AST, before: int) -> set[str] | None:
+    """Tags assigned to *name* above line *before*, or ``None`` if unreadable."""
+    tags: set[str] = set()
+    for node in ast.walk(func):
+        if not isinstance(node, ast.Assign) or getattr(node, "lineno", 0) > before:
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                if _unreadable(node.value):
+                    return None
+                tags |= _literal_keys(node.value)
+            elif (
+                isinstance(target, ast.Subscript)
+                and isinstance(target.value, ast.Name)
+                and target.value.id == name
+                and isinstance(target.slice, ast.Constant)
+                and isinstance(target.slice.value, str)
+            ):
+                tags.add(target.slice.value)
+    return tags
+
+
+def unbaselined_comparisons(text: str) -> list[int]:
+    """Line of every ``compare(...)`` that names no baseline and carries no marker."""
+    tree = ast.parse(text)
+    marked = [i for i, line in enumerate(text.split("\n"), start=1) if MARKER in line]
+    findings = []
+    for func in ast.walk(tree):
+        if not isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for node in ast.walk(func):
+            if not (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "compare"
+                and node.args
+            ):
+                continue
+            if any(func.lineno <= m <= node.lineno for m in marked):
+                continue  # the row states why it has none
+            arg = node.args[0]
+            if isinstance(arg, ast.Dict):
+                tags = None if _unreadable(arg) else _literal_keys(arg)
+            elif isinstance(arg, ast.Name):
+                tags = _tags_of(arg.id, func, node.lineno)
+            else:
+                continue  # a call or comprehension builds it
+            if tags and not (tags - {OURS}):
+                findings.append(node.lineno)
+    return findings
+
+
+def main(argv: list[str]) -> int:
+    paths = [Path(a) for a in argv] if argv else sorted(BENCH_DIR.rglob("*.py"))
+    failed = False
+    for path in paths:
+        try:
+            findings = unbaselined_comparisons(path.read_text(encoding="utf-8"))
+        except (OSError, SyntaxError):
+            continue
+        for lineno in findings:
+            failed = True
+            print(
+                f"{path}:{lineno}: comparison names only {OURS!r}. Add an implementation "
+                f"that is not ours, or say why the row has none with a {MARKER} block "
+                f"above it.",
+                file=sys.stderr,
+            )
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Problems

- `test_bmm_fp8_kn_bench` passed `compare` only `tileops`, so `BmmFp8KNFwdOp` rendered with no comparison.
- Nothing checked the invariant the prefill marker states — every benchmark records ≥1 non-tileops baseline — which is why it went unnoticed.

## Changes

- The KN case names `torch-fp32-ref` and probes flashinfer as the sibling NK case does; `b_kn` is already the `[B, K, N]` order flashinfer reads. On an H200 the row reports all three: b4-1k tileops 241 TFLOPs vs flashinfer 291, b8-2k 482 vs 265.
- `scripts/lint/bench_baseline_lint.py` enforces the invariant, in pre-commit, which CI runs `--all-files`.
- It reads the tags a call site passes above the comparison, not which survive at runtime — a baseline behind an optional import still counts. A dict built by `**` unpacking or returned by a helper is left alone; `bench_convolution.py` takes its baselines that way.
- The lint found a second gap: under expert parallelism `bench_moe_permute_nopad.py` has no baseline because vLLM's and torch's permute take the whole expert table while the rank owns a slice. That reason was a plain comment; it is a `FIXME(staged-rollout)` block now.
