### PR TITLE
[Doc] The two docstrings each op's API page is built from

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,6 +75,12 @@ repos:
         language: python
         files: ^benchmarks/.*\.py$
 
+      - id: op-docstrings-lint
+        name: op docstring lint
+        entry: python scripts/lint/op_docstrings_lint.py
+        language: python
+        files: ^src/tileops/ops/.*\.py$
+
   - repo: https://github.com/executablebooks/mdformat
     rev: 0.7.22
     hooks:

--- a/docs/development.md
+++ b/docs/development.md
@@ -73,6 +73,49 @@ The `packaging` marker is separate from the tiers: it is a minimal wheel-install
 pre-commit run --all-files
 ```
 
+## Docstrings
+
+Docstrings are the API reference on
+[the docs site](https://tile-ai.github.io/TileOPs.github.io/), and mkdocstrings
+renders them **as Markdown** — reStructuredText reaches the page as literal text.
+
+Three docstrings per op, each answering one question:
+
+| Docstring  | Answers             | Sections                                               |
+| ---------- | ------------------- | ------------------------------------------------------ |
+| the class  | what the op is      | prose: the formula, the shapes, when a kernel rebuilds |
+| `__init__` | how to construct it | `Args:`                                                |
+| `forward`  | how to call it      | `Args:`, `Returns:`, `Raises:`, `Example:` last        |
+
+Both members need one: the page gives every member an entry, so a missing
+docstring publishes a heading with nothing under it. Parameters go on `__init__`,
+not in the class's `Args:`, and the example goes last in `forward` — a class
+docstring renders above both signatures.
+
+How to write each element:
+
+| Element                | Write                                                              | Not                                                              |
+| ---------------------- | ------------------------------------------------------------------ | ---------------------------------------------------------------- |
+| Code example           | a fenced block inside `Example:`: ```` ```python linenums="1" ```` | `>>>` prompts — `>` is a Markdown blockquote                     |
+| Tensor shape           | `$[B \\times M \\times K]$`                                        | `` `[B, M, K]` ``                                                |
+| Formula                | `$d_i = a_i \\mathbin{@} b_i$`, or `$$…$$` on its own line         | `.. math::`                                                      |
+| Four or more variants  | a table                                                            | an indented bullet list, which Markdown folds into one paragraph |
+| Callout                | `!!! note "Title"`, body indented four spaces                      | `.. note::`                                                      |
+| Cross-reference        | `` `torch.nn.functional.rms_norm` ``                               | `:func:` and the other roles                                     |
+| Identifier, path, flag | inline code                                                        | math                                                             |
+
+Two that bite:
+
+- **Double every backslash.** A docstring is a regular string literal, so
+  `\\times` is a tab followed by `imes`. Write `\\\\times`, or make the docstring raw.
+- **A shape is a product of dimensions.** `` `(flops, bytes)` `` is a return pair
+  and stays code.
+
+[`bmm.py`](../src/tileops/ops/gemm/bmm.py) carries all of it and is the one to copy
+from. `scripts/lint/op_docstrings_lint.py` fails a missing docstring,
+reStructuredText, or an `Args:` left on a class; it runs as the
+`op-docstrings-lint` pre-commit hook and in the `pre-commit` CI job.
+
 ## Benchmarks
 
 Benchmarks compare against external baselines, which the `bench` extra pulls in:

--- a/scripts/lint/op_docstrings_lint.py
+++ b/scripts/lint/op_docstrings_lint.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Lint op classes for the docstrings the API reference is built from.
+
+The docs site gives every rendered member an entry, so a missing docstring
+publishes a heading and a signature with nothing under them. For each class under
+``src/tileops/ops/`` that defines either method, this checks that ``__init__`` and
+``forward`` have a docstring, that neither carries reStructuredText the site
+renders as literal text, and that construction parameters sit on ``__init__``
+rather than in the class docstring's ``Args:``. See docs/development.md.
+
+Usage: ``op_docstrings_lint.py [FILE ...]``; with no arguments, scans the tree.
+"""
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+OPS_DIR = REPO_ROOT / "src" / "tileops" / "ops"
+
+RST = re.compile(r"\.\. (?:math|note|warning)::|:(?:func|meth|class|mod):`|>>> ")
+CLASS_ARGS = re.compile(r"^\s*Args:\s*$", re.M)
+
+
+def check_file(path: Path) -> list[str]:
+    try:
+        tree = ast.parse(path.read_text())
+    except SyntaxError as exc:  # ruff reports these; do not double up
+        return [f"{path}: cannot parse ({exc})"]
+
+    try:
+        rel = path.resolve().relative_to(REPO_ROOT)
+    except ValueError:
+        rel = path
+
+    problems: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        methods = {n.name: n for n in node.body if isinstance(n, ast.FunctionDef)}
+        if not ({"__init__", "forward"} & methods.keys()):
+            continue
+
+        for name in ("__init__", "forward"):
+            method = methods.get(name)
+            if method is None:
+                continue
+            doc = ast.get_docstring(method)
+            if doc is None:
+                problems.append(
+                    f"{rel}:{method.lineno}: {node.name}.{name} has no docstring; "
+                    f"the API page renders an empty entry for it"
+                )
+            elif RST.search(doc):
+                problems.append(
+                    f"{rel}:{method.lineno}: {node.name}.{name} carries "
+                    f"reStructuredText; docstrings render as Markdown"
+                )
+
+        if "__init__" in methods and CLASS_ARGS.search(ast.get_docstring(node) or ""):
+            problems.append(
+                f"{rel}:{node.lineno}: {node.name} documents parameters in its class "
+                f"docstring; they belong on __init__"
+            )
+    return problems
+
+
+def main(argv: list[str]) -> int:
+    files = [Path(a) for a in argv] or sorted(OPS_DIR.rglob("*.py"))
+    problems = [
+        problem
+        for path in files
+        if path.suffix == ".py" and path.exists()
+        for problem in check_file(path)
+    ]
+    for problem in problems:
+        print(problem, file=sys.stderr)
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/tileops/kernels/elementwise/masked_fill.py
+++ b/src/tileops/kernels/elementwise/masked_fill.py
@@ -146,7 +146,7 @@ def _make_masked_fill_tensor_value_kernel(
             x: data tensor (length N).
             mask: bool mask packed as uint8 (length N).
             value: scalar fill value carried as a length-1 tensor (``forward``
-                reshapes the 0-dim Tensor to ``(1,)``).
+                reshapes the 0-dim Tensor to $[1]$).
 
         Output:
             out: ``out[i] = value[0] if mask[i] else x[i]``.

--- a/src/tileops/kernels/engram/engram_bwd.py
+++ b/src/tileops/kernels/engram/engram_bwd.py
@@ -474,18 +474,18 @@ class EngramGateConvBwdKernel(Kernel):
         """Run the fused gate + conv backward pass.
 
         Args:
-            dY: Gradient of the output, shape ``(M, seq_len, d)``.
-            H: Hidden states of shape ``(M, seq_len, d)``.
-            k: Key projection of shape ``(M, seq_len, d)``.
-            v: Value projection of shape ``(M, seq_len, d)``.
-            rms_w_h: RMSNorm weight of shape ``(d,)`` for ``H`` and ``k``.
-            rms_w_v: RMSNorm weight of shape ``(d,)`` for the gated value.
-            conv_w: Depthwise conv weights of shape ``(4, d)``.
+            dY: Gradient of the output, shape $[M \\times seq\\_len \\times d]$.
+            H: Hidden states of shape $[M \\times seq\\_len \\times d]$.
+            k: Key projection of shape $[M \\times seq\\_len \\times d]$.
+            v: Value projection of shape $[M \\times seq\\_len \\times d]$.
+            rms_w_h: RMSNorm weight of shape $[d]$ for ``H`` and ``k``.
+            rms_w_v: RMSNorm weight of shape $[d]$ for the gated value.
+            conv_w: Depthwise conv weights of shape $[4 \\times d]$.
             vhat: Gated value saved by the forward pass, ``(M, seq_len, d)``.
             alpha: Scalar gate saved by the forward pass, ``(M, seq_len)``.
-            rrms_h: Reciprocal RMS of ``H``, shape ``(M, seq_len)``.
-            rrms_k: Reciprocal RMS of ``k``, shape ``(M, seq_len)``.
-            rrms_v: Reciprocal RMS of ``vhat``, shape ``(M, seq_len)``.
+            rrms_h: Reciprocal RMS of ``H``, shape $[M \\times seq\\_len]$.
+            rrms_k: Reciprocal RMS of ``k``, shape $[M \\times seq\\_len]$.
+            rrms_v: Reciprocal RMS of ``vhat``, shape $[M \\times seq\\_len]$.
 
         Returns:
             ``[dH, dk, dv, drms_w_h, drms_w_v, dconv_w]``, trimmed to ``d``.

--- a/src/tileops/kernels/engram/engram_decode.py
+++ b/src/tileops/kernels/engram/engram_decode.py
@@ -380,19 +380,19 @@ class EngramDecodeKernel(Kernel):
         """Run one fused decode step.
 
         Args:
-            e_t: Gathered N-gram embedding, shape ``(B, d_mem)``.
-            h_t: Hidden state for the current token, shape ``(B, d)``.
-            conv_state: Conv history of shape ``(B, L, d)`` with
+            e_t: Gathered N-gram embedding, shape $[B \\times d\\_mem]$.
+            h_t: Hidden state for the current token, shape $[B \\times d]$.
+            conv_state: Conv history of shape $[B \\times L \\times d]$ with
                 ``L <= max_conv_len``; left-padded to the compiled capacity
                 here.
-            W_K: Key projection weight of shape ``(d_mem, d)``.
-            W_V: Value projection weight of shape ``(d_mem, d)``.
-            rms_w_h: RMSNorm weight of shape ``(d,)`` for ``h`` and ``k``.
-            rms_w_v: RMSNorm weight of shape ``(d,)`` for the gated value.
-            conv_w: Depthwise conv weights of shape ``(w, d)``.
+            W_K: Key projection weight of shape $[d\\_mem \\times d]$.
+            W_V: Value projection weight of shape $[d\\_mem \\times d]$.
+            rms_w_h: RMSNorm weight of shape $[d]$ for ``h`` and ``k``.
+            rms_w_v: RMSNorm weight of shape $[d]$ for the gated value.
+            conv_w: Depthwise conv weights of shape $[w \\times d]$.
 
         Returns:
-            ``[y_t, new_conv_state]`` of shapes ``(B, d)`` and
+            ``[y_t, new_conv_state]`` of shapes $[B \\times d]$ and
             ``(B, max_conv_len, d)``. The alignment padding the prim_func
             requires is applied and trimmed here.
         """

--- a/src/tileops/kernels/engram/engram_fwd.py
+++ b/src/tileops/kernels/engram/engram_fwd.py
@@ -287,15 +287,15 @@ class EngramGateConvFwdKernel(Kernel):
         """Run the fused gate + conv forward pass.
 
         Args:
-            H: Hidden states of shape ``(M, seq_len, d)``.
-            k: Key projection of shape ``(M, seq_len, d)``.
-            v: Value projection of shape ``(M, seq_len, d)``.
-            rms_w_h: RMSNorm weight of shape ``(d,)`` for ``H`` and ``k``.
-            rms_w_v: RMSNorm weight of shape ``(d,)`` for the gated value.
-            conv_w: Depthwise conv weights of shape ``(4, d)``.
+            H: Hidden states of shape $[M \\times seq\\_len \\times d]$.
+            k: Key projection of shape $[M \\times seq\\_len \\times d]$.
+            v: Value projection of shape $[M \\times seq\\_len \\times d]$.
+            rms_w_h: RMSNorm weight of shape $[d]$ for ``H`` and ``k``.
+            rms_w_v: RMSNorm weight of shape $[d]$ for the gated value.
+            conv_w: Depthwise conv weights of shape $[4 \\times d]$.
 
         Returns:
-            ``[Y, vhat, alpha, rrms_h, rrms_k, rrms_v]``. ``Y`` and ``vhat``
+            $[Y \\times vhat \\times alpha \\times rrms\\_h \\times rrms\\_k \\times rrms\\_v]$. ``Y`` and ``vhat``
             are ``(M, seq_len, d)``; the alignment padding the prim_func
             requires is applied and trimmed here.
         """

--- a/src/tileops/kernels/fp8_quant.py
+++ b/src/tileops/kernels/fp8_quant.py
@@ -90,7 +90,7 @@ def _(batch, seq_len_kv, kv_group, index_dim, in_dtype, num_stages, block_m, *in
 
 
 class FP8QuantKernel(Kernel):
-    """Per-group fp8 quantization of a ``[B, S_kv, G, D]`` index tensor.
+    """Per-group fp8 quantization of a $[B \\times S\\_kv \\times G \\times D]$ index tensor.
 
     Args:
         batch: Batch size.

--- a/src/tileops/kernels/gemm/bmm.py
+++ b/src/tileops/kernels/gemm/bmm.py
@@ -1,6 +1,6 @@
 """Batched GEMM kernel for BmmFwdOp.
 
-Shapes are strict 3D-3D — ``a: [B, M, K]``, ``b: [B, K,N]``, ``c: [B, M, N]``.
+Shapes are strict 3D-3D — ``a``: $[B \\times M \\times K]$, ``b``: $[B \\times K \\times N]$, ``c``: $[B \\times M \\times N]$.
 """
 
 import functools

--- a/src/tileops/kernels/gemm/dense.py
+++ b/src/tileops/kernels/gemm/dense.py
@@ -359,8 +359,8 @@ def _gemm_kernel(
     One producer warpgroup (128 threads) issues TMA loads into a double-buffered
     SMEM ring; one consumer warpgroup (128 threads) runs the WGMMA and accumulates
     over K. All four layouts are covered by ``trans_a`` / ``trans_b`` (forwarded to
-    the WGMMA transpose flags): ``A`` is ``[M,K]`` (or ``[K,M]`` transposed), ``B``
-    is ``[K,N]`` (or ``[N,K]`` transposed), ``C`` is ``[M,N]``. fp16 / bf16 inputs,
+    the WGMMA transpose flags): ``A`` is $[M \\times K]$ (or $[K \\times M]$ transposed), ``B``
+    is $[K \\times N]$ (or $[N \\times K]$ transposed), ``C`` is $[M \\times N]$. fp16 / bf16 inputs,
     fp32 accumulation. The auto warp-specialization pass is disabled so it does not
     fire on top of this manual layout.
 
@@ -374,8 +374,8 @@ def _gemm_kernel(
         m: Rows of ``op(A)`` / ``C``.
         n: Columns of ``op(B)`` / ``C``.
         k: Contraction dim.
-        trans_a: Whether ``A`` is stored transposed (``[K, M]``).
-        trans_b: Whether ``B`` is stored transposed (``[N, K]``).
+        trans_a: Whether ``A`` is stored transposed ($[K \\times M]$).
+        trans_b: Whether ``B`` is stored transposed ($[N \\times K]$).
         dtype: Activation / weight dtype string (``"float16"`` or ``"bfloat16"``).
         traced: Build with in-kernel timeline markers materialized (``True``) or
             stripped to zero cost (``False``). **Part of the cache key**: traced

--- a/src/tileops/kernels/grouped_gemm/grouped_gemm_persistent_3wg.py
+++ b/src/tileops/kernels/grouped_gemm/grouped_gemm_persistent_3wg.py
@@ -224,18 +224,18 @@ class GroupedGemmPersistent3WGKernel(Kernel):
         """Run the grouped GEMM ``C[e] = A[e] @ B[e]^T`` for every expert.
 
         Args:
-            A: ``[numel, K]`` tokens, grouped by expert (tight, no padding).
-            B: ``[num_experts, N, K]`` expert weights (NT layout).
-            true_sizes: ``[num_experts]`` int32 row count per expert.
-            true_offsets: ``[num_experts]`` int32 start offset per expert in A.
-            out: optional ``[numel, N]`` output buffer to write into and reuse
+            A: $[numel \\times K]$ tokens, grouped by expert (tight, no padding).
+            B: $[num\\_experts \\times N \\times K]$ expert weights (NT layout).
+            true_sizes: $[num\\_experts]$ int32 row count per expert.
+            true_offsets: $[num\\_experts]$ int32 start offset per expert in A.
+            out: optional $[numel \\times N]$ output buffer to write into and reuse
                 across calls. Allocated internally with ``torch.empty`` if omitted.
                 Must be contiguous and must not overlap ``A`` or ``B`` in memory
                 (the kernel reads inputs and writes the output concurrently).
                 Disjoint slices of a shared workspace buffer are allowed.
 
         Returns:
-            The ``[numel, N]`` output (``out`` if provided).
+            The $[numel \\times N]$ output (``out`` if provided).
         """
         block_m = self.config["block_m"]
         block_n = self.config["block_n"]

--- a/src/tileops/kernels/grouped_tiling.py
+++ b/src/tileops/kernels/grouped_tiling.py
@@ -19,9 +19,10 @@ class GroupTiling:
     """Tiles enumerated per group, for ``num_groups`` groups of ``block_m`` rows.
 
     Example:
-        >>> tiling = GroupTiling(num_groups=16, block_m=64)
-        >>> tiling.tile_upper_bound(4096)
-        80
+        ```python linenums="1"
+        tiling = GroupTiling(num_groups=16, block_m=64)
+        tiling.tile_upper_bound(4096) # 80
+        ```
     """
 
     def __init__(self, num_groups: int, block_m: int) -> None:

--- a/src/tileops/kernels/moe/moe_grouped_gemm_nopad.py
+++ b/src/tileops/kernels/moe/moe_grouped_gemm_nopad.py
@@ -328,9 +328,11 @@ class MoeGroupedGemmNopadKernel(Kernel):
         tune: Whether to autotune.
 
     Example:
-        >>> kernel = MoeGroupedGemmNopadKernel(numel=16384, num_experts=256, N=4096, K=2048,
-        ...                               dtype=torch.bfloat16)
-        >>> C = kernel(A, B, true_sizes, true_offsets)  # [numel, N]
+        ```python linenums="1"
+        kernel = MoeGroupedGemmNopadKernel(numel=16384, num_experts=256, N=4096, K=2048,
+                                      dtype=torch.bfloat16)
+        C = kernel(A, B, true_sizes, true_offsets)  # [numel, N]
+        ```
     """
 
     supported_archs: list[int] = [80, 86, 89, 90]

--- a/src/tileops/kernels/moe/moe_grouped_gemm_separate_act.py
+++ b/src/tileops/kernels/moe/moe_grouped_gemm_separate_act.py
@@ -18,7 +18,7 @@ class MoeGroupedGemmSeparateActKernel(Kernel):
     """Gate/up GEMM of width ``2 * ffn``, then the gated activation.
 
     Serves the same call as the fused-epilogue kernel and produces the same
-    ``[numel, ffn]`` output, in two launches with the wide intermediate in global
+    $[numel \\times ffn]$ output, in two launches with the wide intermediate in global
     memory. It is the general implementation of that role.
 
     ``gemm_cls`` is the grouped GEMM to compose with: the op that builds this holds

--- a/src/tileops/kernels/moe/permute_align.py
+++ b/src/tileops/kernels/moe/permute_align.py
@@ -340,8 +340,10 @@ class MoePermuteAlignKernel(Kernel):
         GEMM index contract, so there is no free element type to select.
 
     Example:
-        >>> kernel = MoePermuteAlignKernel(numel=32, num_experts=8, block_size=16)
-        >>> sorted_ids, expert_ids, num_post_pad = kernel(topk_ids)
+        ```python linenums="1"
+        kernel = MoePermuteAlignKernel(numel=32, num_experts=8, block_size=16)
+        sorted_ids, expert_ids, num_post_pad = kernel(topk_ids)
+        ```
     """
 
     supported_archs: list[int] = [80, 86, 89, 90]

--- a/src/tileops/kernels/moe/permute_nopad.py
+++ b/src/tileops/kernels/moe/permute_nopad.py
@@ -283,8 +283,10 @@ class MoePermuteNopadKernel(Kernel):
             warning from ``Kernel.init_config``.
 
     Example:
-        >>> kernel = MoePermuteNopadKernel(num_tokens=4, top_k=2, num_experts=8, hidden_size=128)
-        >>> perm_h, offsets, sizes, expert_offset, fwd_idx = kernel(hidden_states, topk_ids)
+        ```python linenums="1"
+        kernel = MoePermuteNopadKernel(num_tokens=4, top_k=2, num_experts=8, hidden_size=128)
+        perm_h, offsets, sizes, expert_offset, fwd_idx = kernel(hidden_states, topk_ids)
+        ```
     """
 
     supported_archs: list[int] = [80, 86, 89, 90]

--- a/src/tileops/kernels/moe/unpermute.py
+++ b/src/tileops/kernels/moe/unpermute.py
@@ -132,8 +132,10 @@ class MoeUnpermuteKernel(Kernel):
             ``Kernel.init_config``.
 
     Example:
-        >>> kernel = MoeUnpermuteKernel(num_tokens=4, top_k=2, hidden_size=128, padded_batch_sum=512)
-        >>> output = kernel(mm2_pad, fwd_idx, topk_weights)
+        ```python linenums="1"
+        kernel = MoeUnpermuteKernel(num_tokens=4, top_k=2, hidden_size=128, padded_batch_sum=512)
+        output = kernel(mm2_pad, fwd_idx, topk_weights)
+        ```
     """
 
     supported_archs: list[int] = [80, 86, 89, 90]

--- a/src/tileops/kernels/norm/batch_norm.py
+++ b/src/tileops/kernels/norm/batch_norm.py
@@ -300,7 +300,7 @@ class BatchNormFwdTrainKernel(Kernel):
     ):
         """Run training forward pass on an ``(N, C, *spatial)`` input.
 
-        Moving the input into the ``(C, L)`` layout, and the output back, happens here.
+        Moving the input into the $[C \\times L]$ layout, and the output back, happens here.
 
         Returns:
             y: Normalized output, shaped like *x*.
@@ -437,7 +437,7 @@ class BatchNormFwdInferKernel(Kernel):
     ) -> torch.Tensor:
         """Run inference forward pass on an ``(N, C, *spatial)`` input.
 
-        Moving the input into the ``(C, L)`` layout, and the output back, happens here.
+        Moving the input into the $[C \\times L]$ layout, and the output back, happens here.
 
         Returns:
             Normalized output, shaped like *x*.
@@ -660,7 +660,7 @@ class BatchNormBwdKernel(Kernel):
     ):
         """Run the backward pass on ``(N, C, *spatial)`` inputs.
 
-        Moving the inputs into the ``(C, L)`` layout, and ``grad_x`` back, happens here.
+        Moving the inputs into the $[C \\times L]$ layout, and ``grad_x`` back, happens here.
 
         Returns:
             grad_x: Gradient w.r.t. the input, shaped like *x*.

--- a/src/tileops/kernels/norm/group_norm.py
+++ b/src/tileops/kernels/norm/group_norm.py
@@ -40,7 +40,7 @@ __all__ = ["GroupNormKernel", "GroupNormNoAffineKernel"]
 
 
 def _channel_of(row, col, num_groups: int, channels_per_group: int, spatial_size: int):
-    """Return the channel owning element ``(row, col)`` of the (M, D) reshape.
+    """Return the channel owning element $[row \\times col]$ of the (M, D) reshape.
 
     Row ``m`` of the ``(N*G, (C/G)*spatial_size)`` view holds group
     ``m % G``, and column ``d`` holds that group's local channel
@@ -265,8 +265,8 @@ class GroupNormKernel(Kernel):
 
         Args:
             x: Input of shape ``(N, C, *spatial)``, contiguous, on a CUDA device.
-            weight: Affine scale of shape ``(C,)`` on the same device.
-            bias: Affine shift of shape ``(C,)`` on the same device.
+            weight: Affine scale of shape $[C]$ on the same device.
+            bias: Affine shift of shape $[C]$ on the same device.
 
         Returns:
             Tensor shaped like *x*.
@@ -379,7 +379,7 @@ def _group_norm_no_affine_kernel(M, D, eps, dtype):
 class GroupNormNoAffineKernel(Kernel):
     """GroupNorm forward kernel without affine scale/shift.
 
-    Computes ``y = (x - mean) * rstd`` row-wise for shape ``(M, D)`` reshaped
+    Computes ``y = (x - mean) * rstd`` row-wise for shape $[M \\times D]$ reshaped
     inputs. Shares the build/launch parameters and shared-memory layout of
     `GroupNormKernel`; only the output stage differs (no weight/bias
     multiply-add). Used by the no-affine variants of GroupNorm and

--- a/src/tileops/kernels/reduction/_primitives.py
+++ b/src/tileops/kernels/reduction/_primitives.py
@@ -729,7 +729,7 @@ def restore_reduced(
     axes: "tuple[int, ...]",
     keepdim: bool,
 ) -> torch.Tensor:
-    """Shape an ``(M,)`` result the way the reduction's caller expects.
+    """Shape an $[M]$ result the way the reduction's caller expects.
 
     Reducing every axis without *keepdim* gives a 0-D tensor.
     """

--- a/src/tileops/kernels/reduction/logsumexp.py
+++ b/src/tileops/kernels/reduction/logsumexp.py
@@ -119,7 +119,7 @@ def _logsumexp_kernel_tiled(M: int, N: int, dtype: str, tile_n: int):
       Single pass: compute running max and rescaled running sum.
       Then: logsumexp = max + log(sum).
 
-    The input tensor has the raw shape ``(M, N)`` (no host-side padding).
+    The input tensor has the raw shape $[M \\times N]$ (no host-side padding).
     Boundary handling for the last tile is performed via masked loads.
     """
     N_padded = align_up(N, DEFAULT_ALIGNMENT)

--- a/src/tileops/kernels/reduction/softmax.py
+++ b/src/tileops/kernels/reduction/softmax.py
@@ -191,7 +191,7 @@ def _softmax_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_n: int)
       Pass 1 (all tiles): compute running max and rescaled running sum.
       Pass 2 (all tiles): normalize using global max and sum.
 
-    The input tensor has the raw shape ``(M, N)`` (no host-side padding).
+    The input tensor has the raw shape $[M \\times N]$ (no host-side padding).
     Boundary handling for the last tile (where ``t * tile_n + j`` may
     exceed ``N``) is performed inside the kernel via ``T.if_then_else``
     masked loads.  Output columns are ``total_cols = num_tiles * tile_n``.

--- a/src/tileops/kernels/topk_selector.py
+++ b/src/tileops/kernels/topk_selector.py
@@ -274,7 +274,7 @@ def _(batch, seq_len, seq_len_kv, kv_group, topk, in_dtype, out_dtype, *inputs) 
 
 
 class TopkSelectorKernel(Kernel):
-    """Per-row top-k index selection over an ``[B, S, S_kv, G]`` score tensor.
+    """Per-row top-k index selection over an $[B \\times S \\times S\\_kv \\times G]$ score tensor.
 
     Args:
         batch: Batch size.

--- a/src/tileops/manifest/__init__.py
+++ b/src/tileops/manifest/__init__.py
@@ -81,9 +81,11 @@ def load_workloads(op_name: str) -> list[dict[str, Any]]:
     *op_name* must be the canonical PascalCase manifest key
     (e.g. ``RMSNormFwdOp``).
 
-    >>> workloads = load_workloads("RMSNormFwdOp")
-    >>> workloads[0]
-    {'x_shape': [2048, 4096], 'dtypes': ['float16', 'bfloat16'], 'label': 'llama-8b-prefill'}
+    ```python linenums="1"
+    workloads = load_workloads("RMSNormFwdOp")
+    workloads[0]
+    # {'x_shape': [2048, 4096], 'dtypes': ['float16', 'bfloat16'], 'label': 'llama-8b-prefill'}
+    ```
     """
     ops = load_manifest()
     if op_name not in ops:
@@ -99,7 +101,7 @@ WORKLOAD_RESERVED_KEYS: frozenset[str] = frozenset({"dtypes", "label"})
 def single_input_workload_contract(
     signature: dict[str, Any],
 ) -> tuple[str, frozenset[str]] | None:
-    """Return ``(shape_key, allowed_workload_keys)`` for a signature with
+    """Return $[shape\_key \\times allowed\_workload\_keys]$ for a signature with
     exactly one tensor input; ``None`` for any other input arity.
 
     The shape key is ``{input}_shape``; allowed keys are the shape key,

--- a/src/tileops/ops/_roofline_codegen.py
+++ b/src/tileops/ops/_roofline_codegen.py
@@ -58,6 +58,7 @@ class _ShapeProxy:
     __slots__ = ("shape", "ndim")
 
     def __init__(self, shape: tuple) -> None:
+        """Build the op. Shapes and dtype are taken from the first call."""
         self.shape = tuple(shape)
         self.ndim = len(self.shape)
 
@@ -225,6 +226,7 @@ class _VarsExprValidator(ast.NodeVisitor):
         input_names: set[str],
         optional_names: set[str] | None = None,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call."""
         self.op_name = op_name
         self.var_name = var_name
         # Cleared by ``visit_Compare`` when they carry a presence test.

--- a/src/tileops/ops/attention/deepseek_dsa.py
+++ b/src/tileops/ops/attention/deepseek_dsa.py
@@ -19,23 +19,6 @@ class DeepSeekSparseAttentionDecodeWithKVCacheFwdOp(Op):
 
     The layout of the operation is BSHD.
 
-    Args:
-        batch (int): The batch size.
-        heads (int): The number of attention heads.
-        seq_len (int): The length of the input sequence.
-        seq_len_kv (int): The length of the key-value sequence.
-        dim (int): The dimension of the attention vectors.
-        dim_tail (int): The dimension of the tail portion of the attention vectors.
-        topk (int): The number of top elements to consider in sparse attention.
-        stride_kv (int): The stride for the key-value sequence.
-        heads_kv (int): The number of key-value heads.
-        q_start_index_s (int): The start index for queries in the sequence.
-        sm_scale (Optional[float], default=None): Scaling factor for the softmax function.
-        is_causal (bool, default=True): Whether the attention is causal
-                    (True for causal, False for non-causal).
-        kernel_map (Optional[Dict[str, Kernel]], default=None):
-                    Optional mapping for custom kernels.
-        tune (bool, default=False): Whether to enable kernel tuning.
     """
 
     def __init__(
@@ -55,6 +38,26 @@ class DeepSeekSparseAttentionDecodeWithKVCacheFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            batch (int): The batch size.
+            heads (int): The number of attention heads.
+            seq_len (int): The length of the input sequence.
+            seq_len_kv (int): The length of the key-value sequence.
+            dim (int): The dimension of the attention vectors.
+            dim_tail (int): The dimension of the tail portion of the attention vectors.
+            topk (int): The number of top elements to consider in sparse attention.
+            stride_kv (int): The stride for the key-value sequence.
+            heads_kv (int): The number of key-value heads.
+            q_start_index_s (int): The start index for queries in the sequence.
+            sm_scale (Optional[float], default=None): Scaling factor for the softmax function.
+            is_causal (bool, default=True): Whether the attention is causal
+                        (True for causal, False for non-causal).
+            kernel_map (Optional[Dict[str, Kernel]], default=None):
+                        Optional mapping for custom kernels.
+            tune (bool, default=False): Whether to enable kernel tuning.
+        """
         self.batch = batch
         self.heads = heads
         self.seq_len = seq_len

--- a/src/tileops/ops/attention/deepseek_mla.py
+++ b/src/tileops/ops/attention/deepseek_mla.py
@@ -24,6 +24,13 @@ class MultiHeadLatentAttentionDecodeWithKVCacheFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            pe_dim: Manifest ``params.pe_dim``, ``int``.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         self.batch = batch
         self.heads = heads
         self.heads_kv = heads_kv
@@ -68,6 +75,17 @@ class MultiHeadLatentAttentionDecodeWithKVCacheFwdOp(Op):
     def forward(
         self, q: torch.Tensor, q_pe: torch.Tensor, k: torch.Tensor, k_pe: torch.Tensor
     ) -> torch.Tensor:
+        """Run the op on the inputs the manifest declares.
+
+        Args:
+            q: Input tensor, dtype ``float16 | bfloat16``.
+            q_pe: Input tensor, dtype ``same_as(q)``.
+            k: Input tensor, dtype ``same_as(q)``.
+            k_pe: Input tensor, dtype ``same_as(q)``.
+
+        Returns:
+            ``o``, as the manifest declares. Shape rules: ``o.shape == (B, H, D)``.
+        """
         self._validate_dtypes(q, q_pe, k, k_pe)
         self.dtype = q.dtype
         return self._get_kernel((q, q_pe, k, k_pe), q.dtype)(q, q_pe, k, k_pe)

--- a/src/tileops/ops/attention/deepseek_nsa.py
+++ b/src/tileops/ops/attention/deepseek_nsa.py
@@ -35,6 +35,12 @@ class NSATopkVarlenOp(UnmanifestedOp):
         tune: bool = False,
         kernel_map: Optional[Dict[str, Kernel]] = None,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            tune: Whether to autotune, applied when a kernel is first built.
+            kernel_map: Optional kernel override dict.
+        """
         params = {k: v for k, v in locals().items() if k not in ("self", "kernel_map")}
         for key, value in params.items():
             setattr(self, key, value)
@@ -66,6 +72,7 @@ class NSATopkVarlenOp(UnmanifestedOp):
         chunk_offsets: torch.Tensor,
         token_indices: torch.Tensor,
     ) -> torch.Tensor:
+        """Run the op on ``q``, ``k_cmp``, ``lse_in``, ``offsets``, ``chunk_offsets`` and ``token_indices``."""
         self.dtype = q.dtype
         tensors = (q, k_cmp, lse_in, offsets, chunk_offsets, token_indices)
         return self._get_kernel(tensors, q.dtype)(*tensors)
@@ -87,6 +94,12 @@ class NSAFwdVarlenOp(UnmanifestedOp):
         tune: bool = False,
         kernel_map: Optional[Dict[str, Kernel]] = None,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            tune: Whether to autotune, applied when a kernel is first built.
+            kernel_map: Optional kernel override dict.
+        """
         params = {k: v for k, v in locals().items() if k not in ("self", "kernel_map")}
         for key, value in params.items():
             setattr(self, key, value)
@@ -119,6 +132,7 @@ class NSAFwdVarlenOp(UnmanifestedOp):
         offsets: torch.Tensor,
         token_indices: torch.Tensor,
     ) -> torch.Tensor:
+        """Run the op on ``q``, ``k``, ``v``, ``block_indices``, ``block_counts``, ``offsets`` and ``token_indices``."""
         self.dtype = q.dtype
         tensors = (q, k, v, block_indices, block_counts, offsets, token_indices)
         return self._get_kernel(tensors, q.dtype)(*tensors)
@@ -141,6 +155,12 @@ class NSACmpFwdVarlenOp(UnmanifestedOp):
         tune: bool = False,
         kernel_map: Optional[Dict[str, Kernel]] = None,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            tune: Whether to autotune, applied when a kernel is first built.
+            kernel_map: Optional kernel override dict.
+        """
         params = {
             "seq_num": seq_num,
             "c_seq_len": c_seq_len,
@@ -185,6 +205,7 @@ class NSACmpFwdVarlenOp(UnmanifestedOp):
         chunk_offsets: torch.Tensor,
         token_indices: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Run the op on ``q``, ``k_cmp``, ``v_cmp``, ``offsets``, ``chunk_offsets`` and ``token_indices``."""
         self.dtype = q.dtype
         tensors = (q, k_cmp, v_cmp, offsets, chunk_offsets, token_indices)
         return self._get_kernel(tensors, q.dtype)(*tensors)

--- a/src/tileops/ops/attention/gqa.py
+++ b/src/tileops/ops/attention/gqa.py
@@ -146,6 +146,13 @@ class GroupedQueryAttentionFwdOp(Op):
     ) -> None:
         # Nothing downstream validates these: this op builds its kernel itself,
         # so a zero heads_kv would surface as ZeroDivisionError inside a region.
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            is_causal: Manifest ``params.is_causal``, ``bool``, default ``True``.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         _validate_gqa_dims(heads, heads_kv, dim)
         _validate_positive(batch=batch, seq_len=seq_len)
         self.batch = batch
@@ -256,11 +263,6 @@ class GroupedQueryAttentionPrefillFwdOp(Op):
     prefill uses the same fixed public tensor list. Scale tensors are required
     for manifest stability; non-FP8 kernels ignore them.
 
-    Args:
-        dtype: Element type of ``o``. The inputs do not determine it: identical
-            float8_e4m3fn q/k/v admit either a float16 or a bfloat16 output, so
-            the caller chooses here. For float16 / bfloat16 inputs it must equal
-            their element type.
     """
 
     def __init__(
@@ -282,6 +284,14 @@ class GroupedQueryAttentionPrefillFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            dtype: Element type of ``o``. The inputs do not determine it: identical
+                float8_e4m3fn q/k/v admit either a float16 or a bfloat16 output, so
+                the caller chooses here. For float16 / bfloat16 inputs it must equal
+                their element type.
+        """
         _validate_gqa_dims(heads, heads_kv, dim)
         _validate_positive(batch=batch, max_seqlen_q=max_seqlen_q, max_seqlen_kv=max_seqlen_kv)
         if is_causal and max_seqlen_q > max_seqlen_kv:
@@ -513,6 +523,21 @@ class GroupedQueryAttentionPrefillFwdOp(Op):
         k_scale: torch.Tensor,
         v_scale: torch.Tensor,
     ) -> torch.Tensor:
+        """Run the op on the inputs the manifest declares.
+
+        Args:
+            q: Input tensor, dtype ``float16 | bfloat16 | float8_e4m3fn``.
+            k: Input tensor, dtype ``same_as(q)``.
+            v: Input tensor, dtype ``same_as(q)``.
+            cu_seqlens_q: Input tensor, dtype ``int32``.
+            cu_seqlens_kv: Input tensor, dtype ``int32``.
+            q_scale: Input tensor, dtype ``float32``.
+            k_scale: Input tensor, dtype ``float32``.
+            v_scale: Input tensor, dtype ``float32``.
+
+        Returns:
+            ``o``, as the manifest declares. Shape rules: ``o.shape == (total_q, H, D)``.
+        """
         self._validate_dtypes(q, k, v, cu_seqlens_q, cu_seqlens_kv, q_scale, k_scale, v_scale)
         self._validate_common_shapes(
             q, k, v, cu_seqlens_q, cu_seqlens_kv, q_scale, k_scale, v_scale
@@ -576,6 +601,12 @@ class GroupedQueryAttentionPrefillVarlenFwdOp(UnmanifestedOp):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         _validate_gqa_dims(heads, heads_kv, dim)
         _validate_positive(batch=batch, max_seqlen_q=max_seqlen_q, max_seqlen_kv=max_seqlen_kv)
         self.batch = batch
@@ -732,6 +763,7 @@ class GroupedQueryAttentionPrefillVarlenFwdOp(UnmanifestedOp):
         cu_seqlens_q: torch.Tensor,
         cu_seqlens_kv: torch.Tensor,
     ) -> torch.Tensor:
+        """Run the op on ``q``, ``k``, ``v``, ``cu_seqlens_q`` and ``cu_seqlens_kv``."""
         self._validate_forward_inputs(q, k, v, cu_seqlens_q, cu_seqlens_kv)
         self.dtype = q.dtype
         tensors = (q, k, v, cu_seqlens_q, cu_seqlens_kv)
@@ -789,6 +821,22 @@ class GroupedQueryAttentionPrefillPagedWithKVCacheFwdOp(Op):
         max_position: Optional[int] = None,
         rotary_dim: Optional[int] = None,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            max_pages_per_req: Manifest ``params.max_pages_per_req``, ``int``.
+            page_size: Manifest ``params.page_size``, ``int``.
+            is_causal: Manifest ``params.is_causal``, ``bool``, default ``True``.
+            cache_dtype: Manifest ``params.cache_dtype``, ``dtype | None``, default ``None``.
+            sm_scale: Manifest ``params.sm_scale``, ``float | None``, default ``None``.
+            softcap: Manifest ``params.softcap``, ``float | None``, default ``None``.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+            fuse_rope: Manifest ``params.fuse_rope``, ``bool``, default ``False``.
+            rope_base: Manifest ``params.rope_base``, ``float``, default ``10000.0``.
+            max_position: Manifest ``params.max_position``, ``int | None``, default ``None``.
+            rotary_dim: Manifest ``params.rotary_dim``, ``int | None``, default ``None``.
+        """
         _validate_gqa_dims(heads, heads_kv, dim)
         if fuse_rope:
             rotary_dim = _rope_rotary_dim(dim, rotary_dim)
@@ -1094,6 +1142,23 @@ class GroupedQueryAttentionPrefillPagedWithKVCacheFwdOp(Op):
         block_table: torch.Tensor,
         max_seqlen_q: int,
     ) -> torch.Tensor:
+        """Run the op on the inputs the manifest declares.
+
+        Args:
+            q: Input tensor, dtype ``float16 | bfloat16``.
+            k_new: Input tensor, dtype ``same_as(q)``.
+            v_new: Input tensor, dtype ``same_as(q)``.
+            k_pages: Input tensor, dtype ``float16 | bfloat16 | float8_e4m3fn``.
+            v_pages: Input tensor, dtype ``same_as(k_pages)``.
+            k_scale: Input tensor, dtype ``float32``.
+            v_scale: Input tensor, dtype ``float32``.
+            cu_seqlens_q: Input tensor, dtype ``int32``.
+            cache_seqlens: Input tensor, dtype ``int32``.
+            block_table: Input tensor, dtype ``int32``.
+
+        Returns:
+            ``o``, as the manifest declares. Shape rules: ``o.shape == (total_q, H, D)``.
+        """
         self._validate_forward_inputs(
             q,
             k_new,
@@ -1171,6 +1236,13 @@ class GroupedQueryAttentionBwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            is_causal: Manifest ``params.is_causal``, ``bool``, default ``True``.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         self.batch = batch
         self.heads = heads
         self.heads_kv = heads_kv
@@ -1243,6 +1315,19 @@ class GroupedQueryAttentionBwdOp(Op):
         do: torch.Tensor,
         lse: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Run the op on the inputs the manifest declares.
+
+        Args:
+            q: Input tensor, dtype ``float16 | bfloat16``.
+            k: Input tensor, dtype ``same_as(q)``.
+            v: Input tensor, dtype ``same_as(q)``.
+            o: Input tensor, dtype ``same_as(q)``.
+            do: Input tensor, dtype ``same_as(q)``.
+            lse: Input tensor, dtype ``float32``.
+
+        Returns:
+            ``dq``, ``dk``, ``dv``, as the manifest declares. Shape rules: ``dq.shape == (B, S, H, D)``; ``dk.shape == (B, S, H_kv, D)``; ``dv.shape == (B, S, H_kv, D)``.
+        """
         do = do.contiguous()
         self._validate_dtypes(q, k, v, o, do, lse)
         self.dtype = q.dtype
@@ -1272,6 +1357,12 @@ class GroupedQueryAttentionDecodeWithKVCacheFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         _validate_gqa_dims(heads, heads_kv, dim)
         self.batch = batch
         self.heads = heads
@@ -1340,6 +1431,16 @@ class GroupedQueryAttentionDecodeWithKVCacheFwdOp(Op):
         return {"o": tuple(q_shape)}
 
     def forward(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
+        """Run the op on the inputs the manifest declares.
+
+        Args:
+            q: Input tensor, dtype ``float16 | bfloat16``.
+            k: Input tensor, dtype ``same_as(q)``.
+            v: Input tensor, dtype ``same_as(q)``.
+
+        Returns:
+            ``o``, as the manifest declares. Shape rules: ``o.shape == (B, H, D)``.
+        """
         real_seqlen_kv = k.shape[1]
         if real_seqlen_kv < self.seqlen_kv:
             k = F.pad(
@@ -1355,7 +1456,7 @@ class GroupedQueryAttentionDecodeWithKVCacheFwdOp(Op):
 
 
 class GroupedQueryAttentionDecodePagedWithKVCacheFwdOp(Op):
-    """Paged GQA decode with dynamic KV cache. Layout: Q [batch, heads, dim] (BHD);
+    """Paged GQA decode with dynamic KV cache. Layout: ``Q`` $[batch \\times heads \\times dim]$ (BHD);
     K, V physical cache [seqlen_kv, heads_kv, dim]; real_seqlen_kv [batch]; block_table [batch, num_pages].
     """
 
@@ -1372,6 +1473,15 @@ class GroupedQueryAttentionDecodePagedWithKVCacheFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            page_size: Manifest ``params.page_size``, ``int``.
+            sm_scale: Manifest ``params.sm_scale``, ``float | None``, default ``None``.
+            softcap: Manifest ``params.softcap``, ``float | None``, default ``None``.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         _validate_gqa_dims(heads, heads_kv, dim)
         self.batch = batch
         self.heads = heads
@@ -1448,6 +1558,18 @@ class GroupedQueryAttentionDecodePagedWithKVCacheFwdOp(Op):
         real_seqlen_kv: torch.Tensor,
         block_table: torch.Tensor,
     ) -> torch.Tensor:
+        """Run the op on the inputs the manifest declares.
+
+        Args:
+            q: Input tensor, dtype ``float16 | bfloat16``.
+            k: Input tensor, dtype ``same_as(q)``.
+            v: Input tensor, dtype ``same_as(q)``.
+            real_seqlen_kv: Input tensor, dtype ``int32``.
+            block_table: Input tensor, dtype ``int32``.
+
+        Returns:
+            ``o``, as the manifest declares. Shape rules: ``o.shape == (B, H, D)``.
+        """
         self.dtype = q.dtype
         return self._get_kernel((q, k, v, real_seqlen_kv, block_table), q.dtype)(
             q, k, v, real_seqlen_kv, block_table
@@ -1464,17 +1586,6 @@ class GroupedQueryAttentionSlidingWindowFwdOp(Op):
 
     Use window_size_left=-1 / window_size_right=-1 for no restriction.
 
-    Args:
-        batch: Batch size.
-        heads: Number of query heads.
-        heads_kv: Number of KV heads (must divide heads evenly).
-        seq_len: Sequence length (same for Q, K, V).
-        dim: Head dimension.
-        is_causal: Whether to apply causal masking.
-        window_size_left: Left window size (-1 = unlimited).
-        window_size_right: Right window size (-1 = unlimited).
-        kernel_map: Optional override for hardware-specific kernel dispatch.
-        tune: Whether to run autotuning on kernel instantiation.
     """
 
     def __init__(
@@ -1490,6 +1601,20 @@ class GroupedQueryAttentionSlidingWindowFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            batch: Batch size.
+            heads: Number of query heads.
+            heads_kv: Number of KV heads (must divide heads evenly).
+            seq_len: Sequence length (same for Q, K, V).
+            dim: Head dimension.
+            is_causal: Whether to apply causal masking.
+            window_size_left: Left window size (-1 = unlimited).
+            window_size_right: Right window size (-1 = unlimited).
+            kernel_map: Optional override for hardware-specific kernel dispatch.
+            tune: Whether to run autotuning on kernel instantiation.
+        """
         if heads % heads_kv != 0:
             raise ValueError("heads must be divisible by heads_kv")
         if window_size_left != -1 and window_size_left < 0:
@@ -1554,12 +1679,12 @@ class GroupedQueryAttentionSlidingWindowFwdOp(Op):
         """Run fixed-length GQA sliding window forward.
 
         Args:
-            q: Query tensor, shape [batch, seq_len, heads, dim].
-            k: Key tensor, shape [batch, seq_len, heads_kv, dim].
-            v: Value tensor, shape [batch, seq_len, heads_kv, dim].
+            q: Query tensor, shape $[batch \\times seq\\_len \\times heads \\times dim]$.
+            k: Key tensor, shape $[batch \\times seq\\_len \\times heads\\_kv \\times dim]$.
+            v: Value tensor, shape $[batch \\times seq\\_len \\times heads\\_kv \\times dim]$.
 
         Returns:
-            Output tensor, shape [batch, seq_len, heads, dim].
+            Output tensor, shape $[batch \\times seq\\_len \\times heads \\times dim]$.
         """
         for t, name in [(q, "q"), (k, "k"), (v, "v")]:
             if t.device.type != "cuda":
@@ -1640,17 +1765,6 @@ class GroupedQueryAttentionSlidingWindowVarlenFwdOp(Op):
       k_pos >= q_pos + offset - window_size_left   (window_size_left >= 0)
       k_pos <= q_pos + offset + window_size_right  (window_size_right >= 0)
 
-    Args:
-        batch: Number of sequences in the batch.
-        heads: Number of query heads.
-        heads_kv: Number of KV heads (must divide heads evenly).
-        dim: Head dimension.
-        is_causal: Whether to apply causal masking.
-        window_size_left: Left window size (-1 = unlimited).
-        window_size_right: Right window size (-1 = unlimited).
-        accum_dtype: Accumulator data type for intermediate computations.
-        kernel_map: Optional override for hardware-specific kernel dispatch.
-        tune: Whether to run autotuning on kernel instantiation.
     """
 
     def __init__(
@@ -1666,6 +1780,20 @@ class GroupedQueryAttentionSlidingWindowVarlenFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            batch: Number of sequences in the batch.
+            heads: Number of query heads.
+            heads_kv: Number of KV heads (must divide heads evenly).
+            dim: Head dimension.
+            is_causal: Whether to apply causal masking.
+            window_size_left: Left window size (-1 = unlimited).
+            window_size_right: Right window size (-1 = unlimited).
+            accum_dtype: Accumulator data type for intermediate computations.
+            kernel_map: Optional override for hardware-specific kernel dispatch.
+            tune: Whether to run autotuning on kernel instantiation.
+        """
         if heads % heads_kv != 0:
             raise ValueError("heads must be divisible by heads_kv")
         if window_size_left != -1 and window_size_left < 0:
@@ -1741,15 +1869,15 @@ class GroupedQueryAttentionSlidingWindowVarlenFwdOp(Op):
         """Run variable-length GQA sliding window forward.
 
         Args:
-            q: Query tensor, shape [total_q, heads, dim].
-            k: Key tensor, shape [total_k, heads_kv, dim].
-            v: Value tensor, shape [total_k, heads_kv, dim].
-            cu_seqlens_q: Cumulative Q lengths, shape [batch+1], dtype int32.
-            cu_seqlens_k: Cumulative K lengths, shape [batch+1], dtype int32.
+            q: Query tensor, shape $[total\\_q \\times heads \\times dim]$.
+            k: Key tensor, shape $[total\\_k \\times heads\\_kv \\times dim]$.
+            v: Value tensor, shape $[total\\_k \\times heads\\_kv \\times dim]$.
+            cu_seqlens_q: Cumulative Q lengths, shape $[batch+1]$, dtype int32.
+            cu_seqlens_k: Cumulative K lengths, shape $[batch+1]$, dtype int32.
             max_seqlen_q: Maximum Q sequence length across the batch.
 
         Returns:
-            Output tensor, shape [total_q, heads, dim].
+            Output tensor, shape $[total\\_q \\times heads \\times dim]$.
         """
         for t, name in [(q, "q"), (k, "k"), (v, "v")]:
             if t.device.type != "cuda":

--- a/src/tileops/ops/attention/mha.py
+++ b/src/tileops/ops/attention/mha.py
@@ -48,6 +48,13 @@ class MultiHeadAttentionFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            is_causal: Manifest ``params.is_causal``, ``bool``, default ``True``.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         self.batch = batch
         self.heads = heads
         self.seq_len = seq_len  # TODO: support s_q != s_kv
@@ -123,6 +130,13 @@ class MultiHeadAttentionBwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            is_causal: Manifest ``params.is_causal``, ``bool``, default ``True``.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         self.batch = batch
         self.heads = heads
         self.seq_len = seq_len  # TODO: support s_q != s_kv
@@ -188,6 +202,19 @@ class MultiHeadAttentionBwdOp(Op):
         do: torch.Tensor,
         lse: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Run the op on the inputs the manifest declares.
+
+        Args:
+            q: Input tensor, dtype ``float16 | bfloat16``.
+            k: Input tensor, dtype ``same_as(q)``.
+            v: Input tensor, dtype ``same_as(q)``.
+            o: Input tensor, dtype ``same_as(q)``.
+            do: Input tensor, dtype ``same_as(q)``.
+            lse: Input tensor, dtype ``float32``.
+
+        Returns:
+            ``dq``, ``dk``, ``dv``, as the manifest declares. Shape rules: ``dq.shape == (B, S, H, D)``; ``dk.shape == (B, S, H, D)``; ``dv.shape == (B, S, H, D)``.
+        """
         return self._gqa_op(q, k, v, o, do, lse)
 
 
@@ -204,6 +231,12 @@ class MultiHeadAttentionDecodeWithKVCacheFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         self.batch = batch
         self.heads = heads
         self.seqlen_q = seqlen_q
@@ -244,6 +277,16 @@ class MultiHeadAttentionDecodeWithKVCacheFwdOp(Op):
         return {"o": tuple(q_shape)}
 
     def forward(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
+        """Run the op on the inputs the manifest declares.
+
+        Args:
+            q: Input tensor, dtype ``float16 | bfloat16``.
+            k: Input tensor, dtype ``same_as(q)``.
+            v: Input tensor, dtype ``same_as(q)``.
+
+        Returns:
+            ``o``, as the manifest declares. Shape rules: ``o.shape == (B, S_q, H, D)``.
+        """
         real_seqlen_kv = k.shape[1]
         if real_seqlen_kv < self.seqlen_kv:
             k = F.pad(
@@ -257,7 +300,7 @@ class MultiHeadAttentionDecodeWithKVCacheFwdOp(Op):
 
 
 class MultiHeadAttentionDecodePagedWithKVCacheFwdOp(Op):
-    """Paged MHA decode with dynamic KV cache. Layout: Q [batch, seqlen_q, heads, dim] (BSHD);
+    """Paged MHA decode with dynamic KV cache. Layout: ``Q`` $[batch \\times seqlen\\_q \\times heads \\times dim]$ (BSHD);
     K, V physical cache [seqlen_kv, heads, dim]; real_seqlen_kv [batch]; block_table [batch, num_pages].
     """
 
@@ -273,6 +316,14 @@ class MultiHeadAttentionDecodePagedWithKVCacheFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            page_size: Manifest ``params.page_size``, ``int``.
+            is_causal: Manifest ``params.is_causal``, ``bool``, default ``False``.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         self.batch = batch
         self.heads = heads
         self.seqlen_q = seqlen_q
@@ -349,6 +400,18 @@ class MultiHeadAttentionDecodePagedWithKVCacheFwdOp(Op):
         real_seqlen_kv: torch.Tensor,
         block_table: torch.Tensor,
     ) -> torch.Tensor:
+        """Run the op on the inputs the manifest declares.
+
+        Args:
+            q: Input tensor, dtype ``float16 | bfloat16``.
+            k: Input tensor, dtype ``same_as(q)``.
+            v: Input tensor, dtype ``same_as(q)``.
+            real_seqlen_kv: Input tensor, dtype ``int32``.
+            block_table: Input tensor, dtype ``int32``.
+
+        Returns:
+            ``o``, as the manifest declares. Shape rules: ``o.shape == (B, S_q, H, D)``.
+        """
         self.dtype = q.dtype
         return self._get_kernel((q, k, v, real_seqlen_kv, block_table), q.dtype)(
             q, k, v, real_seqlen_kv, block_table

--- a/src/tileops/ops/convolution.py
+++ b/src/tileops/ops/convolution.py
@@ -242,6 +242,17 @@ class Conv1dFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            stride: Manifest ``params.stride``, ``int | tuple[int]``, default ``1``.
+            padding: Manifest ``params.padding``, ``int | tuple[int] | str``, default ``0``.
+            dilation: Manifest ``params.dilation``, ``int | tuple[int]``, default ``1``.
+            groups: Manifest ``params.groups``, ``int``, default ``1``.
+            target: Backend target to serve this op, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         _validate_positive_int("groups", groups, "Conv1d")
         self.n = None
         self.c_in = None
@@ -574,6 +585,17 @@ class Conv2dFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            stride: Manifest ``params.stride``, ``int | tuple[int, int]``, default ``1``.
+            padding: Manifest ``params.padding``, ``int | tuple[int, int] | str``, default ``0``.
+            dilation: Manifest ``params.dilation``, ``int | tuple[int, int]``, default ``1``.
+            groups: Manifest ``params.groups``, ``int``, default ``1``.
+            target: Backend target to serve this op, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         _validate_positive_int("groups", groups, "Conv2d")
         self.n = None
         self.c_in = None
@@ -976,6 +998,17 @@ class Conv3dFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            stride: Manifest ``params.stride``, ``int | tuple[int, int, int]``, default ``1``.
+            padding: Manifest ``params.padding``, ``int | tuple[int, int, int] | str``, default ``0``.
+            dilation: Manifest ``params.dilation``, ``int | tuple[int, int, int]``, default ``1``.
+            groups: Manifest ``params.groups``, ``int``, default ``1``.
+            target: Backend target to serve this op, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         _validate_positive_int("groups", groups, "Conv3d")
         self.n = None
         self.c_in = None

--- a/src/tileops/ops/dropout.py
+++ b/src/tileops/ops/dropout.py
@@ -36,12 +36,6 @@ class DropoutFwdOp(Op):
     Uses T.rng_init / T.rng_rand_float (backed by cuRAND Philox4_32_10
     by default) for per-thread random number generation.
 
-    Args:
-        p: Drop probability in [0, 1].
-        seed: Integer seed for RNG.
-        training: If False, dropout is disabled (identity pass-through).
-        kernel_map: Optional kernel dispatch override.
-        tune: Whether to autotune.
     """
 
     _op_name = "dropout"
@@ -55,6 +49,15 @@ class DropoutFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            p: Drop probability in [0, 1].
+            seed: Integer seed for RNG.
+            training: If False, dropout is disabled (identity pass-through).
+            kernel_map: Optional kernel dispatch override.
+            tune: Whether to autotune.
+        """
         if not (0.0 <= p <= 1.0):
             raise ValueError(f"Dropout probability must be in [0, 1], got {p}")
         self.N_total = None
@@ -124,6 +127,14 @@ class DropoutFwdOp(Op):
         return {"output": tuple(input_shape)}
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Run the op on the inputs the manifest declares.
+
+        Args:
+            input: Input tensor, dtype ``float16 | bfloat16 | float32``.
+
+        Returns:
+            ``output``, as the manifest declares.
+        """
         if not input.is_cuda:
             raise ValueError("input must be a CUDA tensor")
         if input.dtype not in (torch.float16, torch.bfloat16, torch.float32):

--- a/src/tileops/ops/elementwise/_base.py
+++ b/src/tileops/ops/elementwise/_base.py
@@ -68,7 +68,7 @@ def _validate_scalar_param_repr(
     - Signed int: any value in ``[iinfo.min, iinfo.max]``, truncated toward
       zero. NaN/Inf and out-of-range raise.
     - ``uint8``: ints in ``[-255, 255]``, negatives wrapping via ``& 0xFF``;
-      float scalars must be in ``[0, 255]``.
+      float scalars must be in $[0 \\times 255]$.
 
     Floats always accept ``NaN`` and require finite values in ``finfo`` range.
     ``+/-Inf`` passes only under ``allow_nonfinite_float`` — used by
@@ -376,11 +376,6 @@ class UnaryOp(_PerDtypeKernels, Op):
     Subclass must set ``kernel_cls`` and ``_op_name``. The element count arrives with
     the tensor, so nothing about shape is a construction parameter.
 
-    Args:
-        target: Which set of kernels serves this op — a target name, ``BUILTIN`` for
-            the in-tree kernels, or ``None`` to decide from the input device.
-        kernel_map: Optional kernel dispatch override.
-        tune: Whether to autotune.
     """
 
     kernel_cls: type
@@ -399,6 +394,14 @@ class UnaryOp(_PerDtypeKernels, Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            target: Which set of kernels serves this op — a target name, ``BUILTIN`` for
+                the in-tree kernels, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel dispatch override.
+            tune: Whether to autotune.
+        """
         self.target = target
         self.tune = tune
         self.input_shape: Optional[tuple] = None
@@ -482,6 +485,7 @@ class UnaryOp(_PerDtypeKernels, Op):
         return result
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Run the op on ``input``."""
         return type(self)._wrapped(input, self._instance_key)
 
 
@@ -492,11 +496,6 @@ class BinaryOp(_PerDtypeKernels, Op):
     the tensors; the broadcast *lowering* — dim coalescing and stride synthesis — is the
     kernel's, so this class only hands the two shapes down.
 
-    Args:
-        target: Which set of kernels serves this op — a target name, ``BUILTIN`` for
-            the in-tree kernels, or ``None`` to decide from the input device.
-        kernel_map: Optional kernel dispatch override.
-        tune: Whether to autotune.
     """
 
     kernel_cls: type
@@ -540,6 +539,14 @@ class BinaryOp(_PerDtypeKernels, Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            target: Which set of kernels serves this op — a target name, ``BUILTIN`` for
+                the in-tree kernels, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel dispatch override.
+            tune: Whether to autotune.
+        """
         self.target = target
         self.tune = tune
         self.input_shape: Optional[tuple] = None
@@ -637,6 +644,7 @@ class BinaryOp(_PerDtypeKernels, Op):
         return result
 
     def forward(self, input: torch.Tensor, other: torch.Tensor) -> torch.Tensor:
+        """Run the op on ``input`` and ``other``."""
         return type(self)._wrapped(input, other, self._instance_key)
 
 
@@ -649,11 +657,6 @@ class FusedGatedOp(_PerDtypeKernels, Op):
     Subclass must set ``kernel_cls`` and ``_op_name``. Both dimensions arrive with the
     tensor.
 
-    Args:
-        target: Which set of kernels serves this op — a target name, ``BUILTIN`` for
-            the in-tree kernels, or ``None`` to decide from the input device.
-        kernel_map: Optional kernel dispatch override.
-        tune: Whether to autotune.
     """
 
     kernel_cls: type
@@ -668,6 +671,14 @@ class FusedGatedOp(_PerDtypeKernels, Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            target: Which set of kernels serves this op — a target name, ``BUILTIN`` for
+                the in-tree kernels, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel dispatch override.
+            tune: Whether to autotune.
+        """
         self.target = target
         self.tune = tune
         self.x_shape: Optional[tuple] = None
@@ -742,6 +753,7 @@ class FusedGatedOp(_PerDtypeKernels, Op):
         return result
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the op on ``x``."""
         return type(self)._wrapped(x, self._instance_key)
 
 
@@ -765,6 +777,7 @@ class _UnaryActivationMixin:
     _wrapped_inplace = None
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Run the op on ``input``."""
         if self.inplace:
             type(self)._wrapped_inplace(input, self._instance_key)
             return input
@@ -790,6 +803,13 @@ class _ParamFreeActivationOp(_UnaryActivationMixin, UnaryOp):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            target: Backend target to serve this op, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         super().__init__(target=target, kernel_map=kernel_map, tune=tune)
         self.inplace = inplace
 
@@ -843,6 +863,13 @@ class _AlphaScaledBinaryOp(BinaryOp):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            target: Backend target to serve this op, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         self.alpha = alpha
         super().__init__(target=target, kernel_map=kernel_map, tune=tune)
 
@@ -876,6 +903,7 @@ class _IntFallbackCall:
     """
 
     def __init__(self, handler):
+        """Build the op. Shapes and dtype are taken from the first call."""
         self._handler = handler
 
     def __call__(self, input: torch.Tensor) -> torch.Tensor:
@@ -930,6 +958,13 @@ class _GeluApproximateBase(UnaryOp):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            target: Backend target to serve this op, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         if approximate not in ("none", "tanh"):
             raise ValueError(
                 f"{type(self).__name__}: approximate must be 'none' or 'tanh', got {approximate!r}"

--- a/src/tileops/ops/elementwise/activations.py
+++ b/src/tileops/ops/elementwise/activations.py
@@ -141,17 +141,7 @@ class SeluFwdOp(_ParamFreeActivationOp):
 
 
 class LeakyReluFwdOp(_ParametricActivationOp):
-    """Leaky ReLU: y = x if x > 0 else negative_slope * x.
-
-    Args:
-        negative_slope: Slope for negative inputs (default 0.01).
-        inplace: When True, copy the result back into ``input`` and
-            return ``input`` (preserving tensor identity). The kernel
-            still computes into a fresh buffer; only the user-visible
-            tensor is mutated, mirroring ``torch.nn.functional.leaky_relu``.
-        kernel_map: Optional kernel dispatch override.
-        tune: Whether to autotune the kernel.
-    """
+    """Leaky ReLU: y = x if x > 0 else negative_slope * x."""
 
     _op_name = "leaky_relu"
     _wrapped = None
@@ -170,6 +160,17 @@ class LeakyReluFwdOp(_ParametricActivationOp):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            negative_slope: Slope for negative inputs (default 0.01).
+            inplace: When True, copy the result back into ``input`` and
+                return ``input`` (preserving tensor identity). The kernel
+                still computes into a fresh buffer; only the user-visible
+                tensor is mutated, mirroring ``torch.nn.functional.leaky_relu``.
+            kernel_map: Optional kernel dispatch override.
+            tune: Whether to autotune the kernel.
+        """
         self.negative_slope = negative_slope
         self.inplace = inplace
         super().__init__(target=target, kernel_map=kernel_map, tune=tune)
@@ -180,15 +181,7 @@ class LeakyReluFwdOp(_ParametricActivationOp):
 
 
 class EluFwdOp(_ParametricActivationOp):
-    """ELU: y = x if x > 0 else alpha * (exp(x) - 1).
-
-    Args:
-        alpha: Scale for the negative part (default 1.0).
-        inplace: When True, copy the result back into ``input`` and
-            return ``input`` (preserving tensor identity).
-        kernel_map: Optional kernel dispatch override.
-        tune: Whether to autotune the kernel.
-    """
+    """ELU: y = x if x > 0 else alpha * (exp(x) - 1)."""
 
     _op_name = "elu"
     _wrapped = None
@@ -207,6 +200,15 @@ class EluFwdOp(_ParametricActivationOp):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            alpha: Scale for the negative part (default 1.0).
+            inplace: When True, copy the result back into ``input`` and
+                return ``input`` (preserving tensor identity).
+            kernel_map: Optional kernel dispatch override.
+            tune: Whether to autotune the kernel.
+        """
         self.alpha = alpha
         self.inplace = inplace
         super().__init__(target=target, kernel_map=kernel_map, tune=tune)
@@ -217,16 +219,7 @@ class EluFwdOp(_ParametricActivationOp):
 
 
 class HardtanhFwdOp(_ParametricActivationOp):
-    """Hardtanh: y = clamp(x, min_val, max_val).
-
-    Args:
-        min_val: Lower bound (default -1.0).
-        max_val: Upper bound (default 1.0).
-        inplace: When True, copy the result back into ``input`` and
-            return ``input`` (preserving tensor identity).
-        kernel_map: Optional kernel dispatch override.
-        tune: Whether to autotune the kernel.
-    """
+    """Hardtanh: y = clamp(x, min_val, max_val)."""
 
     _op_name = "hardtanh"
     _wrapped = None
@@ -246,6 +239,16 @@ class HardtanhFwdOp(_ParametricActivationOp):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            min_val: Lower bound (default -1.0).
+            max_val: Upper bound (default 1.0).
+            inplace: When True, copy the result back into ``input`` and
+                return ``input`` (preserving tensor identity).
+            kernel_map: Optional kernel dispatch override.
+            tune: Whether to autotune the kernel.
+        """
         self.min_val = min_val
         self.max_val = max_val
         self.inplace = inplace
@@ -257,14 +260,7 @@ class HardtanhFwdOp(_ParametricActivationOp):
 
 
 class SoftplusFwdOp(_ParametricActivationOp):
-    """Softplus: y = log(1 + exp(x*beta))/beta if x*beta <= threshold else x.
-
-    Args:
-        beta: Scaling factor (default 1.0).
-        threshold: Linear regime threshold (default 20.0).
-        kernel_map: Optional kernel dispatch override.
-        tune: Whether to autotune the kernel.
-    """
+    """Softplus: y = log(1 + exp(x*beta))/beta if x*beta <= threshold else x."""
 
     _op_name = "softplus"
     _wrapped = None
@@ -284,6 +280,14 @@ class SoftplusFwdOp(_ParametricActivationOp):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            beta: Scaling factor (default 1.0).
+            threshold: Linear regime threshold (default 20.0).
+            kernel_map: Optional kernel dispatch override.
+            tune: Whether to autotune the kernel.
+        """
         self.beta = beta
         self.threshold = threshold
         # Softplus does not expose ``inplace`` to callers.

--- a/src/tileops/ops/elementwise/alibi.py
+++ b/src/tileops/ops/elementwise/alibi.py
@@ -23,16 +23,6 @@ class AlibiFwdOp(Op):
         zero tensor inputs and constructs its output entirely from
         ``__init__`` parameters; no compile-time wrapping is needed.
 
-    Args:
-        seq_len: Sequence length.
-        num_heads: Number of attention heads.
-        dtype: Torch dtype.
-        target: Which set of kernels serves this op — a target name, ``BUILTIN`` for
-            the in-tree kernels, or ``None``. Nothing is probed: with no tensor input
-            there is no device to detect, so the in-tree kernels serve unless a target
-            is named.
-        kernel_map: Optional dispatch override mapping kernel keys to
-            ``Kernel`` subclasses. Falls back to ``default_kernel_map``.
     """
 
     _op_name = "alibi"
@@ -46,6 +36,19 @@ class AlibiFwdOp(Op):
         target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            seq_len: Sequence length.
+            num_heads: Number of attention heads.
+            dtype: Torch dtype.
+            target: Which set of kernels serves this op — a target name, ``BUILTIN`` for
+                the in-tree kernels, or ``None``. Nothing is probed: with no tensor input
+                there is no device to detect, so the in-tree kernels serve unless a target
+                is named.
+            kernel_map: Optional dispatch override mapping kernel keys to
+                ``Kernel`` subclasses. Falls back to ``default_kernel_map``.
+        """
         self.seq_len = seq_len
         self.num_heads = num_heads
         self.dtype = dtype
@@ -77,6 +80,11 @@ class AlibiFwdOp(Op):
     def forward(self) -> torch.Tensor:
         # The op promised ``self.dtype``; whichever storage the backend chose to
         # compute in is its own business and does not reach the caller.
+        """Run the op on the inputs the manifest declares.
+
+        Returns:
+            ``output``, as the manifest declares.
+        """
         kernel = self.get_or_build_kernel(
             self._op_name,
             (),  # no tensor input, so no device to detect: in-tree only

--- a/src/tileops/ops/elementwise/arithmetic.py
+++ b/src/tileops/ops/elementwise/arithmetic.py
@@ -94,6 +94,14 @@ class DivFwdOp(BinaryOp):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            rounding_mode: Manifest ``params.rounding_mode``, ``str | None``, default ``None``.
+            target: Backend target to serve this op, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         if rounding_mode not in _DIV_KERNEL_BY_ROUNDING_MODE:
             raise ValueError(
                 f"DivFwdOp received rounding_mode={rounding_mode!r}; "
@@ -149,12 +157,6 @@ class LerpFwdOp(BinaryOp):
     kernel. This enables compile-time folding but means a new Op instance is
     needed for each distinct weight value.
 
-    Args:
-        weight: Scalar interpolation weight, fixed at construction (manifest
-            ``params.weight``, default 0.5).
-        target: Which set of kernels serves this op.
-        kernel_map: Optional kernel dispatch override.
-        tune: Whether to autotune.
     """
 
     _op_name = "lerp"
@@ -173,6 +175,15 @@ class LerpFwdOp(BinaryOp):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            weight: Scalar interpolation weight, fixed at construction (manifest
+                ``params.weight``, default 0.5).
+            target: Which set of kernels serves this op.
+            kernel_map: Optional kernel dispatch override.
+            tune: Whether to autotune.
+        """
         self.weight = weight
         super().__init__(target=target, kernel_map=kernel_map, tune=tune)
 
@@ -202,10 +213,6 @@ class LerpTensorFwdOp(_PerDtypeKernels, Op):
     broadcasts together with ``input`` and ``end`` to the output shape. The scalar-weight
     overload is handled separately by ``LerpFwdOp``.
 
-    Args:
-        target: Which set of kernels serves this op.
-        kernel_map: Optional kernel dispatch override.
-        tune: Whether to autotune.
     """
 
     _op_name = "lerp_tensor"
@@ -223,6 +230,13 @@ class LerpTensorFwdOp(_PerDtypeKernels, Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            target: Which set of kernels serves this op.
+            kernel_map: Optional kernel dispatch override.
+            tune: Whether to autotune.
+        """
         self.target = target
         self.tune = tune
         self.input_shape: Optional[tuple] = None
@@ -303,6 +317,16 @@ class LerpTensorFwdOp(_PerDtypeKernels, Op):
         end: torch.Tensor,
         weight: torch.Tensor,
     ) -> torch.Tensor:
+        """Run the op on the inputs the manifest declares.
+
+        Args:
+            input: Input tensor, dtype ``float16 | bfloat16 | float32``.
+            end: Input tensor, dtype ``same_as(input)``.
+            weight: Input tensor, dtype ``same_as(input)``.
+
+        Returns:
+            ``output``, as the manifest declares. Shape rules: ``output.shape == broadcast_shapes(input.shape, end.shape, weight.shape)``.
+        """
         return type(self)._wrapped(input, end, weight, self._instance_key)
 
 

--- a/src/tileops/ops/elementwise/clamp.py
+++ b/src/tileops/ops/elementwise/clamp.py
@@ -35,11 +35,6 @@ class ClampFwdOp(_PerDtypeKernels, Op):
     gets built. One instance therefore serves ``clamp``, ``clamp_min`` and
     ``clamp_max``, one specialization each.
 
-    Args:
-        target: Which set of kernels serves this op — a target name, ``BUILTIN`` for
-            the in-tree kernels, or ``None`` to decide from the input device.
-        kernel_map: Optional kernel dispatch override.
-        tune: Whether to autotune.
     """
 
     _op_name = "clamp"
@@ -52,6 +47,14 @@ class ClampFwdOp(_PerDtypeKernels, Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            target: Which set of kernels serves this op — a target name, ``BUILTIN`` for
+                the in-tree kernels, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel dispatch override.
+            tune: Whether to autotune.
+        """
         self.target = target
         self.tune = tune
         self.input_shape: Optional[tuple] = None
@@ -148,20 +151,21 @@ class ClampFwdOp(_PerDtypeKernels, Op):
         min: Optional[torch.Tensor] = None,
         max: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
+        """Run the op on the inputs the manifest declares.
+
+        Args:
+            input: Input tensor, dtype ``float16 | bfloat16 | float32``.
+            min: Input tensor, dtype ``same_as(input)``. Optional.
+            max: Input tensor, dtype ``same_as(input)``. Optional.
+
+        Returns:
+            ``output``, as the manifest declares. Shape rules: ``min is None or max is None or output.shape == broadcast_shapes(input.shape, min.shape, max.shape)``; ``min is None or max is not None or output.shape == broadcast_shapes(input.shape, min.shape)``; ``max is None or min is not None or output.shape == broadcast_shapes(input.shape, max.shape)``.
+        """
         return type(self)._wrapped(input, min, max, self._instance_key)
 
 
 class ClampScalarFwdOp(_PerDtypeKernels, Op):
-    """Scalar-bound clamp (``torch.clamp(input, min: Number|None, max: Number|None)``).
-
-    Args:
-        min: Lower bound (Number or None).
-        max: Upper bound (Number or None).
-        target: Which set of kernels serves this op — a target name, ``BUILTIN`` for
-            the in-tree kernels, or ``None`` to decide from the input device.
-        kernel_map: Optional kernel dispatch override.
-        tune: Whether to autotune.
-    """
+    """Scalar-bound clamp (``torch.clamp(input, min: Number|None, max: Number|None)``)."""
 
     _op_name = "clamp"
     _wrapped = None
@@ -175,6 +179,16 @@ class ClampScalarFwdOp(_PerDtypeKernels, Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            min: Lower bound (Number or None).
+            max: Upper bound (Number or None).
+            target: Which set of kernels serves this op — a target name, ``BUILTIN`` for
+                the in-tree kernels, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel dispatch override.
+            tune: Whether to autotune.
+        """
         if min is None and max is None:
             raise ValueError(
                 "ClampScalarFwdOp requires at least one of `min` or `max` to be a "
@@ -228,6 +242,14 @@ class ClampScalarFwdOp(_PerDtypeKernels, Op):
         return result
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Run the op on the inputs the manifest declares.
+
+        Args:
+            input: Input tensor, dtype ``float16 | bfloat16 | float32``.
+
+        Returns:
+            ``output``, as the manifest declares. Shape rules: ``output.shape == input.shape``.
+        """
         return type(self)._wrapped(input, self._instance_key)
 
 

--- a/src/tileops/ops/elementwise/masked_fill.py
+++ b/src/tileops/ops/elementwise/masked_fill.py
@@ -31,11 +31,6 @@ class MaskedFillFwdOp(_PerDtypeKernels, Op):
     ``value`` must be a 0-dim Tensor. The kernel reads ``value`` at forward time,
     which is consistent with the 0-dim semantics.
 
-    Args:
-        target: Which set of kernels serves this op — a target name, ``BUILTIN`` for
-            the in-tree kernels, or ``None`` to decide from the input device.
-        kernel_map: Optional dispatch override mapping kernel keys to
-            ``Kernel`` subclasses. Falls back to ``default_kernel_map``.
     """
 
     _op_name = "masked_fill"
@@ -47,6 +42,14 @@ class MaskedFillFwdOp(_PerDtypeKernels, Op):
         target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            target: Which set of kernels serves this op — a target name, ``BUILTIN`` for
+                the in-tree kernels, or ``None`` to decide from the input device.
+            kernel_map: Optional dispatch override mapping kernel keys to
+                ``Kernel`` subclasses. Falls back to ``default_kernel_map``.
+        """
         self.target = target
         self.input_shape: Optional[tuple] = None
         self.mask_shape: Optional[tuple] = None
@@ -125,6 +128,16 @@ class MaskedFillFwdOp(_PerDtypeKernels, Op):
         mask: torch.Tensor,
         value: torch.Tensor,
     ) -> torch.Tensor:
+        """Run the op on the inputs the manifest declares.
+
+        Args:
+            input: Input tensor, dtype ``bool | uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32``.
+            mask: Input tensor, dtype ``bool``.
+            value: Input tensor, dtype ``same_as(input)``.
+
+        Returns:
+            ``output``, as the manifest declares. Shape rules: ``output.shape == broadcast_shapes(input.shape, mask.shape)``.
+        """
         return type(self)._wrapped(input, mask, value, self._instance_key)
 
 
@@ -140,18 +153,6 @@ class MaskedFillScalarFwdOp(_PerDtypeKernels, Op):
     whatever storage the selected kernel requires; the op passes and receives
     semantic bool either way.
 
-    Args:
-        value: Scalar fill value (bool / int / float). Range-validated
-            against the element type of the call with PyTorch
-            ``Tensor.masked_fill`` coercion: bool reduces non-zero to
-            ``True``; integer dtypes range-check the real value against
-            ``torch.iinfo`` and truncate floats toward zero (``1.5 -> 1``);
-            ``torch.uint8`` additionally wraps Python ints in ``[-255, 0)``
-            via two's complement.
-        target: Which set of kernels serves this op — a target name, ``BUILTIN`` for
-            the in-tree kernels, or ``None`` to decide from the input device.
-        kernel_map: Optional dispatch override mapping kernel keys to
-            ``Kernel`` subclasses. Falls back to ``default_kernel_map``.
     """
 
     _op_name = "masked_fill"
@@ -164,6 +165,21 @@ class MaskedFillScalarFwdOp(_PerDtypeKernels, Op):
         target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            value: Scalar fill value (bool / int / float). Range-validated
+                against the element type of the call with PyTorch
+                ``Tensor.masked_fill`` coercion: bool reduces non-zero to
+                ``True``; integer dtypes range-check the real value against
+                ``torch.iinfo`` and truncate floats toward zero (``1.5 -> 1``);
+                ``torch.uint8`` additionally wraps Python ints in ``[-255, 0)``
+                via two's complement.
+            target: Which set of kernels serves this op — a target name, ``BUILTIN`` for
+                the in-tree kernels, or ``None`` to decide from the input device.
+            kernel_map: Optional dispatch override mapping kernel keys to
+                ``Kernel`` subclasses. Falls back to ``default_kernel_map``.
+        """
         self.value = value
         self.target = target
         self.input_shape: Optional[tuple] = None
@@ -230,6 +246,15 @@ class MaskedFillScalarFwdOp(_PerDtypeKernels, Op):
         return result
 
     def forward(self, input: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+        """Run the op on the inputs the manifest declares.
+
+        Args:
+            input: Input tensor, dtype ``bool | uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32``.
+            mask: Input tensor, dtype ``bool``.
+
+        Returns:
+            ``output``, as the manifest declares. Shape rules: ``output.shape == broadcast_shapes(input.shape, mask.shape)``.
+        """
         return type(self)._wrapped(input, mask, self._instance_key)
 
 

--- a/src/tileops/ops/elementwise/math_unary.py
+++ b/src/tileops/ops/elementwise/math_unary.py
@@ -141,6 +141,7 @@ class _RoundDecimalsCall:
     """
 
     def __init__(self, decimals: int):
+        """Build the op. Shapes and dtype are taken from the first call."""
         self._decimals = decimals
 
     def __call__(self, input: torch.Tensor) -> torch.Tensor:
@@ -163,12 +164,6 @@ class RoundFwdOp(_IntIdentityUnaryOp):
     fixed for the instance and handed to whichever kernel serves the op; in-tree, a
     non-zero value selects ``_RoundDecimalsCall``.
 
-    Args:
-        decimals: Number of decimal places to round to (manifest
-            ``params.decimals``, default 0).
-        target: Which set of kernels serves this op.
-        kernel_map: Optional kernel dispatch override.
-        tune: Whether to autotune.
     """
 
     _op_name = "round"
@@ -182,6 +177,15 @@ class RoundFwdOp(_IntIdentityUnaryOp):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            decimals: Number of decimal places to round to (manifest
+                ``params.decimals``, default 0).
+            target: Which set of kernels serves this op.
+            kernel_map: Optional kernel dispatch override.
+            tune: Whether to autotune.
+        """
         self.decimals = int(decimals)
         super().__init__(target=target, kernel_map=kernel_map, tune=tune)
 

--- a/src/tileops/ops/elementwise/nan_to_num.py
+++ b/src/tileops/ops/elementwise/nan_to_num.py
@@ -14,25 +14,7 @@ from ._base import _PerDtypeKernels, _validate_scalar_param_repr
 
 
 class NanToNumFwdOp(_PerDtypeKernels, Op):
-    """NanToNum: replace NaN, +Inf, -Inf with specified values.
-
-    Args:
-        nan: Replacement for NaN (default 0.0).
-        posinf: Replacement for +Inf. Manifest default ``None`` resolves
-            to the largest finite value representable in the element type of the
-            call (matches ``torch.nan_to_num``). Explicit values
-            must also be representable in that dtype end-to-end; values
-            that fit only in the kernel's intermediate dtype (e.g. fp16
-            for fp8_e5m2) are rejected so the post-cast cannot resurface
-            them as Inf.
-        neginf: Replacement for -Inf. Manifest default ``None`` resolves
-            to the smallest (most negative) finite value representable
-            in the element type of the call.
-        target: Which set of kernels serves this op — a target name, ``BUILTIN`` for
-            the in-tree kernels, or ``None`` to decide from the input device.
-        kernel_map: Optional kernel dispatch override.
-        tune: Whether to autotune the kernel.
-    """
+    """NanToNum: replace NaN, +Inf, -Inf with specified values."""
 
     _op_name = "nan_to_num"
     _wrapped = None
@@ -47,6 +29,25 @@ class NanToNumFwdOp(_PerDtypeKernels, Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            nan: Replacement for NaN (default 0.0).
+            posinf: Replacement for +Inf. Manifest default ``None`` resolves
+                to the largest finite value representable in the element type of the
+                call (matches ``torch.nan_to_num``). Explicit values
+                must also be representable in that dtype end-to-end; values
+                that fit only in the kernel's intermediate dtype (e.g. fp16
+                for fp8_e5m2) are rejected so the post-cast cannot resurface
+                them as Inf.
+            neginf: Replacement for -Inf. Manifest default ``None`` resolves
+                to the smallest (most negative) finite value representable
+                in the element type of the call.
+            target: Which set of kernels serves this op — a target name, ``BUILTIN`` for
+                the in-tree kernels, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel dispatch override.
+            tune: Whether to autotune the kernel.
+        """
         self.nan = nan
         self.posinf = posinf
         self.neginf = neginf
@@ -108,4 +109,12 @@ class NanToNumFwdOp(_PerDtypeKernels, Op):
         return result
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Run the op on the inputs the manifest declares.
+
+        Args:
+            input: Input tensor, dtype ``float16 | bfloat16 | float32``.
+
+        Returns:
+            ``output``, as the manifest declares. Shape rules: ``output.shape == input.shape``.
+        """
         return type(self)._wrapped(input, self._instance_key)

--- a/src/tileops/ops/elementwise/prelu.py
+++ b/src/tileops/ops/elementwise/prelu.py
@@ -26,12 +26,6 @@ class PreluFwdOp(_PerDtypeKernels, Op):
     with ndim >= 2, dimension 0 for 1-D inputs. Both the shape and the channel
     count arrive with the tensors.
 
-    Args:
-        target: Which set of kernels serves this op — a target name, ``BUILTIN`` for
-            the in-tree kernels, or ``None`` to decide from the input device.
-        kernel_map: Optional dispatch override mapping kernel keys to
-            ``Kernel`` subclasses. Falls back to ``default_kernel_map``.
-        tune: Whether to autotune.
     """
 
     _op_name = "prelu"
@@ -44,6 +38,15 @@ class PreluFwdOp(_PerDtypeKernels, Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            target: Which set of kernels serves this op — a target name, ``BUILTIN`` for
+                the in-tree kernels, or ``None`` to decide from the input device.
+            kernel_map: Optional dispatch override mapping kernel keys to
+                ``Kernel`` subclasses. Falls back to ``default_kernel_map``.
+            tune: Whether to autotune.
+        """
         self.target = target
         self.tune = tune
         # The synthesized eval_roofline resolves each signature.inputs entry as
@@ -127,6 +130,15 @@ class PreluFwdOp(_PerDtypeKernels, Op):
         input: torch.Tensor,
         weight: torch.Tensor,
     ) -> torch.Tensor:
+        """Run the op on the inputs the manifest declares.
+
+        Args:
+            input: Input tensor, dtype ``float16 | bfloat16 | float32``.
+            weight: Input tensor, dtype ``same_as(input)``.
+
+        Returns:
+            ``output``, as the manifest declares. Shape rules: ``output.shape == input.shape``.
+        """
         return type(self)._wrapped(input, weight, self._instance_key)
 
 

--- a/src/tileops/ops/elementwise/sinusoidal.py
+++ b/src/tileops/ops/elementwise/sinusoidal.py
@@ -23,16 +23,6 @@ class SinusoidalFwdOp(Op):
         zero tensor inputs and constructs its output entirely from
         ``__init__`` parameters; no compile-time wrapping is needed.
 
-    Args:
-        seq_len: Sequence length.
-        d_model: Model dimension.
-        dtype: Torch dtype.
-        target: Which set of kernels serves this op — a target name, ``BUILTIN`` for
-            the in-tree kernels, or ``None``. Nothing is probed: with no tensor input
-            there is no device to detect, so the in-tree kernels serve unless a target
-            is named.
-        kernel_map: Optional dispatch override mapping kernel keys to
-            ``Kernel`` subclasses. Falls back to ``default_kernel_map``.
     """
 
     _op_name = "sinusoidal"
@@ -46,6 +36,19 @@ class SinusoidalFwdOp(Op):
         target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            seq_len: Sequence length.
+            d_model: Model dimension.
+            dtype: Torch dtype.
+            target: Which set of kernels serves this op — a target name, ``BUILTIN`` for
+                the in-tree kernels, or ``None``. Nothing is probed: with no tensor input
+                there is no device to detect, so the in-tree kernels serve unless a target
+                is named.
+            kernel_map: Optional dispatch override mapping kernel keys to
+                ``Kernel`` subclasses. Falls back to ``default_kernel_map``.
+        """
         self.seq_len = seq_len
         self.d_model = d_model
         self.dtype = dtype
@@ -77,6 +80,11 @@ class SinusoidalFwdOp(Op):
     def forward(self) -> torch.Tensor:
         # The op promised ``self.dtype``; whichever storage the backend chose to
         # compute in is its own business and does not reach the caller.
+        """Run the op on the inputs the manifest declares.
+
+        Returns:
+            ``output``, as the manifest declares.
+        """
         kernel = self.get_or_build_kernel(
             self._op_name,
             (),  # no tensor input, so no device to detect: in-tree only

--- a/src/tileops/ops/elementwise/where.py
+++ b/src/tileops/ops/elementwise/where.py
@@ -28,12 +28,6 @@ class WhereFwdOp(_PerDtypeKernels, Op):
     with ``condition`` to produce the output. The three operand shapes arrive with
     the tensors; broadcasting them is the kernel's business.
 
-    Args:
-        target: Which set of kernels serves this op — a target name, ``BUILTIN`` for
-            the in-tree kernels, or ``None`` to decide from the input device.
-        kernel_map: Optional dispatch override mapping kernel keys to
-            ``Kernel`` subclasses. Falls back to ``default_kernel_map``.
-        tune: Whether to autotune.
     """
 
     _op_name = "where"
@@ -51,6 +45,15 @@ class WhereFwdOp(_PerDtypeKernels, Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            target: Which set of kernels serves this op — a target name, ``BUILTIN`` for
+                the in-tree kernels, or ``None`` to decide from the input device.
+            kernel_map: Optional dispatch override mapping kernel keys to
+                ``Kernel`` subclasses. Falls back to ``default_kernel_map``.
+            tune: Whether to autotune.
+        """
         self.target = target
         self.tune = tune
         self.condition_shape: Optional[tuple] = None
@@ -147,6 +150,16 @@ class WhereFwdOp(_PerDtypeKernels, Op):
         input: torch.Tensor,
         other: torch.Tensor,
     ) -> torch.Tensor:
+        """Run the op on the inputs the manifest declares.
+
+        Args:
+            condition: Input tensor, dtype ``bool``.
+            input: Input tensor, dtype ``float16 | bfloat16 | float32``.
+            other: Input tensor, dtype ``same_as(input)``.
+
+        Returns:
+            ``output``, as the manifest declares. Shape rules: ``output.shape == broadcast_shapes(condition.shape, input.shape, other.shape)``.
+        """
         return type(self)._wrapped(condition, input, other, self._instance_key)
 
 

--- a/src/tileops/ops/fft.py
+++ b/src/tileops/ops/fft.py
@@ -24,12 +24,15 @@ class FFTC2CFwdOp(Op):
     Uses pre-computed twiddle factor LUT and shared-memory butterfly fusion
     for optimal GPU performance.
 
-    Args:
-        tune: Whether to enable autotuning (default: False)
-        kernel_map: Optional custom kernel mapping for testing
     """
 
     def __init__(self, tune: bool = False, kernel_map: Optional[Dict[str, Kernel]] = None) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            tune: Whether to enable autotuning (default: False)
+            kernel_map: Optional custom kernel mapping for testing
+        """
         self.n = None
         self.dtype = None
         self.tune = tune

--- a/src/tileops/ops/fp8_lightning_indexer.py
+++ b/src/tileops/ops/fp8_lightning_indexer.py
@@ -18,6 +18,14 @@ class FP8LightningIndexerFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune=False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            clean_logits: Manifest ``params.clean_logits``, ``bool``, default ``True``.
+            config: Manifest ``params.config``, ``dict | None``, default ``None``.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         self.batch = None
         self.seq_len = None
         self.heads = None
@@ -168,7 +176,7 @@ class FP8LightningIndexerFwdOp(Op):
         cu_seqlen_ke_shape: tuple[int, ...],
         index_k_scale_shape: tuple[int, ...],
     ) -> dict[str, tuple[int, ...]]:
-        """Manifest ``outputs``: ``[batch, seq_len, seq_len_kv, kv_group]``."""
+        """Manifest ``outputs``: $[batch \\times seq\\_len \\times seq\\_len\\_kv \\times kv\\_group]$."""
         batch, seq_len = index_q_shape[0], index_q_shape[1]
         return {"logits": (batch, seq_len, index_k_shape[1], index_k_shape[2])}
 
@@ -181,6 +189,19 @@ class FP8LightningIndexerFwdOp(Op):
         cu_seqlen_ke: torch.Tensor,
         index_k_scale: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
+        """Run the op on the inputs the manifest declares.
+
+        Args:
+            index_q: Input tensor, dtype ``bfloat16 | float8_e4m3fn``.
+            index_k: Input tensor, dtype ``bfloat16 | float8_e4m3fn``.
+            weights: Input tensor, dtype ``float32``.
+            cu_seqlen_ks: Input tensor, dtype ``int32``.
+            cu_seqlen_ke: Input tensor, dtype ``int32``.
+            index_k_scale: Input tensor, dtype ``float32``. Optional.
+
+        Returns:
+            ``logits``, as the manifest declares.
+        """
         self._resolve_and_bind(index_q, index_k, weights, cu_seqlen_ks, cu_seqlen_ke, index_k_scale)
         if index_k_scale is None:
             return self.torch_quant_forward(index_q, index_k, weights, cu_seqlen_ks, cu_seqlen_ke)

--- a/src/tileops/ops/fp8_quant.py
+++ b/src/tileops/ops/fp8_quant.py
@@ -12,6 +12,12 @@ __all__ = ["FP8QuantFwdOp"]
 
 class FP8QuantFwdOp(Op):
     def __init__(self, kernel_map: Optional[Dict[str, Kernel]] = None, tune: bool = False):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         self.batch = None
         self.seq_len_kv = None
         self.kv_group = None
@@ -56,6 +62,14 @@ class FP8QuantFwdOp(Op):
         }
 
     def forward(self, input_tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Run the op on the inputs the manifest declares.
+
+        Args:
+            input_tensor: Input tensor, dtype ``float16 | bfloat16 | float32``.
+
+        Returns:
+            ``scale_tensor``, ``output_tensor``, as the manifest declares.
+        """
         if not input_tensor.is_cuda:
             raise ValueError("FP8QuantFwdOp expects a CUDA input tensor")
         if input_tensor.ndim != 4:

--- a/src/tileops/ops/gemm/bmm.py
+++ b/src/tileops/ops/gemm/bmm.py
@@ -18,21 +18,13 @@ __all__ = ["BmmFp8KNFwdOp", "BmmFp8NKFwdOp", "BmmFwdOp"]
 
 
 class BmmFwdOp(Op):
-    """Batched dense GEMM: ``d[i] = a[i] @ b[i]``.
+    """Batched dense GEMM: $d_i = a_i \\mathbin{@} b_i \\quad \\text{for } i \\in [0, B)$.
 
-    Input shapes are strict 3D — ``a: [B, M, K]``, ``b: [B, K, N]``,
-    ``d: [B, M, N]``. Batch and contraction dims are checked at
-    ``forward()`` time;  The kernel is compiled on first use for each ``(batch, m, n, k, dtype)`` combo
-    and cached.
+    Shapes are strictly 3D: ``a`` is $[B \\times M \\times K]$, ``b`` is
+    $[B \\times K \\times N]$, and ``d`` is $[B \\times M \\times N]$. The batch and
+    contraction dims are checked at ``forward()`` time. A kernel is compiled on first
+    use for each ``(batch, m, n, k, dtype)`` combination and cached.
 
-    Args:
-        kernel_map: Optional kernel override dict.
-        tune: Whether to autotune (applied when a kernel is first built).
-
-    Example:
-        >>> op = BmmFwdOp()
-        >>> d = op(a, b)                          # a=[B,M,K], b=[B,K,N] -> d=[B,M,N]
-        >>> flops, nbytes = op.eval_roofline()    # valid after the forward
     """
 
     def __init__(
@@ -40,6 +32,12 @@ class BmmFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. No shape or dtype is bound until the first call.
+
+        Args:
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         self.tune = tune
         self.dispatch_kernel(kernel_map)
         # (batch, m, n, k, dtype) -> Kernel instance; built lazily on first use.
@@ -62,7 +60,7 @@ class BmmFwdOp(Op):
         a: torch.Tensor,
         b: torch.Tensor,
     ) -> Tuple[int, int, int, int]:
-        """Derive logical ``(batch, m, n, k)`` from ``[B,M,K]`` and ``[B,K,N]``.
+        """Derive logical ``(batch, m, n, k)`` from $[B \\times M \\times K]$ and $[B \\times K \\times N]$.
 
         Raises:
             ValueError: If ranks are wrong, batch dims mismatch, or the
@@ -128,6 +126,26 @@ class BmmFwdOp(Op):
         return {"d": (a_shape[0], a_shape[1], b_shape[2])}
 
     def forward(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+        """Multiply the two batches, one GEMM per batch item.
+
+        Args:
+            a: Left operand, $[B \\times M \\times K]$.
+            b: Right operand, $[B \\times K \\times N]$.
+
+        Returns:
+            The product, $[B \\times M \\times N]$, in the dtype of the inputs.
+
+        Raises:
+            ValueError: The operands disagree on dtype or device, either is not 3D,
+                or their batch or contraction dims do not match.
+
+        Example:
+            ```python linenums="1"
+            op = BmmFwdOp()
+            d = op(a, b)                          # a=[B,M,K], b=[B,K,N] -> d=[B,M,N]
+            flops, nbytes = op.eval_roofline()    # valid after the forward
+            ```
+        """
         # Fast path: same input signature as the last call → reuse the already
         # built/JIT'd kernel directly.
         sig = (a.shape, b.shape, a.dtype, b.dtype)
@@ -149,20 +167,12 @@ class BmmFwdOp(Op):
 
 
 class BmmFp8KNFwdOp(Op):
-    """Batched FP8 GEMM over ``b`` in ``[B, K, N]``: ``d[i] = (a[i] @ b[i]) * scale_a * scale_b``.
+    """Batched FP8 GEMM over ``b`` in $[B \\times K \\times N]$: ``d[i] = (a[i] @ b[i]) * scale_a * scale_b``.
 
     This is torch.bmm's memory order. The fp8-TN WGMMA kernel wants K innermost,
-    so this op transposes ``b`` before the call; ``BmmFp8NKFwdOp`` takes ``[B, N, K]``
+    so this op transposes ``b`` before the call; ``BmmFp8NKFwdOp`` takes $[B \\times N \\times K]$
     and hands it over as it stands.
-    Args:
-        out_dtype: Output tensor dtype (``torch.float16`` or ``torch.bfloat16``).
-        kernel_map: Optional kernel override dict.
-        tune: Whether to autotune (applied when a kernel is first built).
 
-    Example:
-        >>> op = BmmFp8KNFwdOp(out_dtype=torch.bfloat16)
-        >>> d = op(a, b_kn, scale_a, scale_b)
-        >>> flops, nbytes = op.eval_roofline()    # valid after the forward
     """
 
     #: Whether ``b`` arrives with K innermost, which is what the kernel wants.
@@ -174,6 +184,13 @@ class BmmFp8KNFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            out_dtype: Output tensor dtype (``torch.float16`` or ``torch.bfloat16``).
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune (applied when a kernel is first built).
+        """
         if isinstance(out_dtype, str):
             out_dtype = getattr(torch, out_dtype)
         if out_dtype not in (torch.float16, torch.bfloat16):
@@ -318,6 +335,29 @@ class BmmFp8KNFwdOp(Op):
         scale_a: torch.Tensor,
         scale_b: torch.Tensor,
     ) -> torch.Tensor:
+        """Multiply the two FP8 batches and apply the two scales.
+
+        Args:
+            a: Left operand, $[B \\times M \\times K]$, ``torch.float8_e4m3fn``.
+            b: Right operand, $[B \\times K \\times N]$, same dtype as ``a``.
+            scale_a: Per-tensor scale for ``a``, a 0-dim ``torch.float32`` tensor.
+            scale_b: Per-tensor scale for ``b``, a 0-dim ``torch.float32`` tensor.
+
+        Returns:
+            The scaled product, $[B \\times M \\times N]$, in ``out_dtype``.
+
+        Raises:
+            ValueError: An input is not on CUDA, a dtype is not the one listed above,
+                a scale is not 0-dim, the batch or contraction dims do not match, or
+                $K$ is not a multiple of 32 — the FP8 WGMMA K-step.
+
+        Example:
+            ```python linenums="1"
+            op = BmmFp8KNFwdOp(out_dtype=torch.bfloat16)
+            d = op(a, b_kn, scale_a, scale_b)
+            flops, nbytes = op.eval_roofline()    # valid after the forward
+            ```
+        """
         sig = (
             a.shape,
             b.shape,
@@ -369,16 +409,21 @@ class BmmFp8KNFwdOp(Op):
 
 
 class BmmFp8NKFwdOp(BmmFp8KNFwdOp):
-    """Batched FP8 GEMM over ``b`` in ``[B, N, K]``.
+    """Batched FP8 GEMM over ``b`` in $[B \\times N \\times K]$.
 
     K is innermost, which is the order the fp8-TN WGMMA kernel reads, so ``b``
     reaches it without a transpose. Same kernel and same arithmetic as
     ``BmmFp8KNFwdOp``; only the memory order ``b`` arrives in differs, and memory
     order is part of the signature, so it is its own entry.
 
+    ``b`` is $[B \\times N \\times K]$; every other argument, the return value and the
+    errors are ``BmmFp8KNFwdOp.forward``'s.
+
     Example:
-        >>> op = BmmFp8NKFwdOp(out_dtype=torch.bfloat16)
-        >>> d = op(a, b_nk, scale_a, scale_b)
+        ```python linenums="1"
+        op = BmmFp8NKFwdOp(out_dtype=torch.bfloat16)
+        d = op(a, b_nk, scale_a, scale_b)
+        ```
     """
 
     B_IS_NK: ClassVar[bool] = True

--- a/src/tileops/ops/gemm/gemm.py
+++ b/src/tileops/ops/gemm/gemm.py
@@ -26,22 +26,16 @@ class GemmFwdOp(Op):
     is built (and cached) on first use for each ``(m, n, k, dtype)`` — mirroring
     DeepGEMM's compile-on-first-call + per-config cache.
 
-    Layouts via ``(trans_a, trans_b)`` (== DeepGEMM ``nt``/``nn``/``tn``/``tt``):
-      - ``(False, True)``  NT (default): ``A @ Bᵀ``
-      - ``(False, False)`` NN:           ``A @ B``
-      - ``(True,  False)`` TN:           ``Aᵀ @ B``
-      - ``(True,  True)``  TT:           ``Aᵀ @ Bᵀ``
+    The ``(trans_a, trans_b)`` pair selects one of four layouts, matching DeepGEMM's
+    ``nt`` / ``nn`` / ``tn`` / ``tt``:
 
-    Args:
-        trans_a: Whether ``a`` is stored transposed (``[K, M]``).
-        trans_b: Whether ``b`` is stored transposed (``[N, K]``). Default ``True`` (NT).
-        kernel_map: Optional kernel override dict.
-        tune: Whether to autotune (applied when a kernel is first built).
+    | Flags | Layout | Product |
+    | --- | --- | --- |
+    | ``(False, True)`` | NT, the default | $d = a \\mathbin{@} b^{\\top}$ |
+    | ``(False, False)`` | NN | $d = a \\mathbin{@} b$ |
+    | ``(True, False)`` | TN | $d = a^{\\top} \\mathbin{@} b$ |
+    | ``(True, True)`` | TT | $d = a^{\\top} \\mathbin{@} b^{\\top}$ |
 
-    Example:
-        >>> op = GemmFwdOp()                       # NT by default
-        >>> d = op(a, b)                         # a=[M,K], b=[N,K] -> d=[M,N]
-        >>> flops, nbytes = op.eval_roofline()   # valid after the forward
     """
 
     def __init__(
@@ -51,6 +45,14 @@ class GemmFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            trans_a: Whether ``a`` is stored transposed ($[K \\times M]$).
+            trans_b: Whether ``b`` is stored transposed ($[N \\times K]$). Default ``True`` (NT).
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune (applied when a kernel is first built).
+        """
         self.trans_a = trans_a
         self.trans_b = trans_b
         self.tune = tune
@@ -136,6 +138,26 @@ class GemmFwdOp(Op):
         return {"d": (m, n)}
 
     def forward(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+        """Multiply the two matrices under the layout the constructor selected.
+
+        Args:
+            a: Left operand, $[M \\times K]$, or $[K \\times M]$ when ``trans_a``.
+            b: Right operand, $[N \\times K]$ under the default NT layout, or
+                $[K \\times N]$ when ``trans_b`` is false.
+
+        Returns:
+            The product, $[M \\times N]$, in the dtype of the inputs.
+
+        Raises:
+            ValueError: The contraction dims the two operands contribute do not match.
+
+        Example:
+            ```python linenums="1"
+            op = GemmFwdOp()                      # NT by default
+            d = op(a, b)                          # a=[M,K], b=[N,K] -> d=[M,N]
+            flops, nbytes = op.eval_roofline()    # valid after the forward
+            ```
+        """
         # Fast path: same input signature as the last call → reuse the already
         # built/JIT'd kernel directly, skipping dtype validation, shape
         # inference, and the cache lookup (this is the steady state in
@@ -166,9 +188,9 @@ class GemmFwdOp(Op):
 class GemmFp8FwdOp(Op):
     """Dense FP8 NT GEMM, input-inferred.
 
-    Public layout is ``a=[M, K]`` and ``b=[N, K]``. ``scale_a`` and
-    ``scale_b`` must be either per-tensor ``(1, 1)`` scales or block128
-    scales with shapes ``(M, ceil(K / 128))`` and ``(N, ceil(K / 128))``.
+    Public layout is ``a``: $[M \\times K]$ and ``b``: $[N \\times K]$. ``scale_a`` and
+    ``scale_b`` must be either per-tensor $[1 \\times 1]$ scales or block128
+    scales with shapes $[M \\times \\lceil K/128 \\rceil]$ and $[N \\times \\lceil K/128 \\rceil]$.
     """
 
     def __init__(
@@ -177,6 +199,13 @@ class GemmFp8FwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            out_dtype: Output dtype.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         if isinstance(out_dtype, str):
             out_dtype = getattr(torch, out_dtype)
         if out_dtype not in (torch.float16, torch.bfloat16):
@@ -317,6 +346,32 @@ class GemmFp8FwdOp(Op):
         scale_b: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
+        """Multiply the two FP8 matrices, apply the scales, and add the bias.
+
+        Args:
+            a: Left operand, $[M \\times K]$, ``torch.float8_e4m3fn``.
+            b: Right operand, $[N \\times K]$, same dtype as ``a``.
+            scale_a: ``torch.float32`` scales for ``a``: per-tensor $[1 \\times 1]$, or
+                block128 $[M \\times \\lceil K/128 \\rceil]$.
+            scale_b: The same for ``b``: $[1 \\times 1]$ or
+                $[N \\times \\lceil K/128 \\rceil]$. Both scales take the same form.
+            bias: Optional bias, $[N]$, in ``out_dtype``.
+
+        Returns:
+            The scaled product plus bias, $[M \\times N]$, in ``out_dtype``.
+
+        Raises:
+            ValueError: A dtype is not one of those listed above, ``a`` or ``b`` is not
+                2D, the contraction dims do not match, the two scales are not both
+                per-tensor or both block128, or the bias is not $[N]$.
+
+        Example:
+            ```python linenums="1"
+            op = GemmFp8FwdOp(out_dtype=torch.bfloat16)
+            d = op(a, b, scale_a, scale_b)        # per-tensor scales
+            flops, nbytes = op.eval_roofline()    # valid after the forward
+            ```
+        """
         sig = (
             a.shape,
             b.shape,
@@ -358,10 +413,10 @@ class GemmFp8FwdOp(Op):
 class GemmW4A16FwdOp(Op):
     """Dense W4A16 NT GEMM with group-wise affine weight dequantization.
 
-    Public layout is ``activation=[M, K]`` and ``packed_weight=[N, K / 2]``.
+    Public layout is ``activation``: $[M \\times K]$ and ``packed_weight``: $[N \\times K/2]$.
     Two unsigned INT4 values are packed per byte: the low nibble stores even K
     and the high nibble stores odd K. ``weight_scale`` and ``weight_zero`` are
-    group128 metadata with shape ``[N, K / 128]``. The kernel dequantizes the
+    group128 metadata with shape $[N \\times K/128]$. The kernel dequantizes the
     current W4 tile into A16 shared memory and computes ``activation @ W.T``.
     """
 
@@ -371,6 +426,13 @@ class GemmW4A16FwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            group_size: Manifest ``params.group_size``, ``int``, default ``128``.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         if group_size != GROUP_SIZE:
             raise ValueError(
                 f"GemmW4A16FwdOp currently supports group_size={GROUP_SIZE}, got {group_size}"
@@ -496,6 +558,30 @@ class GemmW4A16FwdOp(Op):
         weight_scale: torch.Tensor,
         weight_zero: torch.Tensor,
     ) -> torch.Tensor:
+        """Dequantize the INT4 weight tile by tile and multiply.
+
+        Args:
+            activation: Activations, $[M \\times K]$, ``torch.float16``.
+            packed_weight: Weights, $[N \\times K/2]$, ``torch.uint8`` — two INT4
+                values per byte, even $K$ in the low nibble.
+            weight_scale: Group scales, $[N \\times K/128]$, ``torch.float32``.
+            weight_zero: Group zero points, $[N \\times K/128]$, ``torch.uint8``.
+
+        Returns:
+            The product, $[M \\times N]$, in ``torch.float16``.
+
+        Raises:
+            ValueError: A dtype is not one of those listed above, ``activation`` or
+                ``packed_weight`` is not 2D, $K$ is odd, $K$ is not divisible by
+                ``group_size``, or a packed or metadata shape disagrees with $K$.
+
+        Example:
+            ```python linenums="1"
+            op = GemmW4A16FwdOp()
+            d = op(activation, packed_weight, weight_scale, weight_zero)
+            flops, nbytes = op.eval_roofline()    # valid after the forward
+            ```
+        """
         sig = (
             activation.shape,
             packed_weight.shape,

--- a/src/tileops/ops/gemm/grouped_gemm.py
+++ b/src/tileops/ops/gemm/grouped_gemm.py
@@ -16,14 +16,16 @@ __all__ = ["GroupedGemmFwdOp"]
 
 
 class GroupedGemmFwdOp(Op):
-    """
-    Grouped GEMM with configurable transpose modes.
+    """Grouped GEMM with configurable transpose modes.
 
-    Supports four layouts via (transpose_a, transpose_b):
-      - (False, True)  NT: A @ B^T -> C
-      - (False, False)  NN: A @ B   -> C
-      - (True,  False) TN: A^T @ B  -> C
-      - (True,  True)  TT: A^T @ B^T -> C
+    The ``(transpose_a, transpose_b)`` pair selects one of four layouts:
+
+    | Flags | Layout | Product |
+    | --- | --- | --- |
+    | ``(False, True)`` | NT | $C = A \\mathbin{@} B^{\\top}$ |
+    | ``(False, False)`` | NN | $C = A \\mathbin{@} B$ |
+    | ``(True, False)`` | TN | $C = A^{\\top} \\mathbin{@} B$ |
+    | ``(True, True)`` | TT | $C = A^{\\top} \\mathbin{@} B^{\\top}$ |
     """
 
     def __init__(
@@ -33,6 +35,14 @@ class GroupedGemmFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            transpose_a: Manifest ``params.transpose_a``, ``bool``, default ``False``.
+            transpose_b: Manifest ``params.transpose_b``, ``bool``, default ``True``.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         self.batch_sum = None
         self.batch_count = None
         self.N = None
@@ -176,6 +186,34 @@ class GroupedGemmFwdOp(Op):
         batch_offsets: torch.Tensor,
         batch_padded_offsets: torch.Tensor,
     ) -> torch.Tensor:
+        """Run one GEMM per group, with the groups packed along a single axis.
+
+        Args:
+            a: Activations for every group, $[\\mathit{batch\\_sum} \\times K]$, or
+                $[K \\times \\mathit{batch\\_sum}]$ when ``transpose_a``.
+            b: Per-group weights, $[\\mathit{batch\\_count} \\times N \\times K]$ when
+                ``transpose_a`` is false, or $[\\mathit{batch\\_sum} \\times N]$ when it is.
+            batch_sizes: Rows per group, 1D ``torch.int32``.
+            batch_offsets: Start row of each group in ``a``, 1D ``torch.int32``.
+            batch_padded_offsets: Start row of each group in the padded output,
+                1D ``torch.int32``.
+
+        Returns:
+            The per-group products, $[\\mathit{batch\\_sum} \\times N]$, in the dtype of
+            the inputs.
+
+        Raises:
+            ValueError: ``a`` or ``b`` is not on CUDA, their dtypes differ or are
+                neither float16 nor bfloat16, the metadata tensors are not 1D int32 of
+                equal length, or the operand ranks and dims disagree with the layout
+                flags.
+
+        Example:
+            ```python linenums="1"
+            op = GroupedGemmFwdOp()               # NT by default
+            d = op(a, b, batch_sizes, batch_offsets, batch_padded_offsets)
+            ```
+        """
         batch_sum, batch_count, n, k, dtype, device_index = self._resolve_spec(
             a,
             b,

--- a/src/tileops/ops/linear_attention/deltanet.py
+++ b/src/tileops/ops/linear_attention/deltanet.py
@@ -29,10 +29,6 @@ class DeltaNetFwdOp(Op):
         FLA (``fla.ops.delta_rule.chunk_delta_rule``) uses **BTHN**
         layout: ``q/k [B, T, H, K]``, ``v [B, T, H, V]``, ``beta [B, T, H]``.
 
-    Args:
-        chunk_size: Chunk size for chunked linear attention.
-        kernel_map: Optional kernel overrides.
-        tune: Whether to autotune kernels.
     """
 
     def __init__(
@@ -41,6 +37,13 @@ class DeltaNetFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            chunk_size: Chunk size for chunked linear attention.
+            kernel_map: Optional kernel overrides.
+            tune: Whether to autotune kernels.
+        """
         self.batch = None
         self.heads = None
         self.seq_len = None
@@ -170,10 +173,6 @@ class DeltaNetBwdOp(Op):
 
     Pipeline: prepare_wy_repr -> fwd (to get Aw, Au) -> bwd kernel -> (dq, dk, dv, dbeta).
 
-    Args:
-        chunk_size: Chunk size for chunked linear attention.
-        kernel_map: Optional kernel overrides.
-        tune: Whether to autotune kernels.
     """
 
     def __init__(
@@ -182,6 +181,13 @@ class DeltaNetBwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            chunk_size: Chunk size for chunked linear attention.
+            kernel_map: Optional kernel overrides.
+            tune: Whether to autotune kernels.
+        """
         self.batch = None
         self.heads = None
         self.seq_len = None
@@ -329,6 +335,7 @@ class _DeltaNetFunction(torch.autograd.Function):
 
     @staticmethod
     def forward(ctx, q, k, v, beta, fwd_kernel, bwd_kernel):
+        """Run the op on ``q``, ``k``, ``v``, ``beta``, ``fwd_kernel`` and ``bwd_kernel``."""
         o, S, Aw, Au, w, u = fwd_kernel(q, k, v, beta)
         ctx.save_for_backward(q, k, v, beta, S, Aw, Au, w, u)
         ctx.bwd_kernel = bwd_kernel
@@ -350,10 +357,6 @@ class DeltaNetOp(UnmanifestedOp):
 
     Layout: BHSD (batch, head, seq_len, dim).
 
-    Args:
-        chunk_size: Chunk size for chunked linear attention.
-        kernel_map: Optional kernel overrides.
-        tune: Whether to autotune kernels.
     """
 
     def __init__(
@@ -362,6 +365,13 @@ class DeltaNetOp(UnmanifestedOp):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            chunk_size: Chunk size for chunked linear attention.
+            kernel_map: Optional kernel overrides.
+            tune: Whether to autotune kernels.
+        """
         self.batch = None
         self.heads = None
         self.seq_len = None

--- a/src/tileops/ops/linear_attention/deltanet_recurrence.py
+++ b/src/tileops/ops/linear_attention/deltanet_recurrence.py
@@ -42,6 +42,12 @@ class DeltaNetDecodeFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         self.batch = None
         self.heads = None
         self.dim_k = None
@@ -184,6 +190,18 @@ class DeltaNetDecodeFwdOp(Op):
         beta: torch.Tensor,
         state: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Run the op on the inputs the manifest declares.
+
+        Args:
+            q: Input tensor, dtype ``float16 | bfloat16 | float32``.
+            k: Input tensor, dtype ``same_as(q)``.
+            v: Input tensor, dtype ``same_as(q)``.
+            beta: Input tensor, dtype ``same_as(q)``.
+            state: Input tensor, dtype ``same_as(q)``.
+
+        Returns:
+            ``o``, ``new_state``, as the manifest declares. Shape rules: ``o.shape == (B, H, DV)``; ``new_state.shape == (B, H, DK, DV)``.
+        """
         sig = (
             q.shape,
             k.shape,

--- a/src/tileops/ops/linear_attention/gated_deltanet.py
+++ b/src/tileops/ops/linear_attention/gated_deltanet.py
@@ -150,10 +150,6 @@ class GatedDeltaNetBHTDFwdOp(Op):
     ``g/beta [B, H, S]``. ``GatedDeltaNetBwdOp`` consumes the ``S`` this returns,
     in the same layout. Token-major callers want ``GatedDeltaNetBTHDFwdOp``.
 
-    Args:
-        chunk_size: Chunk size for chunked linear attention.
-        kernel_map: Optional kernel overrides.
-        tune: Whether to autotune kernels.
     """
 
     def __init__(
@@ -162,6 +158,13 @@ class GatedDeltaNetBHTDFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            chunk_size: Chunk size for chunked linear attention.
+            kernel_map: Optional kernel overrides.
+            tune: Whether to autotune kernels.
+        """
         self.batch = None
         self.heads = None
         self.seq_len = None
@@ -293,10 +296,6 @@ class GatedDeltaNetBTHDFwdOp(Op):
     ``chunk_size=64``, equal K/V dimensions in {64, 128}, and float16 or
     bfloat16. Any other call is refused, naming what it failed.
 
-    Args:
-        chunk_size: Chunk size for chunked linear attention.
-        kernel_map: Optional kernel overrides.
-        tune: Whether to autotune kernels.
     """
 
     def __init__(
@@ -305,6 +304,13 @@ class GatedDeltaNetBTHDFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            chunk_size: Chunk size for chunked linear attention.
+            kernel_map: Optional kernel overrides.
+            tune: Whether to autotune kernels.
+        """
         self.batch = None
         self.heads = None
         self.seq_len = None
@@ -458,6 +464,13 @@ class GatedDeltaNetPrefillBTHDFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            chunk_size: Manifest ``params.chunk_size``, ``int | None``, default ``None``.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         self.batch = None
         self.heads = None
         self.seq_len = None
@@ -636,6 +649,18 @@ class GatedDeltaNetPrefillBTHDFwdOp(Op):
         g: torch.Tensor,
         beta: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Run the op on the inputs the manifest declares.
+
+        Args:
+            q: Input tensor, dtype ``float16 | bfloat16 | float32``.
+            k: Input tensor, dtype ``same_as(q)``.
+            v: Input tensor, dtype ``same_as(q)``.
+            g: Input tensor, dtype ``same_as(q)``.
+            beta: Input tensor, dtype ``same_as(q)``.
+
+        Returns:
+            ``o``, ``final_state``, as the manifest declares. Shape rules: ``final_state.shape == (B, H, DK, DV)``.
+        """
         q = q.contiguous()
         k = k.contiguous()
         v = v.contiguous()
@@ -685,10 +710,6 @@ class GatedDeltaNetBwdOp(Op):
 
     Pipeline: prepare_wy_repr -> fwd (to get Aw, Au) -> bwd kernel -> (dq, dk, dv, dg, dbeta).
 
-    Args:
-        chunk_size: Chunk size for chunked linear attention.
-        kernel_map: Optional kernel overrides.
-        tune: Whether to autotune kernels.
     """
 
     def __init__(
@@ -697,6 +718,13 @@ class GatedDeltaNetBwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            chunk_size: Chunk size for chunked linear attention.
+            kernel_map: Optional kernel overrides.
+            tune: Whether to autotune kernels.
+        """
         self.batch = None
         self.heads = None
         self.seq_len = None
@@ -809,6 +837,7 @@ class _GatedDeltaNetFunction(torch.autograd.Function):
 
     @staticmethod
     def forward(ctx, q, k, v, g, beta, fwd_kernel, bwd_kernel):
+        """Run the op on ``q``, ``k``, ``v``, ``g``, ``beta``, ``fwd_kernel`` and ``bwd_kernel``."""
         o, S, Aw, Au = fwd_kernel(q, k, v, g, beta)
         ctx.save_for_backward(q, k, v, g, beta, S)
         ctx.bwd_kernel = bwd_kernel
@@ -836,10 +865,6 @@ class GatedDeltaNetOp(UnmanifestedOp):
 
     Layout: BHSD (batch, head, seq_len, dim).
 
-    Args:
-        chunk_size: Chunk size for chunked linear attention.
-        kernel_map: Optional kernel overrides.
-        tune: Whether to autotune kernels.
     """
 
     def __init__(
@@ -848,6 +873,13 @@ class GatedDeltaNetOp(UnmanifestedOp):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            chunk_size: Chunk size for chunked linear attention.
+            kernel_map: Optional kernel overrides.
+            tune: Whether to autotune kernels.
+        """
         self.batch = None
         self.heads = None
         self.seq_len = None
@@ -965,6 +997,12 @@ class GatedDeltaNetDecodeFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         self.batch = None
         self.heads = None
         self.dim_k = None
@@ -1119,6 +1157,19 @@ class GatedDeltaNetDecodeFwdOp(Op):
         beta: torch.Tensor,
         state: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Run the op on the inputs the manifest declares.
+
+        Args:
+            q: Input tensor, dtype ``float16 | bfloat16 | float32``.
+            k: Input tensor, dtype ``same_as(q)``.
+            v: Input tensor, dtype ``same_as(q)``.
+            g: Input tensor, dtype ``same_as(q)``.
+            beta: Input tensor, dtype ``same_as(q)``.
+            state: Input tensor, dtype ``same_as(q)``.
+
+        Returns:
+            ``o``, ``new_state``, as the manifest declares. Shape rules: ``o.shape == (B, H, DV)``; ``new_state.shape == (B, H, DK, DV)``.
+        """
         sig = (
             q.shape,
             k.shape,

--- a/src/tileops/ops/linear_attention/gla.py
+++ b/src/tileops/ops/linear_attention/gla.py
@@ -46,11 +46,6 @@ class GLAFwdOp(Op):
 
     Layout: BTHD (batch, seq_len, heads, dim).
 
-    Args:
-        chunk_size: Chunk size for chunked linear attention.
-        scale: Query scale factor (default: dim_k**-0.5).
-        kernel_map: Optional kernel overrides.
-        tune: Whether to autotune kernels.
     """
 
     def __init__(
@@ -60,6 +55,14 @@ class GLAFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            chunk_size: Chunk size for chunked linear attention.
+            scale: Query scale factor (default: dim_k**-0.5).
+            kernel_map: Optional kernel overrides.
+            tune: Whether to autotune kernels.
+        """
         self.batch = None
         self.seq_len = None
         self.heads = None
@@ -179,11 +182,6 @@ class GLABwdOp(Op):
 
     Layout: BTHD (batch, seq_len, heads, dim).
 
-    Args:
-        chunk_size: Chunk size for chunked linear attention.
-        scale: Query scale factor (default: dim_k**-0.5).
-        kernel_map: Optional kernel overrides.
-        tune: Whether to autotune kernels.
     """
 
     def __init__(
@@ -193,6 +191,14 @@ class GLABwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            chunk_size: Chunk size for chunked linear attention.
+            scale: Query scale factor (default: dim_k**-0.5).
+            kernel_map: Optional kernel overrides.
+            tune: Whether to autotune kernels.
+        """
         self.batch = None
         self.seq_len = None
         self.heads = None

--- a/src/tileops/ops/linear_attention/gla_recurrence.py
+++ b/src/tileops/ops/linear_attention/gla_recurrence.py
@@ -30,6 +30,13 @@ class GLADecodeFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            scale: Manifest ``params.scale``, ``float``, default ``-1.0``.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         self.batch = None
         self.heads = None
         self.dim_k = None
@@ -171,6 +178,18 @@ class GLADecodeFwdOp(Op):
         gk: torch.Tensor,
         state: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Run the op on the inputs the manifest declares.
+
+        Args:
+            q: Input tensor, dtype ``float16 | bfloat16 | float32``.
+            k: Input tensor, dtype ``same_as(q)``.
+            v: Input tensor, dtype ``same_as(q)``.
+            gk: Input tensor, dtype ``same_as(q)``.
+            state: Input tensor, dtype ``same_as(q)``.
+
+        Returns:
+            ``o``, ``new_state``, as the manifest declares. Shape rules: ``o.shape == (B, H, DV)``; ``new_state.shape == (B, H, DK, DV)``.
+        """
         self._validate_dtypes(q, k, v, gk, state)
         self._validate_shapes(q, k, v, gk, state)
         o, new_state = self.kernel(q, k, v, gk, state)

--- a/src/tileops/ops/mamba/cb_producer.py
+++ b/src/tileops/ops/mamba/cb_producer.py
@@ -21,14 +21,6 @@ class CBProducerFwdOp(Op):
     Computes cb[b,c,g,l,s] = sum_n C[b,c,g,l,n] * B[b,c,g,s,n]
     with causal masking (cb[l,s] = 0 if s > l).
 
-    Args:
-        batch: Batch size
-        num_chunks: Number of chunks
-        n_groups: Number of groups
-        chunk_len: Chunk length (Q)
-        d_state: State dimension (N)
-        tune: Whether to autotune
-        kernel_map: Optional pre-initialized kernels
     """
 
     def __init__(
@@ -41,6 +33,17 @@ class CBProducerFwdOp(Op):
         tune: bool = False,
         kernel_map: Optional[Dict[str, Kernel]] = None,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            batch: Batch size
+            num_chunks: Number of chunks
+            n_groups: Number of groups
+            chunk_len: Chunk length (Q)
+            d_state: State dimension (N)
+            tune: Whether to autotune
+            kernel_map: Optional pre-initialized kernels
+        """
         self.batch = batch
         self.num_chunks = num_chunks
         self.n_groups = n_groups

--- a/src/tileops/ops/mamba/da_cumsum.py
+++ b/src/tileops/ops/mamba/da_cumsum.py
@@ -32,12 +32,6 @@ class DaCumsumFwdOp(Op):
     Note: dt_out is cast to the target dtype for storage efficiency, but dA_cumsum
     is computed from the fp32 dt values before casting, ensuring numerical precision.
 
-    Args:
-        chunk_len:    Tokens per chunk.
-        dt_softplus:  Whether to apply softplus (with bypass for dt > 20) to dt.
-        dt_min:       Lower clamp bound applied after bias and softplus.
-        dt_max:       Upper clamp bound applied after bias and softplus.
-        tune:         Whether to autotune tile config on construction.
     """
 
     def __init__(
@@ -50,6 +44,15 @@ class DaCumsumFwdOp(Op):
         tune: bool = False,
         kernel_map: Optional[Dict[str, Kernel]] = None,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            chunk_len:    Tokens per chunk.
+            dt_softplus:  Whether to apply softplus (with bypass for dt > 20) to dt.
+            dt_min:       Lower clamp bound applied after bias and softplus.
+            dt_max:       Upper clamp bound applied after bias and softplus.
+            tune:         Whether to autotune tile config on construction.
+        """
         declared = _dt_out_dtypes()
         if dtype not in declared:
             supported = ", ".join(str(dt) for dt in declared)
@@ -122,7 +125,7 @@ class DaCumsumFwdOp(Op):
         A_shape: tuple[int, ...],
         dt_bias_shape: tuple[int, ...],
     ) -> dict[str, tuple[int, ...]]:
-        """Manifest ``outputs``: ``[B, H, NC, chunk_len]``, with ``NC = S // chunk_len``."""
+        """Manifest ``outputs``: $[B \\times H \\times NC \\times chunk\\_len]$, with ``NC = S // chunk_len``."""
         b, s, h = dt_shape
         chunked = (b, h, s // self.chunk_len, self.chunk_len)
         return {"dt_out": chunked, "dA_cumsum": chunked}

--- a/src/tileops/ops/mamba/mamba2_fwd.py
+++ b/src/tileops/ops/mamba/mamba2_fwd.py
@@ -48,10 +48,6 @@ class Mamba2FwdOp(Op):
     a single callable whose interface matches mamba_chunk_scan_combined from
     the official mamba_ssm library.
 
-    Args:
-        chunk_size:         Tokens per chunk (default 256).
-        dt_softplus:        Apply softplus to (dt + dt_bias) before use.
-        tune:               Whether to autotune tile configs on construction.
     """
 
     def __init__(
@@ -61,6 +57,13 @@ class Mamba2FwdOp(Op):
         tune: bool = False,
         kernel_map: Optional[Dict[str, Kernel]] = None,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            chunk_size:         Tokens per chunk (default 256).
+            dt_softplus:        Apply softplus to (dt + dt_bias) before use.
+            tune:               Whether to autotune tile configs on construction.
+        """
         self.batch = None
         self.seqlen = None
         self.chunk_size = chunk_size

--- a/src/tileops/ops/mamba/ssd_chunk_scan.py
+++ b/src/tileops/ops/mamba/ssd_chunk_scan.py
@@ -19,8 +19,6 @@ class SSDChunkScanFwdOp(Op):
       out[l, p] = exp(dA_cumsum[l]) * (C[l] @ prev_states)
                 + sum_{s <= l} cb[l, s] * exp(dA_cumsum[l] - dA_cumsum[s]) * dt[s] * x[s, p]
 
-    Args:
-        tune:       Whether to autotune tile config on construction.
     """
 
     def __init__(
@@ -28,6 +26,11 @@ class SSDChunkScanFwdOp(Op):
         tune: bool = False,
         kernel_map: Optional[Dict[str, Kernel]] = None,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            tune:       Whether to autotune tile config on construction.
+        """
         self.batch = None
         self.num_chunks = None
         self.chunk_len = None
@@ -95,7 +98,7 @@ class SSDChunkScanFwdOp(Op):
         prev_states_shape: tuple[int, ...],
         dt_shape: tuple[int, ...],
     ) -> dict[str, tuple[int, ...]]:
-        """Manifest ``outputs``: ``y`` has the shape of *x*, ``[B, S, H, P]``."""
+        """Manifest ``outputs``: ``y`` has the shape of *x*, $[B \\times S \\times H \\times P]$."""
         return {"y": tuple(x_shape)}
 
     def forward(

--- a/src/tileops/ops/mamba/ssd_chunk_state.py
+++ b/src/tileops/ops/mamba/ssd_chunk_state.py
@@ -23,8 +23,6 @@ class SSDChunkStateFwdOp(Op):
               * dt[b, h, c, l]
               * (1 if seq_idx is None else (seq_idx[b,c*Q+Q-1] >= 0 and seq_idx[b,c*Q+l] == seq_idx[b,c*Q+Q-1]))
 
-    Args:
-        tune:       Whether to autotune tile config on construction.
     """
 
     def __init__(
@@ -32,6 +30,11 @@ class SSDChunkStateFwdOp(Op):
         tune: bool = False,
         kernel_map: Optional[Dict[str, Kernel]] = None,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            tune:       Whether to autotune tile config on construction.
+        """
         self.batch = None
         self.num_chunks = None
         self.chunk_len = None
@@ -106,7 +109,7 @@ class SSDChunkStateFwdOp(Op):
         dA_cumsum_shape: tuple[int, ...],
         seq_idx_shape: tuple[int, ...],
     ) -> dict[str, tuple[int, ...]]:
-        """Manifest ``outputs``: ``[B, NC, H, P, N]`` — chunks from *dt*, state size from *Bmat*."""
+        """Manifest ``outputs``: $[B \\times NC \\times H \\times P \\times N]$ — chunks from *dt*, state size from *Bmat*."""
         b, _, h, p = x_shape
         return {"states": (b, dt_shape[2], h, p, Bmat_shape[-1])}
 

--- a/src/tileops/ops/mamba/ssd_decode.py
+++ b/src/tileops/ops/mamba/ssd_decode.py
@@ -25,8 +25,6 @@ class SSDDecodeFwdOp(Op):
     The skip connection (D * x) and output gate (z * silu) are not fused
     here and must be applied by the caller if needed.
 
-    Args:
-        tune:     Whether to autotune tile config on construction.
     """
 
     def __init__(
@@ -34,6 +32,11 @@ class SSDDecodeFwdOp(Op):
         tune: bool = False,
         kernel_map: Optional[Dict[str, Kernel]] = None,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            tune:     Whether to autotune tile config on construction.
+        """
         self.batch = None
         self.n_heads = None
         self.d_head = None
@@ -78,7 +81,7 @@ class SSDDecodeFwdOp(Op):
         C_in_shape: tuple[int, ...],
         state_shape: tuple[int, ...],
     ) -> dict[str, tuple[int, ...]]:
-        """Manifest ``outputs``: ``y_out`` has the shape of *x*, ``[B, H, P]``."""
+        """Manifest ``outputs``: ``y_out`` has the shape of *x*, $[B \\times H \\times P]$."""
         return {"y_out": tuple(x_shape)}
 
     def forward(

--- a/src/tileops/ops/mamba/ssd_state_passing.py
+++ b/src/tileops/ops/mamba/ssd_state_passing.py
@@ -19,8 +19,6 @@ class SSDStatePassingFwdOp(Op):
 
     with s_{-1} = initial_states, or 0 when it is not passed.
 
-    Args:
-        tune:               Whether to autotune tile config on construction.
     """
 
     def __init__(
@@ -28,6 +26,11 @@ class SSDStatePassingFwdOp(Op):
         tune: bool = False,
         kernel_map: Optional[Dict[str, Kernel]] = None,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            tune:               Whether to autotune tile config on construction.
+        """
         self.batch = None
         self.num_chunks = None
         self.n_heads = None

--- a/src/tileops/ops/moe/fused_moe.py
+++ b/src/tileops/ops/moe/fused_moe.py
@@ -33,23 +33,6 @@ class FusedMoe(Op):
     The concrete manifest identity (`FusedMoeFwdOp`) subclasses this; the
     routing-and-expert pipeline below is shared with `SharedFusedMoE`.
 
-    Args:
-        num_tokens: T -- number of input tokens.
-        num_experts: E -- total number of experts (global count).
-        top_k: K -- experts selected per token.
-        hidden_size: H -- model hidden dimension.
-        ffn_size: F -- per-expert intermediate dimension.
-        scoring_func: "softmax" (Qwen3) or "sigmoid" (Kimi K2 / DeepSeek-V3).
-        renormalize: Renormalize top-k weights to sum to 1.
-        routed_scaling_factor: Multiplier on expert output (Kimi K2: 2.827).
-        expert_map: [E_global] int32 for Expert Parallel local filtering.
-        num_experts_local: Number of experts this rank owns. Required with
-            `expert_map` and rejected without it: it sizes the expert
-            pipeline's kernels, which are built here, and reading it off the
-            map would mean a device read at construction.
-        prepare_finalize: Override the PrepareAndFinalize implementation.
-        experts: Override the Experts implementation.
-        kernel_map: Override the dispatched kernel map.
     """
 
     def __init__(
@@ -70,6 +53,26 @@ class FusedMoe(Op):
         *,
         activation: str = "silu_and_mul",
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            num_tokens: T -- number of input tokens.
+            num_experts: E -- total number of experts (global count).
+            top_k: K -- experts selected per token.
+            hidden_size: H -- model hidden dimension.
+            ffn_size: F -- per-expert intermediate dimension.
+            scoring_func: "softmax" (Qwen3) or "sigmoid" (Kimi K2 / DeepSeek-V3).
+            renormalize: Renormalize top-k weights to sum to 1.
+            routed_scaling_factor: Multiplier on expert output (Kimi K2: 2.827).
+            expert_map: [E_global] int32 for Expert Parallel local filtering.
+            num_experts_local: Number of experts this rank owns. Required with
+                `expert_map` and rejected without it: it sizes the expert
+                pipeline's kernels, which are built here, and reading it off the
+                map would mean a device read at construction.
+            prepare_finalize: Override the PrepareAndFinalize implementation.
+            experts: Override the Experts implementation.
+            kernel_map: Override the dispatched kernel map.
+        """
         if (expert_map is None) != (num_experts_local is None):
             raise ValueError(
                 "expert_map and num_experts_local go together: the map carries the "
@@ -175,6 +178,7 @@ class FusedMoe(Op):
         w_down: torch.Tensor,  # [E, H, F]
         correction_bias: Optional[torch.Tensor] = None,  # [E] float32
     ) -> torch.Tensor:  # [T, H]
+        """Run the op on ``hidden_states``, ``gating_output``, ``w_gate_up``, ``w_down`` and ``correction_bias``."""
         topk_weights, topk_ids = self._fused_topk(gating_output, correction_bias)
         # The roofline counts the bias bytes of the call that ran, so this is
         # set once routing succeeded. Keep the shape, not the tensor: the op
@@ -260,6 +264,20 @@ class FusedMoeFwdOp(FusedMoe):
         *,
         activation: str = "silu_and_mul",
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            num_tokens: Manifest ``params.num_tokens``, ``int``.
+            num_experts: Manifest ``params.num_experts``, ``int``.
+            top_k: Manifest ``params.top_k``, ``int``.
+            hidden_size: Manifest ``params.hidden_size``, ``int``.
+            ffn_size: Manifest ``params.ffn_size``, ``int``.
+            scoring_func: Manifest ``params.scoring_func``, ``str``, default ``'softmax'``.
+            renormalize: Manifest ``params.renormalize``, ``bool``, default ``False``.
+            routed_scaling_factor: Manifest ``params.routed_scaling_factor``, ``float``, default ``1.0``.
+            kernel_map: Optional kernel override dict.
+            activation: Manifest ``params.activation``, ``str``, default ``'silu_and_mul'``.
+        """
         super().__init__(
             num_tokens=num_tokens,
             num_experts=num_experts,

--- a/src/tileops/ops/moe/fused_topk.py
+++ b/src/tileops/ops/moe/fused_topk.py
@@ -18,25 +18,13 @@ class FusedTopKOp(UnmanifestedOp):
     Applies scoring (softmax or sigmoid) to router logits and selects the
     top-k experts per token.
 
-    Args:
-        num_tokens: Optional committed number of input tokens T. Preferred
-            API infers it from ``gating_output.shape[0]``.
-        num_experts: Optional committed number of experts E. Preferred API
-            infers it from ``gating_output.shape[1]``.
-        top_k: Number of experts to select per token K.
-        scoring_func: "softmax" (Qwen3/Qwen2) or "sigmoid" (DeepSeek-V3/GLM-4/Kimi K2).
-        renormalize: If True, normalize top-k weights to sum to 1.
-        scoring_func: see above. Passing ``correction_bias`` to ``forward``
-            requires ``"sigmoid"``: the bias is added to sigmoid scores for
-            selection only, and the output weights stay the original scores.
-        kernel_map: Optional kernel map override.
-        config: Optional kernel config dict.
-
     Example:
-        >>> op = FusedTopKOp(top_k=8)
-        >>> topk_weights, topk_ids = op(gating_output)
-        >>> # topk_weights: [512, 8] float32
-        >>> # topk_ids:     [512, 8] int32
+        ```python linenums="1"
+        op = FusedTopKOp(top_k=8)
+        topk_weights, topk_ids = op(gating_output)
+        # topk_weights: [512, 8] float32
+        # topk_ids:     [512, 8] int32
+        ```
     """
 
     def __init__(
@@ -49,6 +37,22 @@ class FusedTopKOp(UnmanifestedOp):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         config: Optional[dict] = None,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            num_tokens: Optional committed number of input tokens T. Preferred
+                API infers it from ``gating_output.shape[0]``.
+            num_experts: Optional committed number of experts E. Preferred API
+                infers it from ``gating_output.shape[1]``.
+            top_k: Number of experts to select per token K.
+            scoring_func: "softmax" (Qwen3/Qwen2) or "sigmoid" (DeepSeek-V3/GLM-4/Kimi K2).
+            renormalize: If True, normalize top-k weights to sum to 1.
+            scoring_func: see above. Passing ``correction_bias`` to ``forward``
+                requires ``"sigmoid"``: the bias is added to sigmoid scores for
+                selection only, and the output weights stay the original scores.
+            kernel_map: Optional kernel map override.
+            config: Optional kernel config dict.
+        """
         self.num_tokens = num_tokens
         self.num_experts = num_experts
         self.top_k = top_k

--- a/src/tileops/ops/moe/permute_align.py
+++ b/src/tileops/ops/moe/permute_align.py
@@ -20,17 +20,11 @@ class MoePermuteAlignFwdOp(Op):
     grouped GEMM: sorted token indices, per-block expert ids, and the total
     padded token count.
 
-    Args:
-        total_tokens: Number of input tokens T.
-        top_k: Number of experts selected per token K.
-        num_experts: Number of experts.
-        block_size: GEMM tile size (M dimension); default 64.
-        kernel_map: Optional kernel override dict.
-        tune: Whether to autotune the kernel.
-
     Example:
-        >>> op = MoePermuteAlignFwdOp(total_tokens=4, top_k=8, num_experts=8, block_size=16)
-        >>> sorted_ids, expert_ids, num_post_pad = op(topk_ids)
+        ```python linenums="1"
+        op = MoePermuteAlignFwdOp(total_tokens=4, top_k=8, num_experts=8, block_size=16)
+        sorted_ids, expert_ids, num_post_pad = op(topk_ids)
+        ```
     """
 
     #: The operator this op registers; a test asserts the graph holds nothing else.
@@ -45,6 +39,16 @@ class MoePermuteAlignFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            total_tokens: Number of input tokens T.
+            top_k: Number of experts selected per token K.
+            num_experts: Number of experts.
+            block_size: GEMM tile size (M dimension); default 64.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune the kernel.
+        """
         self.total_tokens = total_tokens
         self.top_k = top_k
         self.num_experts = num_experts

--- a/src/tileops/ops/moe/routed_expert/fused_routed_expert.py
+++ b/src/tileops/ops/moe/routed_expert/fused_routed_expert.py
@@ -38,27 +38,13 @@ class FusedMoEExpertsNopadPersistent3WGFwdOp(FusedMoEExpertsModular):
     forward() output shape is (T, H): reduction is done internally by
     MoeUnpermuteFwdOp, so make_weighted_reduce() returns WeightedReduceNoOp.
 
-    Args:
-        num_tokens: Number of input tokens T (rows of hidden_states).
-        num_experts: Total number of experts E in the routing table.
-        num_experts_local: Number of those experts this rank owns; the weights
-            and both grouped GEMMs are sized by it. Equal to ``num_experts``
-            outside expert parallelism.
-        top_k: Number of experts each token is routed to (K).
-        hidden_size: Model hidden dimension H (GEMM contraction dim for
-            gate_up, output dim for down).
-        ffn_size: Per-expert FFN intermediate dimension F.
-        routed_scaling_factor: Scalar applied to the final reduced output.
-            Defaults to 1.0 (no scaling).
-        kernel_map: Optional kernel overrides forwarded to the inner Ops.
-        activation: Gated activation applied to gate_up: 'silu_and_mul' or
-            'gelu_and_mul'.
-
     Example:
-        >>> experts = FusedMoEExpertsNopadPersistent3WGFwdOp(
-        ...     num_tokens=512, num_experts=128, num_experts_local=128, top_k=8,
-        ...     hidden_size=7168, ffn_size=2048,
-        ... )
+        ```python linenums="1"
+        experts = FusedMoEExpertsNopadPersistent3WGFwdOp(
+            num_tokens=512, num_experts=128, num_experts_local=128, top_k=8,
+            hidden_size=7168, ffn_size=2048,
+        )
+        ```
     """
 
     def __init__(
@@ -74,6 +60,24 @@ class FusedMoEExpertsNopadPersistent3WGFwdOp(FusedMoEExpertsModular):
         *,
         activation: str = "silu_and_mul",
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            num_tokens: Number of input tokens T (rows of hidden_states).
+            num_experts: Total number of experts E in the routing table.
+            num_experts_local: Number of those experts this rank owns; the weights
+                and both grouped GEMMs are sized by it. Equal to ``num_experts``
+                outside expert parallelism.
+            top_k: Number of experts each token is routed to (K).
+            hidden_size: Model hidden dimension H (GEMM contraction dim for
+                gate_up, output dim for down).
+            ffn_size: Per-expert FFN intermediate dimension F.
+            routed_scaling_factor: Scalar applied to the final reduced output.
+                Defaults to 1.0 (no scaling).
+            kernel_map: Optional kernel overrides forwarded to the inner Ops.
+            activation: Gated activation applied to gate_up: 'silu_and_mul' or
+                'gelu_and_mul'.
+        """
         self.dispatch_kernel(kernel_map)
         self.num_tokens = num_tokens
         self.num_experts = num_experts

--- a/src/tileops/ops/moe/routed_expert/gate_up.py
+++ b/src/tileops/ops/moe/routed_expert/gate_up.py
@@ -31,18 +31,11 @@ class MoeGateUpFwdOp(GroupedOperandEagerForward, Op):
     Takes the tight permuted rows and the stacked gate||up weights, and returns
     activated rows of width ``ffn``.
 
-    Args:
-        numel: T * top_k tight row count.
-        num_experts: Number of local experts E.
-        ffn: FFN width; ``b`` holds 2*ffn rows (gate||up).
-        k: Hidden size K.
-        activation: 'silu_and_mul' or 'gelu_and_mul'.
-        kernel_map: Optional kernel override dict.
-        tune: Whether to autotune.
-
     Example:
-        >>> op = MoeGateUpFwdOp(numel=4096, num_experts=128, ffn=2048, k=7168)
-        >>> act = op(a, b, true_sizes, true_offsets)  # [4096, 2048]
+        ```python linenums="1"
+        op = MoeGateUpFwdOp(numel=4096, num_experts=128, ffn=2048, k=7168)
+        act = op(a, b, true_sizes, true_offsets)  # [4096, 2048]
+        ```
     """
 
     #: The operator this op registers; a test asserts the graph holds nothing else.
@@ -58,6 +51,17 @@ class MoeGateUpFwdOp(GroupedOperandEagerForward, Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            numel: T * top_k tight row count.
+            num_experts: Number of local experts E.
+            ffn: FFN width; ``b`` holds 2*ffn rows (gate||up).
+            k: Hidden size K.
+            activation: 'silu_and_mul' or 'gelu_and_mul'.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune.
+        """
         self.numel = numel
         self.num_experts = num_experts
         self.ffn = ffn

--- a/src/tileops/ops/moe/routed_expert/moe_grouped_gemm_nopad.py
+++ b/src/tileops/ops/moe/routed_expert/moe_grouped_gemm_nopad.py
@@ -27,18 +27,12 @@ class MoeGroupedGemmNopadFwdOp(GroupedOperandEagerForward, Op):
     Accepts tight A[T*K, K] inputs (no padding between experts) from
     MoePermuteNoPadOp, producing tight C[T*K, N] outputs.
 
-    Args:
-        numel: T * top_k, total (token, expert) pairs = tight row count.
-        num_experts: Total number of experts E.
-        n: Output feature dimension N (e.g. 2*ffn_size or hidden_size).
-        k: Input feature dimension K (hidden_size or ffn_size).
-        kernel_map: Optional kernel override dict.
-        tune: Whether to autotune.
-
     Example:
-        >>> op = MoeGroupedGemmNopadFwdOp(numel=16384, num_experts=256, n=4096, k=2048,
-        ...)
-        >>> C = op(A, B, true_sizes, true_offsets)  # [numel, N]
+        ```python linenums="1"
+        op = MoeGroupedGemmNopadFwdOp(numel=16384, num_experts=256, n=4096, k=2048,
+        )
+        C = op(A, B, true_sizes, true_offsets)  # [numel, N]
+        ```
     """
 
     #: The operator this op registers; a test asserts the graph holds nothing else.
@@ -53,6 +47,16 @@ class MoeGroupedGemmNopadFwdOp(GroupedOperandEagerForward, Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            numel: T * top_k, total (token, expert) pairs = tight row count.
+            num_experts: Total number of experts E.
+            n: Output feature dimension N (e.g. 2*ffn_size or hidden_size).
+            k: Input feature dimension K (hidden_size or ffn_size).
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune.
+        """
         self.numel = numel
         self.num_experts = num_experts
         self.n = n

--- a/src/tileops/ops/moe/routed_expert/permute_nopad.py
+++ b/src/tileops/ops/moe/routed_expert/permute_nopad.py
@@ -29,21 +29,11 @@ class MoePermuteNopadFwdOp(Op):
     The output perm_h has exactly T*K rows with no inter-expert padding,
     enabling smaller intermediate tensors throughout the MoE pipeline.
 
-    Args:
-        num_experts: Total number of experts E in the routing table.
-        num_experts_local: Number of those experts this rank lays out. Equal to
-            ``num_experts`` outside expert parallelism.
-        total_tokens: Optional committed number of input tokens T. Preferred
-            API infers it from ``hidden_states.shape[0]``.
-        top_k: Optional committed number of experts selected per token K.
-            Preferred API infers it from ``topk_ids.shape[1]``.
-        hidden_size: Optional committed hidden dimension H. Preferred API
-            infers it from ``hidden_states.shape[1]``.
-        kernel_map: Optional kernel override dict.
-
     Example:
-        >>> op = MoePermuteNopadFwdOp(num_experts=8, num_experts_local=8)
-        >>> perm_h, offsets, sizes, expert_offset, fwd_idx = op(hidden_states, topk_ids)
+        ```python linenums="1"
+        op = MoePermuteNopadFwdOp(num_experts=8, num_experts_local=8)
+        perm_h, offsets, sizes, expert_offset, fwd_idx = op(hidden_states, topk_ids)
+        ```
     """
 
     #: The operator this op registers; a test asserts the graph holds nothing else.
@@ -58,6 +48,20 @@ class MoePermuteNopadFwdOp(Op):
         hidden_size: Optional[int] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            num_experts: Total number of experts E in the routing table.
+            num_experts_local: Number of those experts this rank lays out. Equal to
+                ``num_experts`` outside expert parallelism.
+            total_tokens: Optional committed number of input tokens T. Preferred
+                API infers it from ``hidden_states.shape[0]``.
+            top_k: Optional committed number of experts selected per token K.
+                Preferred API infers it from ``topk_ids.shape[1]``.
+            hidden_size: Optional committed hidden dimension H. Preferred API
+                infers it from ``hidden_states.shape[1]``.
+            kernel_map: Optional kernel override dict.
+        """
         if not 0 < num_experts_local <= num_experts:
             raise ValueError(
                 f"num_experts_local must be in (0, {num_experts}], got {num_experts_local}"

--- a/src/tileops/ops/moe/routed_expert/unpermute.py
+++ b/src/tileops/ops/moe/routed_expert/unpermute.py
@@ -16,23 +16,11 @@ __all__ = ["MoeUnpermuteFwdOp"]
 class MoeUnpermuteFwdOp(Op):
     """Scatter padded expert outputs back to original token order with weighted reduction.
 
-    Args:
-        total_tokens: Number of input tokens T.
-        top_k: Number of experts selected per token K.
-        hidden_size: Hidden dimension H.
-        padded_batch_sum: Size of the padded mm2_pad buffer (first dim of mm2_pad).
-            Must be >= T*K. When used with MoePermuteOp, pass the padded_batch_sum
-            value returned by the kernel (T*K + E*block_m upper bound).
-            Defaults to total_tokens * top_k for standalone testing only — do NOT
-            use the default when mm2_pad comes from MoePermuteOp, as the padded
-            buffer will be larger and the kernel will index out of bounds.
-        kernel_map: Optional kernel override dict.
-        routed_scaling_factor: Scalar applied to the reduced output, folded into
-            the unpermute kernel. Defaults to 1.0 (no scaling).
-
     Example:
-        >>> op = MoeUnpermuteFwdOp(total_tokens=4, top_k=2, hidden_size=128, padded_batch_sum=512)
-        >>> output = op(mm2_pad, fwd_idx, topk_weights)
+        ```python linenums="1"
+        op = MoeUnpermuteFwdOp(total_tokens=4, top_k=2, hidden_size=128, padded_batch_sum=512)
+        output = op(mm2_pad, fwd_idx, topk_weights)
+        ```
     """
 
     #: Two operators, because ``mutates_args`` is fixed at registration while ``out``
@@ -53,6 +41,22 @@ class MoeUnpermuteFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         routed_scaling_factor: float = 1.0,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            total_tokens: Number of input tokens T.
+            top_k: Number of experts selected per token K.
+            hidden_size: Hidden dimension H.
+            padded_batch_sum: Size of the padded mm2_pad buffer (first dim of mm2_pad).
+                Must be >= T*K. When used with MoePermuteOp, pass the padded_batch_sum
+                value returned by the kernel (T*K + E*block_m upper bound).
+                Defaults to total_tokens * top_k for standalone testing only — do NOT
+                use the default when mm2_pad comes from MoePermuteOp, as the padded
+                buffer will be larger and the kernel will index out of bounds.
+            kernel_map: Optional kernel override dict.
+            routed_scaling_factor: Scalar applied to the reduced output, folded into
+                the unpermute kernel. Defaults to 1.0 (no scaling).
+        """
         self.total_tokens = total_tokens
         self.top_k = top_k
         self.hidden_size = hidden_size

--- a/src/tileops/ops/moe/shared_fused_moe.py
+++ b/src/tileops/ops/moe/shared_fused_moe.py
@@ -58,18 +58,6 @@ class SharedFusedMoE(FusedMoe, UnmanifestedOp):
         The returned shared_out is a partial sum; the caller must all-reduce
         across TP ranks. The routed expert path is not affected.
 
-    Args:
-        shared_ffn_size: FFN intermediate size for the shared expert (full size,
-            before TP sharding). If None, no shared expert is computed.
-        tp_size: Tensor parallel world size. Default 1 (no TP).
-        tp_rank: This rank's index in the TP group. Default 0.
-        num_experts_local: Number of experts this rank owns; required with
-            expert_map. See FusedMoe.
-        prepare_finalize: Override the PrepareAndFinalize implementation.
-        experts: Override the Experts implementation.
-        kernel_map: Override the dispatched kernel map.
-        Other args: same as FusedMoe.
-
     Returns:
         (shared_output, routed_output): tuple of [T, H] tensors.
             shared_output is None when shared_ffn_size is None.
@@ -102,6 +90,21 @@ class SharedFusedMoE(FusedMoe, UnmanifestedOp):
         # silently produce mixed outputs (routed=gelu, shared=silu). Validate
         # before super().__init__() to avoid building routed experts that
         # would be discarded by the exception.
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            shared_ffn_size: FFN intermediate size for the shared expert (full size,
+                before TP sharding). If None, no shared expert is computed.
+            tp_size: Tensor parallel world size. Default 1 (no TP).
+            tp_rank: This rank's index in the TP group. Default 0.
+            num_experts_local: Number of experts this rank owns; required with
+                expert_map. See FusedMoe.
+            prepare_finalize: Override the PrepareAndFinalize implementation.
+            experts: Override the Experts implementation.
+            kernel_map: Override the dispatched kernel map.
+
+        Every other parameter is ``FusedMoe``'s, with the same meaning.
+        """
         if shared_ffn_size is not None and activation != "silu_and_mul":
             raise NotImplementedError(
                 "SharedFusedMoE shared-expert path only supports "

--- a/src/tileops/ops/norm/ada_layer_norm.py
+++ b/src/tileops/ops/norm/ada_layer_norm.py
@@ -34,12 +34,6 @@ class AdaLayerNormFwdOp(Op):
         Supports arbitrary leading dimensions (3-D+) via flatten/unflatten.
         Handles non-contiguous inputs and non-power-of-two hidden dims.
 
-    Args:
-        eps: Epsilon for numerical stability (manifest ``params.eps``).
-        target: Which set of kernels serves this op — a target name, ``BUILTIN`` for the
-            in-tree kernels, or ``None`` to decide from the input device.
-        kernel_map: Optional kernel override dictionary.
-        tune: If ``True``, autotune tile configurations.
     """
 
     #: The operator this op registers; a test asserts the graph holds nothing else.
@@ -53,6 +47,15 @@ class AdaLayerNormFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            eps: Epsilon for numerical stability (manifest ``params.eps``).
+            target: Which set of kernels serves this op — a target name, ``BUILTIN`` for the
+                in-tree kernels, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel override dictionary.
+            tune: If ``True``, autotune tile configurations.
+        """
         self.eps = eps
         self.target = target
         self.tune = tune

--- a/src/tileops/ops/norm/ada_layer_norm_zero.py
+++ b/src/tileops/ops/norm/ada_layer_norm_zero.py
@@ -24,7 +24,7 @@ class AdaLayerNormZeroFwdOp(Op):
     $$
 
     where *s* (scale), *d* (shift), and *g* (gate) are per-token tensors of
-    shape ``(M, N)``, pre-computed by the caller from a conditioning signal.
+    shape $[M \\times N]$, pre-computed by the caller from a conditioning signal.
     Linear projection from the conditioning input to scale/shift/gate is the
     caller's responsibility.
 
@@ -35,12 +35,6 @@ class AdaLayerNormZeroFwdOp(Op):
         Supports arbitrary leading dimensions (3-D+) via flatten/unflatten.
         Handles non-contiguous inputs and non-power-of-two hidden dims.
 
-    Args:
-        eps: Epsilon for numerical stability (manifest ``params.eps``).
-        target: Which set of kernels serves this op — a target name, ``BUILTIN`` for the
-            in-tree kernels, or ``None`` to decide from the input device.
-        kernel_map: Optional kernel override dictionary.
-        tune: If ``True``, autotune tile configurations.
     """
 
     #: The operator this op registers; a test asserts the graph holds nothing else.
@@ -54,6 +48,15 @@ class AdaLayerNormZeroFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            eps: Epsilon for numerical stability (manifest ``params.eps``).
+            target: Which set of kernels serves this op — a target name, ``BUILTIN`` for the
+                in-tree kernels, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel override dictionary.
+            tune: If ``True``, autotune tile configurations.
+        """
         self.eps = eps
         self.target = target
         self.tune = tune

--- a/src/tileops/ops/norm/batch_norm.py
+++ b/src/tileops/ops/norm/batch_norm.py
@@ -16,7 +16,7 @@ Forward returns the normalized output only (manifest contract); ``mean`` and
 backward pass can recompute on the original input.
 
 Input tensors accept any shape ``(N, C, *spatial)``; the kernel moves them into its
-``(C, L)`` layout. ``L = N * prod(spatial)`` must be divisible by the kernel's block_l
+$[C \\times L]$ layout. ``L = N * prod(spatial)`` must be divisible by the kernel's block_l
 (chosen automatically by the kernel's default_config).
 """
 
@@ -60,16 +60,6 @@ class BatchNormFwdOp(Op):
     Supported dtypes:
         ``torch.float32``, ``torch.float16``, ``torch.bfloat16``.
 
-    Args:
-        training: Whether the batch statistics come from this call's input, which is also
-            what decides whether the running statistics are written (manifest
-            ``params.training``).
-        momentum: Running-stat update momentum (used in training mode).
-        eps: Epsilon for numerical stability.
-        target: Which set of kernels serves this op — a target name, ``BUILTIN`` for the
-            in-tree kernels, or ``None`` to decide from the input device.
-        kernel_map: Optional kernel override dictionary.
-        tune: If ``True``, autotune tile configurations.
     """
 
     #: The operator this op registers; a test asserts the graph holds nothing else.
@@ -85,6 +75,19 @@ class BatchNormFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            training: Whether the batch statistics come from this call's input, which is also
+                what decides whether the running statistics are written (manifest
+                ``params.training``).
+            momentum: Running-stat update momentum (used in training mode).
+            eps: Epsilon for numerical stability.
+            target: Which set of kernels serves this op — a target name, ``BUILTIN`` for the
+                in-tree kernels, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel override dictionary.
+            tune: If ``True``, autotune tile configurations.
+        """
         self.dtype: Optional[torch.dtype] = None
         self.training = training
         self.eps = eps
@@ -220,15 +223,15 @@ class BatchNormFwdOp(Op):
 
         Args:
             x: Input tensor of shape ``(N, C, *spatial)`` on CUDA.
-            running_mean: Running mean of shape ``(C,)`` on the same CUDA
+            running_mean: Running mean of shape $[C]$ on the same CUDA
                 device as ``x``, with dtype ``torch.float32``. Updated
                 in-place during training.
-            running_var: Running variance of shape ``(C,)`` on the same
+            running_var: Running variance of shape $[C]$ on the same
                 CUDA device as ``x``, with dtype ``torch.float32``. Updated
                 in-place during training.
-            weight: Affine scale (gamma) of shape ``(C,)`` on the same CUDA
+            weight: Affine scale (gamma) of shape $[C]$ on the same CUDA
                 device as ``x``.
-            bias: Affine shift (beta) of shape ``(C,)`` on the same CUDA
+            bias: Affine shift (beta) of shape $[C]$ on the same CUDA
                 device as ``x``.
 
         Returns:
@@ -248,11 +251,6 @@ class BatchNormBwdOp(Op):
     Supported dtypes:
         ``torch.float32``, ``torch.float16``, ``torch.bfloat16``.
 
-    Args:
-        target: Which set of kernels serves this op — a target name, ``BUILTIN`` for the
-            in-tree kernels, or ``None`` to decide from the input device.
-        kernel_map: Optional kernel override dictionary.
-        tune: If ``True``, autotune tile configurations.
     """
 
     #: The operator this op registers; a test asserts the graph holds nothing else.
@@ -265,6 +263,14 @@ class BatchNormBwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            target: Which set of kernels serves this op — a target name, ``BUILTIN`` for the
+                in-tree kernels, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel override dictionary.
+            tune: If ``True``, autotune tile configurations.
+        """
         self.dtype: Optional[torch.dtype] = None
         self.target = target
         self.tune = tune
@@ -385,18 +391,18 @@ class BatchNormBwdOp(Op):
         Args:
             grad_out: Upstream gradient of shape ``(N, C, *spatial)``.
             x: Original input tensor of shape ``(N, C, *spatial)``.
-            weight: Affine scale (gamma) of shape ``(C,)`` on the same CUDA
+            weight: Affine scale (gamma) of shape $[C]$ on the same CUDA
                 device as ``x``. Internally cast to ``torch.float32`` for the
                 backward kernel.
             mean: Per-channel batch mean from the forward pass, shape
                 ``(C,)``. Expected as ``torch.float32``.
             rstd: Per-channel reciprocal std from the forward pass,
-                shape ``(C,)``. Expected as ``torch.float32``.
+                shape $[C]$. Expected as ``torch.float32``.
 
         Returns:
             Tuple of ``(grad_x, grad_weight, grad_bias)`` where ``grad_x``
-            has the same shape as ``x``, ``grad_weight`` has shape ``(C,)``,
-            and ``grad_bias`` has shape ``(C,)``.
+            has the same shape as ``x``, ``grad_weight`` has shape $[C]$,
+            and ``grad_bias`` has shape $[C]$.
         """
         return _batch_norm_bwd_wrapped(grad_out, x, weight, mean, rstd, self._instance_key)
 

--- a/src/tileops/ops/norm/fused_add_layer_norm.py
+++ b/src/tileops/ops/norm/fused_add_layer_norm.py
@@ -37,12 +37,6 @@ class FusedAddLayerNormFwdOp(Op):
         Handles non-contiguous inputs and non-power-of-two hidden dims
         by padding to 256-element alignment.
 
-    Args:
-        eps: Epsilon for numerical stability (manifest ``params.eps``).
-        target: Which set of kernels serves this op — a target name, ``BUILTIN`` for the
-            in-tree kernels, or ``None`` to decide from the input device.
-        kernel_map: Optional kernel override dictionary.
-        tune: If ``True``, autotune tile configurations.
     """
 
     #: The operator this op registers; a test asserts the graph holds nothing else.
@@ -56,6 +50,15 @@ class FusedAddLayerNormFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            eps: Epsilon for numerical stability (manifest ``params.eps``).
+            target: Which set of kernels serves this op — a target name, ``BUILTIN`` for the
+                in-tree kernels, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel override dictionary.
+            tune: If ``True``, autotune tile configurations.
+        """
         self.eps = eps
         self.target = target
         self.tune = tune
@@ -97,8 +100,8 @@ class FusedAddLayerNormFwdOp(Op):
         Args:
             x: Input tensor of shape ``(*leading, N)``.
             residual: Residual tensor of the same shape as *x*.
-            weight: Affine scale of shape ``(N,)``.
-            bias: Affine shift of shape ``(N,)``.
+            weight: Affine scale of shape $[N]$.
+            bias: Affine shift of shape $[N]$.
 
         Returns:
             ``(y, residual_out)``, where *residual_out* is ``x + residual``, both of the

--- a/src/tileops/ops/norm/fused_add_rms_norm.py
+++ b/src/tileops/ops/norm/fused_add_rms_norm.py
@@ -36,12 +36,6 @@ class FusedAddRMSNormFwdOp(Op):
         Handles non-contiguous inputs and non-power-of-two hidden dims
         by padding to 256-element alignment.
 
-    Args:
-        eps: Epsilon for numerical stability (manifest ``params.eps``).
-        target: Which set of kernels serves this op — a target name, ``BUILTIN`` for the
-            in-tree kernels, or ``None`` to decide from the input device.
-        kernel_map: Optional kernel override dictionary.
-        tune: If ``True``, autotune tile configurations.
     """
 
     #: The operator this op registers; a test asserts the graph holds nothing else.
@@ -55,6 +49,15 @@ class FusedAddRMSNormFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            eps: Epsilon for numerical stability (manifest ``params.eps``).
+            target: Which set of kernels serves this op — a target name, ``BUILTIN`` for the
+                in-tree kernels, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel override dictionary.
+            tune: If ``True``, autotune tile configurations.
+        """
         self.eps = eps
         self.target = target
         self.tune = tune
@@ -95,7 +98,7 @@ class FusedAddRMSNormFwdOp(Op):
         Args:
             x: Input tensor of shape ``(*leading, N)``.
             residual: Residual tensor of the same shape as *x*.
-            weight: Affine scale of shape ``(N,)``.
+            weight: Affine scale of shape $[N]$.
 
         Returns:
             ``(y, residual_out)``, where *residual_out* is ``x + residual``, both of the

--- a/src/tileops/ops/norm/group_norm.py
+++ b/src/tileops/ops/norm/group_norm.py
@@ -53,14 +53,6 @@ class GroupNormFwdOp(Op):
     pass neither for ``torch.nn.GroupNorm(affine=False)``. Passing one alone
     is an error — the manifest states the same in ``shape_rules``.
 
-    Args:
-        num_groups: Number of groups (manifest ``params.num_groups``).
-            Must divide *C* evenly.
-        eps: Epsilon for numerical stability (manifest ``params.eps``).
-        target: Which set of kernels serves this op — a target name, ``BUILTIN`` for the
-            in-tree kernels, or ``None`` to decide from the input device.
-        kernel_map: Optional kernel override dictionary.
-        tune: If ``True``, autotune tile configurations.
     """
 
     #: The operator this op registers; a test asserts the graph holds nothing else.
@@ -75,6 +67,17 @@ class GroupNormFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            num_groups: Number of groups (manifest ``params.num_groups``).
+                Must divide *C* evenly.
+            eps: Epsilon for numerical stability (manifest ``params.eps``).
+            target: Which set of kernels serves this op — a target name, ``BUILTIN`` for the
+                in-tree kernels, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel override dictionary.
+            tune: If ``True``, autotune tile configurations.
+        """
         self.num_groups = num_groups
         self.dtype: Optional[torch.dtype] = None
         self.eps = eps
@@ -144,8 +147,8 @@ class GroupNormFwdOp(Op):
 
         Args:
             x: Input tensor of shape ``(N, C, *spatial)``.
-            weight: Affine scale of shape ``(C,)``, or ``None``.
-            bias: Affine shift of shape ``(C,)``, or ``None``.
+            weight: Affine scale of shape $[C]$, or ``None``.
+            bias: Affine shift of shape $[C]$, or ``None``.
                 ``weight`` and ``bias`` are one switch: give both or neither.
 
         Returns:

--- a/src/tileops/ops/norm/instance_norm.py
+++ b/src/tileops/ops/norm/instance_norm.py
@@ -56,19 +56,6 @@ class InstanceNormFwdOp(Op):
         which applies the per-channel affine itself; without affine it
         delegates to `InstanceNormNoAffineKernel`.
 
-    Args:
-        use_input_stats: Mirrors ``torch.nn.functional.instance_norm``. When
-            ``True`` (the default), per-instance statistics are computed from
-            the input. ``False`` normalizes by the passed running stats, and
-            is implemented for the affine-free call only.
-        momentum: Mirrors ``torch.nn.functional.instance_norm``. Stored on the
-            op instance for API parity with PyTorch but unused: neither path
-            updates the running stats.
-        eps: Epsilon for numerical stability (manifest ``params.eps``).
-        target: Which set of kernels serves this op — a target name, ``BUILTIN`` for the
-            in-tree kernels, or ``None`` to decide from the input device.
-        kernel_map: Optional kernel override dictionary.
-        tune: If ``True``, autotune tile configurations.
     """
 
     #: The operator this op registers; a test asserts the graph holds nothing else.
@@ -84,6 +71,22 @@ class InstanceNormFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            use_input_stats: Mirrors ``torch.nn.functional.instance_norm``. When
+                ``True`` (the default), per-instance statistics are computed from
+                the input. ``False`` normalizes by the passed running stats, and
+                is implemented for the affine-free call only.
+            momentum: Mirrors ``torch.nn.functional.instance_norm``. Stored on the
+                op instance for API parity with PyTorch but unused: neither path
+                updates the running stats.
+            eps: Epsilon for numerical stability (manifest ``params.eps``).
+            target: Which set of kernels serves this op — a target name, ``BUILTIN`` for the
+                in-tree kernels, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel override dictionary.
+            tune: If ``True``, autotune tile configurations.
+        """
         self.dtype: Optional[torch.dtype] = None
         self.use_input_stats = use_input_stats
         self.momentum = momentum
@@ -236,11 +239,11 @@ class InstanceNormFwdOp(Op):
 
         Args:
             x: Input tensor of shape ``(N, C, *spatial)``.
-            running_mean: Per-channel running mean of shape ``(C,)``, dtype
+            running_mean: Per-channel running mean of shape $[C]$, dtype
                 ``torch.float32``, on ``x``'s device. Required when
                 ``use_input_stats=False``.
             running_var: Per-channel running variance, same constraints.
-            weight: Affine scale of shape ``(C,)``, ``x``'s dtype. Must be passed
+            weight: Affine scale of shape $[C]$, ``x``'s dtype. Must be passed
                 together with ``bias``.
             bias: Affine shift, same constraints as ``weight``.
 

--- a/src/tileops/ops/norm/layer_norm.py
+++ b/src/tileops/ops/norm/layer_norm.py
@@ -30,15 +30,6 @@ class LayerNormFwdOp(Op):
     Supported dtypes:
         ``torch.float32``, ``torch.float16``, ``torch.bfloat16``.
 
-    Args:
-        normalized_shape: Trailing-axis shape tuple over which the
-            reduction runs (manifest ``params.normalized_shape``).
-        eps: Epsilon for numerical stability (manifest ``params.eps``).
-            ``None`` uses the PyTorch default ``1e-5``.
-        target: Which set of kernels serves this op — a target name, ``BUILTIN`` for the
-            in-tree kernels, or ``None`` to decide from the input device.
-        kernel_map: Optional kernel override dictionary.
-        tune: If ``True``, autotune tile configurations.
     """
 
     #: Manifest ``params.eps.default``, which PyTorch shares. The signature default and the
@@ -57,6 +48,18 @@ class LayerNormFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            normalized_shape: Trailing-axis shape tuple over which the
+                reduction runs (manifest ``params.normalized_shape``).
+            eps: Epsilon for numerical stability (manifest ``params.eps``).
+                ``None`` uses the PyTorch default ``1e-5``.
+            target: Which set of kernels serves this op — a target name, ``BUILTIN`` for the
+                in-tree kernels, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel override dictionary.
+            tune: If ``True``, autotune tile configurations.
+        """
         self.N = normalized_shape_to_n(normalized_shape)
         self.normalized_shape = tuple(int(d) for d in normalized_shape)
         # The manifest type is ``float | None``: an explicit None means the same default,

--- a/src/tileops/ops/norm/rms_norm.py
+++ b/src/tileops/ops/norm/rms_norm.py
@@ -40,22 +40,13 @@ class RMSNormFwdOp(Op):
     where the reduction runs over the trailing ``len(normalized_shape)``
     axes; ``normalized_shape`` is the only entry point (the manifest spec).
 
-    Args:
-        normalized_shape: Trailing-axis shape tuple over which the
-            reduction runs (manifest ``params.normalized_shape``).
-        eps: Epsilon for numerical stability (manifest ``params.eps``). ``None``
-            selects the same default the signature carries. Normalized here, so a
-            backend is handed the number rather than ``None``.
-        target: Which set of kernels serves this op — a target name, ``BUILTIN`` for the
-            in-tree kernels, or ``None`` to decide from the input device.
-        kernel_map: Optional kernel override dictionary.
-        tune: Whether to autotune (default ``False``).
-
     Example:
-        >>> op = RMSNormFwdOp(normalized_shape=(4096,))
-        >>> x = torch.randn(1024, 4096, dtype=torch.float16, device="cuda")
-        >>> w = torch.randn(4096, dtype=torch.float16, device="cuda")
-        >>> y = op(x, w)  # shape: (1024, 4096)
+        ```python linenums="1"
+        op = RMSNormFwdOp(normalized_shape=(4096,))
+        x = torch.randn(1024, 4096, dtype=torch.float16, device="cuda")
+        w = torch.randn(4096, dtype=torch.float16, device="cuda")
+        y = op(x, w)  # shape: (1024, 4096)
+        ```
     """
 
     #: Manifest ``params.eps.default``. The signature default and the ``None``
@@ -74,6 +65,19 @@ class RMSNormFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            normalized_shape: Trailing-axis shape tuple over which the
+                reduction runs (manifest ``params.normalized_shape``).
+            eps: Epsilon for numerical stability (manifest ``params.eps``). ``None``
+                selects the same default the signature carries. Normalized here, so a
+                backend is handed the number rather than ``None``.
+            target: Which set of kernels serves this op — a target name, ``BUILTIN`` for the
+                in-tree kernels, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel override dictionary.
+            tune: Whether to autotune (default ``False``).
+        """
         self.N = normalized_shape_to_n(normalized_shape)
         self.normalized_shape = tuple(int(d) for d in normalized_shape)
         # The manifest type is ``float | None``: an explicit None means the same default,

--- a/src/tileops/ops/op_base.py
+++ b/src/tileops/ops/op_base.py
@@ -60,12 +60,14 @@ class Op(ABC):
     - Autotuning interface
 
     Examples:
-        >>> from tileops.ops import MultiHeadAttentionFwdOp
-        >>> op = MultiHeadAttentionFwdOp(batch=1, heads=8, seq_len=512, dim=64, is_causal=True)
-        >>> Q, K, V = op.gen_inputs()
-        >>> output = op(Q, K, V)
-        >>> op.check()  # Verify correctness
-        >>> latency = op.profile()  # Benchmark performance
+        ```python linenums="1"
+        from tileops.ops import MultiHeadAttentionFwdOp
+        op = MultiHeadAttentionFwdOp(batch=1, heads=8, seq_len=512, dim=64, is_causal=True)
+        Q, K, V = op.gen_inputs()
+        output = op(Q, K, V)
+        op.check()  # Verify correctness
+        latency = op.profile()  # Benchmark performance
+        ```
 
     Attributes:
         kernel: single kernel, for ops that hold one; ops that build per
@@ -552,6 +554,7 @@ class Op(ABC):
 
     @abstractmethod
     def forward(self, *args: object, **kwargs: object) -> Union[torch.Tensor, tuple]:
+        """Run the op."""
         raise NotImplementedError("forward method is not implemented")
 
     def __call__(self, *args: object, **kwargs: object) -> Union[torch.Tensor, tuple]:

--- a/src/tileops/ops/pool.py
+++ b/src/tileops/ops/pool.py
@@ -134,6 +134,12 @@ class MeanPoolingForwardOp(UnmanifestedOp):
         tune: bool = False,
         kernel_map: Optional[Dict[str, Kernel]] = None,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            tune: Whether to autotune, applied when a kernel is first built.
+            kernel_map: Optional kernel override dict.
+        """
         params = {k: v for k, v in locals().items() if k not in ("self", "kernel_map")}
         for key, value in params.items():
             setattr(self, key, value)
@@ -164,6 +170,7 @@ class MeanPoolingForwardOp(UnmanifestedOp):
         offsets: torch.Tensor,
         indices: torch.Tensor,
     ) -> torch.Tensor:
+        """Run the op on ``x``, ``offsets`` and ``indices``."""
         kernel = self._get_kernel((x, offsets, indices), x.dtype)
         out = kernel(x, offsets, indices=indices)
         self.dtype = x.dtype
@@ -223,6 +230,13 @@ class _AvgPoolFwdOpBase(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            target: Backend target to serve this op, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         nd = self.ndim
         self.n = None
         self.c_in = None
@@ -370,6 +384,7 @@ class _AvgPoolFwdOpBase(Op):
         return {"output": (n, c_in, *out_dims)}
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Run the op on ``input``."""
         return type(self)._wrapped(input, self._instance_key)
 
     def _eager_forward(self, input: torch.Tensor) -> torch.Tensor:
@@ -415,6 +430,18 @@ class AvgPool1dFwdOp(_AvgPoolFwdOpBase):
         tune: bool = False,
     ) -> None:
         # No divisor_override: torch.nn.functional.avg_pool1d does not take one.
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            kernel_size: Manifest ``params.kernel_size``, ``int | tuple[int]``.
+            stride: Manifest ``params.stride``, ``int | tuple[int] | None``, default ``None``.
+            padding: Manifest ``params.padding``, ``int | tuple[int]``, default ``0``.
+            ceil_mode: Manifest ``params.ceil_mode``, ``bool``, default ``False``.
+            count_include_pad: Manifest ``params.count_include_pad``, ``bool``, default ``True``.
+            target: Backend target to serve this op, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         super().__init__(
             kernel_size=kernel_size,
             stride=stride,
@@ -469,6 +496,19 @@ class AvgPool2dFwdOp(_AvgPoolFwdOpBase):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            kernel_size: Manifest ``params.kernel_size``, ``int | tuple[int, int]``.
+            stride: Manifest ``params.stride``, ``int | tuple[int, int] | None``, default ``None``.
+            padding: Manifest ``params.padding``, ``int | tuple[int, int]``, default ``0``.
+            ceil_mode: Manifest ``params.ceil_mode``, ``bool``, default ``False``.
+            count_include_pad: Manifest ``params.count_include_pad``, ``bool``, default ``True``.
+            divisor_override: Manifest ``params.divisor_override``, ``int | None``, default ``None``.
+            target: Backend target to serve this op, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         super().__init__(
             kernel_size=kernel_size,
             stride=stride,
@@ -570,6 +610,13 @@ class _MaxPoolFwdOpBase(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            target: Backend target to serve this op, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         nd = self.ndim
         self.n = None
         self.c_in = None
@@ -697,6 +744,7 @@ class _MaxPoolFwdOpBase(Op):
         return {"output": full}
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Run the op on ``input``."""
         return type(self)._wrapped(input, self._instance_key)
 
     def _eager_forward(self, input: torch.Tensor):
@@ -742,6 +790,18 @@ class MaxPool1dFwdOp(_MaxPoolFwdOpBase):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            kernel_size: Manifest ``params.kernel_size``, ``int | tuple[int]``.
+            stride: Manifest ``params.stride``, ``int | tuple[int] | None``, default ``None``.
+            padding: Manifest ``params.padding``, ``int | tuple[int]``, default ``0``.
+            dilation: Manifest ``params.dilation``, ``int | tuple[int]``, default ``1``.
+            ceil_mode: Manifest ``params.ceil_mode``, ``bool``, default ``False``.
+            target: Backend target to serve this op, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         super().__init__(
             kernel_size=kernel_size,
             stride=stride,
@@ -783,6 +843,18 @@ class MaxPool1dIndicesFwdOp(_MaxPoolFwdOpBase):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            kernel_size: Manifest ``params.kernel_size``, ``int | tuple[int]``.
+            stride: Manifest ``params.stride``, ``int | tuple[int] | None``, default ``None``.
+            padding: Manifest ``params.padding``, ``int | tuple[int]``, default ``0``.
+            dilation: Manifest ``params.dilation``, ``int | tuple[int]``, default ``1``.
+            ceil_mode: Manifest ``params.ceil_mode``, ``bool``, default ``False``.
+            target: Backend target to serve this op, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         super().__init__(
             kernel_size=kernel_size,
             stride=stride,
@@ -801,6 +873,14 @@ class MaxPool1dIndicesFwdOp(_MaxPoolFwdOpBase):
         }
 
     def forward(self, input: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Run the op on the inputs the manifest declares.
+
+        Args:
+            input: Input tensor, dtype ``float16 | bfloat16 | float32``.
+
+        Returns:
+            ``output``, ``indices``, as the manifest declares.
+        """
         return type(self)._wrapped(input, self._instance_key)
 
     def eval_roofline(self) -> tuple[int, int]:
@@ -826,6 +906,18 @@ class MaxPool2dFwdOp(_MaxPoolFwdOpBase):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            kernel_size: Manifest ``params.kernel_size``, ``int | tuple[int, int]``.
+            stride: Manifest ``params.stride``, ``int | tuple[int, int] | None``, default ``None``.
+            padding: Manifest ``params.padding``, ``int | tuple[int, int]``, default ``0``.
+            dilation: Manifest ``params.dilation``, ``int | tuple[int, int]``, default ``1``.
+            ceil_mode: Manifest ``params.ceil_mode``, ``bool``, default ``False``.
+            target: Backend target to serve this op, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         super().__init__(
             kernel_size=kernel_size,
             stride=stride,
@@ -867,6 +959,18 @@ class MaxPool2dIndicesFwdOp(_MaxPoolFwdOpBase):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            kernel_size: Manifest ``params.kernel_size``, ``int | tuple[int, int]``.
+            stride: Manifest ``params.stride``, ``int | tuple[int, int] | None``, default ``None``.
+            padding: Manifest ``params.padding``, ``int | tuple[int, int]``, default ``0``.
+            dilation: Manifest ``params.dilation``, ``int | tuple[int, int]``, default ``1``.
+            ceil_mode: Manifest ``params.ceil_mode``, ``bool``, default ``False``.
+            target: Backend target to serve this op, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         super().__init__(
             kernel_size=kernel_size,
             stride=stride,
@@ -885,6 +989,14 @@ class MaxPool2dIndicesFwdOp(_MaxPoolFwdOpBase):
         }
 
     def forward(self, input: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Run the op on the inputs the manifest declares.
+
+        Args:
+            input: Input tensor, dtype ``float16 | bfloat16 | float32``.
+
+        Returns:
+            ``output``, ``indices``, as the manifest declares.
+        """
         return type(self)._wrapped(input, self._instance_key)
 
     def eval_roofline(self) -> tuple[int, int]:
@@ -910,6 +1022,18 @@ class MaxPool3dFwdOp(_MaxPoolFwdOpBase):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            kernel_size: Manifest ``params.kernel_size``, ``int | tuple[int, int, int]``.
+            stride: Manifest ``params.stride``, ``int | tuple[int, int, int] | None``, default ``None``.
+            padding: Manifest ``params.padding``, ``int | tuple[int, int, int]``, default ``0``.
+            dilation: Manifest ``params.dilation``, ``int | tuple[int, int, int]``, default ``1``.
+            ceil_mode: Manifest ``params.ceil_mode``, ``bool``, default ``False``.
+            target: Backend target to serve this op, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         super().__init__(
             kernel_size=kernel_size,
             stride=stride,
@@ -951,6 +1075,18 @@ class MaxPool3dIndicesFwdOp(_MaxPoolFwdOpBase):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            kernel_size: Manifest ``params.kernel_size``, ``int | tuple[int, int, int]``.
+            stride: Manifest ``params.stride``, ``int | tuple[int, int, int] | None``, default ``None``.
+            padding: Manifest ``params.padding``, ``int | tuple[int, int, int]``, default ``0``.
+            dilation: Manifest ``params.dilation``, ``int | tuple[int, int, int]``, default ``1``.
+            ceil_mode: Manifest ``params.ceil_mode``, ``bool``, default ``False``.
+            target: Backend target to serve this op, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         super().__init__(
             kernel_size=kernel_size,
             stride=stride,
@@ -969,6 +1105,14 @@ class MaxPool3dIndicesFwdOp(_MaxPoolFwdOpBase):
         }
 
     def forward(self, input: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Run the op on the inputs the manifest declares.
+
+        Args:
+            input: Input tensor, dtype ``float16 | bfloat16 | float32``.
+
+        Returns:
+            ``output``, ``indices``, as the manifest declares.
+        """
         return type(self)._wrapped(input, self._instance_key)
 
     def eval_roofline(self) -> tuple[int, int]:
@@ -994,6 +1138,19 @@ class AvgPool3dFwdOp(_AvgPoolFwdOpBase):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            kernel_size: Manifest ``params.kernel_size``, ``int | tuple[int, int, int]``.
+            stride: Manifest ``params.stride``, ``int | tuple[int, int, int] | None``, default ``None``.
+            padding: Manifest ``params.padding``, ``int | tuple[int, int, int]``, default ``0``.
+            ceil_mode: Manifest ``params.ceil_mode``, ``bool``, default ``False``.
+            count_include_pad: Manifest ``params.count_include_pad``, ``bool``, default ``True``.
+            divisor_override: Manifest ``params.divisor_override``, ``int | None``, default ``None``.
+            target: Backend target to serve this op, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         super().__init__(
             kernel_size=kernel_size,
             stride=stride,
@@ -1114,6 +1271,13 @@ class _AdaptivePool2dFwdOpBase(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            target: Backend target to serve this op, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         self.n = None
         self.c_in = None
         self.h_in = None
@@ -1154,6 +1318,7 @@ class _AdaptivePool2dFwdOpBase(Op):
         return {"output": full}
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Run the op on ``input``."""
         return type(self)._wrapped(input, self._instance_key)
 
     def _eager_forward(self, input: torch.Tensor):
@@ -1228,6 +1393,14 @@ class AdaptiveAvgPool2dFwdOp(_AdaptivePool2dFwdOpBase):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            output_size: Manifest ``params.output_size``, ``int | None | tuple[int | None, int | None] | list[int | None]``.
+            target: Backend target to serve this op, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         super().__init__(
             output_size=output_size,
             target=target,
@@ -1259,6 +1432,14 @@ class AdaptiveMaxPool2dFwdOp(_AdaptivePool2dFwdOpBase):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            output_size: Manifest ``params.output_size``, ``int | None | tuple[int | None, int | None] | list[int | None]``.
+            target: Backend target to serve this op, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         super().__init__(
             output_size=output_size,
             target=target,
@@ -1291,6 +1472,14 @@ class AdaptiveMaxPool2dIndicesFwdOp(_AdaptivePool2dFwdOpBase):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            output_size: Manifest ``params.output_size``, ``int | None | tuple[int | None, int | None] | list[int | None]``.
+            target: Backend target to serve this op, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         super().__init__(
             output_size=output_size,
             target=target,
@@ -1305,6 +1494,14 @@ class AdaptiveMaxPool2dIndicesFwdOp(_AdaptivePool2dFwdOpBase):
         }
 
     def forward(self, input: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Run the op on the inputs the manifest declares.
+
+        Args:
+            input: Input tensor, dtype ``float16 | bfloat16``.
+
+        Returns:
+            ``output``, ``indices``, as the manifest declares.
+        """
         return type(self)._wrapped(input, self._instance_key)
 
     def eval_roofline(self) -> tuple[int, int]:

--- a/src/tileops/ops/reduction/argreduce.py
+++ b/src/tileops/ops/reduction/argreduce.py
@@ -42,16 +42,6 @@ class ArgmaxFwdOp(_ArgreduceOpBase):
 
     Construction: ``ArgmaxFwdOp(dim=None, keepdim=False)``.
 
-    Args:
-        dim: Reduction dimension. ``None`` (the default) matches
-            ``torch.argmax(x)`` semantics: the input is treated as a
-            contiguous flattened 1D buffer and the returned index is into
-            that flattened tensor.
-        keepdim: Whether to retain the reduced dimension as size 1.
-        target: Which set of kernels serves this op — a target name, ``BUILTIN``
-            for the in-tree kernels, or ``None`` to decide from the input device.
-        kernel_map: Optional custom kernel map.
-        tune: Whether to autotune the kernel.
     """
 
     _op_kind = "argmax"
@@ -67,6 +57,19 @@ class ArgmaxFwdOp(_ArgreduceOpBase):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            dim: Reduction dimension. ``None`` (the default) matches
+                ``torch.argmax(x)`` semantics: the input is treated as a
+                contiguous flattened 1D buffer and the returned index is into
+                that flattened tensor.
+            keepdim: Whether to retain the reduced dimension as size 1.
+            target: Which set of kernels serves this op — a target name, ``BUILTIN``
+                for the in-tree kernels, or ``None`` to decide from the input device.
+            kernel_map: Optional custom kernel map.
+            tune: Whether to autotune the kernel.
+        """
         super().__init__(
             dim=dim,
             keepdim=keepdim,
@@ -95,16 +98,6 @@ class ArgminFwdOp(_ArgreduceOpBase):
 
     Construction: ``ArgminFwdOp(dim=None, keepdim=False)``.
 
-    Args:
-        dim: Reduction dimension. ``None`` (the default) matches
-            ``torch.argmin(x)`` semantics: the input is treated as a
-            contiguous flattened 1D buffer and the returned index is into
-            that flattened tensor.
-        keepdim: Whether to retain the reduced dimension as size 1.
-        target: Which set of kernels serves this op — a target name, ``BUILTIN``
-            for the in-tree kernels, or ``None`` to decide from the input device.
-        kernel_map: Optional custom kernel map.
-        tune: Whether to autotune the kernel.
     """
 
     _op_kind = "argmin"
@@ -120,6 +113,19 @@ class ArgminFwdOp(_ArgreduceOpBase):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            dim: Reduction dimension. ``None`` (the default) matches
+                ``torch.argmin(x)`` semantics: the input is treated as a
+                contiguous flattened 1D buffer and the returned index is into
+                that flattened tensor.
+            keepdim: Whether to retain the reduced dimension as size 1.
+            target: Which set of kernels serves this op — a target name, ``BUILTIN``
+                for the in-tree kernels, or ``None`` to decide from the input device.
+            kernel_map: Optional custom kernel map.
+            tune: Whether to autotune the kernel.
+        """
         super().__init__(
             dim=dim,
             keepdim=keepdim,

--- a/src/tileops/ops/reduction/cumulative.py
+++ b/src/tileops/ops/reduction/cumulative.py
@@ -21,13 +21,6 @@ class CumulativeOp(Op):
     Subclasses must override `_op_kind` (class attribute) — the kernel's
     op-kind dispatch string (`"sum"` or `"prod"`).
 
-    Args:
-        dim: Reduction axis (default -1). Negative values are normalized at
-            forward time (`dim % x.ndim`).
-        target: Which set of kernels serves this op — a target name, ``BUILTIN``
-            for the in-tree kernels, or ``None`` to decide from the input device.
-        kernel_map: Optional kernel override dict.
-        tune: If True, autotune tile configs.
     """
 
     _op_kind: str
@@ -43,6 +36,16 @@ class CumulativeOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            dim: Reduction axis (default -1). Negative values are normalized at
+                forward time (`dim % x.ndim`).
+            target: Which set of kernels serves this op — a target name, ``BUILTIN``
+                for the in-tree kernels, or ``None`` to decide from the input device.
+            kernel_map: Optional kernel override dict.
+            tune: If True, autotune tile configs.
+        """
         self.N = None
         self.dim = dim
         self.target = target
@@ -146,9 +149,11 @@ class CumsumFwdOp(CumulativeOp):
         tune: Whether to autotune (default False).
 
     Example:
-        >>> op = CumsumFwdOp()
-        >>> x = torch.randn(1024, 4096, dtype=torch.float16, device="cuda")
-        >>> y = op(x)  # shape: (1024, 4096)
+        ```python linenums="1"
+        op = CumsumFwdOp()
+        x = torch.randn(1024, 4096, dtype=torch.float16, device="cuda")
+        y = op(x)  # shape: (1024, 4096)
+        ```
     """
 
     _op_kind = "sum"
@@ -169,9 +174,11 @@ class CumprodFwdOp(CumulativeOp):
         tune: Whether to autotune (default False).
 
     Example:
-        >>> op = CumprodFwdOp()
-        >>> x = torch.randn(1024, 4096, dtype=torch.float16, device="cuda") * 0.01 + 0.99
-        >>> y = op(x)  # shape: (1024, 4096)
+        ```python linenums="1"
+        op = CumprodFwdOp()
+        x = torch.randn(1024, 4096, dtype=torch.float16, device="cuda") * 0.01 + 0.99
+        y = op(x)  # shape: (1024, 4096)
+        ```
     """
 
     _op_kind = "prod"

--- a/src/tileops/ops/reduction/logical_reduce.py
+++ b/src/tileops/ops/reduction/logical_reduce.py
@@ -30,15 +30,6 @@ class AllFwdOp(_ReduceOpBase):
     Empty-dim contract: ``dim=[]`` / ``dim=()`` is a no-op -- forward returns
     ``x.bool()`` with the input shape, matching ``torch.all`` semantics.
 
-    Args:
-        dim: Reduction dimension (default ``None``, i.e. full reduction).
-            Accepts ``int``, ``list[int]``, or ``tuple[int, ...]`` for
-            multi-dim reduction.
-        keepdim: Whether to retain the reduced dimension as size 1.
-        target: Which set of kernels serves this op — a target name, ``BUILTIN``
-            for the in-tree kernels, or ``None`` to decide from the input device.
-        kernel_map: Optional custom kernel map.
-        tune: Whether to autotune the kernel.
     """
 
     _op_kind = "all"
@@ -66,6 +57,16 @@ class AllFwdOp(_ReduceOpBase):
                 for the in-tree kernels, or ``None`` to decide from the input device.
             kernel_map: Optional override for kernel dispatch.
             tune: Whether to autotune (default ``False``).
+
+        Args:
+            dim: Reduction dimension (default ``None``, i.e. full reduction).
+                Accepts ``int``, ``list[int]``, or ``tuple[int, ...]`` for
+                multi-dim reduction.
+            keepdim: Whether to retain the reduced dimension as size 1.
+            target: Which set of kernels serves this op — a target name, ``BUILTIN``
+                for the in-tree kernels, or ``None`` to decide from the input device.
+            kernel_map: Optional custom kernel map.
+            tune: Whether to autotune the kernel.
         """
         super().__init__(
             dim=dim,
@@ -94,15 +95,6 @@ class AnyFwdOp(_ReduceOpBase):
     Empty-dim contract: ``dim=[]`` / ``dim=()`` is a no-op -- forward returns
     ``x.bool()`` with the input shape, matching ``torch.any`` semantics.
 
-    Args:
-        dim: Reduction dimension (default ``None``, i.e. full reduction).
-            Accepts ``int``, ``list[int]``, or ``tuple[int, ...]`` for
-            multi-dim reduction.
-        keepdim: Whether to retain the reduced dimension as size 1.
-        target: Which set of kernels serves this op — a target name, ``BUILTIN``
-            for the in-tree kernels, or ``None`` to decide from the input device.
-        kernel_map: Optional custom kernel map.
-        tune: Whether to autotune the kernel.
     """
 
     _op_kind = "any"
@@ -130,6 +122,16 @@ class AnyFwdOp(_ReduceOpBase):
                 for the in-tree kernels, or ``None`` to decide from the input device.
             kernel_map: Optional override for kernel dispatch.
             tune: Whether to autotune (default ``False``).
+
+        Args:
+            dim: Reduction dimension (default ``None``, i.e. full reduction).
+                Accepts ``int``, ``list[int]``, or ``tuple[int, ...]`` for
+                multi-dim reduction.
+            keepdim: Whether to retain the reduced dimension as size 1.
+            target: Which set of kernels serves this op — a target name, ``BUILTIN``
+                for the in-tree kernels, or ``None`` to decide from the input device.
+            kernel_map: Optional custom kernel map.
+            tune: Whether to autotune the kernel.
         """
         super().__init__(
             dim=dim,
@@ -156,14 +158,6 @@ class CountNonzeroFwdOp(_ReduceOpBase):
     types. A dtype TileLang cannot store as shared memory is converted inside the
     kernel, so this op hands over the tensor its manifest declares.
 
-    Args:
-        dim: Reduction dimension (default ``None``, i.e. full reduction).
-            Accepts ``int``, ``list[int]``, or ``tuple[int, ...]`` for
-            multi-dim reduction.
-        target: Which set of kernels serves this op — a target name, ``BUILTIN``
-            for the in-tree kernels, or ``None`` to decide from the input device.
-        kernel_map: Optional custom kernel map.
-        tune: Whether to autotune the kernel.
     """
 
     _op_kind = "count_nonzero"
@@ -180,6 +174,17 @@ class CountNonzeroFwdOp(_ReduceOpBase):
         tune: bool = False,
     ):
         # count_nonzero never keeps dim (matches torch.count_nonzero)
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            dim: Reduction dimension (default ``None``, i.e. full reduction).
+                Accepts ``int``, ``list[int]``, or ``tuple[int, ...]`` for
+                multi-dim reduction.
+            target: Which set of kernels serves this op — a target name, ``BUILTIN``
+                for the in-tree kernels, or ``None`` to decide from the input device.
+            kernel_map: Optional custom kernel map.
+            tune: Whether to autotune the kernel.
+        """
         super().__init__(
             dim=dim,
             keepdim=False,

--- a/src/tileops/ops/reduction/reduce.py
+++ b/src/tileops/ops/reduction/reduce.py
@@ -540,16 +540,7 @@ class _WelfordReduceOp(_ReduceOpBase):
     """Base for Welford-based reduce ops (std, var, var_mean).
 
     Construction: ``op(dim=None, correction=1, keepdim=False)``.
-    Args:
-        dim: Reduction dimension (default ``None``, i.e. full reduction).
-            Accepts ``int``, ``list[int]``, or ``tuple[int, ...]`` for
-            multi-dim reduction.
-        correction: Bessel's correction (default 1).
-        keepdim: Whether to retain the reduced dimension as size 1.
-        target: Which set of kernels serves this op — a target name, ``BUILTIN``
-            for the in-tree kernels, or ``None`` to decide from the input device.
-        kernel_map: Optional override for kernel dispatch.
-        tune: Whether to autotune (default False).
+
     """
 
     _empty_dim_policy: EmptyDimPolicy = "full"
@@ -576,6 +567,17 @@ class _WelfordReduceOp(_ReduceOpBase):
                 for the in-tree kernels, or ``None`` to decide from the input device.
             kernel_map: Optional override for kernel dispatch.
             tune: Whether to autotune (default ``False``).
+
+        Args:
+            dim: Reduction dimension (default ``None``, i.e. full reduction).
+                Accepts ``int``, ``list[int]``, or ``tuple[int, ...]`` for
+                multi-dim reduction.
+            correction: Bessel's correction (default 1).
+            keepdim: Whether to retain the reduced dimension as size 1.
+            target: Which set of kernels serves this op — a target name, ``BUILTIN``
+                for the in-tree kernels, or ``None`` to decide from the input device.
+            kernel_map: Optional override for kernel dispatch.
+            tune: Whether to autotune (default False).
         """
         self.correction = correction
         super().__init__(

--- a/src/tileops/ops/reduction/softmax.py
+++ b/src/tileops/ops/reduction/softmax.py
@@ -39,12 +39,6 @@ class _SoftmaxBaseOp(Op):
     resolved. A subclass sets ``_op_kind``, ``_kernel_key`` and ``_kernel_cls``, and
     overrides ``_kernel_ctor_kwargs`` when its kernel takes something else.
 
-    Args:
-        dim: Reduction dimension (default -1).
-        target: Which set of kernels serves this op — a target name, ``BUILTIN``
-            for the in-tree kernels, or ``None`` to decide from the input device.
-        kernel_map: Optional override for kernel dispatch.
-        tune: Whether to autotune (default False).
     """
 
     #: Set by ``register_reduction_op`` on each concrete op; a base registers none.
@@ -64,6 +58,15 @@ class _SoftmaxBaseOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            dim: Reduction dimension (default -1).
+            target: Which set of kernels serves this op — a target name, ``BUILTIN``
+                for the in-tree kernels, or ``None`` to decide from the input device.
+            kernel_map: Optional override for kernel dispatch.
+            tune: Whether to autotune (default False).
+        """
         self.dim = dim
         self.keepdim = False
         self.target = target
@@ -182,16 +185,6 @@ class SoftmaxFwdOp(_SoftmaxBaseOp):
     Output has the same shape and dtype as input. The reduction-dim extent
     ``N`` and dtype are inferred from ``x`` during ``forward()``.
 
-    Args:
-        dim: Reduction dimension (default ``None``, matching PyTorch's
-            ``torch.nn.functional.softmax``). When ``None``, the axis is
-            resolved at forward time using PyTorch's implicit-axis rule
-            (``0`` for ``ndim in {0, 1, 3}`` else ``1``) and the same
-            deprecation ``UserWarning`` is emitted.
-        target: Which set of kernels serves this op — a target name, ``BUILTIN``
-            for the in-tree kernels, or ``None`` to decide from the input device.
-        kernel_map: Optional override for kernel dispatch.
-        tune: Whether to autotune (default False).
     """
 
     _op_kind = "softmax"
@@ -206,6 +199,19 @@ class SoftmaxFwdOp(_SoftmaxBaseOp):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            dim: Reduction dimension (default ``None``, matching PyTorch's
+                ``torch.nn.functional.softmax``). When ``None``, the axis is
+                resolved at forward time using PyTorch's implicit-axis rule
+                (``0`` for ``ndim in {0, 1, 3}`` else ``1``) and the same
+                deprecation ``UserWarning`` is emitted.
+            target: Which set of kernels serves this op — a target name, ``BUILTIN``
+                for the in-tree kernels, or ``None`` to decide from the input device.
+            kernel_map: Optional override for kernel dispatch.
+            tune: Whether to autotune (default False).
+        """
         super().__init__(dim=dim, target=target, kernel_map=kernel_map, tune=tune)
 
 
@@ -215,16 +221,6 @@ class LogSoftmaxFwdOp(_SoftmaxBaseOp):
     Output has the same shape and dtype as input. The reduction-dim extent
     ``N`` and dtype are inferred from ``x`` during ``forward()``.
 
-    Args:
-        dim: Reduction dimension (default ``None``, matching PyTorch's
-            ``torch.nn.functional.log_softmax``). When ``None``, the axis is
-            resolved at forward time using PyTorch's implicit-axis rule
-            (``0`` for ``ndim in {0, 1, 3}`` else ``1``) and the same
-            deprecation ``UserWarning`` is emitted.
-        target: Which set of kernels serves this op — a target name, ``BUILTIN``
-            for the in-tree kernels, or ``None`` to decide from the input device.
-        kernel_map: Optional override for kernel dispatch.
-        tune: Whether to autotune (default False).
     """
 
     _op_kind = "log_softmax"
@@ -239,6 +235,19 @@ class LogSoftmaxFwdOp(_SoftmaxBaseOp):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            dim: Reduction dimension (default ``None``, matching PyTorch's
+                ``torch.nn.functional.log_softmax``). When ``None``, the axis is
+                resolved at forward time using PyTorch's implicit-axis rule
+                (``0`` for ``ndim in {0, 1, 3}`` else ``1``) and the same
+                deprecation ``UserWarning`` is emitted.
+            target: Which set of kernels serves this op — a target name, ``BUILTIN``
+                for the in-tree kernels, or ``None`` to decide from the input device.
+            kernel_map: Optional override for kernel dispatch.
+            tune: Whether to autotune (default False).
+        """
         super().__init__(dim=dim, target=target, kernel_map=kernel_map, tune=tune)
 
 
@@ -248,13 +257,6 @@ class LogSumExpFwdOp(_SoftmaxBaseOp):
     Output shape is input shape without the reduction dimension
     (or with size-1 if keepdim=True).
 
-    Args:
-        dim: Reduction dimension (default -1).
-        keepdim: Retain reduced dimension (default False).
-        target: Which set of kernels serves this op — a target name, ``BUILTIN``
-            for the in-tree kernels, or ``None`` to decide from the input device.
-        kernel_map: Optional override for kernel dispatch.
-        tune: Whether to autotune (default False).
     """
 
     _op_kind = "logsumexp"
@@ -271,6 +273,16 @@ class LogSumExpFwdOp(_SoftmaxBaseOp):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            dim: Reduction dimension (default -1).
+            keepdim: Retain reduced dimension (default False).
+            target: Which set of kernels serves this op — a target name, ``BUILTIN``
+                for the in-tree kernels, or ``None`` to decide from the input device.
+            kernel_map: Optional override for kernel dispatch.
+            tune: Whether to autotune (default False).
+        """
         super().__init__(dim=dim, target=target, kernel_map=kernel_map, tune=tune)
         self.keepdim = keepdim
 

--- a/src/tileops/ops/reduction/vector_norm.py
+++ b/src/tileops/ops/reduction/vector_norm.py
@@ -19,18 +19,6 @@ class L1NormFwdOp(_ReduceOpBase):
 
     Construction: ``L1NormFwdOp(dim=None, keepdim=False)``.
 
-    Args:
-        dim: Reduction dimension (default ``None`` -> full reduction, matching
-            ``torch.linalg.vector_norm``). Accepts ``int``, ``list[int]``, or
-            ``None``.
-        keepdim: Whether to retain the reduced dimension as size 1.
-        ord: Norm order. Must equal 1 for ``L1NormFwdOp`` (manifest fixes
-            ``ord == 1``); accepted as a kwarg to mirror
-            ``torch.linalg.vector_norm``.
-        target: Which set of kernels serves this op — a target name, ``BUILTIN``
-            for the in-tree kernels, or ``None`` to decide from the input device.
-        kernel_map: Optional custom kernel map.
-        tune: Whether to autotune the kernel.
     """
 
     _op_kind = "l1"
@@ -49,6 +37,21 @@ class L1NormFwdOp(_ReduceOpBase):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            dim: Reduction dimension (default ``None`` -> full reduction, matching
+                ``torch.linalg.vector_norm``). Accepts ``int``, ``list[int]``, or
+                ``None``.
+            keepdim: Whether to retain the reduced dimension as size 1.
+            ord: Norm order. Must equal 1 for ``L1NormFwdOp`` (manifest fixes
+                ``ord == 1``); accepted as a kwarg to mirror
+                ``torch.linalg.vector_norm``.
+            target: Which set of kernels serves this op — a target name, ``BUILTIN``
+                for the in-tree kernels, or ``None`` to decide from the input device.
+            kernel_map: Optional custom kernel map.
+            tune: Whether to autotune the kernel.
+        """
         if ord != self._required_ord:
             raise ValueError(
                 f"{type(self).__name__} only supports ord={self._required_ord!r}, got ord={ord!r}"
@@ -68,18 +71,6 @@ class L2NormFwdOp(_ReduceOpBase):
 
     Construction: ``L2NormFwdOp(dim=None, keepdim=False)``.
 
-    Args:
-        dim: Reduction dimension (default ``None`` -> full reduction, matching
-            ``torch.linalg.vector_norm``). Accepts ``int``, ``list[int]``, or
-            ``None``.
-        keepdim: Whether to retain the reduced dimension as size 1.
-        ord: Norm order. Must equal 2 for ``L2NormFwdOp`` (manifest fixes
-            ``ord == 2``); accepted as a kwarg to mirror
-            ``torch.linalg.vector_norm``.
-        target: Which set of kernels serves this op — a target name, ``BUILTIN``
-            for the in-tree kernels, or ``None`` to decide from the input device.
-        kernel_map: Optional custom kernel map.
-        tune: Whether to autotune the kernel.
     """
 
     _op_kind = "l2"
@@ -98,6 +89,21 @@ class L2NormFwdOp(_ReduceOpBase):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            dim: Reduction dimension (default ``None`` -> full reduction, matching
+                ``torch.linalg.vector_norm``). Accepts ``int``, ``list[int]``, or
+                ``None``.
+            keepdim: Whether to retain the reduced dimension as size 1.
+            ord: Norm order. Must equal 2 for ``L2NormFwdOp`` (manifest fixes
+                ``ord == 2``); accepted as a kwarg to mirror
+                ``torch.linalg.vector_norm``.
+            target: Which set of kernels serves this op — a target name, ``BUILTIN``
+                for the in-tree kernels, or ``None`` to decide from the input device.
+            kernel_map: Optional custom kernel map.
+            tune: Whether to autotune the kernel.
+        """
         if ord != self._required_ord:
             raise ValueError(
                 f"{type(self).__name__} only supports ord={self._required_ord!r}, got ord={ord!r}"
@@ -121,18 +127,6 @@ class InfNormFwdOp(_ReduceOpBase):
     torch.linalg.vector_norm(ord=inf) semantics. The kernel drops NaN values and patches
     those rows itself, so the compensation stays with the implementation that needs it.
 
-    Args:
-        dim: Reduction dimension (default ``None`` -> full reduction, matching
-            ``torch.linalg.vector_norm``). Accepts ``int``, ``list[int]``, or
-            ``None``.
-        keepdim: Whether to retain the reduced dimension as size 1.
-        ord: Norm order. Must equal ``float('inf')`` for ``InfNormFwdOp``
-            (manifest fixes ``ord == float('inf')``); accepted as a kwarg to
-            mirror ``torch.linalg.vector_norm``.
-        target: Which set of kernels serves this op — a target name, ``BUILTIN``
-            for the in-tree kernels, or ``None`` to decide from the input device.
-        kernel_map: Optional custom kernel map.
-        tune: Whether to autotune the kernel.
     """
 
     _op_kind = "inf"
@@ -151,6 +145,21 @@ class InfNormFwdOp(_ReduceOpBase):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            dim: Reduction dimension (default ``None`` -> full reduction, matching
+                ``torch.linalg.vector_norm``). Accepts ``int``, ``list[int]``, or
+                ``None``.
+            keepdim: Whether to retain the reduced dimension as size 1.
+            ord: Norm order. Must equal ``float('inf')`` for ``InfNormFwdOp``
+                (manifest fixes ``ord == float('inf')``); accepted as a kwarg to
+                mirror ``torch.linalg.vector_norm``.
+            target: Which set of kernels serves this op — a target name, ``BUILTIN``
+                for the in-tree kernels, or ``None`` to decide from the input device.
+            kernel_map: Optional custom kernel map.
+            tune: Whether to autotune the kernel.
+        """
         if ord != self._required_ord:
             raise ValueError(
                 f"{type(self).__name__} only supports ord={self._required_ord!r}, got ord={ord!r}"

--- a/src/tileops/ops/rope.py
+++ b/src/tileops/ops/rope.py
@@ -12,8 +12,8 @@ Variants and frequency computation:
 - **RopeLongRopeFwdOp**: per-dimension rescaled frequencies
 
 Layouts:
-- ``"1d"``: input shape ``(seq_len, head_dim)``
-- ``"2d"``: input shape ``(batch, seq_len, num_heads, head_dim)``
+- ``"1d"``: input shape $[seq\\_len \\times head\\_dim]$
+- ``"2d"``: input shape $[batch \\times seq\\_len \\times num\\_heads \\times head\\_dim]$
 
 torch.compile support:
 - All 5 concrete ops are registered via @torch.library.custom_op at module
@@ -350,10 +350,6 @@ class _RopeOpBase(Op):
     Cos/sin tables are computed lazily at forward time on the same device as
     the input tensor, avoiding device-mismatch issues in multi-GPU settings.
 
-    Args:
-        layout: "1d" or "2d".
-        kernel_map: Optional kernel dispatch override.
-        tune: Whether to autotune.
     """
 
     kernel_cls: type
@@ -366,6 +362,13 @@ class _RopeOpBase(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            layout: "1d" or "2d".
+            kernel_map: Optional kernel dispatch override.
+            tune: Whether to autotune.
+        """
         self.seq_len = None
         self.head_dim = None
         self.dtype = None
@@ -515,11 +518,6 @@ class RopeNeoxFwdOp(_RopeOpBase):
 
     Reference: GPT-NeoX / HuggingFace transformers RotaryEmbedding.
 
-    Args:
-        layout: "1d" or "2d".
-        base: Frequency base (default 10000).
-        kernel_map: Optional kernel dispatch override.
-        tune: Whether to autotune.
     """
 
     _op_name = "rope_neox"
@@ -532,6 +530,14 @@ class RopeNeoxFwdOp(_RopeOpBase):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            layout: "1d" or "2d".
+            base: Frequency base (default 10000).
+            kernel_map: Optional kernel dispatch override.
+            tune: Whether to autotune.
+        """
         self.base = base
         super().__init__(layout, kernel_map, tune)
 
@@ -555,6 +561,15 @@ class RopeNeoxPositionIdsFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            max_position: Manifest ``params.max_position``, ``int``.
+            base: Manifest ``params.base``, ``float``, default ``10000.0``.
+            rotary_dim: Manifest ``params.rotary_dim``, ``int | None``, default ``None``.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         if rotary_dim is not None and rotary_dim <= 0:
             raise ValueError("rotary_dim must be positive")
         if rotary_dim is not None and rotary_dim % 2 != 0:
@@ -685,6 +700,15 @@ class RopeNeoxPositionIdsFwdOp(Op):
         return {"output": tuple(x_shape)}
 
     def forward(self, x: torch.Tensor, position_ids: torch.Tensor) -> torch.Tensor:
+        """Run the op on the inputs the manifest declares.
+
+        Args:
+            x: Input tensor, dtype ``float16 | bfloat16 | float32``.
+            position_ids: Input tensor, dtype ``int32 | int64``.
+
+        Returns:
+            ``output``, as the manifest declares. Shape rules: ``output.shape == x.shape``.
+        """
         x, position_ids = self._validate_and_prepare(x, position_ids)
         wrapped = type(self)._wrapped
         if wrapped is not None:
@@ -699,11 +723,6 @@ class RopeNonNeoxFwdOp(_RopeOpBase):
 
     Reference: Su et al., "RoFormer: Enhanced Transformer with Rotary Position Embedding".
 
-    Args:
-        layout: "1d" or "2d".
-        base: Frequency base (default 10000).
-        kernel_map: Optional kernel dispatch override.
-        tune: Whether to autotune.
     """
 
     _op_name = "rope_non_neox"
@@ -716,6 +735,14 @@ class RopeNonNeoxFwdOp(_RopeOpBase):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            layout: "1d" or "2d".
+            base: Frequency base (default 10000).
+            kernel_map: Optional kernel dispatch override.
+            tune: Whether to autotune.
+        """
         self.base = base
         super().__init__(layout, kernel_map, tune)
 
@@ -733,15 +760,6 @@ class RopeLlama31FwdOp(_RopeOpBase):
 
     Reference: Meta Llama 3.1 model implementation.
 
-    Args:
-        layout: "1d" or "2d".
-        base: Frequency base (default 10000).
-        scale_factor: Scaling factor for low frequencies (default 8.0).
-        low_freq_factor: Low-frequency wavelen threshold (default 1.0).
-        high_freq_factor: High-frequency wavelen threshold (default 4.0).
-        original_max_position: Original max position (default 8192).
-        kernel_map: Optional kernel dispatch override.
-        tune: Whether to autotune.
     """
 
     _op_name = "rope_llama31"
@@ -758,6 +776,18 @@ class RopeLlama31FwdOp(_RopeOpBase):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            layout: "1d" or "2d".
+            base: Frequency base (default 10000).
+            scale_factor: Scaling factor for low frequencies (default 8.0).
+            low_freq_factor: Low-frequency wavelen threshold (default 1.0).
+            high_freq_factor: High-frequency wavelen threshold (default 4.0).
+            original_max_position: Original max position (default 8192).
+            kernel_map: Optional kernel dispatch override.
+            tune: Whether to autotune.
+        """
         self.base = base
         self.scale_factor = scale_factor
         self.low_freq_factor = low_freq_factor
@@ -787,16 +817,6 @@ class RopeYarnFwdOp(_RopeOpBase):
 
     Reference: Peng et al., "YaRN: Efficient Context Window Extension of LLMs".
 
-    Args:
-        layout: "1d" or "2d".
-        base: Frequency base (default 10000).
-        scale: Context extension scale (default 16.0).
-        original_max_position: Original max position (default 4096).
-        beta_fast: Fast decay boundary (default 32.0).
-        beta_slow: Slow decay boundary (default 1.0).
-        attn_factor: Attention scaling factor (default 1.0).
-        kernel_map: Optional kernel dispatch override.
-        tune: Whether to autotune.
     """
 
     _op_name = "rope_yarn"
@@ -814,6 +834,19 @@ class RopeYarnFwdOp(_RopeOpBase):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            layout: "1d" or "2d".
+            base: Frequency base (default 10000).
+            scale: Context extension scale (default 16.0).
+            original_max_position: Original max position (default 4096).
+            beta_fast: Fast decay boundary (default 32.0).
+            beta_slow: Slow decay boundary (default 1.0).
+            attn_factor: Attention scaling factor (default 1.0).
+            kernel_map: Optional kernel dispatch override.
+            tune: Whether to autotune.
+        """
         self.base = base
         self.scale = scale
         self.original_max_position = original_max_position
@@ -847,16 +880,6 @@ class RopeLongRopeFwdOp(_RopeOpBase):
     Reference: TVM ``rope_freq_longrope`` in position_embedding.py;
     Ding et al., "LongRoPE: Extending LLM Context Window Beyond 2M Tokens".
 
-    Args:
-        layout: "1d" or "2d".
-        base: Frequency base (default 10000).
-        rescale_factors: Per-dimension rescale factors (ext_factors) of shape
-            (head_dim // 2,). These multiply the divisor.
-        max_position_embeddings: Extended max position length (default 4096).
-        original_max_position_embeddings: Original max position length
-            (default 4096).
-        kernel_map: Optional kernel dispatch override.
-        tune: Whether to autotune.
     """
 
     _op_name = "rope_longrope"
@@ -872,6 +895,19 @@ class RopeLongRopeFwdOp(_RopeOpBase):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            layout: "1d" or "2d".
+            base: Frequency base (default 10000).
+            rescale_factors: Per-dimension rescale factors (ext_factors) of shape
+                (head_dim // 2,). These multiply the divisor.
+            max_position_embeddings: Extended max position length (default 4096).
+            original_max_position_embeddings: Original max position length
+                (default 4096).
+            kernel_map: Optional kernel dispatch override.
+            tune: Whether to autotune.
+        """
         self.base = base
         self.rescale_factors = rescale_factors
         self.max_position_embeddings = max_position_embeddings

--- a/src/tileops/ops/sequence_modeling/engram.py
+++ b/src/tileops/ops/sequence_modeling/engram.py
@@ -23,11 +23,6 @@ class EngramGateConvFwdOp(Op):
     Returns Y plus saved intermediates for backward (strategy B):
         vhat, alpha, rrms_h, rrms_k, rrms_v
 
-    Args:
-        M: Batch size.
-        seq_len: Sequence length.
-        d: Model hidden dimension.
-        eps: RMSNorm epsilon (default 1e-6).
     """
 
     def __init__(
@@ -39,6 +34,14 @@ class EngramGateConvFwdOp(Op):
         tune: bool = False,
         kernel_map: Optional[Dict[str, Kernel]] = None,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            M: Batch size.
+            seq_len: Sequence length.
+            d: Model hidden dimension.
+            eps: RMSNorm epsilon (default 1e-6).
+        """
         self.M = M
         self.seq_len = seq_len
         self.d = d
@@ -74,7 +77,7 @@ class EngramGateConvFwdOp(Op):
         rms_w_v_shape: tuple[int, ...],
         conv_w_shape: tuple[int, ...],
     ) -> dict[str, tuple[int, ...]]:
-        """Manifest ``outputs``: the two ``[M, seq_len, d]`` tensors, plus four per-row statistics."""
+        """Manifest ``outputs``: the two $[M \\times seq\\_len \\times d]$ tensors, plus four per-row statistics."""
         rows = H_shape[:2]
         return {
             "Y": tuple(H_shape),
@@ -141,11 +144,6 @@ class EngramGateConvBwdOp(Op):
         dW_K = E^T @ dk
         dW_V = E^T @ dv
 
-    Args:
-        M: Batch size.
-        seq_len: Sequence length.
-        d: Model hidden dimension.
-        eps: RMSNorm epsilon (default 1e-6).
     """
 
     def __init__(
@@ -157,6 +155,14 @@ class EngramGateConvBwdOp(Op):
         tune: bool = False,
         kernel_map: Optional[Dict[str, Kernel]] = None,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            M: Batch size.
+            seq_len: Sequence length.
+            d: Model hidden dimension.
+            eps: RMSNorm epsilon (default 1e-6).
+        """
         self.M = M
         self.seq_len = seq_len
         self.d = d

--- a/src/tileops/ops/sequence_modeling/engram_decode.py
+++ b/src/tileops/ops/sequence_modeling/engram_decode.py
@@ -19,14 +19,6 @@ class EngramDecodeFwdOp(Op):
     at runtime, this op compiles with max_conv_len and accepts the actual
     conv_state length at runtime without recompilation.
 
-    Args:
-        batch: Batch size.
-        d_mem: Memory embedding dimension.
-        d: Model hidden dimension.
-        max_conv_len: Max conv cache capacity (compile-time).
-        conv_kernel_size: Number of conv taps w (model param, e.g. 4).
-        dilation: Dilation factor δ (model param, e.g. max N-gram order).
-        eps: RMSNorm epsilon (default 1e-6).
     """
 
     def __init__(
@@ -41,6 +33,17 @@ class EngramDecodeFwdOp(Op):
         tune: bool = False,
         kernel_map: Optional[Dict[str, Kernel]] = None,
     ):
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            batch: Batch size.
+            d_mem: Memory embedding dimension.
+            d: Model hidden dimension.
+            max_conv_len: Max conv cache capacity (compile-time).
+            conv_kernel_size: Number of conv taps w (model param, e.g. 4).
+            dilation: Dilation factor δ (model param, e.g. max N-gram order).
+            eps: RMSNorm epsilon (default 1e-6).
+        """
         self.batch = batch
         self.d_mem = d_mem
         self.d = d

--- a/src/tileops/ops/sequence_modeling/mhc.py
+++ b/src/tileops/ops/sequence_modeling/mhc.py
@@ -15,6 +15,12 @@ class MHCPreFwdOp(Op):
     """Layout: BSHD"""
 
     def __init__(self, kernel_map: Optional[Dict[str, Kernel]] = None, tune: bool = False) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         self.batch = None
         self.n_expand = None
         self.c_x = None
@@ -83,6 +89,16 @@ class MHCPreFwdOp(Op):
         sinkhorn_repeat: int,
         sinkhorn_eps: float = 0.02,
     ) -> torch.Tensor:
+        """Run the op on the inputs the manifest declares.
+
+        Args:
+            phi: Input tensor, dtype ``float32``.
+            x: Input tensor, dtype ``bfloat16``.
+            b: Input tensor, dtype ``float32``.
+
+        Returns:
+            ``x_res``, ``x_layer``, as the manifest declares.
+        """
         if phi.ndim != 2 or x.ndim != 2 or b.ndim != 1:
             raise ValueError("MHCPreFwdOp expects phi/x/b shapes [D, P], [B, D], [P]")
         batch, x_dim = x.shape
@@ -110,6 +126,12 @@ class MHCPostFwdOp(Op):
     """Layout: BSHD"""
 
     def __init__(self, kernel_map: Optional[Dict[str, Kernel]] = None, tune: bool = False) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         self.batch = None
         self.n_expand = None
         self.c_x = None
@@ -159,6 +181,16 @@ class MHCPostFwdOp(Op):
     def forward(
         self, x_layer_out: torch.Tensor, h_post: torch.Tensor, x_res: torch.Tensor
     ) -> torch.Tensor:
+        """Run the op on the inputs the manifest declares.
+
+        Args:
+            x_layer_out: Input tensor, dtype ``bfloat16``.
+            h_post: Input tensor, dtype ``float32``.
+            x_res: Input tensor, dtype ``bfloat16``.
+
+        Returns:
+            ``x_out``, as the manifest declares.
+        """
         if x_layer_out.ndim != 2 or h_post.ndim != 2 or x_res.ndim != 2:
             raise ValueError("MHCPostFwdOp expects x_layer_out/h_post/x_res to be 2D tensors")
         batch, c_x = x_layer_out.shape

--- a/src/tileops/ops/topk_selector.py
+++ b/src/tileops/ops/topk_selector.py
@@ -14,6 +14,13 @@ class TopkSelectorFwdOp(Op):
     def __init__(
         self, topk: int, kernel_map: Optional[Dict[str, Kernel]] = None, tune: bool = False
     ) -> None:
+        """Build the op. Shapes and dtype are taken from the first call.
+
+        Args:
+            topk: Manifest ``params.topk``, ``int``.
+            kernel_map: Optional kernel override dict.
+            tune: Whether to autotune, applied when a kernel is first built.
+        """
         self.batch = None
         self.seq_len = None
         self.seq_len_kv = None
@@ -63,11 +70,21 @@ class TopkSelectorFwdOp(Op):
         starts_shape: tuple[int, ...],
         ends_shape: tuple[int, ...],
     ) -> dict[str, tuple[int, ...]]:
-        """Manifest ``outputs``: ``[batch, seq_len, kv_group, topk]``."""
+        """Manifest ``outputs``: $[batch \\times seq\\_len \\times kv\\_group \\times topk]$."""
         batch, seq_len, _, kv_group = index_score_shape
         return {"indexes": (batch, seq_len, kv_group, self.topk)}
 
     def forward(self, index_score, starts, ends) -> torch.Tensor:
+        """Run the op on the inputs the manifest declares.
+
+        Args:
+            index_score: Input tensor, dtype ``float32``.
+            starts: Input tensor, dtype ``int32``.
+            ends: Input tensor, dtype ``int32``.
+
+        Returns:
+            ``indexes``, as the manifest declares.
+        """
         if not index_score.is_cuda:
             raise ValueError("TopkSelectorFwdOp expects CUDA inputs")
         if index_score.ndim != 4:

--- a/src/tileops/perf/formulas.py
+++ b/src/tileops/perf/formulas.py
@@ -1366,8 +1366,8 @@ def bmm_fwd_roofline(op: "Op") -> tuple[int, int]:
 def bmm_fp8_fwd_roofline(op: "Op") -> tuple[int, int]:
     """Roofline for batched FP8 GEMM ``BmmFp8KNFwdOp``.
 
-    Layout matches the fp16 ``bmm_fwd_roofline``: ``a: [B, M, K]``,
-    ``b: [B, K, N]``. Per-tensor scales only and no fused bias, so bytes are
+    Layout matches the fp16 ``bmm_fwd_roofline``: ``a``: $[B \\times M \\times K]$,
+    ``b``: $[B \\times K \\times N]$. Per-tensor scales only and no fused bias, so bytes are
     ``B*M*K`` (A, fp8) + ``B*K*N`` (B, fp8) + ``B*M*N`` (C, ``out_dtype``)
     + 8 for the two batch-independent fp32 scales.
 

--- a/src/tileops/trace/api.py
+++ b/src/tileops/trace/api.py
@@ -74,8 +74,9 @@ class _Trace:
         """Whether tracing is on for this process (default ``False``).
 
         Example:
-            >>> trace.enabled
-            False
+            ```python linenums="1"
+            trace.enabled         # False
+            ```
         """
         return self._enabled
 
@@ -84,8 +85,9 @@ class _Trace:
         """Output directory for dumped artifacts (default ``"debug"``).
 
         Example:
-            >>> trace.output
-            'debug'
+            ```python linenums="1"
+            trace.output          # 'debug'
+            ```
         """
         return self._output
 
@@ -100,8 +102,10 @@ class _Trace:
                 Defaults to ``"debug"`` (gitignored).
 
         Example:
-            >>> trace.enable()              # dumps under debug/
-            >>> trace.enable("out/traces")  # or a directory of your choosing
+            ```python linenums="1"
+            trace.enable()              # dumps under debug/
+            trace.enable("out/traces")  # or a directory of your choosing
+            ```
         """
         self._enabled = True
         self._output = output
@@ -110,7 +114,9 @@ class _Trace:
         """Turn tracing off for this process.
 
         Example:
-            >>> trace.disable()
+            ```python linenums="1"
+            trace.disable()
+            ```
         """
         self._enabled = False
 
@@ -130,9 +136,11 @@ class _Trace:
             A ``with`` context manager.
 
         Example:
-            >>> with trace.group("producer", lead=0):
-            ...     with trace.range("tma"):
-            ...         ...  # only thread 0 records
+            ```python linenums="1"
+            with trace.group("producer", lead=0):
+                with trace.range("tma"):
+                    ...  # only thread 0 records
+            ```
         """
         return GroupScope(name, lead)
 
@@ -152,12 +160,14 @@ class _Trace:
             A ``with`` context manager.
 
         Example:
-            >>> with trace.range("mma", lane="wgmma"):
-            ...     T.wgmma_gemm(...)
-            >>> # Explicitly tag each iteration with its index:
-            >>> for i in range(N):
-            ...     with trace.range("iteration", payload=i):
-            ...         work()
+            ```python linenums="1"
+            with trace.range("mma", lane="wgmma"):
+                T.wgmma_gemm(...)
+            # Explicitly tag each iteration with its index:
+            for i in range(N):
+                with trace.range("iteration", payload=i):
+                    work()
+            ```
         """
         return RangeScope(name, lane, payload)
 
@@ -176,13 +186,15 @@ class _Trace:
             A token to pass to ``range_end``.
 
         Example:
-            >>> tok = trace.range_start("phase")
-            >>> ...  # work
-            >>> trace.range_end(tok)
-            >>> # Explicitly tag with payload:
-            >>> tok = trace.range_start("iteration", payload=i)
-            >>> ...
-            >>> trace.range_end(tok)
+            ```python linenums="1"
+            tok = trace.range_start("phase")
+            ...  # work
+            trace.range_end(tok)
+            # Explicitly tag with payload:
+            tok = trace.range_start("iteration", payload=i)
+            ...
+            trace.range_end(tok)
+            ```
         """
         return open_range(name, lane, payload)
 
@@ -193,7 +205,9 @@ class _Trace:
             tok: The token returned by ``range_start``.
 
         Example:
-            >>> trace.range_end(tok)
+            ```python linenums="1"
+            trace.range_end(tok)
+            ```
         """
         close_range(tok)
 
@@ -207,7 +221,9 @@ class _Trace:
             lane: Render sub-lane, interned dynamically (default ``"main"``).
 
         Example:
-            >>> trace.record("iter", payload=ki)  # tag the mark with the loop index
+            ```python linenums="1"
+            trace.record("iter", payload=ki)  # tag the mark with the loop index
+            ```
         """
         emit_instant(name, payload, lane)
 
@@ -223,7 +239,9 @@ class _Trace:
             dst_name: Destination (consumer-side) range name.
 
         Example:
-            >>> trace.dag("arrive", "wait")  # producer "arrive" -> consumer "wait"
+            ```python linenums="1"
+            trace.dag("arrive", "wait")  # producer "arrive" -> consumer "wait"
+            ```
         """
         declare_flow(src_name, dst_name)
 
@@ -246,10 +264,12 @@ class _Trace:
             Negative output indices for ``@tilelang.jit``.
 
         Example:
-            >>> @tilelang.jit(out_idx=trace.out_idx(1))          # follows the switch
-            ... def factory(): ...
-            >>> @tilelang.jit(out_idx=trace.out_idx(1, traced))  # cached builder
-            ... def factory(): ...
+            ```python linenums="1"
+            @tilelang.jit(out_idx=trace.out_idx(1))          # follows the switch
+            def factory(): ...
+            @tilelang.jit(out_idx=trace.out_idx(1, traced))  # cached builder
+            def factory(): ...
+            ```
         """
         enabled = self._enabled if traced is None else traced
         n = n_outputs + 1 if enabled else n_outputs
@@ -273,10 +293,12 @@ class _Trace:
             output when traced).
 
         Example:
-            >>> def factory():
-            ...     @T.prim_func
-            ...     def main(...): ...
-            ...     return trace.finalize(main, traced, max_events=1024)
+            ```python linenums="1"
+            def factory():
+                @T.prim_func
+                def main(...): ...
+                return trace.finalize(main, traced, max_events=1024)
+            ```
         """
         enabled = self._enabled if traced is None else traced
         return self.lower(primfunc, max_events) if enabled else self.strip(primfunc)
@@ -294,7 +316,9 @@ class _Trace:
             The lowered ``PrimFunc`` with a trailing ``slots`` int64 output.
 
         Example:
-            >>> return trace.lower(main, max_events=1024)
+            ```python linenums="1"
+            return trace.lower(main, max_events=1024)
+            ```
         """
         return passes.lower(primfunc, max_events=max_events)
 
@@ -311,7 +335,9 @@ class _Trace:
             A ``PrimFunc`` with markers no-opped, signature unchanged.
 
         Example:
-            >>> return trace.strip(main)
+            ```python linenums="1"
+            return trace.strip(main)
+            ```
         """
         return passes.strip(primfunc)
 
@@ -338,8 +364,10 @@ class _Trace:
             The kernel's real outputs: a single tensor, or a tuple in order.
 
         Example:
-            >>> compiled = build()(block=128)
-            >>> c = trace.run(compiled, (a, b), stem="gemm_128x256x512")
+            ```python linenums="1"
+            compiled = build()(block=128)
+            c = trace.run(compiled, (a, b), stem="gemm_128x256x512")
+            ```
         """
         out = compiled(*inputs)
         if not self._enabled:
@@ -363,8 +391,10 @@ class _Trace:
             A flat list of ``Slice`` / ``Instant`` events.
 
         Example:
-            >>> *_, slots = compiled(a, b)
-            >>> events = trace.decode(compiled, slots)
+            ```python linenums="1"
+            *_, slots = compiled(a, b)
+            events = trace.decode(compiled, slots)
+            ```
         """
         maps = passes.lookup_meta(compiled)
         return _decode(
@@ -391,9 +421,10 @@ class _Trace:
             The base path written (no extension); ``{base}.html`` exists.
 
         Example:
-            >>> base = trace.dump(events, compiled, stem="gemm_128x256x512")
-            >>> base
-            'debug/gemm_128x256x512'
+            ```python linenums="1"
+            base = trace.dump(events, compiled, stem="gemm_128x256x512")
+            base                  # 'debug/gemm_128x256x512'
+            ```
         """
         os.makedirs(self._output, exist_ok=True)
         base = os.path.join(self._output, stem)
@@ -418,7 +449,9 @@ class _Trace:
             sm_clock_ghz: Locked SM clock in GHz for the ``~ns`` hover column.
 
         Example:
-            >>> trace.export_html(events, "timeline.html", compiled=compiled)
+            ```python linenums="1"
+            trace.export_html(events, "timeline.html", compiled=compiled)
+            ```
         """
         maps = passes.lookup_meta(compiled)
         _export_timeline_html(


### PR DESCRIPTION
Follows #1969. Fills what the API pages render, and locks the convention in.

## Problems

- Most ops had no `__init__` or `forward` docstring, and the docs site gives every member an entry — a heading and a signature with nothing under them.
- Construction parameters sat in the class docstring's `Args:`, where the page does not show them under the constructor.
- `>>>` is a blockquote to Markdown, so doctest examples rendered as nested quotes with the code as prose.
- Shapes were code spans (`` ``[B, M, K]`` ``), which read as identifiers.

## Changes

- `__init__`: the class docstring's `Args:` moves onto it.
- `forward`: inputs, outputs and shape rules from the manifest.
- 16 classes outside the manifest (base classes, mixins, autograd functions) get a summary line only; parameters no source describes are left for their author.
- 85 doctest lines become fenced `python` blocks, expected output as a trailing comment.
- Shapes become math — `$[B \times M \times K]$`. A tuple of output names, a literal index, or a variadic shape stays code.
- The two GEMM layout lists become tables; Markdown folded them into one paragraph.
- `scripts/lint/op_docstrings_lint.py` fails a missing docstring, reStructuredText, or an `Args:` left on a class. Runs as the `op-docstrings-lint` pre-commit hook, so the `pre-commit` CI job enforces it. `docs/development.md` states the convention.

Docstring text only; no signature, default or behaviour changes.