### PR TITLE
[Bench] Give three rows a comparison object within reach of the kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 
 <p>
     <a href="https://github.com/tile-ai/tilelang"><img src="https://img.shields.io/badge/built%20on-TileLang-1E90FF" alt="Built on TileLang"></a>
-    <a href="https://github.com/tile-ai/TileOPs/tree/main/src/tileops/manifest"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftile-ai%2FTileOPs%2Fstats%2Fmanifest-implemented.json" alt="Spec coverage"></a>
-    <a href="https://github.com/tile-ai/TileOPs/tree/main/benchmarks"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftile-ai%2FTileOPs%2Fstats%2Fmanifest-benchmark.json" alt="Bench coverage"></a>
-    <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="MIT license"></a>
+    <a href="https://tile-ai.github.io/TileOPs.github.io/manifest/"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftile-ai%2FTileOPs%2Fstats%2Fmanifest-implemented.json" alt="Spec coverage"></a>
+    <a href="https://tile-ai.github.io/TileOPs.github.io/benchmarks/"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftile-ai%2FTileOPs%2Fstats%2Fmanifest-benchmark.json" alt="Bench coverage"></a>
+    <a href="https://tile-ai.github.io/TileOPs.github.io/api/"><img src="https://img.shields.io/badge/docs-API%20reference-1E90FF" alt="API reference"></a>
     <!-- <a href="https://pypi.org/project/src/tileops/"><img src="https://img.shields.io/badge/PyPI-tileops-1E90FF" alt="PyPI version"></a> -->
   </p>
 
@@ -18,7 +18,8 @@
     <a href="#built-for-agents"><b>Why it's different</b></a> ·
     <a href="#how-it-works"><b>How it works</b></a> ·
     <a href="#installation"><b>Installation</b></a> ·
-    <a href="#documentation"><b>Docs</b></a>
+    <a href="https://tile-ai.github.io/TileOPs.github.io/benchmarks/"><b>Benchmarks</b></a> ·
+    <a href="https://tile-ai.github.io/TileOPs.github.io/"><b>Docs</b></a>
   </p>
 </div>
 
@@ -122,7 +123,10 @@ build troubleshooting.
 | [roofline.md](docs/design/roofline.md)         | How performance is scored against Speed-of-Light |
 | [trust-model.md](docs/design/trust-model.md)   | What each layer may assume about the others      |
 
-API reference and performance tables: [TileOPs.github.io](https://github.com/tile-ai/TileOPs.github.io).
+The rendered site carries what this table cannot: the
+[API reference](https://tile-ai.github.io/TileOPs.github.io/api/) generated from the operator
+signatures, and the [performance tables](https://tile-ai.github.io/TileOPs.github.io/benchmarks/)
+from the nightly run, each operator against the tuned libraries it competes with.
 
 ## Contributing
 

--- a/benchmarks/baselines.py
+++ b/benchmarks/baselines.py
@@ -18,12 +18,14 @@ from typing import Any, Callable, Optional
 import torch
 
 __all__ = [
+    "DEEPGEMM_TAG",
     "FLAGGEMS_TAG",
     "FLASHINFER_TAG",
     "TORCH_COMPILE_TAG",
     "VLLM_TAG",
     "assert_matches_reference",
     "compiled_reference",
+    "deepgemm_op",
     "flaggems_dims",
     "flaggems_group_norm",
     "flaggems_op",
@@ -41,6 +43,7 @@ _TOLERANCES = {
     torch.float64: (1e-7, 1e-7),
 }
 
+DEEPGEMM_TAG = "deepgemm"
 TORCH_COMPILE_TAG = "torch-compile"
 FLAGGEMS_TAG = "flaggems"
 FLASHINFER_TAG = "flashinfer"
@@ -176,6 +179,15 @@ def flaggems_group_norm(n: int, c: int, hxw: int, groups: int, eps: float) -> Ca
         return fn(x, weight, bias, n, c, hxw, groups, eps)[0]
 
     return baseline_fn
+
+
+def deepgemm_op(name: str) -> Callable:
+    """Return the ``deep_gemm`` entry point *name*.
+
+    Its GEMMs write into a caller-allocated output and return ``None``, so an adapter
+    allocates before it calls.
+    """
+    return _resolve("deep_gemm", name, "deepgemm")
 
 
 def flashinfer_op(name: str) -> Callable:

--- a/benchmarks/ops/attention/bench_deepseek_dsa_decode.py
+++ b/benchmarks/ops/attention/bench_deepseek_dsa_decode.py
@@ -1,7 +1,12 @@
 import pytest
 import torch
 
-from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
+from benchmarks.baselines import (
+    TORCH_COMPILE_TAG,
+    assert_matches_reference,
+    compiled_reference,
+    reference_tolerance,
+)
 from benchmarks.benchmark_base import (
     ManifestBenchmark,
     then_dtype,
@@ -22,6 +27,60 @@ _DSA_DECODE_BENCH_PARAMS = workload_params(
         tune=False,
     ),
 )
+
+
+def _torch_sdpa_dsa(test: DsaDecodeWorkload):
+    """SDPA over the selection ``ref_program`` masks, or None for a row it cannot serve.
+
+    Same computation, without the reference's float32 upcast and materialized score
+    tensor. A single kv head lets the mask and the cache broadcast over the query heads.
+    """
+    if test.heads_kv != 1:
+        return None
+
+    def fn(q, kv, indices):
+        b, sq, h, dim_q = q.shape
+        sk = kv.shape[1]
+        dim = test.dim
+        mask = test.selection_mask(indices).expand(b, h, sq, sk)
+        k = kv.permute(0, 2, 1, 3).expand(b, h, sk, dim_q)
+        v = kv[..., :dim].permute(0, 2, 1, 3).expand(b, h, sk, dim)
+        out = torch.nn.functional.scaled_dot_product_attention(
+            q.permute(0, 2, 1, 3),
+            k,
+            v,
+            attn_mask=mask,
+            scale=test.sm_scale if test.sm_scale is not None else dim_q**-0.5,
+        )
+        return out.permute(0, 2, 1, 3).reshape(b, sq, h, dim).to(torch.float16)
+
+    return fn
+
+
+def _torch_gather_dsa(test: DsaDecodeWorkload):
+    """Dense attention over only the gathered selection, or None when it buys nothing.
+
+    Gathering beats masking only where the selection is smaller than the cache.
+    """
+    if test.heads_kv != 1 or test.topk >= test.seq_len_kv:
+        return None
+
+    def fn(q, kv, indices):
+        b, sq, h, dim_q = q.shape
+        sk = kv.shape[1]
+        dim, topk = test.dim, indices.shape[-1]
+        idx = indices.transpose(1, 2).clamp(max=sk - 1).long()
+        valid = torch.gather(test.selection_mask(indices), 3, idx)
+        gathered = torch.gather(
+            kv.squeeze(2), 1, idx.reshape(b, sq * topk, 1).expand(-1, -1, dim_q)
+        ).view(b, sq, topk, dim_q)
+        scale = test.sm_scale if test.sm_scale is not None else dim_q**-0.5
+        scores = torch.einsum("bhqd,bqkd->bhqk", q.permute(0, 2, 1, 3), gathered)
+        probs = scores.float().mul(scale).masked_fill(~valid, float("-inf")).softmax(-1)
+        out = torch.einsum("bhqk,bqkd->bhqd", probs.to(kv.dtype), gathered[..., :dim])
+        return out.permute(0, 2, 1, 3).reshape(b, sq, h, dim).to(torch.float16)
+
+    return fn
 
 
 @pytest.mark.parametrize(
@@ -75,11 +134,22 @@ def test_dsa_decode_bench(
     )
     bm = ManifestBenchmark(_OP_NAME, op, test)
 
+    baselines = {}
+    sdpa_fn = _torch_sdpa_dsa(test)
+    if sdpa_fn is not None:
+        baselines["torch-sdpa"] = sdpa_fn
+    gather_fn = _torch_gather_dsa(test)
+    if gather_fn is not None:
+        baselines["torch-gather"] = gather_fn
+    for fn in baselines.values():
+        assert_matches_reference(fn, test.ref_program, *inputs, **reference_tolerance(dtype))
+
     bm.compare(
         {
             "tileops": op,
             "torch-ref": test.ref_program,
             TORCH_COMPILE_TAG: compiled_reference(test.ref_program),
+            **baselines,
         },
         *inputs,
         record_as=op,

--- a/benchmarks/ops/attention/bench_gqa.py
+++ b/benchmarks/ops/attention/bench_gqa.py
@@ -410,6 +410,29 @@ def test_gqa_prefill_fwd_bench(
     bm.compare(functors, *packed_inputs, record_as=op, params=locals())
 
 
+def _fa3_gqa_prefill_varlen(test: GQAPrefillVarlenFwdWorkload):
+    """FlashAttention-3 over the same packed-varlen layout."""
+    try:
+        from flash_attn_interface import flash_attn_varlen_func
+    except ImportError:
+        return None
+
+    def _run(q, k, v, cu_seqlens_q, cu_seqlens_kv):
+        out = flash_attn_varlen_func(
+            q,
+            k,
+            v,
+            cu_seqlens_q,
+            cu_seqlens_kv,
+            test.max_seqlen_q,
+            test.max_seqlen_kv,
+            causal=test.is_causal,
+        )
+        return out[0] if isinstance(out, tuple) else out
+
+    return _run
+
+
 _GQA_PREFILL_VARLEN_FWD_BENCH_PARAMS = [
     pytest.param(
         4,
@@ -473,12 +496,14 @@ def test_gqa_prefill_varlen_fwd_bench(
     )
     bm = GQAPrefillVarlenFwdBenchmark(test)
 
-    bm.compare(
-        {"tileops": op, "torch-ref": _torch_gqa_prefill_varlen_ref(test)},
-        *inputs,
-        record_as=op,
-        params=locals(),
-    )
+    functors = {"tileops": op, "torch-ref": _torch_gqa_prefill_varlen_ref(test)}
+    fa3_fn = _fa3_gqa_prefill_varlen(test)
+    if fa3_fn is not None:
+        assert_matches_reference(
+            fa3_fn, functors["torch-ref"], *inputs, **reference_tolerance(dtype)
+        )
+        functors["fa3"] = fa3_fn
+    bm.compare(functors, *inputs, record_as=op, params=locals())
 
 
 def _fa3_gqa_prefill_paged(test, cache_dtype, fuse_rope, softcap):

--- a/benchmarks/ops/bench_gemm.py
+++ b/benchmarks/ops/bench_gemm.py
@@ -291,7 +291,8 @@ def _gemm_args(w: dict, dtype: torch.dtype) -> tuple:
 
 
 def _gemm_fp8_args(w: dict, dtype: torch.dtype) -> tuple:
-    return (w["m"], w["n"], w["k"], w["scale_mode"], dtype)
+    """``(m, n, k, scale_mode, bias, dtype)``; ``bias_shape`` selects the bias epilogue."""
+    return (w["m"], w["n"], w["k"], w["scale_mode"], bool(w.get("bias_shape")), dtype)
 
 
 def _gemm_w4a16_args(w: dict, dtype: torch.dtype) -> tuple:

--- a/benchmarks/ops/bench_gemm.py
+++ b/benchmarks/ops/bench_gemm.py
@@ -4,8 +4,10 @@ import pytest
 import torch
 
 from benchmarks.baselines import (
+    DEEPGEMM_TAG,
     FLAGGEMS_TAG,
     assert_matches_reference,
+    deepgemm_op,
     flaggems_op,
     reference_tolerance,
 )
@@ -86,6 +88,69 @@ def _flashinfer_fp8_blockscale_ref(
             f"got {tuple(scale_a.shape)} and {tuple(scale_b.shape)}"
         )
     return fp8_blockscale_gemm_sm90(a, b, scale_a, scale_b, out_dtype=workload.out_dtype)
+
+
+def _deepgemm_bf16_nt(
+    workload: GemmBenchmarkWorkload, a: torch.Tensor, b: torch.Tensor
+) -> Optional[Callable[..., torch.Tensor]]:
+    """DeepGEMM's dense bf16 GEMM, or None for a row its kernel cannot take.
+
+    It reads both operands K-major and bf16 only, which is the N-T layout here.
+    """
+    if workload.trans_a or not workload.trans_b or a.dtype != torch.bfloat16:
+        return None
+
+    gemm = deepgemm_op("bf16_gemm_nt")
+    m, n = workload.m, workload.n
+
+    def run(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+        out = torch.empty((m, n), dtype=a.dtype, device=a.device)
+        gemm(a, b, out)
+        return out
+
+    return run
+
+
+def _deepgemm_fp8_per_tensor(
+    workload: GemmFp8BenchmarkWorkload, *inputs: torch.Tensor
+) -> Callable[..., torch.Tensor]:
+    """DeepGEMM's dense FP8 GEMM over a per-tensor scale.
+
+    It reads A's scale per token and B's scale per 128x128 block, so a per-tensor scale
+    expands into both without changing the arithmetic.
+
+    Raises:
+        ValueError: When the row falls outside that path.
+    """
+    gemm = deepgemm_op("fp8_gemm_nt")
+    align = deepgemm_op("get_mn_major_tma_aligned_tensor")
+
+    scale_a, scale_b = inputs[2], inputs[3]
+    if len(inputs) == 5:
+        raise ValueError("DeepGEMM FP8 GEMM baseline does not support bias.")
+    if scale_a.shape != (1, 1) or scale_b.shape != (1, 1):
+        raise ValueError(
+            "DeepGEMM FP8 GEMM baseline requires (1, 1) scales, "
+            f"got {tuple(scale_a.shape)} and {tuple(scale_b.shape)}"
+        )
+    if workload.out_dtype != torch.bfloat16:
+        raise ValueError("DeepGEMM FP8 GEMM baseline requires bfloat16 output.")
+    if workload.n % 128 or workload.k % 128:
+        raise ValueError(
+            "DeepGEMM FP8 GEMM baseline requires n and k divisible by 128, "
+            f"got n={workload.n} k={workload.k}"
+        )
+
+    m, n, k = workload.m, workload.n, workload.k
+    aligned_scale_a = align(scale_a.expand(m, k // 128).contiguous())
+    block_scale_b = scale_b.expand(n // 128, k // 128).contiguous()
+
+    def run(a: torch.Tensor, b: torch.Tensor, *_: torch.Tensor) -> torch.Tensor:
+        out = torch.empty((m, n), dtype=workload.out_dtype, device=a.device)
+        gemm((a, aligned_scale_a), (b, block_scale_b), out)
+        return out
+
+    return run
 
 
 def _prepare_flashinfer_fp8_per_tensor(
@@ -257,6 +322,12 @@ def test_gemm_bench(
     # flag_gems' mm takes row-major operands; a transposed row is its own layout,
     # which its kernel does not express, so those rows carry cuBLAS alone.
     functors = {"tileops": op, "torch-cublas": workload.torch_matmul}
+    deepgemm_fn = _deepgemm_bf16_nt(workload, a, b)
+    if deepgemm_fn is not None:
+        assert_matches_reference(
+            deepgemm_fn, workload.torch_matmul, a, b, **reference_tolerance(dtype)
+        )
+        functors[DEEPGEMM_TAG] = deepgemm_fn
     if not trans_a and not trans_b:
         flaggems_mm = flaggems_op("mm")
         assert_matches_reference(
@@ -268,17 +339,19 @@ def test_gemm_bench(
 
 
 @pytest.mark.parametrize(
-    "m, n, k, scale_mode, dtype", workload_params(load_workloads(_FP8_OP_NAME), _gemm_fp8_args)
+    "m, n, k, scale_mode, bias, dtype",
+    workload_params(load_workloads(_FP8_OP_NAME), _gemm_fp8_args),
 )
 def test_gemm_fp8_bench(
     m: int,
     n: int,
     k: int,
     scale_mode: str,
+    bias: bool,
     dtype: torch.dtype,
 ) -> None:
     out_dtype = torch.bfloat16
-    workload = GemmFp8BenchmarkWorkload(m, n, k, dtype, scale_mode, out_dtype=out_dtype)
+    workload = GemmFp8BenchmarkWorkload(m, n, k, dtype, scale_mode, out_dtype=out_dtype, bias=bias)
     inputs = workload.gen_inputs()
 
     op = GemmFp8FwdOp(out_dtype=out_dtype)
@@ -290,6 +363,19 @@ def test_gemm_fp8_bench(
     functors = {"tileops": op, "torch-scaled-mm": workload.torch_scaled_matmul}
 
     if scale_mode == "per_tensor":
+        try:
+            deepgemm_fn = _deepgemm_fp8_per_tensor(workload, *inputs)
+        except ValueError as exc:
+            print(f"  [skip] {DEEPGEMM_TAG}: {exc}")
+        else:
+            assert_matches_reference(
+                deepgemm_fn,
+                workload.torch_scaled_matmul,
+                *inputs,
+                **reference_tolerance(out_dtype),
+            )
+            functors[DEEPGEMM_TAG] = (deepgemm_fn, inputs[:2])
+
         unsupported_reason = _flashinfer_fp8_per_tensor_unsupported_reason(inputs[0].device)
         if unsupported_reason is not None:
             print(f"  [skip] flashinfer-mm-fp8: {unsupported_reason}")

--- a/benchmarks/ops/bench_grouped_gemm.py
+++ b/benchmarks/ops/bench_grouped_gemm.py
@@ -10,7 +10,12 @@ GEMM launches, which no single manifest workload describes.
 import pytest
 import torch
 
-from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
+from benchmarks.baselines import (
+    TORCH_COMPILE_TAG,
+    assert_matches_reference,
+    compiled_reference,
+    reference_tolerance,
+)
 from benchmarks.benchmark_base import (
     ManifestBenchmark,
     fields,
@@ -37,6 +42,37 @@ _GROUPED_GEMM_PARAMS = workload_params(
 )
 
 
+def _torch_grouped_mm(test: GroupedGemmWorkload, inputs: tuple):
+    """``torch._grouped_mm`` over the same groups, or None where it cannot take them.
+
+    Reads B as ``[groups, K, N]`` and takes cumulative group ends, both built here
+    rather than inside the timed callable.
+    """
+    if not hasattr(torch, "_grouped_mm"):
+        return None
+    if test.transpose_a and test.transpose_b:
+        return None
+
+    sizes = torch.tensor(test.batch_sizes_list, device=inputs[0].device, dtype=torch.int32)
+    offsets = torch.cumsum(sizes, dim=0).to(torch.int32)
+
+    if test.transpose_a:
+
+        def fn(a, b, *_):
+            return torch._grouped_mm(a.t(), b, offs=offsets)
+    elif test.transpose_b:
+        b_kn = inputs[1].transpose(1, 2).contiguous()
+
+        def fn(a, _b, *_):
+            return torch._grouped_mm(a, b_kn, offs=offsets)
+    else:
+
+        def fn(a, b, *_):
+            return torch._grouped_mm(a, b, offs=offsets)
+
+    return fn
+
+
 @pytest.mark.parametrize(
     "batch_sum, batch_count, N, K, dtype, transpose_a, transpose_b",
     _GROUPED_GEMM_PARAMS,
@@ -59,13 +95,15 @@ def test_grouped_gemm_bench(
     op = GroupedGemmFwdOp(transpose_a=transpose_a, transpose_b=transpose_b, tune=_TUNE)
     bm = ManifestBenchmark(_GROUPED_GEMM_OP, op, test)
 
-    bm.compare(
-        {
-            "tileops": op,
-            "torch-ref": test.ref_program,
-            TORCH_COMPILE_TAG: compiled_reference(test.ref_program),
-        },
-        *inputs,
-        record_as=name,
-        params=locals(),
-    )
+    functors = {
+        "tileops": op,
+        "torch-ref": test.ref_program,
+        TORCH_COMPILE_TAG: compiled_reference(test.ref_program),
+    }
+    grouped_mm_fn = _torch_grouped_mm(test, inputs)
+    if grouped_mm_fn is not None:
+        assert_matches_reference(
+            grouped_mm_fn, test.ref_program, *inputs, **reference_tolerance(dtype)
+        )
+        functors["torch"] = grouped_mm_fn
+    bm.compare(functors, *inputs, record_as=name, params=locals())

--- a/benchmarks/ops/bench_topk_selector.py
+++ b/benchmarks/ops/bench_topk_selector.py
@@ -4,15 +4,21 @@ Workload shapes, dtypes, and ``topk`` come from the ops manifest; roofline
 FLOP and byte counts come from the op's ``eval_roofline()`` via
 :class:`ManifestBenchmark`.
 
-The row is timed against torch eager and the same reference through inductor.
-flag_gems' top-k selects over the last dimension only, and this op selects over
-``seq_len_kv``, dim 2 of 4.
+The row is timed against torch eager, the same reference through inductor, and
+FlashInfer's top-k. flag_gems' top-k selects over the last dimension only, and this
+op selects over ``seq_len_kv``, dim 2 of 4; FlashInfer's carries the same restriction
+but a single ``kv_group`` makes that dimension the last one.
 """
 
 import pytest
 import torch
 
-from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
+from benchmarks.baselines import (
+    FLASHINFER_TAG,
+    TORCH_COMPILE_TAG,
+    compiled_reference,
+    flashinfer_op,
+)
 from benchmarks.benchmark_base import (
     ManifestBenchmark,
     fields,
@@ -35,6 +41,45 @@ _TOPK_SELECTOR_PARAMS = workload_params(
 )
 
 
+def _flashinfer_topk(test: TopkSelectorWorkload, starts: torch.Tensor, ends: torch.Tensor):
+    """FlashInfer's top-k over the same scores, or None for a row it cannot serve.
+
+    It selects over the last dimension, which is ``seq_len_kv`` only while
+    ``kv_group`` is 1, and over the whole row, so a narrowed ``[start, end)`` is out.
+    """
+    if test.kv_group != 1:
+        return None
+    if not (bool((starts == 0).all()) and bool((ends == test.seq_len_kv).all())):
+        return None
+
+    top_k = flashinfer_op("top_k")
+    rows, topk, out_dtype = test.batch * test.seq_len, test.topk, test.out_dtype
+
+    def fn(index_score, *_):
+        _, indices = top_k(index_score.squeeze(-1).reshape(rows, test.seq_len_kv), topk)
+        return indices.reshape(test.batch, test.seq_len, 1, topk).to(out_dtype)
+
+    return fn
+
+
+def _assert_selects_same_scores(fn, reference, *inputs: torch.Tensor) -> None:
+    """Check a baseline selects the same scores, not the same order among ties.
+
+    Two exact top-k implementations disagree on which index they keep where scores
+    tie, so comparing index tensors would reject a correct baseline.
+
+    Raises:
+        AssertionError: When the selected scores differ.
+    """
+    flat = inputs[0].squeeze(-1).flatten(0, 1)
+
+    def selected(indices: torch.Tensor) -> torch.Tensor:
+        gathered = torch.gather(flat, 1, indices.reshape(flat.shape[0], -1).long())
+        return torch.sort(gathered, dim=-1)[0]
+
+    torch.testing.assert_close(selected(fn(*inputs)), selected(reference(*inputs)))
+
+
 @pytest.mark.parametrize(
     "batch, seq_len, seq_len_kv, kv_group, topk, in_dtype, out_dtype",
     _TOPK_SELECTOR_PARAMS,
@@ -54,13 +99,14 @@ def test_topk_selector_bench(
     op = TopkSelectorFwdOp(topk=topk, tune=_TUNE)
     bm = ManifestBenchmark(_TOPK_SELECTOR_OP, op, test)
 
-    bm.compare(
-        {
-            "tileops": op,
-            "torch": test.ref_program,
-            TORCH_COMPILE_TAG: compiled_reference(test.ref_program),
-        },
-        *inputs,
-        record_as=op,
-        params=locals(),
-    )
+    functors = {
+        "tileops": op,
+        "torch": test.ref_program,
+        TORCH_COMPILE_TAG: compiled_reference(test.ref_program),
+    }
+    flashinfer_fn = _flashinfer_topk(test, inputs[1], inputs[2])
+    if flashinfer_fn is not None:
+        _assert_selects_same_scores(flashinfer_fn, test.ref_program, *inputs)
+        functors[FLASHINFER_TAG] = flashinfer_fn
+
+    bm.compare(functors, *inputs, record_as=op, params=locals())

--- a/workloads/attention/deepseek.py
+++ b/workloads/attention/deepseek.py
@@ -579,15 +579,42 @@ class DsaDecodeWorkload(WorkloadBase):
                     indices[b, t, h, : len(i_i)] = i_i
         return q, kv, indices
 
+    def selection_mask(self, indices: torch.Tensor) -> torch.Tensor:
+        """Return the ``[batch, kv heads, q, kv]`` mask this workload's top-k selection implies.
+
+        The mask combines the selected positions with the compressed causal limit.
+        ``ref_program`` and any baseline attending over the same selection both read it,
+        so the two cannot drift apart.
+        """
+        idx = indices.transpose(1, 2)
+        b, g, sq, _ = idx.shape
+        sk = self.seq_len_kv
+        q_start_index_s = self.q_start_index_s
+        if q_start_index_s is None:
+            q_start_index_s = sk * self.stride_kv - sq
+        device = indices.device
+        compressed_causal_mask = torch.arange(
+            q_start_index_s, sq + q_start_index_s, dtype=torch.int32, device=device
+        ).view(-1, 1) >= torch.arange(
+            self.stride_kv - 1,
+            sk * self.stride_kv,
+            self.stride_kv,
+            dtype=torch.int32,
+            device=device,
+        ).view(1, -1)
+
+        mask = torch.zeros(b, g, sq, sk + 1, dtype=torch.bool, device=device).scatter(
+            3, idx.long(), 1
+        )[..., :-1]
+        mask = mask & compressed_causal_mask.view(1, 1, sq, sk)
+        mask[:, :, : self.stride_kv - 1, 0] = True
+        return mask
+
     def ref_program(self, q: torch.Tensor, kv: torch.Tensor, indices: torch.Tensor) -> torch.Tensor:
         q = q.float()
         kv = kv.float()
-        indices = indices.transpose(1, 2)
         b, sq, h, dim_q = q.shape
         b, sk, g, _ = kv.shape
-        q_start_index_s = self.q_start_index_s
-        if self.q_start_index_s is None:
-            q_start_index_s = sk * self.stride_kv - sq
 
         assert kv.shape[-1] == self.dim + self.dim_tail, "you should assign dim otherwise"
         dim = self.dim
@@ -597,21 +624,7 @@ class DsaDecodeWorkload(WorkloadBase):
         b, _, _, dim_v = v.shape
         g_index = g
         h_index = h // g
-        compressed_causal_mask = torch.arange(
-            q_start_index_s, sq + q_start_index_s, dtype=torch.int32, device="cuda"
-        ).view(-1, 1) >= torch.arange(
-            self.stride_kv - 1,
-            sk * self.stride_kv,
-            self.stride_kv,
-            dtype=torch.int32,
-            device="cuda",
-        ).view(1, -1)
-
-        mask = q.new_zeros(b, g_index, sq, sk + 1, dtype=torch.bool).scatter(3, indices.long(), 1)
-        mask = mask[..., :-1]
-        mask = mask & compressed_causal_mask.view(1, 1, sq, sk)
-        mask[:, :, : self.stride_kv - 1, 0] = True
-        mask = mask.view(b, g_index, 1, sq, sk)
+        mask = self.selection_mask(indices).view(b, g_index, 1, sq, sk)
 
         q = q.view(b, sq, g, -1, dim_q)
         score = torch.einsum("bmghd,bngd->bghmn", q, k)


### PR DESCRIPTION
## Problems

- A row measured only against a torch reference that materializes what the kernel fuses reports the reference's shape, not the kernel's speed. Varlen prefill, `grouped_gemm_nt` and DSA decode had no baseline within 5x; the top-k selector's 1.75x said nothing, both sides sitting far below what the input allows.
- FlashInfer's per-tensor FP8 GEMM needs Blackwell, so on Hopper those rows carried `torch._scaled_mm` alone. The dense bf16 rows rested on cuBLAS alone.
- One FP8 row declares `bias_shape`, but `_gemm_fp8_args` dropped it: no FP8 row timed the bias epilogue.

## Changes

| op | new tag | from |
| --- | --- | --- |
| varlen prefill | `fa3` | `flash_attn_varlen_func` |
| grouped GEMM | `torch` | `torch._grouped_mm` |
| DSA decode | `torch-sdpa`, `torch-gather` | masked cache, gathered selection |
| top-k selector | `flashinfer` | `flashinfer.top_k` |
| FP8 GEMM per-tensor, bf16 GEMM N-T | `deepgemm` | `fp8_gemm_nt`, `bf16_gemm_nt` |

- Every baseline is asserted against its reference before its case is timed; every scale expansion, transpose copy and offset table is built outside the timed callable.
- DeepGEMM takes per-tensor scales, which expand into its per-token and per-128x128 layouts unchanged; per-channel scales do not, so the `block128` rows keep FlashInfer.
- The top-k check compares selected scores, not indices: two exact implementations disagree on ties, and 5 of 32768 rows do, with bit-identical scores.
- The DSA selection mask moves into `DsaDecodeWorkload.selection_mask`, read by the reference and both baselines.
- `deepgemm_op` joins the resolvers in `benchmarks/baselines.py`; `_gemm_fp8_args` reads `bias_shape`.
- README: the license badge becomes the API reference; the coverage badges and the Docs link reach the rendered site.

device_busy_ms on H200, what the new tags show:

| row | tileops | best baseline | gap |
| --- | --- | --- | --- |
| varlen prefill | 0.1070 | fa3 0.0606 | 1.8-2.3x |
| grouped_gemm_tn | 0.6922 | torch 0.3021 | 2.3x |
| fp8 per-tensor m=4096 | 0.1814 (663 TFLOPS) | deepgemm 0.0924 (1302) | 2.0x |
| fp8 block128 4096x4096x7168 | 0.7164 (336) | flashinfer 0.1887 (1274) | 3.8x |
| bf16 N-T, 11 rows | 0.0219-1.8182 | cuBLAS / deepgemm | 1.4-3.0x |
| top-k selector k=1024 | 12.8477 (0.68 TB/s) | flashinfer 7.5054 (1.16) | 1.7x |

`FP8LightningIndexerFwdOp` keeps torch-ref and torch-compile at 76.9x: no installed library implements DeepSeek's lightning indexer.

Test node delta: 0.
