### PR TITLE
[Bench] Give the fp8 and paged prefill rows a baseline, and close two lint blind spots

### DIFF
--- a/benchmarks/ops/attention/bench_gqa.py
+++ b/benchmarks/ops/attention/bench_gqa.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 from torch.nn import functional as F
 
+from benchmarks.baselines import assert_matches_reference, reference_tolerance
 from benchmarks.benchmark_base import (
     BenchmarkBase,
     BenchmarkReport,
@@ -480,6 +481,42 @@ def test_gqa_prefill_varlen_fwd_bench(
     )
 
 
+def _fa3_gqa_prefill_paged(test, cache_dtype, fuse_rope, softcap):
+    """FlashAttention-3 over the same paged cache, or None where it cannot serve the row.
+
+    It reads the pages, appends the new KV in place and applies the softcap in one launch,
+    so it times the work the op does rather than a materialized reference.
+    """
+    if fuse_rope or cache_dtype is not None:
+        return None
+    try:
+        from flash_attn_interface import flash_attn_with_kvcache
+    except ImportError:
+        return None
+
+    shape = (test.batch * test.max_pages_per_req, test.page_size, test.heads_kv, test.dim)
+
+    def _run(q, k_new, v_new, k_pages, v_pages, k_scale, v_scale, cu_q, seqlens, table, max_q):
+        del k_scale, v_scale
+        out = flash_attn_with_kvcache(
+            q=q,
+            k_cache=k_pages.view(shape),
+            v_cache=v_pages.view(shape),
+            k=k_new,
+            v=v_new,
+            cache_seqlens=seqlens,
+            page_table=table,
+            cu_seqlens_q=cu_q,
+            cu_seqlens_k_new=cu_q,
+            max_seqlen_q=max_q,
+            causal=test.is_causal,
+            softcap=float(softcap or 0.0),
+        )
+        return out[0] if isinstance(out, tuple) else out
+
+    return _run
+
+
 def _fp8_paged_cache_inputs(
     test: GQAPrefillPagedWithKVCacheFwdWorkload,
 ) -> tuple[torch.Tensor, ...]:
@@ -606,5 +643,18 @@ def test_gqa_prefill_paged_with_kv_cache_fwd_bench(
     op.cache_lens = cache_lens
     op.max_seqlen_q = test.max_seqlen_q
     bm = ManifestBenchmark(_GQA_PREFILL_PAGED_WITH_KV_CACHE_FWD_OP, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    fa3_fn = _fa3_gqa_prefill_paged(test, cache_dtype, fuse_rope, softcap)
+    if fa3_fn is None:
+        # FIXME(staged-rollout): this row records no baseline.
+        #
+        # Broken invariant: every benchmark records >=1 non-tileops baseline.
+        # Why: flash_attn_with_kvcache is the only installed implementation that attends
+        #   over a paged cache in place, and it takes neither a fused-RoPE row, where the
+        #   op builds its own rotary table, nor an fp8 cache, which needs q's dtype.
+        # Cleanup: reach those rows too, or a second paged implementation.
+        result = bm.profile(op, *inputs)
+        BenchmarkReport.record(op, locals(), result, tag="tileops")
+        return
+
+    assert_matches_reference(op, fa3_fn, *inputs, **reference_tolerance(dtype))
+    bm.compare({"tileops": op, "fa3": fa3_fn}, *inputs, record_as=op, params=locals())

--- a/benchmarks/ops/attention/bench_gqa_fp8.py
+++ b/benchmarks/ops/attention/bench_gqa_fp8.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 import pytest
 import torch
 
+from benchmarks.baselines import assert_matches_reference
 from benchmarks.benchmark_base import ManifestBenchmark, workload_params
 from tileops.manifest import load_workloads
 from tileops.ops import GroupedQueryAttentionPrefillFwdOp
@@ -76,6 +77,35 @@ def _make_inputs(case: GQAFp8TensorCoreBenchCase) -> tuple[torch.Tensor, ...]:
     )
 
 
+def _torch_sdpa_dequant_fwd(case: GQAFp8TensorCoreBenchCase):
+    """Dequantize with the descales, then attend in the output dtype.
+
+    Needs nothing optional, so the row reports a comparison whether or not flash-attn 3
+    is installed. ``scaled_dot_product_attention`` avoids the ``seq_len x seq_len`` score
+    matrix a per-head loop would materialize -- 12 GiB at the largest row.
+    """
+    group_size = case.heads // case.heads_kv
+
+    def _run(q, k, v, cu_q, cu_kv, q_descale, k_descale, v_descale):
+        del cu_q, cu_kv
+        batch, seq_len, dim = case.batch, case.seq_len, case.dim
+        heads, heads_kv = case.heads, case.heads_kv
+        q_deq = q.float().reshape(batch, seq_len, heads_kv, group_size, dim)
+        q_deq = (q_deq * q_descale[:, None, :, None, None]).reshape(batch, seq_len, heads, dim)
+        k_deq = k.float().reshape(batch, seq_len, heads_kv, dim) * k_descale[:, None, :, None]
+        v_deq = v.float().reshape(batch, seq_len, heads_kv, dim) * v_descale[:, None, :, None]
+        out = torch.nn.functional.scaled_dot_product_attention(
+            q_deq.transpose(1, 2).to(case.out_dtype),
+            k_deq.transpose(1, 2).to(case.out_dtype),
+            v_deq.transpose(1, 2).to(case.out_dtype),
+            is_causal=False,
+            enable_gqa=True,
+        )
+        return out.transpose(1, 2).reshape(batch * seq_len, heads, dim)
+
+    return _run
+
+
 def _fa3_gqa_fp8_fwd(case: GQAFp8TensorCoreBenchCase):
     try:
         from flash_attn_interface import flash_attn_func
@@ -127,7 +157,12 @@ def test_gqa_prefill_fp8_tensor_core_bench(case: GQAFp8TensorCoreBenchCase) -> N
     torch.cuda.synchronize()
 
     bm = ManifestBenchmark(_OP_NAME, op, case)
-    functors = {"tileops": op}
+    sdpa_fn = _torch_sdpa_dequant_fwd(case)
+    # The tolerance tests/ops/attention/test_gqa_fp8.py holds its own dequantized
+    # reference to: fp8 quantization is the whole difference between the two.
+    assert_matches_reference(op, sdpa_fn, *inputs, atol=5e-2, rtol=5e-2)
+
+    functors = {"tileops": op, "torch-sdpa-dequant": sdpa_fn}
     fa3_fn = _fa3_gqa_fp8_fwd(case)
     if fa3_fn is not None:
         functors["fa3"] = fa3_fn

--- a/benchmarks/ops/bench_fused_moe_experts.py
+++ b/benchmarks/ops/bench_fused_moe_experts.py
@@ -149,8 +149,13 @@ def test_moe_experts_nopad_bench(
     functors = {"tileops-nopad-3wg": _nopad_fn}
 
     if expert_map is not None:
-        # No vLLM column: its fused_experts takes the full weight table, so the
-        # two would not measure the same work.
+        # FIXME(staged-rollout): this row records no baseline.
+        #
+        # Broken invariant: every benchmark records >=1 non-tileops baseline.
+        # Why: under expert parallelism the weights are this rank's slice of the
+        #   expert table, and vLLM's fused_experts takes the full table, so the
+        #   column would time a different amount of work.
+        # Cleanup: a baseline that runs the experts this rank owns.
         bm.compare(
             functors,
             hidden,

--- a/scripts/lint/bench_baseline_lint.py
+++ b/scripts/lint/bench_baseline_lint.py
@@ -21,8 +21,13 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 BENCH_DIR = REPO_ROOT / "benchmarks"
 
-OURS = "tileops"
+OURS = "tileops"  # tags start with it: "tileops", "tileops-nopad-3wg", f"tileops_{variant}"
 MARKER = "FIXME(staged-rollout)"
+
+
+def _theirs(tags: set[str]) -> set[str]:
+    """The tags naming somebody else's implementation."""
+    return {t for t in tags if not t.startswith(OURS)}
 
 
 def _literal_keys(node: ast.AST) -> set[str]:
@@ -66,14 +71,55 @@ def _tags_of(name: str, func: ast.AST, before: int) -> set[str] | None:
     return tags
 
 
+def _recorded_tags(func: ast.AST) -> tuple[set[str], bool]:
+    """Literal tags a ``record(..., tag=...)`` names in *func*, and whether any is opaque.
+
+    The benchmarks that time one implementation at a time reach the report this
+    way instead of through ``compare``.
+    """
+    tags: set[str] = set()
+    opaque = False
+    for node in ast.walk(func):
+        if not (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "record"
+        ):
+            continue
+        for kw in node.keywords:
+            if kw.arg != "tag":
+                continue
+            if isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+                tags.add(kw.value.value)
+            else:
+                opaque = True
+    return tags, opaque
+
+
 def unbaselined_comparisons(text: str) -> list[int]:
-    """Line of every ``compare(...)`` that names no baseline and carries no marker."""
+    """Line of every comparison that names no baseline and carries no marker."""
     tree = ast.parse(text)
     marked = [i for i, line in enumerate(text.split("\n"), start=1) if MARKER in line]
     findings = []
     for func in ast.walk(tree):
         if not isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
             continue
+        compares = [
+            n
+            for n in ast.walk(func)
+            if isinstance(n, ast.Call)
+            and isinstance(n.func, ast.Attribute)
+            and n.func.attr == "compare"
+        ]
+        if not compares:
+            tags, opaque = _recorded_tags(func)
+            if (
+                tags
+                and not opaque
+                and not _theirs(tags)
+                and not any(func.lineno <= m <= func.end_lineno for m in marked)
+            ):
+                findings.append(func.lineno)
         for node in ast.walk(func):
             if not (
                 isinstance(node, ast.Call)
@@ -91,7 +137,7 @@ def unbaselined_comparisons(text: str) -> list[int]:
                 tags = _tags_of(arg.id, func, node.lineno)
             else:
                 continue  # a call or comprehension builds it
-            if tags and not (tags - {OURS}):
+            if tags and not _theirs(tags):
                 findings.append(node.lineno)
     return findings
 
@@ -107,9 +153,8 @@ def main(argv: list[str]) -> int:
         for lineno in findings:
             failed = True
             print(
-                f"{path}:{lineno}: comparison names only {OURS!r}. Add an implementation "
-                f"that is not ours, or say why the row has none with a {MARKER} block "
-                f"above it.",
+                f"{path}:{lineno}: comparison names no implementation but ours. Add one, "
+                f"or say why the row has none with a {MARKER} block above it.",
                 file=sys.stderr,
             )
     return 1 if failed else 0


### PR DESCRIPTION
## Problems

The nightly XML the docs Benchmarks page renders from: **30 of 1137 cases show no comparison**, across six ops.

| op | cases | cause |
| --- | --- | --- |
| `GroupedQueryAttentionPrefillFwdOp` | 8/16 | only baseline is `fa3`, absent where flash-attn 3 is |
| `GroupedQueryAttentionPrefillPagedWithKVCacheFwdOp` | 7/7 | reaches the report through `profile` + `record`, no comparison at all |
| `FusedMoEExpertsNopadPersistent3WGFwdOp` | 2/6 | expert-parallel rows drop the vLLM column |

The other 11 were already fixed or documented. The lint from #1967 saw none of these three: it compared tags to `"tileops"` exactly, and it only read `compare`.

## Changes

- fp8 prefill (8 rows) also name `torch-sdpa-dequant` — dequantize through the descales as `test_gqa_fp8.py` does, then `scaled_dot_product_attention`, which avoids the `seq_len × seq_len` score matrix (12 GiB at the largest row). Held to that test's atol=rtol=5e-2; **worst measured deviation 0.00096**. H200: s896 tileops 0.267 ms vs 0.362 ms.
- Paged prefill (1 of 7) names `fa3`. `flash_attn_with_kvcache` reads the pages, appends in place and applies the softcap in one launch, so it times the op's work, not a materialization — **agrees to 6e-5**. It takes neither a fused-RoPE row (the op builds its own rotary table) nor an fp8 cache (needs q's dtype); those six keep a marker saying so.
- The lint treats ours as a prefix and reads the `profile` + `record(tag=…)` shape. The expert-parallel MoE rows carry the marker the permute benchmark already records.
