### PR TITLE
[Bench] Give three more rows a baseline, and fix one that measured nothing

### DIFF
--- a/benchmarks/ops/bench_batch_norm.py
+++ b/benchmarks/ops/bench_batch_norm.py
@@ -1,9 +1,9 @@
 """Benchmark for BatchNormFwdOp and BatchNormBwdOp.
 
 Compares TileOPs vs PyTorch cuDNN batch norm on common ResNet-style shapes. The
-forward row adds flag_gems' batch_norm and cuDNN through inductor; the backward row
-stays on the autograd reference alone, which is a node driven on this thread and not
-work either of those performs.
+forward row adds flag_gems' batch_norm and cuDNN through inductor. The backward row
+carries two torch tags: an autograd node driven on this thread, and aten's backward
+kernel by itself. The difference between them is the forward the autograd one rebuilds.
 """
 
 import math
@@ -91,6 +91,27 @@ def _torch_bn_bwd(grad_out, x, weight, mean, rstd):
     return backward_of(y)(grad_out.float())
 
 
+def _aten_bn_bwd(grad_out, x, weight, mean, rstd):
+    """aten's batch-norm backward, run by itself on the saved statistics.
+
+    The float32 casts are load-bearing rather than overhead: handed float16 this kernel
+    forms the channel gradients in float16 too, and the reduction over every spatial
+    element then lands far outside tolerance.
+    """
+    return torch.ops.aten.native_batch_norm_backward(
+        grad_out.float(),
+        x.float(),
+        weight.float(),
+        None,
+        None,
+        mean,
+        rstd,
+        True,
+        1e-5,
+        [True, True, True],
+    )
+
+
 # Manifest-driven params
 
 
@@ -155,6 +176,16 @@ def test_batch_norm_bwd_bench(N, C, spatial, dtype):
 
     spatial = str(spatial)  # stringify tuple so it survives BenchmarkReport.record filtering
 
+    # A reduction this long disagrees with the reference's order past float32's tolerance.
+    assert_matches_reference(_aten_bn_bwd, _torch_bn_bwd, *inputs, rtol=1e-3, atol=1e-3)
+
     bm.compare(
-        {"tileops": op, "torch-autograd": _torch_bn_bwd}, *inputs, record_as=op, params=locals()
+        {
+            "tileops": op,
+            "torch-autograd": _torch_bn_bwd,
+            "torch-native-batch-norm": _aten_bn_bwd,
+        },
+        *inputs,
+        record_as=op,
+        params=locals(),
     )

--- a/benchmarks/ops/bench_fp8_lightning_indexer.py
+++ b/benchmarks/ops/bench_fp8_lightning_indexer.py
@@ -2,6 +2,10 @@
 
 Workload shapes come from the ops manifest; roofline FLOP and byte counts
 come from the op's ``eval_roofline()`` via :class:`ManifestBenchmark`.
+
+The reference materializes the ``[batch, heads, seq_len, seq_len_kv]`` scores the op
+folds into its matmul epilogue, and peaks near 104 GB on these rows. A device that
+cannot hold that fails in the reference rather than in the op.
 """
 
 import pytest

--- a/benchmarks/ops/bench_gated_deltanet_prefill.py
+++ b/benchmarks/ops/bench_gated_deltanet_prefill.py
@@ -134,21 +134,28 @@ def test_gated_deltanet_prefill_bhtd_bench(
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
-    """Head-major prefill, timed alone."""
-    # FIXME(staged-rollout): this row records no baseline.
-    #
-    # Broken invariant: every benchmark records ≥1 non-tileops baseline.
-    # Why: FLA reads token-major only, and the workload's chunked reference is a
-    #   Python loop over chunks — at this op's 128k-token rows it costs more than
-    #   the rest of the family's benchmarks together.
-    # Cleanup: a reference that scales to 128k tokens, or an FLA entry point that
-    #   takes head-major input.
+    """Head-major prefill against FLA in its own token-major layout.
+
+    FLA reads token-major only, so its inputs are converted outside the timed region:
+    each row compares the two kernels in the layout each was written for. A head-major
+    caller reaching for FLA also pays that conversion, which this row does not report.
+
+    Neither tag is asserted, for the reason this module's docstring gives.
+    """
     test = GatedDeltaNetPrefillFwdWorkload(
         batch, heads, seq_len, dim_k, dim_v, chunk_size, dtype, layout=layout
     )
+    inputs = test.gen_inputs()
+
     op = GatedDeltaNetPrefillBHTDFwdOp(chunk_size=chunk_size, tune=tune)
     bm = ManifestBenchmark(_BHTD_OP_NAME, op, test)
-    bm.compare({"tileops": op}, *test.gen_inputs(), record_as=op, params=locals())
+    fla_inputs = convert_gdn_prefill_layout(inputs, layout, "bthd")
+    bm.compare(
+        {"tileops": op, "fla": (_fla_prefill_fwd(), fla_inputs)},
+        *inputs,
+        record_as=op,
+        params=locals(),
+    )
 
 
 @pytest.mark.parametrize(

--- a/benchmarks/ops/bench_mean_pooling.py
+++ b/benchmarks/ops/bench_mean_pooling.py
@@ -3,7 +3,11 @@ from typing import List, Optional
 import pytest
 import torch
 
-from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
+from benchmarks.baselines import (
+    TORCH_COMPILE_TAG,
+    assert_matches_reference,
+    compiled_reference,
+)
 from benchmarks.benchmark_base import BenchmarkBase
 from tileops.ops import MeanPoolingForwardOp
 from workloads.nsa_utils import prepare_chunk_indices
@@ -56,6 +60,24 @@ _MEAN_POOLING_BENCH_PARAMS = [
         id="varlen-tail",
     ),
 ]
+
+
+def _torch_view_mean(test: MeanPoolingWorkload):
+    """The same mean over a reshaped view, or None where the chunks are ragged.
+
+    ``ref_program`` averages one slice per chunk, a launch each. Where every chunk is
+    full the chunk axis is a reshape away and the pooling is a single reduction.
+    """
+    if test.use_offsets != 0 or test.seq_len % test.chunk_size:
+        return None
+
+    chunks = test.seq_len // test.chunk_size
+
+    def fn(x, *_):
+        b, _, h, d = x.shape
+        return x.view(b, chunks, test.chunk_size, h, d).mean(dim=2)
+
+    return fn
 
 
 @pytest.mark.parametrize(
@@ -128,13 +150,14 @@ def test_mean_pooling_bench(
 
     op = MeanPoolingForwardOp(**params)
 
-    bm.compare(
-        {
-            "tileops": op,
-            "torch-ref": test.ref_program,
-            TORCH_COMPILE_TAG: compiled_reference(test.ref_program),
-        },
-        *inputs,
-        record_as=op,
-        params=locals(),
-    )
+    functors = {
+        "tileops": op,
+        "torch-ref": test.ref_program,
+        TORCH_COMPILE_TAG: compiled_reference(test.ref_program),
+    }
+    view_mean = _torch_view_mean(test)
+    if view_mean is not None:
+        assert_matches_reference(view_mean, test.ref_program, *inputs)
+        functors["torch-view-mean"] = view_mean
+
+    bm.compare(functors, *inputs, record_as=op, params=locals())

--- a/src/tileops/manifest/attention_indexing.yaml
+++ b/src/tileops/manifest/attention_indexing.yaml
@@ -31,9 +31,11 @@ FP8LightningIndexerFwdOp:
     - "index_k_scale is None or index_k_scale.shape == (index_q.shape[0], index_k.shape[1], index_k.shape[2])"
 
   workloads:
-  - {batch: 1, seq_len: 8192, heads: 32, index_dim: 64, seq_len_kv: 8192, kv_group: 1, clean_logits: true, dtypes: [bfloat16], label: "lightning-indexer-s8k-h32-d64"}
-  - {batch: 1, seq_len: 8192, heads: 32, index_dim: 64, seq_len_kv: 8192, kv_group: 1, clean_logits: true, dtypes: [float8_e4m3fn], label: "lightning-indexer-s8k-h32-d64"}
-  - {batch: 1, seq_len: 8192, heads: 32, index_dim: 64, seq_len_kv: 8192, kv_group: 1, clean_logits: true, dtypes: [float8_e4m3fn], index_k_scale_shape: [1, 8192, 1], label: "lightning-indexer-s8k-h32-d64-kscale"}
+  # cu_seqlen_ks/ke address the whole context-parallel sequence, so seq_len_kv covers
+  # every rank's keys while seq_len counts one rank's queries.
+  - {batch: 1, seq_len: 8192, heads: 32, index_dim: 64, seq_len_kv: 32768, kv_group: 1, clean_logits: true, dtypes: [bfloat16], label: "lightning-indexer-s8k-h32-d64"}
+  - {batch: 1, seq_len: 8192, heads: 32, index_dim: 64, seq_len_kv: 32768, kv_group: 1, clean_logits: true, dtypes: [float8_e4m3fn], label: "lightning-indexer-s8k-h32-d64"}
+  - {batch: 1, seq_len: 8192, heads: 32, index_dim: 64, seq_len_kv: 32768, kv_group: 1, clean_logits: true, dtypes: [float8_e4m3fn], index_k_scale_shape: [1, 32768, 1], label: "lightning-indexer-s8k-h32-d64-kscale"}
 
   roofline:
     func: "tileops.perf.formulas.fp8_lightning_indexer_roofline"

--- a/workloads/fp8_lightning_indexer.py
+++ b/workloads/fp8_lightning_indexer.py
@@ -161,6 +161,12 @@ class FP8LightningIndexerWorkload(WorkloadBase):
             ]
         )
         assert len(ks) == len(ke) == self.seq_len
+        if int(ks.min()) >= self.seq_len_kv:
+            raise ValueError(
+                f"no query row reaches a key: ranges start at {int(ks.min())} and "
+                f"seq_len_kv is {self.seq_len_kv}. These offsets span the "
+                f"{self.seq_len * cp_size} keys of a context-parallel sequence"
+            )
         return ks, ke
 
     def gen_inputs(


### PR DESCRIPTION
## Problems

- GDN prefill, head-major: no baseline. The `FIXME` blamed FLA's token-major input; this file's own converter already handles it and the token-major row already calls it.
- Batch-norm backward: the reference rebuilds the forward graph every call, so it timed a forward too, against an op that does the backward alone.
- Mean pooling: the reference averages one slice per chunk, a launch each — its 5x was the loop.
- Lightning indexer: rows declared `seq_len_kv == seq_len` while the key ranges span `seq_len * cp_size`, so every range started past the cache and both sides returned only -inf. The 76.9x compared two empty results.

## Changes

| op | new tag | from |
| --- | --- | --- |
| GDN prefill, head-major | `fla` | `chunk_gated_delta_rule`, inputs converted outside the timed region |
| batch-norm backward | `torch-native-batch-norm` | `aten.native_batch_norm_backward` on the saved statistics |
| mean pooling, dense rows | `torch-view-mean` | one reduction over a reshaped view |

- Lightning-indexer rows move to `seq_len_kv = 32768`; the generator now refuses ranges no query row can reach.
- The batch-norm float32 casts stay inside the timed callable: given float16 the kernel forms the channel gradients in float16 and misses tolerance.
- Neither GDN tag is asserted, as the token-major sibling documents; ragged mean-pooling rows keep the reference.

device_busy_ms on H200:

| row | was | now | what the tag shows |
| --- | --- | --- | --- |
| GDN prefill BHTD, s=131072 | no baseline | fla 14.28 vs 15.04 | the head-major path costs 3.55x its own token-major path |
| batch-norm bwd, large-spatial | torch-autograd 11.87 | aten 10.76 vs 6.03 | the gap between the torch tags is the forward autograd rebuilds |
| mean pooling, dense s=8192 | torch-ref 0.5325 | view-mean 0.0433 vs 0.1042 | one reduction beats the op by 2.4x |
| lightning indexer | 76.9x on empty output | 0.5563 vs 96.49 | 2.00 TB/s, 42% of this device, against a real reference |

The indexer's remaining 173x is not the reference's writing: any torch composition materializes the scores the op folds into its epilogue, and accumulating per head measured 97.71 ms against 95.19. It peaks near 104 GB, so a smaller device fails there rather than in the op.

`index_k_scale` stays unexercised: the manifest declares a row passing it, the workload has no code to build it, and the bench's shape dedup drops the row.

Test node delta: 0.
