### PR TITLE
[CI] Install FlashAttention-3 for real, and fail the build when a baseline is missing

### DIFF
--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -58,22 +58,35 @@ RUN uv pip install pytest pytest-xdist ruff pytest-timeout pytest-cov py-spy
 # CCCL, so every translation unit fails on `cuda/std/utility`. Only main takes the CUDA 13 path.
 # Only csrc/cutlass: --recursive also pulls AMD composable_kernel, unused at sm_90 and slow.
 ARG FLASH_ATTENTION_GIT_SHA=a369df707e1980fb328abcc1733e3457ec10155f
-RUN { mkdir -p /tmp/flash-attention \
+# Fatal, unlike the bench baselines below: eleven attention benchmarks name `fa3` and
+# lose the column without it. Imported here because a returned 0 has meant an installed
+# wrapper with no compiled extension behind it.
+RUN set -e; \
+    mkdir -p /tmp/flash-attention \
         && cd /tmp/flash-attention \
         && git init -q \
         && git remote add origin https://github.com/Dao-AILab/flash-attention.git \
         && git fetch --depth 1 origin "${FLASH_ATTENTION_GIT_SHA}" \
         && git checkout -q FETCH_HEAD \
-        && git submodule update --init --depth 1 csrc/cutlass \
-        && cd hopper && python setup.py install; }; \
-    status=$?; rm -rf /tmp/flash-attention; \
-    [ "$status" -eq 0 ] || echo "WARNING: FlashAttention-3 (hopper) build failed (non-fatal)"
+        && git submodule update --init --depth 1 csrc/cutlass; \
+    cd /tmp/flash-attention/hopper && python setup.py install; \
+    cd / && rm -rf /tmp/flash-attention; \
+    python -c "import flash_attn_interface as m; assert m.flash_attn_func is not None; print('FA3 OK')"
 
 # Own layer: no wheel for this torch/py, so it builds from source and changes to the bench loop
 # below must not recompile it.
 FROM post-fa3 AS fa2
-RUN uv pip install --no-build-isolation "flash-attn==2.8.3.post1" \
-    || echo "WARNING: flash-attn (FA2) install failed (non-fatal)"
+# Retried like DeepGEMM below: setup.py takes a prebuilt wheel from GitHub releases, and
+# a dropped download fails a step that would have worked. FLASH_ATTENTION_FORCE_BUILD
+# compiles instead -- slower, and the way out where that download keeps failing.
+ARG FLASH_ATTENTION_FORCE_BUILD=
+RUN for attempt in 1 2 3 4 5; do \
+        FLASH_ATTENTION_FORCE_BUILD="${FLASH_ATTENTION_FORCE_BUILD}" \
+            uv pip install --no-build-isolation "flash-attn==2.8.3.post1" && break; \
+        echo "WARNING: flash-attn (FA2) install failed (attempt ${attempt}/5)"; \
+        [ "${attempt}" = 5 ] && exit 1; \
+        sleep "$((attempt * 10))"; \
+    done
 
 # This vllm and no other: its apache-tvm-ffi pin (0.1.11) is the one the tilelang commit needs.
 # Versions come from constraints.txt via UV_CONSTRAINT. sgl-kernel is not installed.
@@ -132,15 +145,23 @@ RUN if [ -n "${TILELANG_GIT_SHA}" ]; then \
         mkdir -p /tmp/tilelang && cd /tmp/tilelang \
         && git init -q \
         && git remote add origin https://github.com/tile-ai/tilelang.git \
-        && git fetch --depth 1 origin "${TILELANG_GIT_SHA}" \
+        && for attempt in 1 2 3 4 5; do \
+            git -c http.version=HTTP/1.1 fetch --depth 1 origin "${TILELANG_GIT_SHA}" && break; \
+            echo "WARNING: tilelang fetch failed (attempt ${attempt}/5)"; \
+            [ "${attempt}" = 5 ] && exit 1; sleep "$((attempt * 10))"; \
+        done \
         && git checkout -q FETCH_HEAD \
-        && git submodule update --init --depth 1 --recursive \
-            3rdparty/composable_kernel 3rdparty/cutlass 3rdparty/tvm \
+        && for attempt in 1 2 3 4 5; do \
+            git -c http.version=HTTP/1.1 submodule update --init --depth 1 --recursive --jobs 1 \
+                3rdparty/composable_kernel 3rdparty/cutlass 3rdparty/tvm && break; \
+            echo "WARNING: tilelang submodule fetch failed (attempt ${attempt}/5)"; \
+            [ "${attempt}" = 5 ] && exit 1; sleep "$((attempt * 10))"; \
+        done \
         && mkdir -p /opt/tilelang-wheels \
         && CMAKE_BUILD_PARALLEL_LEVEL="${MAX_JOBS}" \
             python -m pip wheel . --no-deps --no-build-isolation -w /opt/tilelang-wheels \
         && uv pip install --no-deps --reinstall /opt/tilelang-wheels/tilelang-*.whl \
-        && rm -rf /tmp/tilelang; \
+        && rm -rf /tmp/tilelang /opt/tilelang-wheels; \
     elif [ -n "${TILELANG_VERSION}" ]; then \
         uv pip install --no-deps --reinstall "tilelang==${TILELANG_VERSION}"; \
     else \

--- a/.github/runner/README.md
+++ b/.github/runner/README.md
@@ -58,6 +58,9 @@ What the flags are for:
 - `--build-arg TILEOPS_RUNNER_IMAGE` — bakes the tag in, so a run reports which image produced
   it; the registry cannot answer that later. `-e TILEOPS_RUNNER_IMAGE=<tag>` overrides it for an
   image built before this. With neither, the nightly reports the image as unknown.
+- `--build-arg FLASH_ATTENTION_FORCE_BUILD=TRUE` — compiles FlashAttention-2 instead of
+  taking the prebuilt wheel from its GitHub releases. Slower; reach for it only where that
+  download keeps failing.
 - `--target runtime`, `--target fa2`, … — build an earlier stage to debug.
 
 ## Bump the tilelang commit

--- a/scripts/ci/verify_runner_image.py
+++ b/scripts/ci/verify_runner_image.py
@@ -27,6 +27,14 @@ def main() -> int:
 
     print(f"flashinfer {flashinfer.__version__}")
 
+    # A missing baseline costs the column, not the run, so nothing else notices.
+    import flag_gems  # noqa: F401 - import is the check
+    import flash_attn
+    import flash_attn_interface
+
+    assert flash_attn_interface.flash_attn_func is not None
+    print(f"flash-attn {flash_attn.__version__} | flash-attn-3 | flag_gems")
+
     import mamba_ssm
     import selective_scan_cuda  # noqa: F401 - import is the check
     from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined

--- a/scripts/ci/verify_runtime_stack.py
+++ b/scripts/ci/verify_runtime_stack.py
@@ -66,6 +66,30 @@ if bindings_pin is not None and not bindings_pin.specifier.contains(
         f"{bindings_pin.specifier}. Install cupti-python with --no-deps."
     )
 
+# A missing baseline costs the column, not the run, so nothing else notices. FA3 is
+# imported because a returned 0 has meant an installed wrapper with no extension behind
+# it; the rest are checked for presence, since flag_gems and flashinfer want a device.
+try:
+    import flash_attn_interface
+
+    assert flash_attn_interface.flash_attn_func is not None
+except Exception as exc:  # noqa: BLE001 - a half-built FA3 raises several ways
+    sys.exit(
+        f"FAIL: flash_attn_interface does not import ({exc}). Eleven attention "
+        "benchmarks name `fa3` and would silently drop the column."
+    )
+
+for dist, why in (
+    ("flash-attn", "the FA2 columns"),
+    ("flag_gems", "the flaggems columns"),
+    ("flashinfer-python", "the flashinfer columns"),
+    ("flash-linear-attention", "the linear-attention columns"),
+):
+    try:
+        md.version(dist)
+    except md.PackageNotFoundError:
+        sys.exit(f"FAIL: {dist} is not installed; {why} would be missing.")
+
 print(
     f"runtime-stack OK: tilelang {tilelang.__version__} | "
     f"torch {torch.__version__} (cuda {torch.version.cuda}) | "


### PR DESCRIPTION
## Problems

The runner image shipped without a working FlashAttention-3, and nothing noticed.

- `cd hopper && python setup.py install` left `dist-packages/hopper/flash_attn_interface.py` in place with **no compiled `flash_attn_3` extension** behind it, returned 0, and the step's `|| echo "WARNING: ... (non-fatal)"` swallowed the rest. `pip list` in the published image showed `flash_attn 2.8.3.post1` and no FA3 at all.
- Nothing downstream looked. `verify_runner_image.py` checked tilelang, flashinfer, mamba_ssm and deep_gemm; a benchmark missing a baseline does not fail, it drops the column.
- So eleven attention benchmarks named `fa3` and published without it, and the eight fp8 prefill rows published with no comparison. The nightly XML carries **no `fa3` column across its 1137 cases**.
- Two more silent failures surfaced once the gate existed: FA2's install and tilelang's submodule clone each failed on a dropped connection and were swallowed the same way.

## Changes

- The FA3 step is **fatal**, and imports what it installed. A returned 0 proves nothing here — that is the whole failure — so the import is the check.
- The FA2 install and the tilelang git fetch and submodule update retry five times, which DeepGEMM already did. Each loop **exits non-zero when it runs out of attempts**, so an exhausted retry cannot read as success.
- `FLASH_ATTENTION_FORCE_BUILD` compiles FA2 instead of taking the prebuilt wheel from its GitHub releases. Empty by default, so nothing changes; it is the way out where that download is what keeps failing. Documented in the README.
- The tilelang wheel is deleted after it is installed from.
- Both verifiers name the baselines. `verify_runtime_stack.py` runs on the builder, so it imports FA3 and checks the rest for presence — flag_gems and flashinfer want a device at import. `verify_runner_image.py` runs under GPU and imports all of them.
