### PR TITLE
[Perf][foundry][GEMM] Tune block-scaled FP8 prefill tiles

### DIFF
--- a/src/tileops/kernels/gemm/dense.py
+++ b/src/tileops/kernels/gemm/dense.py
@@ -208,6 +208,10 @@ def _gemm_fp8_kernel(
                 c_local = T.alloc_fragment((block_m, block_n), accum_dtype)
                 if block_scaled:
                     partial = T.alloc_fragment((block_m, block_n), accum_dtype)
+                    # Reuse each row/column scale across the complete output tile instead
+                    # of reloading it for every scaled partial element.
+                    scale_a_local = T.alloc_fragment((block_m,), accum_dtype)
+                    scale_b_local = T.alloc_fragment((block_n,), accum_dtype)
 
                 T.annotate_layout(
                     {
@@ -236,6 +240,18 @@ def _gemm_fp8_kernel(
                         )
                     if block_scaled:
                         scale_idx = kk * block_k // 128
+                        for i in T.Parallel(block_m):
+                            scale_a_local[i] = T.if_then_else(
+                                m_start + i < m,
+                                scale_a[m_start + i, scale_idx],
+                                0.0,
+                            )
+                        for j in T.Parallel(block_n):
+                            scale_b_local[j] = T.if_then_else(
+                                n_start + j < n,
+                                scale_b[n_start + j, scale_idx],
+                                0.0,
+                            )
                         T.clear(partial)
                         T.gemm(
                             a_shared,
@@ -246,11 +262,7 @@ def _gemm_fp8_kernel(
                         )
                         for i, j in T.Parallel(block_m, block_n):
                             if m_start + i < m and n_start + j < n:
-                                c_local[i, j] += (
-                                    partial[i, j]
-                                    * scale_a[m_start + i, scale_idx]
-                                    * scale_b[n_start + j, scale_idx]
-                                )
+                                c_local[i, j] += partial[i, j] * scale_a_local[i] * scale_b_local[j]
                     else:
                         T.gemm(
                             a_shared,
@@ -287,6 +299,10 @@ def _gemm_fp8_kernel(
                 c_local = T.alloc_fragment((block_m, block_n), accum_dtype)
                 if block_scaled:
                     partial = T.alloc_fragment((block_m, block_n), accum_dtype)
+                    # Reuse each row/column scale across the complete output tile instead
+                    # of reloading it for every scaled partial element.
+                    scale_a_local = T.alloc_fragment((block_m,), accum_dtype)
+                    scale_b_local = T.alloc_fragment((block_n,), accum_dtype)
 
                 T.annotate_layout(
                     {
@@ -315,6 +331,18 @@ def _gemm_fp8_kernel(
                         )
                     if block_scaled:
                         scale_idx = kk * block_k // 128
+                        for i in T.Parallel(block_m):
+                            scale_a_local[i] = T.if_then_else(
+                                m_start + i < m,
+                                scale_a[m_start + i, scale_idx],
+                                0.0,
+                            )
+                        for j in T.Parallel(block_n):
+                            scale_b_local[j] = T.if_then_else(
+                                n_start + j < n,
+                                scale_b[n_start + j, scale_idx],
+                                0.0,
+                            )
                         T.clear(partial)
                         T.gemm(
                             a_shared,
@@ -325,11 +353,7 @@ def _gemm_fp8_kernel(
                         )
                         for i, j in T.Parallel(block_m, block_n):
                             if m_start + i < m and n_start + j < n:
-                                c_local[i, j] += (
-                                    partial[i, j]
-                                    * scale_a[m_start + i, scale_idx]
-                                    * scale_b[n_start + j, scale_idx]
-                                )
+                                c_local[i, j] += partial[i, j] * scale_a_local[i] * scale_b_local[j]
                     else:
                         T.gemm(
                             a_shared,

--- a/src/tileops/kernels/gemm/dense.py
+++ b/src/tileops/kernels/gemm/dense.py
@@ -113,9 +113,18 @@ class GemmFp8BlockScaledKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
+        # Block scaling keeps both the unscaled WGMMA fragment and the scaled
+        # accumulator live. Narrow one output axis on the register-bound prefill
+        # shapes where the additional CTAs recover occupancy.
+        if (self.m, self.n, self.k) == (4096, 2112, 7168):
+            block_m, block_n = 128, 64
+        elif (self.m, self.n, self.k) == (4096, 4096, 7168):
+            block_m, block_n = 64, 128
+        else:
+            block_m, block_n = 128, 128
         return {
-            "block_m": 128,
-            "block_n": 128,
+            "block_m": block_m,
+            "block_n": block_n,
             "block_k": 128,
             "num_stages": 3,
             "threads": 256,

--- a/tests/ops/test_gemm.py
+++ b/tests/ops/test_gemm.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 
 from tests.test_base import FixtureBase, TestBase
+from tileops.kernels.gemm.dense import GemmFp8BlockScaledKernel
 from tileops.ops import GemmFp8FwdOp, GemmFwdOp, GemmW4A16FwdOp
 from workloads.gemm import GemmFp8Workload, GemmW4A16Workload, GemmWorkload, quantize_weight_int4
 
@@ -400,6 +401,41 @@ def test_gemm_fp8_block128_single_k_block_uses_block_kernel() -> None:
     op = GemmFp8FwdOp()
     test.check(op, *test.gen_inputs(), atol=2e-2, rtol=2e-2)
     assert op.kernel.__class__.__name__ == "GemmFp8BlockScaledKernel"
+
+
+@pytest.mark.parametrize(
+    ("shape", "expected_tile"),
+    [
+        pytest.param(
+            (4096, 2112, 7168),
+            (128, 64),
+            marks=pytest.mark.smoke,
+            id="prefill-gate-up",
+        ),
+        pytest.param(
+            (4096, 4096, 7168),
+            (64, 128),
+            marks=pytest.mark.full,
+            id="prefill-attn-proj",
+        ),
+        pytest.param(
+            (4096, 7168, 2048),
+            (128, 128),
+            marks=pytest.mark.full,
+            id="prefill-down-default",
+        ),
+    ],
+)
+def test_gemm_fp8_block128_default_config(
+    shape: tuple[int, int, int], expected_tile: tuple[int, int]
+) -> None:
+    kernel = GemmFp8BlockScaledKernel(
+        *shape,
+        dtype=torch.float8_e4m3fn,
+        out_dtype=torch.bfloat16,
+    )
+
+    assert (kernel.config["block_m"], kernel.config["block_n"]) == expected_tile
 
 
 @pytest.mark.smoke


### PR DESCRIPTION
## Summary

- Cache each block128 K-step's per-row and per-column FP32 scale vectors in fragments, so the scaled partial epilogue reuses them across the output tile instead of reloading the scale grids per output element.
- Retain the two prefill tile specializations while keeping the public `GemmFp8FwdOp`, scale-grid dispatch, fallback behavior, output semantics, manifest, workload, reference, and benchmark path unchanged.
- Correct the TileFoundry hardware model: the primary 4096x2112x7168 launch has a 32x33 = 1056 CTA grid and 256 threads/CTA. H200 has 132 SMs, which gives eight CTA waves in the model, not 132 CTAs.
- Test-node delta: +3 nodes (38 to 41), covering both specialized prefill configurations and an unchanged default-config prefill row.

## TileFoundry Description

The first module is the checked Shard Placed ownership model for the full launch. The second is the checked per-CTA/K-step storage contract matching the production data path: FP8 WGMMA operands stage from GMEM into SMEM; scale vectors and the FP32 partial/accumulator reside in RMEM.

```python
from tilefoundry import func, module
from tilefoundry.dsl import Mesh, Tensor, tf
from tilefoundry.ir.types.shard import Topology
from tilefoundry.target import CudaTarget

M, N, KB, BLOCK = 4096, 2112, 56, 128
K = KB * BLOCK
BM, BN, BK = 128, 64, 128

@module(entry="block128_gemm", target=CudaTarget("nvidia.h200_sxm"),
        topologies=(Topology("cta", 1056), Topology("thread", 256)))
class GemmFP8Block128GateUpPlaced:
    @func
    def block128_gemm(a: Tensor[(M, K), "fp8e4m3"],
                      b: Tensor[(N, K), "fp8e4m3"],
                      scale_a: Tensor[(M, KB), "f32"],
                      scale_b: Tensor[(N, KB), "f32"]) -> Tensor[(M, N), "bf16"]:
        with Mesh(("cta",), layout=(32, 33), names=("m_cta", "n_cta")) as cta:
            a_gmem = tf.reshard(a, (M @ cta.m_cta, K), "gmem")
            b_gmem = tf.reshard(b, (N @ cta.n_cta, K), "gmem")
            sa_gmem = tf.reshard(scale_a, (M @ cta.m_cta, KB), "gmem")
            sb_gmem = tf.reshard(scale_b, (N @ cta.n_cta, KB), "gmem")
            a_blocks = tf.reshape(a_gmem, new_shape=(M, KB, BLOCK))
            b_blocks = tf.reshape(b_gmem, new_shape=(N, KB, BLOCK))
            a_scaled = tf.reshape(tf.cast(a_blocks, dtype="f32") *
                                  tf.reshape(sa_gmem, new_shape=(M, KB, 1)), new_shape=(M, K))
            b_scaled = tf.reshape(tf.cast(b_blocks, dtype="f32") *
                                  tf.reshape(sb_gmem, new_shape=(N, KB, 1)), new_shape=(N, K))
            out = tf.matmul(a_scaled, tf.transpose(b_scaled, perm=(1, 0)))
            return tf.cast(tf.reshard(out, (M @ cta.m_cta, N @ cta.n_cta), "gmem"),
                           dtype="bf16")

@module(entry="block128_k_step", target=CudaTarget("nvidia.h200_sxm"),
        topologies=(Topology("cta", 1), Topology("thread", 256)))
class GemmFP8Block128KStepMemoryTiered:
    @func
    def block128_k_step(a: Tensor[(BM, BK), "fp8e4m3"],
                        b: Tensor[(BN, BK), "fp8e4m3"],
                        scale_a: Tensor[(BM,), "f32"],
                        scale_b: Tensor[(BN,), "f32"]) -> Tensor[(BM, BN), "bf16"]:
        with Mesh(("cta",), layout=(1,)):
            a_gmem = tf.reshard(a, (BM, BK), "gmem")
            b_gmem = tf.reshard(b, (BN, BK), "gmem")
            sa_gmem = tf.reshard(scale_a, (BM,), "gmem")
            sb_gmem = tf.reshard(scale_b, (BN,), "gmem")
            a_smem = tf.reshard(a_gmem, (BM, BK), "smem")
            b_smem = tf.reshard(b_gmem, (BN, BK), "smem")
            sa_rmem = tf.reshard(sa_gmem, (BM,), "rmem")
            sb_rmem = tf.reshard(sb_gmem, (BN,), "rmem")
            partial_smem = tf.matmul(tf.cast(a_smem, dtype="f32"),
                                     tf.transpose(tf.cast(b_smem, dtype="f32"), perm=(1, 0)))
            partial_rmem = tf.reshard(partial_smem, (BM, BN), "rmem")
            scaled_rmem = (partial_rmem * tf.reshape(sa_rmem, new_shape=(BM, 1)) *
                           tf.reshape(sb_rmem, new_shape=(1, BN)))
            return tf.cast(tf.reshard(scaled_rmem, (BM, BN), "gmem"), dtype="bf16")
```

Both runtime twins pass `allclose(atol=rtol=2e-2)` and `nan_inf`. The full-grid HIR analysis is compute-bound with a 1.852341 ms FP8 ideal bound and reports eight waves. The memory-tiered stage confirms the required residency transitions, but its generic FP32 semantic matmul materializes intermediates and is not a production occupancy model.

The installed TileFoundry HIR has no representable genuine SM90 FP8 WGMMA fragment contract; its HIR-to-TIR pass rejects concrete WGMMA lowering. The production TileLang kernel therefore remains the instruction-level source of truth. TileFoundry scheduling also currently rejects the true 1056-CTA grid because it compares grid extent with the 132 concurrent CTA units. Neither limitation is presented as TileFoundry selecting the production configuration.

## Performance

Operator: `GemmFp8FwdOp`

| Environment | Value |
| --- | --- |
| image | `tileops-round-gemm-fp8-block128-prefill-pr-a1d8f32e36` |
| digest | `sha256:7a6ccf00f4b4e71160cad875768889b28f942167adf19f198d5922572c741717` |
| gpu | `NVIDIA H200` |
| driver | `595.71.05` |
| cuda | `13.2` |
| torch | `2.13.0+cu132` |
| tilelang | `0.1.11+cu132.gitafcebed1` |
| FlashInfer | `0.6.16.post3; not applicable to arbitrary-FP32 block scales` |
| timer | `CUPTI device_busy_ms` |

Method: TileOPs `ManifestBenchmark.compare` with forward/reverse interleaving. The incumbent uses the original direct scale-grid loads and 128x128 tile; candidate and incumbent were measured on every primary workload.

Ratio in comparator columns: implementation / candidate. &#x1F7E2; > 1 means the candidate is faster; &#x1F534; <= 1 means it is not.

| Workload | M | N | K | Dtype | TileFoundry candidate (ms) | TileOPs incumbent (ms)<br>/ candidate | FlashInfer (ms)<br>/ candidate |
| --- | ---: | ---: | ---: | --- | ---: | ---: | ---: |
| ds-v3-decode-gate-up-block128 | 128 | 2112 | 7168 | FP8 E4M3FN -> BF16 | 0.147007 | **0.330045<br>&#x1F7E2;&nbsp;2.245101x** | N/A |
| ds-v3-decode-down-block128 | 128 | 7168 | 2048 | FP8 E4M3FN -> BF16 | 0.037504 | **0.038640<br>&#x1F7E2;&nbsp;1.030277x** | N/A |
| ds-v3-prefill-gate-up-block128 | 4096 | 2112 | 7168 | FP8 E4M3FN -> BF16 | 0.384045 | **1.339670<br>&#x1F7E2;&nbsp;3.488312x** | N/A |
| ds-v3-prefill-down-block128 | 4096 | 7168 | 2048 | FP8 E4M3FN -> BF16 | 0.445709 | **0.447277<br>&#x1F7E2;&nbsp;1.003518x** | N/A |
| ds-v3-prefill-attn-proj-block128 | 4096 | 4096 | 7168 | FP8 E4M3FN -> BF16 | 0.768347 | **0.807770<br>&#x1F7E2;&nbsp;1.051309x** | N/A |
| k-dominant-7168x16384-block128 | 4096 | 7168 | 16384 | FP8 E4M3FN -> BF16 | 3.582710 | **3.609974<br>&#x1F7E2;&nbsp;1.007610x** | N/A |
| wide-n-24576-block128 | 4096 | 24576 | 1536 | FP8 E4M3FN -> BF16 | 1.027353 | **1.036008<br>&#x1F7E2;&nbsp;1.008425x** | N/A |
| geometric mean |  |  |  |  | 0.428878 | **0.583701<br>&#x1F7E2;&nbsp;1.360995x** | N/A |

## Result And Limitations

**improvement without SOTA**

- The candidate improves every primary workload and the seven-row incumbent geometric mean by 1.360995x. It is 1.132361x faster than the same selected tiles with the previous direct scale-grid epilogue, isolating the fragment-cache body improvement.
- The largest improvements are 3.488312x on prefill gate-up and 2.245101x on decode gate-up; the remaining workloads improve from 1.003518x to 1.051309x.
- The specialization applies only to the two listed block128 prefill shapes; all other shapes retain the existing 128x128 configuration and existing dispatch/fallback behavior.
- FlashInfer is not reported as a comparator because its installed SM90 interface does not cover this Op's arbitrary-FP32-scale contract.
