### PR TITLE
[Doc] Docstring markup the docs site can render

### DIFF
--- a/src/tileops/__init__.py
+++ b/src/tileops/__init__.py
@@ -1,6 +1,6 @@
 """TileOPs: TileLang kernels for efficient LLM inference.
 
-The names below steer dispatch; a *backend* imports :mod:`tileops.backend` instead. They
+The names below steer dispatch; a *backend* imports `tileops.backend` instead. They
 resolve on first access (PEP 562), so importing this package pulls in neither torch nor any
 backend — the manifest tooling reads YAML where neither is installed.
 """

--- a/src/tileops/backend/__init__.py
+++ b/src/tileops/backend/__init__.py
@@ -27,9 +27,9 @@ the target picks a kernel.
 
 Depends on torch only — importing this does not import tilelang.
 
-:mod:`~tileops.backend.protocol` is what crosses the boundary,
-:mod:`~tileops.backend.errors` what goes wrong, :mod:`~tileops.backend.registry` the tables,
-:mod:`~tileops.backend.dispatch` how they are read. ``select_target``,
+`tileops.backend.protocol` is what crosses the boundary,
+`tileops.backend.errors` what goes wrong, `tileops.backend.registry` the tables,
+`tileops.backend.dispatch` how they are read. ``select_target``,
 ``detect_target`` and ``registered_kernel_builder`` live in ``dispatch`` but are not
 exported: only the op layer reads the tables, and a second public path to them is a second
 thing to keep consistent.

--- a/src/tileops/backend/protocol.py
+++ b/src/tileops/backend/protocol.py
@@ -24,7 +24,7 @@ class TensorSpec(NamedTuple):
 #: cannot express a return value aliasing an input.
 KernelResult = Union[torch.Tensor, tuple[torch.Tensor, ...], None]
 
-#: Called ``build_kernel(*inputs, **params)``: a :class:`TensorSpec` per input in
+#: Called ``build_kernel(*inputs, **params)``: a `TensorSpec` per input in
 #: ``signature.inputs`` order — ``None`` for an ``optional: true`` input the call did not
 #: pass, so presence is read off the slot rather than off how many slots there are — then
 #: ``signature.params`` by keyword. Both lists are per-op, which the type system cannot

--- a/src/tileops/backend/registry.py
+++ b/src/tileops/backend/registry.py
@@ -66,7 +66,7 @@ def register_kernel_builder(op: str, target: str, build_kernel: BuildKernel) -> 
     Args:
         op: The op's manifest key, e.g. ``"RMSNormFwdOp"``.
         target: The name this backend gives its set of kernels.
-        build_kernel: Called with a :class:`~.protocol.TensorSpec` per input and the op's
+        build_kernel: Called with a `.protocol.TensorSpec` per input and the op's
             params by keyword. Must be lazy: importing this module must not compile anything.
 
     Raises:
@@ -157,7 +157,7 @@ def load_failure_suffix() -> str:
 
 
 class RegistryState(NamedTuple):
-    """What :func:`snapshot` captures, named so :func:`restore` cannot mis-order it."""
+    """What `snapshot` captures, named so `restore` cannot mis-order it."""
 
     detectors: dict[str, DetectFn]
     builders: dict[tuple[str, str], BuildKernel]
@@ -182,7 +182,7 @@ def snapshot() -> RegistryState:
 
 
 def restore(state: RegistryState) -> None:
-    """Undo everything since the matching :func:`snapshot`."""
+    """Undo everything since the matching `snapshot`."""
     global default_target, _loaded
     with LOCK:
         DETECTORS.clear()

--- a/src/tileops/kernels/grouped_gemm/grouped_gemm_persistent_3wg.py
+++ b/src/tileops/kernels/grouped_gemm/grouped_gemm_persistent_3wg.py
@@ -106,7 +106,7 @@ class GroupedGemmPersistent3WGKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
-        """The schedule this shape asks for; see :mod:`.regimes`."""
+        """The schedule this shape asks for; see `.regimes`."""
         if rows_per_group_regime(self.numel, self.num_experts) is not None and _tiling_divides(
             self.N, self.K
         ):

--- a/src/tileops/kernels/moe/moe_grouped_gemm_persistent_3wg_fused_act.py
+++ b/src/tileops/kernels/moe/moe_grouped_gemm_persistent_3wg_fused_act.py
@@ -114,7 +114,7 @@ class MoeGroupedGemmPersistent3WGFusedActKernel(Kernel):
     def schedule_for(cls, numel: int, num_experts: int, k: int) -> dict | None:
         """The short-group schedule this shape asks for, or ``None`` for the default.
 
-        See :mod:`..grouped_gemm.regimes` for the regimes. A subclass that changes
+        See `..grouped_gemm.regimes` for the regimes. A subclass that changes
         which shapes it wants fused overrides this with it, so the two answers
         cannot disagree.
         """

--- a/src/tileops/kernels/norm/group_norm.py
+++ b/src/tileops/kernels/norm/group_norm.py
@@ -305,7 +305,7 @@ class GroupNormKernel(Kernel):
 def _group_norm_no_affine_kernel(M, D, eps, dtype):
     """Build a row-wise normalization kernel for shape (M, D) without affine.
 
-    Same numerics and same boundary handling as :func:`_group_norm_kernel`,
+    Same numerics and same boundary handling as `_group_norm_kernel`,
     but omits the trailing weight/bias multiply-add — output is
     ``(x - mean) * rstd``. Used for the no-affine variants of GroupNorm and
     InstanceNorm.
@@ -381,7 +381,7 @@ class GroupNormNoAffineKernel(Kernel):
 
     Computes ``y = (x - mean) * rstd`` row-wise for shape ``(M, D)`` reshaped
     inputs. Shares the build/launch parameters and shared-memory layout of
-    :class:`GroupNormKernel`; only the output stage differs (no weight/bias
+    `GroupNormKernel`; only the output stage differs (no weight/bias
     multiply-add). Used by the no-affine variants of GroupNorm and
     InstanceNorm.
 

--- a/src/tileops/kernels/norm/instance_norm.py
+++ b/src/tileops/kernels/norm/instance_norm.py
@@ -5,7 +5,7 @@ its own group). The math reduces exactly to the GroupNorm row-wise kernel
 on a reshape of ``(N, C, *spatial) -> (N*C, spatial_size)``.
 
 The TileLang bodies are GroupNorm's; these classes exist so that
-:mod:`tileops.ops.norm.instance_norm` and the manifest can name an
+`tileops.ops.norm.instance_norm` and the manifest can name an
 InstanceNorm-specific kernel, and so that both take the five inputs
 ``InstanceNormFwdOp``'s signature declares.
 """

--- a/src/tileops/kernels/reduction/_primitives.py
+++ b/src/tileops/kernels/reduction/_primitives.py
@@ -744,7 +744,7 @@ def restore_same_shape(
     in_shape: "tuple[int, ...]",
     axes: "tuple[int, ...]",
 ) -> torch.Tensor:
-    """Undo :func:`rows_for_axes` on a result that kept its input's shape.
+    """Undo `rows_for_axes` on a result that kept its input's shape.
 
     For an op that writes one element per input element — softmax, a prefix scan — whose
     row layout is unwound rather than collapsed.
@@ -768,7 +768,7 @@ class RowTiledAutotuneMixin:
     value costs a recompilation.
 
     A subclass must set, before autotuning: ``_planner`` (a
-    :class:`BlockConfigPlanner`), ``_smem_budget``, ``N_padded``, ``_elem_bytes``,
+    `BlockConfigPlanner`), ``_smem_budget``, ``N_padded``, ``_elem_bytes``,
     and ``_MAX_TILE_N_CANDIDATES``.
     """
 

--- a/src/tileops/manifest/__init__.py
+++ b/src/tileops/manifest/__init__.py
@@ -4,13 +4,13 @@ The manifest is split across one or more YAML files per op family in this
 package directory. Most families use a single file, but large families
 (e.g., ``elementwise``) are sharded across multiple files. At load time,
 all files are merged into a single ``ops`` dict; duplicate op names
-across files raise :class:`ValueError`.
+across files raise `ValueError`.
 
 Public entry points:
 
-- :func:`load_workloads` — return the workloads list for an op.
-- :func:`load_manifest` — return the full merged ``ops`` dict.
-- :func:`manifest_files` — list the YAML files contributing to the manifest.
+- `load_workloads` — return the workloads list for an op.
+- `load_manifest` — return the full merged ``ops`` dict.
+- `manifest_files` — list the YAML files contributing to the manifest.
 """
 
 from __future__ import annotations

--- a/src/tileops/manifest/shape_rules.py
+++ b/src/tileops/manifest/shape_rules.py
@@ -115,9 +115,9 @@ def reduced_axes(x: Any, dim: Any) -> frozenset:
     (parity check skipped). Anything else (``None``, a set, a string) falls
     through to the "all axes" branch.
 
-    Pair this helper with :func:`dim_range_validity` and
-    :func:`dim_uniqueness` so range / uniqueness violations surface
-    before the output-shape rules consult :func:`reduced_axes`.
+    Pair this helper with `dim_range_validity` and
+    `dim_uniqueness` so range / uniqueness violations surface
+    before the output-shape rules consult `reduced_axes`.
 
     Args:
         x: A tensor-like object exposing ``.ndim``.
@@ -146,7 +146,7 @@ def reduced_axes(x: Any, dim: Any) -> frozenset:
 
 
 class _Ranked:
-    """The ``.ndim`` view of a shape tuple, so :func:`reduced_axes` can read it."""
+    """The ``.ndim`` view of a shape tuple, so `reduced_axes` can read it."""
 
     __slots__ = ("ndim",)
 
@@ -164,7 +164,7 @@ def reduced_shape(shape: Any, dim: Any, keepdim: bool = False, empty_dim: str = 
     Args:
         shape: The input shape, as a sequence of ints.
         dim: An int, ``None``, or a list/tuple of ints, read the way
-            :func:`reduced_axes` reads it.
+            `reduced_axes` reads it.
         keepdim: Whether a reduced axis stays as a length-1 axis.
         empty_dim: What an empty list/tuple means, matching the op layer's
             ``_empty_dim_policy``: ``"full"`` reduces every axis, ``"noop"``

--- a/src/tileops/ops/_params_codegen.py
+++ b/src/tileops/ops/_params_codegen.py
@@ -17,7 +17,7 @@ ATTRIBUTE = "__manifest_param_names__"
 def maybe_install_param_names(cls: type) -> None:
     """Attach the op's manifest param names to *cls*.
 
-    Resolution mirrors :func:`tileops.ops._dtype_codegen.maybe_install_validator`: a
+    Resolution mirrors `tileops.ops._dtype_codegen.maybe_install_validator`: a
     class-attached ``__manifest_signature__`` first, then the manifest entry keyed by class
     name. A name in the class body wins.
 

--- a/src/tileops/ops/_roofline_codegen.py
+++ b/src/tileops/ops/_roofline_codegen.py
@@ -76,9 +76,9 @@ def _resolve_tensor_binding(
     1. ``self.<name>`` exposes ``.shape`` (a real tensor or any object
        exposing ``.shape`` / ``.ndim``).
     2. ``self.<name>_shape`` is a shape tuple/list; wrapped in a
-       :class:`_ShapeProxy` for uniform ``.shape``/``.ndim`` access.
+       `_ShapeProxy` for uniform ``.shape``/``.ndim`` access.
 
-    Anything else raises :class:`ValueError`, naming the op and the input, so a
+    Anything else raises `ValueError`, naming the op and the input, so a
     missing binding is diagnosable rather than a vacuous ``'NoneType' object has
     no attribute 'shape'`` from inside the generated body.
 

--- a/src/tileops/ops/compile_boundary.py
+++ b/src/tileops/ops/compile_boundary.py
@@ -41,5 +41,5 @@ def register_instance(op: object) -> str:
 
 
 def get_instance(key: str) -> object:
-    """Resolve a key registered by :func:`register_instance`."""
+    """Resolve a key registered by `register_instance`."""
     return _OP_REGISTRY[key]

--- a/src/tileops/ops/convolution.py
+++ b/src/tileops/ops/convolution.py
@@ -404,7 +404,7 @@ class Conv1dFwdOp(Op):
 
         Raises:
             ValueError: Dtypes or shapes disagree with the manifest. Raised from inside the
-                operator, by :meth:`_eager_forward`.
+                operator, by `_eager_forward`.
         """
         return _conv1d_fwd(input, weight, bias, self._instance_key)
 
@@ -803,7 +803,7 @@ class Conv2dFwdOp(Op):
 
         Raises:
             ValueError: Dtypes or shapes disagree with the manifest. Raised from inside the
-                operator, by :meth:`_eager_forward`.
+                operator, by `_eager_forward`.
         """
         return _conv2d_fwd(input, weight, bias, self._instance_key)
 
@@ -1174,7 +1174,7 @@ class Conv3dFwdOp(Op):
 
         Raises:
             ValueError: Dtypes or shapes disagree with the manifest. Raised from inside the
-                operator, by :meth:`_eager_forward`.
+                operator, by `_eager_forward`.
         """
         return _conv3d_fwd(input, weight, bias, self._instance_key)
 

--- a/src/tileops/ops/linear_attention/deltanet.py
+++ b/src/tileops/ops/linear_attention/deltanet.py
@@ -21,7 +21,7 @@ class DeltaNetFwdOp(Op):
 
     Layout: BHSD (batch, head, seq_len, dim).
 
-    .. note:: Layout convention difference with FLA
+    !!! note "Layout convention difference with FLA"
 
         TileOPs uses **BHSD** layout: ``q/k [B, H, S, DK]``, ``v [B, H, S, DV]``,
         ``beta [B, H, S]``.

--- a/src/tileops/ops/norm/ada_layer_norm.py
+++ b/src/tileops/ops/norm/ada_layer_norm.py
@@ -17,10 +17,10 @@ class AdaLayerNormFwdOp(Op):
 
     Applies layer normalization with per-token adaptive scale and shift:
 
-    .. math::
-
-        y = s \\cdot \\frac{x - \\mathrm{E}[x]}{\\sqrt{\\mathrm{Var}[x]
-            + \\epsilon}} + d
+    $$
+    y = s \\cdot \\frac{x - \\mathrm{E}[x]}{\\sqrt{\\mathrm{Var}[x]
+    + \\epsilon}} + d
+    $$
 
     where *s* (scale) and *d* (shift) are per-token tensors of shape
     ``(M, N)``, pre-computed by the caller from a conditioning signal.
@@ -95,7 +95,7 @@ class AdaLayerNormFwdOp(Op):
 
         Raises:
             ValueError: Dtypes or shapes disagree. Raised from inside the operator, by
-                :meth:`_eager_forward`.
+                `_eager_forward`.
         """
         return _norm_ada_layer_norm_fwd(x, scale, shift, self._instance_key)
 

--- a/src/tileops/ops/norm/ada_layer_norm_zero.py
+++ b/src/tileops/ops/norm/ada_layer_norm_zero.py
@@ -18,10 +18,10 @@ class AdaLayerNormZeroFwdOp(Op):
     Applies layer normalization with per-token adaptive scale, shift, and
     gating:
 
-    .. math::
-
-        y = g \\cdot \\left( s \\cdot \\frac{x - \\mathrm{E}[x]}
-            {\\sqrt{\\mathrm{Var}[x] + \\epsilon}} + d \\right)
+    $$
+    y = g \\cdot \\left( s \\cdot \\frac{x - \\mathrm{E}[x]}
+    {\\sqrt{\\mathrm{Var}[x] + \\epsilon}} + d \\right)
+    $$
 
     where *s* (scale), *d* (shift), and *g* (gate) are per-token tensors of
     shape ``(M, N)``, pre-computed by the caller from a conditioning signal.
@@ -100,7 +100,7 @@ class AdaLayerNormZeroFwdOp(Op):
 
         Raises:
             ValueError: Dtypes or shapes disagree. Raised from inside the operator, by
-                :meth:`_eager_forward`.
+                `_eager_forward`.
         """
         return _norm_ada_layer_norm_zero_fwd(x, scale, shift, gate, self._instance_key)
 

--- a/src/tileops/ops/norm/batch_norm.py
+++ b/src/tileops/ops/norm/batch_norm.py
@@ -3,7 +3,7 @@
 Wraps BatchNormFwdTrainKernel, BatchNormFwdInferKernel, and BatchNormBwdKernel
 in a standard TileOPs Op interface.
 
-User-facing API mirrors :func:`torch.nn.functional.batch_norm`:
+User-facing API mirrors `torch.nn.functional.batch_norm`:
 
     fwd_op = BatchNormFwdOp(training=False, momentum=0.1, eps=1e-5)
     y = fwd_op(x, running_mean, running_var, weight, bias)
@@ -43,15 +43,15 @@ class BatchNormFwdOp(Op):
 
     Computes batch normalization over the channel dimension:
 
-    .. math::
-
-        y = \\frac{x - \\mathrm{E}[x]}{\\sqrt{\\mathrm{Var}[x] + \\epsilon}}
-            \\cdot \\gamma + \\beta
+    $$
+    y = \\frac{x - \\mathrm{E}[x]}{\\sqrt{\\mathrm{Var}[x] + \\epsilon}}
+    \\cdot \\gamma + \\beta
+    $$
 
     where the mean and variance are computed per channel over ``(N, *spatial)``
     elements.
 
-    Mirrors :func:`torch.nn.functional.batch_norm`: ``forward`` accepts
+    Mirrors `torch.nn.functional.batch_norm`: ``forward`` accepts
     ``(input, running_mean, running_var, weight, bias)`` in PyTorch's
     positional order and returns only the normalized output. Internal
     mean/rstd computed in training mode stay private; callers needing them

--- a/src/tileops/ops/norm/fused_add_layer_norm.py
+++ b/src/tileops/ops/norm/fused_add_layer_norm.py
@@ -18,13 +18,13 @@ class FusedAddLayerNormFwdOp(Op):
     Computes the residual sum followed by layer normalization in a single
     fused kernel:
 
-    .. math::
-
-        \\begin{aligned}
-        r &= x + \\mathrm{residual} \\\\
-        y &= \\frac{r - \\mathrm{E}[r]}{\\sqrt{\\mathrm{Var}[r] + \\epsilon}}
-            \\cdot w + b
-        \\end{aligned}
+    $$
+    \\begin{aligned}
+    r &= x + \\mathrm{residual} \\\\
+    y &= \\frac{r - \\mathrm{E}[r]}{\\sqrt{\\mathrm{Var}[r] + \\epsilon}}
+    \\cdot w + b
+    \\end{aligned}
+    $$
 
     Returns dual outputs ``(y, residual_out)`` so downstream residual connections can
     reuse the pre-norm sum without recomputation.
@@ -106,7 +106,7 @@ class FusedAddLayerNormFwdOp(Op):
 
         Raises:
             ValueError: Dtypes or shapes disagree. Raised from inside the operator, by
-                :meth:`_eager_forward`.
+                `_eager_forward`.
         """
         return _norm_fused_add_layer_norm_fwd(x, residual, weight, bias, self._instance_key)
 

--- a/src/tileops/ops/norm/fused_add_rms_norm.py
+++ b/src/tileops/ops/norm/fused_add_rms_norm.py
@@ -18,12 +18,12 @@ class FusedAddRMSNormFwdOp(Op):
     Computes the residual sum followed by RMS normalization in a single
     fused kernel:
 
-    .. math::
-
-        \\begin{aligned}
-        r &= x + \\mathrm{residual} \\\\
-        y &= \\frac{r}{\\sqrt{\\mathrm{mean}(r^2) + \\epsilon}} \\cdot w
-        \\end{aligned}
+    $$
+    \\begin{aligned}
+    r &= x + \\mathrm{residual} \\\\
+    y &= \\frac{r}{\\sqrt{\\mathrm{mean}(r^2) + \\epsilon}} \\cdot w
+    \\end{aligned}
+    $$
 
     Returns dual outputs ``(y, residual_out)`` so downstream residual connections can
     reuse the pre-norm sum without recomputation.
@@ -103,7 +103,7 @@ class FusedAddRMSNormFwdOp(Op):
 
         Raises:
             ValueError: Dtypes or shapes disagree. Raised from inside the operator, by
-                :meth:`_eager_forward`.
+                `_eager_forward`.
         """
         return _norm_fused_add_rms_norm_fwd(x, residual, weight, self._instance_key)
 

--- a/src/tileops/ops/norm/group_norm.py
+++ b/src/tileops/ops/norm/group_norm.py
@@ -32,10 +32,10 @@ class GroupNormFwdOp(Op):
 
     Computes group normalization over ``(C/num_groups, *spatial)`` slices:
 
-    .. math::
-
-        y = \\frac{x - \\mathrm{E}[x]}{\\sqrt{\\mathrm{Var}[x] + \\epsilon}}
-            \\cdot w + b
+    $$
+    y = \\frac{x - \\mathrm{E}[x]}{\\sqrt{\\mathrm{Var}[x] + \\epsilon}}
+    \\cdot w + b
+    $$
 
     where the mean and variance are computed per group over
     ``(C/num_groups, *spatial)`` elements.
@@ -154,7 +154,7 @@ class GroupNormFwdOp(Op):
         Raises:
             ValueError: Only one of ``weight`` / ``bias`` is given, dtypes disagree, or a
                 shape is incompatible with *x*. Raised from inside the operator, by
-                :meth:`_eager_forward`.
+                `_eager_forward`.
         """
         return _norm_group_norm_fwd(x, weight, bias, self._instance_key)
 

--- a/src/tileops/ops/norm/instance_norm.py
+++ b/src/tileops/ops/norm/instance_norm.py
@@ -2,9 +2,9 @@
 
 Instance Normalization (IN) is a special case of Group Normalization (GN)
 where ``num_groups = C`` (each channel is its own group). The affine path
-delegates to :class:`GroupNormKernel` with that grouping.
+delegates to `GroupNormKernel` with that grouping.
 
-User-facing API mirrors :func:`torch.nn.functional.instance_norm`:
+User-facing API mirrors `torch.nn.functional.instance_norm`:
 
     op = InstanceNormFwdOp()
     y = op(x, running_mean, running_var, weight, bias)
@@ -37,10 +37,10 @@ class InstanceNormFwdOp(Op):
     Computes instance normalization over spatial dimensions for each
     ``(batch, channel)`` independently:
 
-    .. math::
-
-        y = \\frac{x - \\mathrm{E}[x]}{\\sqrt{\\mathrm{Var}[x] + \\epsilon}}
-            \\cdot w + b
+    $$
+    y = \\frac{x - \\mathrm{E}[x]}{\\sqrt{\\mathrm{Var}[x] + \\epsilon}}
+    \\cdot w + b
+    $$
 
     where the mean and variance are computed over ``*spatial`` for each
     sample-channel pair, and the trailing affine applies only when ``weight``
@@ -52,9 +52,9 @@ class InstanceNormFwdOp(Op):
 
     Note:
         Supports arbitrary spatial dimensions (1-D, 2-D, 3-D+). The affine
-        call delegates to :class:`GroupNormKernel` with one group per channel,
+        call delegates to `GroupNormKernel` with one group per channel,
         which applies the per-channel affine itself; without affine it
-        delegates to :class:`InstanceNormNoAffineKernel`.
+        delegates to `InstanceNormNoAffineKernel`.
 
     Args:
         use_input_stats: Mirrors ``torch.nn.functional.instance_norm``. When
@@ -251,7 +251,7 @@ class InstanceNormFwdOp(Op):
             ValueError: A dtype mismatches, a shape is incompatible, one half of a pair
                 is passed, or ``use_input_stats=False`` without running stats.
             NotImplementedError: ``use_input_stats=False`` combined with the affine
-                tensors. Both raised from inside the operator, by :meth:`_eager_forward`.
+                tensors. Both raised from inside the operator, by `_eager_forward`.
         """
         return _norm_instance_norm_fwd(
             x, running_mean, running_var, weight, bias, self._instance_key

--- a/src/tileops/ops/norm/layer_norm.py
+++ b/src/tileops/ops/norm/layer_norm.py
@@ -19,12 +19,12 @@ class LayerNormFwdOp(Op):
     Computes layer normalization over the trailing ``normalized_shape``
     axes:
 
-    .. math::
+    $$
+    y = \\frac{x - \\mathrm{E}[x]}{\\sqrt{\\mathrm{Var}[x] + \\epsilon}}
+    \\cdot w + b
+    $$
 
-        y = \\frac{x - \\mathrm{E}[x]}{\\sqrt{\\mathrm{Var}[x] + \\epsilon}}
-            \\cdot w + b
-
-    Mirrors :func:`torch.nn.functional.layer_norm`. ``normalized_shape``
+    Mirrors `torch.nn.functional.layer_norm`. ``normalized_shape``
     is the only entry point (the manifest spec).
 
     Supported dtypes:
@@ -112,7 +112,7 @@ class LayerNormFwdOp(Op):
         Raises:
             ValueError: Dtypes or devices disagree, or shapes are incompatible with the
                 configured ``normalized_shape``. Raised from inside the operator, by
-                :meth:`_eager_forward`.
+                `_eager_forward`.
         """
         return _layer_norm_fwd(x, weight, bias, self._instance_key)
 

--- a/src/tileops/ops/norm/rms_norm.py
+++ b/src/tileops/ops/norm/rms_norm.py
@@ -33,7 +33,7 @@ __all__ = ["RMSNormFwdOp"]
 class RMSNormFwdOp(Op):
     """Standalone Root Mean Square (RMS) Norm operator.
 
-    Mirrors :func:`torch.nn.functional.rms_norm`. Computes::
+    Mirrors `torch.nn.functional.rms_norm`. Computes::
 
         y = x * rsqrt(mean(x ** 2, trailing_axes) + eps) * weight
 
@@ -119,7 +119,7 @@ class RMSNormFwdOp(Op):
         Raises:
             ValueError: Dtypes or devices disagree, or shapes are incompatible with the
                 configured ``normalized_shape``. Raised from inside the operator, by
-                :meth:`_eager_forward`.
+                `_eager_forward`.
         """
         return _rms_norm_fwd(x, weight, self._instance_key)
 

--- a/src/tileops/ops/op_base.py
+++ b/src/tileops/ops/op_base.py
@@ -559,7 +559,7 @@ class Op(ABC):
 
         Settles which set of kernels serves this instance, once, then delegates to
         ``forward`` — which is the same for every target. The only fork is inside
-        :meth:`get_or_build_kernel`, which settles it a second time when this settling
+        `get_or_build_kernel`, which settles it a second time when this settling
         could not reach it; see there.
 
         A call that fails settles nothing. Otherwise one invalid call would aim the instance

--- a/src/tileops/ops/reduction/_multidim.py
+++ b/src/tileops/ops/reduction/_multidim.py
@@ -3,7 +3,7 @@
 Turning ``dim`` into the axes a call reduces is the op's contract: which forms an empty
 ``dim`` takes, and which values a given rank accepts, differ per op and are declared in
 the manifest. What a kernel then does with those axes — the permute to rows and back —
-lives in :mod:`tileops.kernels.reduction._primitives`.
+lives in `tileops.kernels.reduction._primitives`.
 """
 
 from __future__ import annotations

--- a/src/tileops/ops/reduction/argreduce.py
+++ b/src/tileops/ops/reduction/argreduce.py
@@ -22,7 +22,7 @@ class _ArgreduceOpBase(_ReduceOpBase):
     copies the whole tensor, or give a thread each output element and stride along the
     axis, which reads the original buffer coalesced. Which one pays off follows from the
     row count, the axis length and its stride — all three facts the kernel already holds,
-    so the choice is the kernel's (:class:`~tileops.kernels.reduction.argreduce.ArgreduceKernel`).
+    so the choice is the kernel's (`tileops.kernels.reduction.argreduce.ArgreduceKernel`).
     This op's part is the stride, which the shape and the reduced axis decide.
     """
 


### PR DESCRIPTION
## Problems

- Docstrings carry reStructuredText, but mkdocstrings reads them as Markdown, so the markup reaches the API pages as literal text.
- 8 `.. math::` directives and the formulas under them render as `.. math::` followed by raw LaTeX.
- 50 `:func:` / `:meth:` / `:class:` / `:mod:` roles render with the role prefix visible, e.g. `:func:`torch.nn.functional.layer_norm``.
- 1 `.. note::` block renders as a plain paragraph, losing the callout.

## Changes

- `.. math::` → `$$…$$`; the docs site renders it through `pymdownx.arithmatex` + MathJax (tile-ai/TileOPs.github.io adds the extension in the same round).
- `.. note:: <title>` → `!!! note "<title>"`, with its body indented for the admonition.
- Roles → inline code: they never resolved to a link on the site, and the name is what a reader needs.
- Docstring text only. No signature, default, or behaviour changes; `ruff check`, `ruff format`, `codespell` and the repo's pre-commit hooks pass.