### PR TITLE
[Bench][Hardware] Calibrate the compute axis, not just the memory one

### DIFF
--- a/benchmarks/hardware/README.md
+++ b/benchmarks/hardware/README.md
@@ -62,6 +62,22 @@ Method: ILP independent FMA chains per thread, swept 1/2/4/8/16; each config jud
 
 When modifying the kernel, verify it two ways: `cuobjdump -sass` must show a loop body of nothing but the instruction under test, and the runtime must scale linearly with `--iters` (a collapsed loop can still disassemble into a plausible-looking body).
 
+## Tensor-core GEMM Throughput
+
+Sustained cuBLAS GEMM rate per tensor-core dtype (fp16/bf16/tf32/fp8), calibrating `tensor_core.*` in the profile. Runs `torch.matmul` (`torch._scaled_mm` for fp8) over square sizes 4096/8192/16384.
+
+```bash
+CUDA_VISIBLE_DEVICES=<gpu> python benchmarks/hardware/compute/gemm_throughput.py --profile h200
+```
+
+| Flag        | Default | Description                                          |
+| ----------- | ------- | ---------------------------------------------------- |
+| `--profile` | `h200`  | GPU profile name (reads `tensor_core.*.theoretical`) |
+
+Method: per config, warm up until the SM clock holds steady across two consecutive 2 s windows, then take the median of 5 timed runs of ~4 s each — long runs average over the power-cap clock oscillation, which puts run-to-run spread below 1%. The telemetry GPU is resolved from the device UUID, so `CUDA_VISIBLE_DEVICES` is honored.
+
+Clock locking does not apply here: a saturating GEMM drives the board into its power cap and the cap, not the lock, sets the clock. Calibrations are therefore power-cap-limited sustained rates; the output prints the per-dtype clock range to record next to the numbers. A tf32 result at or below the non-tensor fp32 ceiling aborts the run — it means TF32 never engaged.
+
 ## Adding a new GPU profile
 
 1. Create `src/tileops/perf/profiles/<gpu>.yaml` with theoretical specs from the datasheet

--- a/benchmarks/hardware/README.md
+++ b/benchmarks/hardware/README.md
@@ -1,89 +1,30 @@
 # Hardware Microbenchmarks
 
-GPU hardware characterization benchmarks that produce calibration factors for `src/tileops/perf/profiles/`.
+Measure the calibration factors recorded in `src/tileops/perf/profiles/` (`effective = theoretical × calibration`).
 
-## Prerequisites
-
-- NVIDIA GPU with CUDA toolkit (`nvcc` in PATH)
-- TileOPs installed (`pip install -e .` from project root)
-- Root/sudo access for clock locking (recommended)
-
-## Lock GPU clocks (recommended)
-
-Boost clocks fluctuate during benchmarks; lock the SM clock for reproducible results.
+## Run
 
 ```bash
-# Pass a range, not a single value: a lone value that is not a valid clock bin
-# is accepted without effect.
+# Lock the SM clock (pass a range — a lone off-bin value is silently ignored):
 sudo nvidia-smi -i <gpu> -lgc <idle_clock>,$(nvidia-smi -i <gpu> --query-gpu=clocks.max.sm --format=csv,noheader,nounits)
-```
 
-- Memory clocks need no locking on HBM3e parts; recent drivers (595.x) reject `-lmc` outright.
-- Verify the lock took: an idle card jumps to the bottom of the range. Locking does not guarantee the top is reached — record the clock the board holds under load, not the datasheet boost.
-- Unlock after measuring: a locked card idles at the bottom of its range, and the setting is global to the GPU and outlives the process.
+python benchmarks/hardware/memory/hbm_bandwidth.py --profile <gpu> --arch <sm_XX>
+python benchmarks/hardware/compute/fma_throughput.py --profile <gpu> --arch <sm_XX>
+CUDA_VISIBLE_DEVICES=<n> python benchmarks/hardware/compute/gemm_throughput.py --profile <gpu>
 
-```bash
+# Unlock — the setting is global to the GPU and outlives the process:
 sudo nvidia-smi -i <gpu> -rgc
 ```
 
-## HBM Bandwidth
+Each script ends with the `*.calibration` lines to copy into `<gpu>.yaml`; for a new GPU, create the yaml with datasheet numbers first. `--help` lists the remaining flags. Memory clocks need no locking: HBM parts hold max, and 595.x drivers reject `-lmc`.
 
-Peak HBM bandwidth from `float4`-vectorized kernels with `cudaEvent` timing. The calibration factor comes from **STREAM Triad** (`a[i] = b[i] + s*c[i]`, 2 reads + 1 write), whose read:write ratio is closer to real compute kernels than pure copy; copy / read-only / write-only are reported as references.
+## Method
 
-```bash
-python benchmarks/hardware/memory/hbm_bandwidth.py --profile h200 --arch sm_90
-```
+| Benchmark         | Calibrates                         | Kernel                                                   | Selection                                    |
+| ----------------- | ---------------------------------- | -------------------------------------------------------- | -------------------------------------------- |
+| `hbm_bandwidth`   | `hbm`                              | STREAM Triad `a = b + s*c`, `float4`                     | best block size (128/256/512), 200 iters × 5 |
+| `fma_throughput`  | `cuda_core.fp32`                   | register-only FMA chains on the CUDA cores               | best ILP (1..16), median of 5 runs each      |
+| `gemm_throughput` | `tensor_core.{fp16,bf16,tf32,fp8}` | cuBLAS GEMM (`torch.matmul`; `torch._scaled_mm` for fp8) | best n (4096/8192/16384), median of 5 × ~4 s |
 
-| Flag        | Default | Description                                                                 |
-| ----------- | ------- | --------------------------------------------------------------------------- |
-| `--profile` | `h200`  | GPU profile name (reads theoretical peak from `src/tileops/perf/profiles/`) |
-| `--arch`    | `sm_90` | CUDA compute capability for nvcc                                            |
-| `--size-mb` | `2048`  | Working set size in MB (>> L2, so HBM is what is measured)                  |
-
-Method: warmup 100 iterations, then 200 iterations × 5 runs per block size (128/256/512); the calibration is the best Triad bandwidth. The output ends with the `hbm.calibration` line to copy into the profile.
-
-## fp32 FMA Throughput (CUDA cores)
-
-Sustained fp32 FMA issue rate of the CUDA cores — the compute axis of the roofline. Every operand stays in registers; memory is touched once per thread at the end. A MUFU rate (`rsqrt.approx.ftz.f32`) is reported as a reference.
-
-```bash
-python benchmarks/hardware/compute/fma_throughput.py --profile h200 --arch sm_90
-```
-
-| Flag                      | Default | Description                                           |
-| ------------------------- | ------- | ----------------------------------------------------- |
-| `--profile`               | `h200`  | GPU profile name (reads `cuda_core.fp32.theoretical`) |
-| `--arch`                  | `sm_90` | CUDA compute capability for nvcc                      |
-| `--iters`                 | `20000` | FMA iterations per dependency chain                   |
-| `--gpu-index`             | `0`     | Which GPU to sample clock and power telemetry from    |
-| `--allow-unlocked-clocks` | off     | Emit a calibration factor even if the SM clock moved  |
-
-Method: ILP independent FMA chains per thread, swept 1/2/4/8/16; each config judged by the median of 5 runs, the calibration by the best config. SM clock, power and temperature are sampled throughout, and the calibration line is withheld when the clock moves more than one boost bin unless `--allow-unlocked-clocks` is passed. The factor is decomposed as `lane utilisation × clock headroom`; only the first is a property of the silicon.
-
-When modifying the kernel, verify it two ways: `cuobjdump -sass` must show a loop body of nothing but the instruction under test, and the runtime must scale linearly with `--iters` (a collapsed loop can still disassemble into a plausible-looking body).
-
-## Tensor-core GEMM Throughput
-
-Sustained cuBLAS GEMM rate per tensor-core dtype (fp16/bf16/tf32/fp8), calibrating `tensor_core.*` in the profile. Runs `torch.matmul` (`torch._scaled_mm` for fp8) over square sizes 4096/8192/16384.
-
-```bash
-CUDA_VISIBLE_DEVICES=<gpu> python benchmarks/hardware/compute/gemm_throughput.py --profile h200
-```
-
-| Flag        | Default | Description                                          |
-| ----------- | ------- | ---------------------------------------------------- |
-| `--profile` | `h200`  | GPU profile name (reads `tensor_core.*.theoretical`) |
-
-Method: per config, warm up until the SM clock holds steady across two consecutive 2 s windows, then take the median of 5 timed runs of ~4 s each — long runs average over the power-cap clock oscillation, which puts run-to-run spread below 1%. The telemetry GPU is resolved from the device UUID, so `CUDA_VISIBLE_DEVICES` is honored.
-
-Clock locking does not apply here: a saturating GEMM drives the board into its power cap and the cap, not the lock, sets the clock. `calibration` is therefore the power-cap-limited sustained rate; the output prints the per-dtype clock range to record next to the numbers. A tf32 result at or below the non-tensor fp32 ceiling aborts the run — it means TF32 never engaged.
-
-Each config also reports a **burst** rate — the first ~200 ms of load after 5 s of idle, before the cap engages — recorded as `calibration_burst`. Sustained bounds long GEMM-dense phases (prefill); burst is what a short kernel between memory-bound phases can reach. `load_profile()` computes `effective` from the sustained factor only.
-
-## Adding a new GPU profile
-
-1. Create `src/tileops/perf/profiles/<gpu>.yaml` with theoretical specs from the datasheet
-1. Lock GPU clocks (see above)
-1. Run both benchmarks with `--profile <gpu> --arch <sm_XX>`
-1. Update `<gpu>.yaml` with the measured calibration factors
-1. Reset GPU clocks
+- `fma_throughput` withholds the calibration when the SM clock moved more than one boost bin (`--allow-unlocked-clocks` overrides). After editing the kernel, confirm `cuobjdump -sass` shows only the instruction under test and that runtime scales linearly with `--iters`.
+- `gemm_throughput` is power-cap limited — the cap, not the lock, sets the clock. It warms up to a steady clock, then records `calibration` (sustained; what `effective` is computed from) and `calibration_burst` (first ~200 ms of load after 5 s idle, before the cap engages). A tf32 rate at or below the non-tensor fp32 ceiling aborts the run: TF32 never engaged.

--- a/benchmarks/hardware/README.md
+++ b/benchmarks/hardware/README.md
@@ -8,98 +8,43 @@ GPU hardware characterization benchmarks that produce calibration factors for `s
 - TileOPs installed (`pip install -e .` from project root)
 - Root/sudo access for clock locking (recommended)
 
-## HBM Bandwidth
+## Lock GPU clocks (recommended)
 
-Measures peak HBM bandwidth using vectorized CUDA kernels (float4 load/store) with cudaEvent timing. The calibration factor is derived from the **STREAM Triad** kernel (`a[i] = b[i] + s*c[i]`, 2 reads + 1 write), the industry-standard pattern for roofline bandwidth calibration.
-
-Triad's 2:1 read:write ratio is closer to real compute kernels than pure copy (1:1), which suffers worst-case HBM bus turnaround overhead. Copy, read-only, and write-only results are included as reference measurements.
-
-### Lock GPU clocks (recommended)
-
-GPU boost clocks fluctuate during benchmarks. Lock memory and SM clocks to their maximum for stable, reproducible results:
+Boost clocks fluctuate during benchmarks; lock the SM clock for reproducible results.
 
 ```bash
-# Lock the SM clock to a range whose top is the card maximum (requires root/sudo).
-# Pass a range, not a single value: a lone value that is not a valid clock bin is
-# accepted without effect, and the card stays wherever it was.
+# Pass a range, not a single value: a lone value that is not a valid clock bin
+# is accepted without effect.
 sudo nvidia-smi -i <gpu> -lgc <idle_clock>,$(nvidia-smi -i <gpu> --query-gpu=clocks.max.sm --format=csv,noheader,nounits)
 ```
 
-Memory clocks need no locking on HBM3e parts — `clocks.mem` already sits at
-`clocks.max.memory` at all times. Recent drivers (595.x) reject `-lmc` outright
-and point at `--lock-memory-clocks-deferred`, which only takes effect after a GPU
-reset and is therefore useless mid-session.
-
-Verify the lock took: on an idle card `clocks.sm` should jump to the bottom of
-the range you set. Locking does not guarantee the top of the range is reached —
-an H200 holds 1830 MHz under a saturating FMA load and does not approach its
-1980 MHz boost ceiling even with power to spare. Record what it holds, not what
-the datasheet implies.
-
-Unlock when the measurement is done. A locked card idles at the bottom of its
-range: measured on an idle H200, 1830 MHz and 124 W locked against 345 MHz and
-77 W unlocked. On a shared machine the setting is global to that GPU and
-outlives the process that set it.
-
-After benchmarking, reset to default:
+- Memory clocks need no locking on HBM3e parts; recent drivers (595.x) reject `-lmc` outright.
+- Verify the lock took: an idle card jumps to the bottom of the range. Locking does not guarantee the top is reached — record the clock the board holds under load, not the datasheet boost.
+- Unlock after measuring: a locked card idles at the bottom of its range, and the setting is global to the GPU and outlives the process.
 
 ```bash
 sudo nvidia-smi -i <gpu> -rgc
 ```
 
-### Run
+## HBM Bandwidth
 
-Run from project root:
+Peak HBM bandwidth from `float4`-vectorized kernels with `cudaEvent` timing. The calibration factor comes from **STREAM Triad** (`a[i] = b[i] + s*c[i]`, 2 reads + 1 write), whose read:write ratio is closer to real compute kernels than pure copy; copy / read-only / write-only are reported as references.
 
 ```bash
 python benchmarks/hardware/memory/hbm_bandwidth.py --profile h200 --arch sm_90
 ```
 
-Options:
-
 | Flag        | Default | Description                                                                 |
 | ----------- | ------- | --------------------------------------------------------------------------- |
 | `--profile` | `h200`  | GPU profile name (reads theoretical peak from `src/tileops/perf/profiles/`) |
 | `--arch`    | `sm_90` | CUDA compute capability for nvcc                                            |
-| `--size-mb` | `2048`  | Working set size in MB                                                      |
+| `--size-mb` | `2048`  | Working set size in MB (>> L2, so HBM is what is measured)                  |
 
-### Output
-
-```
-Measured peak (triad vec4): 4070.44 GB/s
-Theoretical:               4800.0 GB/s
-Calibration:               0.8480
-
-Update src/tileops/perf/profiles/h200.yaml:
-  hbm.calibration: 0.8480
-```
-
-### Methodology
-
-- **Calibration kernel:** STREAM Triad `a[i] = b[i] + s*c[i]` (2 reads + 1 write, `float4` vectorized)
-- **Reference kernels:** Copy (1:1 read:write), Read-only, Write-only
-- **Timing:** `cudaEvent` (GPU-side, no host overhead)
-- **Warmup:** 100 iterations per config (ensures boost clocks stabilize)
-- **Measurement:** 200 iterations × 5 runs, report best and median
-- **Working set:** 2 GB default (>> L2 cache, ensures HBM is measured)
-- **Calibration source:** best Triad bandwidth across block size sweep (128/256/512)
-
-## Adding a new GPU profile
-
-1. Create `src/tileops/perf/profiles/<gpu>.yaml` with theoretical specs from the datasheet
-1. Lock GPU clocks (see above)
-1. Run `python benchmarks/hardware/memory/hbm_bandwidth.py --profile <gpu> --arch <sm_XX>`
-1. Update `<gpu>.yaml` with the measured calibration factor
-1. Reset GPU clocks
+Method: warmup 100 iterations, then 200 iterations × 5 runs per block size (128/256/512); the calibration is the best Triad bandwidth. The output ends with the `hbm.calibration` line to copy into the profile.
 
 ## fp32 FMA Throughput (CUDA cores)
 
-Measures the sustained fp32 FMA issue rate of the CUDA cores — the compute axis
-of the roofline, and the counterpart to the HBM benchmark above. Every operand
-stays in registers; memory is touched once per thread at the end. A MUFU rate
-(`rsqrt.approx.ftz.f32`) is reported alongside as a reference measurement.
-
-### Run
+Sustained fp32 FMA issue rate of the CUDA cores — the compute axis of the roofline. Every operand stays in registers; memory is touched once per thread at the end. A MUFU rate (`rsqrt.approx.ftz.f32`) is reported as a reference.
 
 ```bash
 python benchmarks/hardware/compute/fma_throughput.py --profile h200 --arch sm_90
@@ -113,29 +58,14 @@ python benchmarks/hardware/compute/fma_throughput.py --profile h200 --arch sm_90
 | `--gpu-index`             | `0`     | Which GPU to sample clock and power telemetry from    |
 | `--allow-unlocked-clocks` | off     | Emit a calibration factor even if the SM clock moved  |
 
-### Methodology
+Method: ILP independent FMA chains per thread, swept 1/2/4/8/16; each config judged by the median of 5 runs, the calibration by the best config. SM clock, power and temperature are sampled throughout, and the calibration line is withheld when the clock moves more than one boost bin unless `--allow-unlocked-clocks` is passed. The factor is decomposed as `lane utilisation × clock headroom`; only the first is a property of the silicon.
 
-- **Calibration kernel:** ILP independent FMA chains per thread, swept over ILP
-  1/2/4/8/16. One chain per thread is latency-bound; the sweep finds where the
-  rate saturates.
-- **Selection:** the *median* of five runs within a config, then the best config
-  across the sweep. Best-of-best reports a rate the hardware does not sustain.
-- **Telemetry:** SM clock, power and temperature are sampled throughout. If the
-  clock moves by more than one boost bin, no calibration factor is printed
-  unless `--allow-unlocked-clocks` is passed.
-- **Decomposition:** the factor is reported as `lane utilisation x clock headroom`. Only the first is a property of the silicon; the second is the
-  site's clock policy. On H200, lane utilisation measured 92.6% / 92.4% / 92.6%
-  across three different clock configurations.
+When modifying the kernel, verify it two ways: `cuobjdump -sass` must show a loop body of nothing but the instruction under test, and the runtime must scale linearly with `--iters` (a collapsed loop can still disassemble into a plausible-looking body).
 
-### Two checks before trusting a number from here
+## Adding a new GPU profile
 
-Both were needed to catch real defects in this benchmark:
-
-1. **Read the SASS.** `cuobjdump -sass` on the kernel must show a loop body
-   containing nothing but the instruction under test. Without `.ftz`,
-   `rcp.approx.f32` expands into a denormal guard of 2 FSEL + 2 FMUL + 2 FSETP
-   per MUFU, and a MUFU benchmark becomes a mostly-ALU one.
-1. **Multiply `--iters` by ten and confirm the time scales with it.** SASS is
-   necessary but not sufficient: a loop the compiler has collapsed can still
-   disassemble into a plausible-looking loop body. A chain of reciprocals is
-   periodic (`1/(1/x) = x`) and gets folded away; `rsqrt` has no such identity.
+1. Create `src/tileops/perf/profiles/<gpu>.yaml` with theoretical specs from the datasheet
+1. Lock GPU clocks (see above)
+1. Run both benchmarks with `--profile <gpu> --arch <sm_XX>`
+1. Update `<gpu>.yaml` with the measured calibration factors
+1. Reset GPU clocks

--- a/benchmarks/hardware/README.md
+++ b/benchmarks/hardware/README.md
@@ -76,7 +76,9 @@ CUDA_VISIBLE_DEVICES=<gpu> python benchmarks/hardware/compute/gemm_throughput.py
 
 Method: per config, warm up until the SM clock holds steady across two consecutive 2 s windows, then take the median of 5 timed runs of ~4 s each — long runs average over the power-cap clock oscillation, which puts run-to-run spread below 1%. The telemetry GPU is resolved from the device UUID, so `CUDA_VISIBLE_DEVICES` is honored.
 
-Clock locking does not apply here: a saturating GEMM drives the board into its power cap and the cap, not the lock, sets the clock. Calibrations are therefore power-cap-limited sustained rates; the output prints the per-dtype clock range to record next to the numbers. A tf32 result at or below the non-tensor fp32 ceiling aborts the run — it means TF32 never engaged.
+Clock locking does not apply here: a saturating GEMM drives the board into its power cap and the cap, not the lock, sets the clock. `calibration` is therefore the power-cap-limited sustained rate; the output prints the per-dtype clock range to record next to the numbers. A tf32 result at or below the non-tensor fp32 ceiling aborts the run — it means TF32 never engaged.
+
+Each config also reports a **burst** rate — the first ~200 ms of load after 5 s of idle, before the cap engages — recorded as `calibration_burst`. Sustained bounds long GEMM-dense phases (prefill); burst is what a short kernel between memory-bound phases can reach. `load_profile()` computes `effective` from the sustained factor only.
 
 ## Adding a new GPU profile
 

--- a/benchmarks/hardware/README.md
+++ b/benchmarks/hardware/README.md
@@ -19,16 +19,32 @@ Triad's 2:1 read:write ratio is closer to real compute kernels than pure copy (1
 GPU boost clocks fluctuate during benchmarks. Lock memory and SM clocks to their maximum for stable, reproducible results:
 
 ```bash
-# Lock clocks (requires root/sudo)
-sudo nvidia-smi -lgc $(nvidia-smi --query-gpu=clocks.max.sm --format=csv,noheader,nounits)
-sudo nvidia-smi -lmc $(nvidia-smi --query-gpu=clocks.max.mem --format=csv,noheader,nounits)
+# Lock the SM clock to a range whose top is the card maximum (requires root/sudo).
+# Pass a range, not a single value: a lone value that is not a valid clock bin is
+# accepted without effect, and the card stays wherever it was.
+sudo nvidia-smi -i <gpu> -lgc <idle_clock>,$(nvidia-smi -i <gpu> --query-gpu=clocks.max.sm --format=csv,noheader,nounits)
 ```
+
+Memory clocks need no locking on HBM3e parts — `clocks.mem` already sits at
+`clocks.max.memory` at all times. Recent drivers (595.x) reject `-lmc` outright
+and point at `--lock-memory-clocks-deferred`, which only takes effect after a GPU
+reset and is therefore useless mid-session.
+
+Verify the lock took: on an idle card `clocks.sm` should jump to the bottom of
+the range you set. Locking does not guarantee the top of the range is reached —
+an H200 holds 1830 MHz under a saturating FMA load and does not approach its
+1980 MHz boost ceiling even with power to spare. Record what it holds, not what
+the datasheet implies.
+
+Unlock when the measurement is done. A locked card idles at the bottom of its
+range: measured on an idle H200, 1830 MHz and 124 W locked against 345 MHz and
+77 W unlocked. On a shared machine the setting is global to that GPU and
+outlives the process that set it.
 
 After benchmarking, reset to default:
 
 ```bash
-sudo nvidia-smi -rgc
-sudo nvidia-smi -rmc
+sudo nvidia-smi -i <gpu> -rgc
 ```
 
 ### Run
@@ -75,3 +91,51 @@ Update src/tileops/perf/profiles/h200.yaml:
 1. Run `python benchmarks/hardware/memory/hbm_bandwidth.py --profile <gpu> --arch <sm_XX>`
 1. Update `<gpu>.yaml` with the measured calibration factor
 1. Reset GPU clocks
+
+## fp32 FMA Throughput (CUDA cores)
+
+Measures the sustained fp32 FMA issue rate of the CUDA cores — the compute axis
+of the roofline, and the counterpart to the HBM benchmark above. Every operand
+stays in registers; memory is touched once per thread at the end. A MUFU rate
+(`rsqrt.approx.ftz.f32`) is reported alongside as a reference measurement.
+
+### Run
+
+```bash
+python benchmarks/hardware/compute/fma_throughput.py --profile h200 --arch sm_90
+```
+
+| Flag                      | Default | Description                                           |
+| ------------------------- | ------- | ----------------------------------------------------- |
+| `--profile`               | `h200`  | GPU profile name (reads `cuda_core.fp32.theoretical`) |
+| `--arch`                  | `sm_90` | CUDA compute capability for nvcc                      |
+| `--iters`                 | `20000` | FMA iterations per dependency chain                   |
+| `--gpu-index`             | `0`     | Which GPU to sample clock and power telemetry from    |
+| `--allow-unlocked-clocks` | off     | Emit a calibration factor even if the SM clock moved  |
+
+### Methodology
+
+- **Calibration kernel:** ILP independent FMA chains per thread, swept over ILP
+  1/2/4/8/16. One chain per thread is latency-bound; the sweep finds where the
+  rate saturates.
+- **Selection:** the *median* of five runs within a config, then the best config
+  across the sweep. Best-of-best reports a rate the hardware does not sustain.
+- **Telemetry:** SM clock, power and temperature are sampled throughout. If the
+  clock moves by more than one boost bin, no calibration factor is printed
+  unless `--allow-unlocked-clocks` is passed.
+- **Decomposition:** the factor is reported as `lane utilisation x clock headroom`. Only the first is a property of the silicon; the second is the
+  site's clock policy. On H200, lane utilisation measured 92.6% / 92.4% / 92.6%
+  across three different clock configurations.
+
+### Two checks before trusting a number from here
+
+Both were needed to catch real defects in this benchmark:
+
+1. **Read the SASS.** `cuobjdump -sass` on the kernel must show a loop body
+   containing nothing but the instruction under test. Without `.ftz`,
+   `rcp.approx.f32` expands into a denormal guard of 2 FSEL + 2 FMUL + 2 FSETP
+   per MUFU, and a MUFU benchmark becomes a mostly-ALU one.
+1. **Multiply `--iters` by ten and confirm the time scales with it.** SASS is
+   necessary but not sufficient: a loop the compiler has collapsed can still
+   disassemble into a plausible-looking loop body. A chain of reciprocals is
+   periodic (`1/(1/x) = x`) and gets folded away; `rsqrt` has no such identity.

--- a/benchmarks/hardware/compute/__init__.py
+++ b/benchmarks/hardware/compute/__init__.py
@@ -1,0 +1,1 @@
+"""GPU compute (CUDA core / tensor core) microbenchmarks."""

--- a/benchmarks/hardware/compute/fma_saturation.cu
+++ b/benchmarks/hardware/compute/fma_saturation.cu
@@ -1,29 +1,13 @@
 // CUDA-Core Saturation Benchmark
-// Measures peak fp32 FMA throughput on the CUDA cores, plus a MUFU
-// (special-function unit) reference measurement.
+// Peak fp32 FMA throughput on the CUDA cores, plus a MUFU (special-function
+// unit) reference rate.
 //
-// The kernels hold every operand in registers and touch memory only once, at
-// the end.  What they measure is therefore the issue rate of the arithmetic
-// pipelines themselves — the ceiling a roofline puts on the compute axis [1].
-//
-// Two knobs decide whether that ceiling is reached:
-//
-//   * ILP — how many independent dependency chains each thread carries.  One
-//     chain per thread is latency-bound (an FMA cannot issue until the previous
-//     one retires), so the sweep starts at 1 and grows until the rate flattens.
-//   * Occupancy — the grid is sized to fill every SM to its 2048-thread limit.
-//
-// The measured peak lands below the datasheet number because a kernel that
-// issues an FMA every cycle draws enough power to pull the SM clock below its
-// boost ceiling.  That gap is exactly what the calibration factor records; the
-// summary prints the implied clock so the cause is visible rather than inferred.
-//
-// References:
-//   [1] Williams, S., Waterman, A. & Patterson, D., 2009. "Roofline: An
-//       Insightful Visual Performance Model for Multicore Architectures."
-//       Communications of the ACM, 52(4), pp.65-76.
-//   [2] NVIDIA CUDA C Programming Guide, "Arithmetic Instructions" —
-//       native throughput per SM per clock by compute capability.
+// Every operand stays in registers and memory is touched once at the end, so
+// the kernels measure the issue rate of the arithmetic pipelines — the compute
+// axis of the roofline (Williams et al., CACM 52(4), 2009).  ILP (independent
+// chains per thread) is swept because one chain is latency-bound and where the
+// rate saturates moves with the architecture; the grid fills every SM to its
+// 2048-thread limit.
 //
 // Compile: nvcc -O3 -arch=sm_90 -Wno-deprecated-gpu-targets -o fma_saturation fma_saturation.cu
 // Usage: ./fma_saturation [iters] [theo_peak_tflops]  (defaults: 20000, 67.0)
@@ -50,26 +34,16 @@
 // Kernels
 // ============================================================
 
-// rsqrt.approx.ftz.f32 issues on the MUFU, the same unit as ex2/lg2/rcp.  It is
-// used here instead of __expf, which carries a multiply by log2(e) that would
-// show up in the measured rate — and instead of rcp, which cannot be chained:
-// 1/(1/x) = x makes the chain periodic and the compiler collapses the loop to a
-// single iteration.  rsqrt has no such identity; the chain converges towards
-// 1.0 and stays there.
+// rsqrt.approx.ftz.f32 issues on the MUFU (same unit as ex2/lg2/rcp).  Not
+// __expf — its multiply by log2(e) would show in the rate — and not rcp, whose
+// chain is periodic (1/(1/x) = x) and gets folded to one iteration.
 //
-// Both qualifiers here are load-bearing, and both were caught by reading SASS
-// rather than by reasoning:
-//
-//   * .ftz — without it ptxas must handle denormal inputs and expands the single
-//     MUFU into a guarded sequence, measured on sm_90 at 2 FSEL + 2 FMUL +
-//     2 FSETP per MUFU.RCP.  That turns a MUFU benchmark into a mostly-ALU one.
-//   * volatile — a plain asm() is a pure expression and may be hoisted out of
-//     the loop wholesale, leaving the kernel to time at launch overhead.
-//
-// SASS is necessary but not sufficient here: `cuobjdump -sass` on k_rsqrt_fp32<8>
-// must show a run of MUFU.RSQ with no FSEL/FMUL between them, AND the measured
-// time must scale linearly when `iters` is multiplied by ten.  A collapsed loop
-// can still leave a plausible-looking loop body in the disassembly.
+// Both qualifiers are load-bearing: without .ftz ptxas guards denormals
+// (2 FSEL + 2 FMUL + 2 FSETP per MUFU on sm_90) and the benchmark turns
+// mostly-ALU; without volatile the asm() may be hoisted out of the loop.
+// Verify both ways: `cuobjdump -sass` must show bare MUFU.RSQ in the loop,
+// and the time must scale linearly with `iters` — a collapsed loop can still
+// disassemble into a plausible-looking body.
 __device__ __forceinline__ float rsqrt_approx(float x) {
     float r;
     asm volatile("rsqrt.approx.ftz.f32 %0, %1;" : "=f"(r) : "f"(x));
@@ -97,11 +71,9 @@ __global__ void k_fma_fp32(float* __restrict__ sink, int iters) {
 #pragma unroll
     for (int i = 0; i < ILP; ++i) s += acc[i];
 
-    // Unconditional store, one per thread, outside the loop.  A predicated store
-    // the compiler "cannot prove" is dead would leave the measurement resting on
-    // an optimizer accident; this leaves nothing to prove.  The cost is one STG
-    // per thread against tens of thousands of FMAs — under 0.1% of the timed
-    // region, and every config pays it identically.
+    // Unconditional store: nothing for the optimizer to prove dead.  One STG
+    // per thread against tens of thousands of FMAs, paid identically by every
+    // config.
     sink[blockIdx.x * blockDim.x + threadIdx.x] = s;
 }
 
@@ -112,12 +84,9 @@ __global__ void k_rsqrt_fp32(float* __restrict__ sink, int iters) {
 #pragma unroll
     for (int i = 0; i < ILP; ++i) acc[i] = 1.5f + 1e-3f * (float)(threadIdx.x + i);
 
-    // Unlike the FMA kernel, whose outer loop the compiler unrolls ~30x, this one
-    // stays rolled: `asm volatile` blocks the duplication, and `#pragma unroll`
-    // is ignored here.  It does not bias the measurement.  Saturating the MUFU
-    // needs one warp-wide instruction every 2 clocks (32 lanes / 16 per clock),
-    // against 4 issue slots per SM per clock, so the loop counter's IADD3/ISETP/
-    // BRA fit in the slack — and with 64 warps resident they overlap anyway.
+    // `asm volatile` keeps this outer loop rolled (the FMA one unrolls ~30x).
+    // No bias: saturating the MUFU takes one warp instruction per 2 clocks
+    // against 4 issue slots, so the loop bookkeeping fits in the slack.
     for (int it = 0; it < iters; ++it) {
 #pragma unroll
         for (int i = 0; i < ILP; ++i) acc[i] = rsqrt_approx(acc[i]);
@@ -149,9 +118,8 @@ BenchResult run_bench(std::function<void()> launch, double ops_per_launch,
     std::vector<float> latencies;
 
     for (int run = 0; run < 5; run++) {
-        // Warmup doubles as the clock-settling window: a saturating FMA loop
-        // drops the SM clock within the first few milliseconds, and measuring
-        // before it settles reports a rate no sustained kernel can hold.
+        // Warmup doubles as the clock-settling window: a saturating load drops
+        // the SM clock within the first few milliseconds.
         for (int i = 0; i < warmup; i++) launch();
         CHECK_CUDA(cudaDeviceSynchronize());
 
@@ -208,9 +176,8 @@ struct Grid {
     float* sink;
 };
 
-// A __global__ function cannot be launched through a function pointer, so the
-// ILP parameter is threaded through the host helper as a template argument
-// rather than passed as a value.
+// A __global__ function cannot be launched through a function pointer, so ILP
+// is a template argument.
 template <int ILP>
 double sweep_fma(const Grid& g, double theo_peak_tflops) {
     double fmas = g.threads * (double)ILP * (double)g.iters;
@@ -223,8 +190,7 @@ double sweep_fma(const Grid& g, double theo_peak_tflops) {
            ILP, g.block, r.best_ms, r.median_ms, r.worst_ms, r.stddev_pct,
            best_tflops, median_tflops, worst_tflops,
            median_tflops / theo_peak_tflops * 100.0);
-    // The median, not the best: one lucky run out of five is not a rate the
-    // hardware sustains, and calibration is a sustained-rate question.
+    // Median, not best: one lucky run out of five is not a sustained rate.
     return median_tflops;
 }
 
@@ -271,8 +237,7 @@ int main(int argc, char* argv[]) {
     printf("Each config: 5 runs x 50 reps, warmup 20; calibration uses the median\n");
     printf("iters=%d  theo_peak_tflops=%.1f\n\n", iters, theo_peak_tflops);
 
-    // One slot per thread: the kernels store their accumulator unconditionally,
-    // so the sink has to be wide enough for all of them.
+    // One slot per thread: every thread stores its accumulator.
     float* d_sink;
     const size_t sink_bytes = (size_t)nblocks * block * sizeof(float);
     CHECK_CUDA(cudaMalloc(&d_sink, sink_bytes));
@@ -307,9 +272,8 @@ int main(int argc, char* argv[]) {
     // ============================================================
     // Derived quantities
     // ============================================================
-    // An FMA-saturated SM issues FMA_LANES_PER_SM results per clock, so the
-    // measured rate divided by that product is the clock the GPU actually held
-    // — the difference from the boost ceiling above is the power cap at work.
+    // measured rate / (lanes * SMs) = the clock the GPU actually held; the gap
+    // to the boost ceiling is the power cap at work.
     double fma_per_s = peak_fma_tflops * 1e12 / 2.0;
     double implied_ghz = fma_per_s / ((double)FMA_LANES_PER_SM * sm_count) / 1e9;
     double mufu_ratio = (peak_mufu_gops > 0) ? fma_per_s / (peak_mufu_gops * 1e9) : 0.0;

--- a/benchmarks/hardware/compute/fma_saturation.cu
+++ b/benchmarks/hardware/compute/fma_saturation.cu
@@ -217,12 +217,17 @@ int main(int argc, char* argv[]) {
     double theo_peak_tflops = 67.0;
     if (argc >= 2) iters = atoi(argv[1]);
     if (argc >= 3) theo_peak_tflops = atof(argv[2]);
+    if (iters <= 0 || theo_peak_tflops <= 0) {
+        fprintf(stderr, "usage: %s [iters > 0] [theo_peak_tflops > 0]\n", argv[0]);
+        return 1;
+    }
 
     cudaDeviceProp prop;
     CHECK_CUDA(cudaGetDeviceProperties(&prop, 0));
     const int sm_count = prop.multiProcessorCount;
     const int block = 256;
-    const int nblocks = sm_count * (2048 / block);   // fill every SM to its thread limit
+    // Fill every SM to its thread limit (2048 on sm_90).
+    const int nblocks = sm_count * (prop.maxThreadsPerMultiProcessor / block);
     const double threads = (double)nblocks * block;
 
     // cudaDeviceProp::clockRate was removed in CUDA 13; the attribute query is
@@ -232,8 +237,8 @@ int main(int argc, char* argv[]) {
 
     printf("GPU: %s | SMs: %d | max SM clock: %.2f GHz\n",
            prop.name, sm_count, clock_khz / 1e6);
-    printf("Grid: %d blocks x %d threads = %.0f threads (2048 per SM)\n",
-           nblocks, block, threads);
+    printf("Grid: %d blocks x %d threads = %.0f threads (%d per SM)\n",
+           nblocks, block, threads, prop.maxThreadsPerMultiProcessor);
     printf("Each config: 5 runs x 50 reps, warmup 20; calibration uses the median\n");
     printf("iters=%d  theo_peak_tflops=%.1f\n\n", iters, theo_peak_tflops);
 

--- a/benchmarks/hardware/compute/fma_saturation.cu
+++ b/benchmarks/hardware/compute/fma_saturation.cu
@@ -1,0 +1,323 @@
+// CUDA-Core Saturation Benchmark
+// Measures peak fp32 FMA throughput on the CUDA cores, plus a MUFU
+// (special-function unit) reference measurement.
+//
+// The kernels hold every operand in registers and touch memory only once, at
+// the end.  What they measure is therefore the issue rate of the arithmetic
+// pipelines themselves — the ceiling a roofline puts on the compute axis [1].
+//
+// Two knobs decide whether that ceiling is reached:
+//
+//   * ILP — how many independent dependency chains each thread carries.  One
+//     chain per thread is latency-bound (an FMA cannot issue until the previous
+//     one retires), so the sweep starts at 1 and grows until the rate flattens.
+//   * Occupancy — the grid is sized to fill every SM to its 2048-thread limit.
+//
+// The measured peak lands below the datasheet number because a kernel that
+// issues an FMA every cycle draws enough power to pull the SM clock below its
+// boost ceiling.  That gap is exactly what the calibration factor records; the
+// summary prints the implied clock so the cause is visible rather than inferred.
+//
+// References:
+//   [1] Williams, S., Waterman, A. & Patterson, D., 2009. "Roofline: An
+//       Insightful Visual Performance Model for Multicore Architectures."
+//       Communications of the ACM, 52(4), pp.65-76.
+//   [2] NVIDIA CUDA C Programming Guide, "Arithmetic Instructions" —
+//       native throughput per SM per clock by compute capability.
+//
+// Compile: nvcc -O3 -arch=sm_90 -Wno-deprecated-gpu-targets -o fma_saturation fma_saturation.cu
+// Usage: ./fma_saturation [iters] [theo_peak_tflops]  (defaults: 20000, 67.0)
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <cuda_runtime.h>
+#include <algorithm>
+#include <vector>
+#include <functional>
+#include <cmath>
+
+#define CHECK_CUDA(call) do { \
+    cudaError_t err = (call); \
+    if (err != cudaSuccess) { \
+        fprintf(stderr, "CUDA error at %s:%d: %s\n", __FILE__, __LINE__, cudaGetErrorString(err)); \
+        exit(1); \
+    } \
+} while(0)
+
+#define CHECK_LAST() CHECK_CUDA(cudaGetLastError())
+
+// ============================================================
+// Kernels
+// ============================================================
+
+// rsqrt.approx.ftz.f32 issues on the MUFU, the same unit as ex2/lg2/rcp.  It is
+// used here instead of __expf, which carries a multiply by log2(e) that would
+// show up in the measured rate — and instead of rcp, which cannot be chained:
+// 1/(1/x) = x makes the chain periodic and the compiler collapses the loop to a
+// single iteration.  rsqrt has no such identity; the chain converges towards
+// 1.0 and stays there.
+//
+// Both qualifiers here are load-bearing, and both were caught by reading SASS
+// rather than by reasoning:
+//
+//   * .ftz — without it ptxas must handle denormal inputs and expands the single
+//     MUFU into a guarded sequence, measured on sm_90 at 2 FSEL + 2 FMUL +
+//     2 FSETP per MUFU.RCP.  That turns a MUFU benchmark into a mostly-ALU one.
+//   * volatile — a plain asm() is a pure expression and may be hoisted out of
+//     the loop wholesale, leaving the kernel to time at launch overhead.
+//
+// SASS is necessary but not sufficient here: `cuobjdump -sass` on k_rsqrt_fp32<8>
+// must show a run of MUFU.RSQ with no FSEL/FMUL between them, AND the measured
+// time must scale linearly when `iters` is multiplied by ten.  A collapsed loop
+// can still leave a plausible-looking loop body in the disassembly.
+__device__ __forceinline__ float rsqrt_approx(float x) {
+    float r;
+    asm volatile("rsqrt.approx.ftz.f32 %0, %1;" : "=f"(r) : "f"(x));
+    return r;
+}
+
+// Each thread runs ILP independent FMA chains.  `iters` is a runtime argument
+// so the outer loop survives constant folding; the inner loop is unrolled so
+// the ILP chains interleave in the issue window.
+template <int ILP>
+__global__ void k_fma_fp32(float* __restrict__ sink, int iters) {
+    float acc[ILP];
+#pragma unroll
+    for (int i = 0; i < ILP; ++i) acc[i] = 1.0f + 1e-3f * (float)(threadIdx.x + i);
+
+    const float m = 0.99999994f;
+    const float b = 1e-7f;
+
+    for (int it = 0; it < iters; ++it) {
+#pragma unroll
+        for (int i = 0; i < ILP; ++i) acc[i] = fmaf(acc[i], m, b);
+    }
+
+    float s = 0.0f;
+#pragma unroll
+    for (int i = 0; i < ILP; ++i) s += acc[i];
+
+    // Unconditional store, one per thread, outside the loop.  A predicated store
+    // the compiler "cannot prove" is dead would leave the measurement resting on
+    // an optimizer accident; this leaves nothing to prove.  The cost is one STG
+    // per thread against tens of thousands of FMAs — under 0.1% of the timed
+    // region, and every config pays it identically.
+    sink[blockIdx.x * blockDim.x + threadIdx.x] = s;
+}
+
+// MUFU reference, same shape as the FMA kernel.
+template <int ILP>
+__global__ void k_rsqrt_fp32(float* __restrict__ sink, int iters) {
+    float acc[ILP];
+#pragma unroll
+    for (int i = 0; i < ILP; ++i) acc[i] = 1.5f + 1e-3f * (float)(threadIdx.x + i);
+
+    // Unlike the FMA kernel, whose outer loop the compiler unrolls ~30x, this one
+    // stays rolled: `asm volatile` blocks the duplication, and `#pragma unroll`
+    // is ignored here.  It does not bias the measurement.  Saturating the MUFU
+    // needs one warp-wide instruction every 2 clocks (32 lanes / 16 per clock),
+    // against 4 issue slots per SM per clock, so the loop counter's IADD3/ISETP/
+    // BRA fit in the slack — and with 64 warps resident they overlap anyway.
+    for (int it = 0; it < iters; ++it) {
+#pragma unroll
+        for (int i = 0; i < ILP; ++i) acc[i] = rsqrt_approx(acc[i]);
+    }
+
+    float s = 0.0f;
+#pragma unroll
+    for (int i = 0; i < ILP; ++i) s += acc[i];
+
+    sink[blockIdx.x * blockDim.x + threadIdx.x] = s;
+}
+
+// ============================================================
+// Benchmark helper
+// ============================================================
+
+struct BenchResult {
+    float best_ms;
+    float median_ms;
+    float worst_ms;
+    float stddev_pct;   // run-to-run spread, relative to the mean
+    double best_ops;    // arithmetic results per second
+    double median_ops;
+    double worst_ops;
+};
+
+BenchResult run_bench(std::function<void()> launch, double ops_per_launch,
+                      int warmup = 20, int reps = 50) {
+    std::vector<float> latencies;
+
+    for (int run = 0; run < 5; run++) {
+        // Warmup doubles as the clock-settling window: a saturating FMA loop
+        // drops the SM clock within the first few milliseconds, and measuring
+        // before it settles reports a rate no sustained kernel can hold.
+        for (int i = 0; i < warmup; i++) launch();
+        CHECK_CUDA(cudaDeviceSynchronize());
+
+        cudaEvent_t t0, t1;
+        CHECK_CUDA(cudaEventCreate(&t0));
+        CHECK_CUDA(cudaEventCreate(&t1));
+        CHECK_CUDA(cudaEventRecord(t0));
+        for (int i = 0; i < reps; i++) launch();
+        CHECK_CUDA(cudaEventRecord(t1));
+        CHECK_CUDA(cudaEventSynchronize(t1));
+
+        float ms;
+        CHECK_CUDA(cudaEventElapsedTime(&ms, t0, t1));
+        latencies.push_back(ms / reps);
+
+        CHECK_CUDA(cudaEventDestroy(t0));
+        CHECK_CUDA(cudaEventDestroy(t1));
+    }
+
+    double mean = 0.0;
+    for (float v : latencies) mean += v;
+    mean /= latencies.size();
+    double var = 0.0;
+    for (float v : latencies) var += (v - mean) * (v - mean);
+    var /= latencies.size();
+    float stddev_pct = (mean > 0) ? (float)(sqrt(var) / mean * 100.0) : 0.0f;
+
+    std::sort(latencies.begin(), latencies.end());
+    float best = latencies[0];
+    float median = latencies[latencies.size() / 2];
+    float worst = latencies.back();
+
+    auto to_ops = [&](float ms) -> double {
+        return (ms > 0) ? ops_per_launch / ((double)ms * 1e-3) : 0.0;
+    };
+
+    return {best, median, worst, stddev_pct,
+            to_ops(best), to_ops(median), to_ops(worst)};
+}
+
+// ============================================================
+// Sweeps
+// ============================================================
+
+// fp32 FMA lanes per SM per clock on compute capability 9.0, from the CUDA C
+// Programming Guide's native arithmetic throughput table.
+static const int FMA_LANES_PER_SM = 128;
+
+struct Grid {
+    int nblocks;
+    int block;
+    int iters;
+    double threads;
+    float* sink;
+};
+
+// A __global__ function cannot be launched through a function pointer, so the
+// ILP parameter is threaded through the host helper as a template argument
+// rather than passed as a value.
+template <int ILP>
+double sweep_fma(const Grid& g, double theo_peak_tflops) {
+    double fmas = g.threads * (double)ILP * (double)g.iters;
+    auto launch = [&]() { k_fma_fp32<ILP><<<g.nblocks, g.block>>>(g.sink, g.iters); CHECK_LAST(); };
+    BenchResult r = run_bench(launch, fmas);
+    double best_tflops = r.best_ops * 2.0 / 1e12;
+    double median_tflops = r.median_ops * 2.0 / 1e12;
+    double worst_tflops = r.worst_ops * 2.0 / 1e12;
+    printf("fma,%d,%d,%.4f,%.4f,%.4f,%.2f,%.2f,%.2f,%.2f,TFLOP/s,%.1f%%\n",
+           ILP, g.block, r.best_ms, r.median_ms, r.worst_ms, r.stddev_pct,
+           best_tflops, median_tflops, worst_tflops,
+           median_tflops / theo_peak_tflops * 100.0);
+    // The median, not the best: one lucky run out of five is not a rate the
+    // hardware sustains, and calibration is a sustained-rate question.
+    return median_tflops;
+}
+
+template <int ILP>
+double sweep_mufu(const Grid& g) {
+    double ops = g.threads * (double)ILP * (double)g.iters;
+    auto launch = [&]() { k_rsqrt_fp32<ILP><<<g.nblocks, g.block>>>(g.sink, g.iters); CHECK_LAST(); };
+    BenchResult r = run_bench(launch, ops);
+    double best_gops = r.best_ops / 1e9;
+    double median_gops = r.median_ops / 1e9;
+    double worst_gops = r.worst_ops / 1e9;
+    printf("mufu,%d,%d,%.4f,%.4f,%.4f,%.2f,%.2f,%.2f,%.2f,Gop/s,-\n",
+           ILP, g.block, r.best_ms, r.median_ms, r.worst_ms, r.stddev_pct,
+           best_gops, median_gops, worst_gops);
+    return median_gops;
+}
+
+// ============================================================
+// Main
+// ============================================================
+
+int main(int argc, char* argv[]) {
+    int iters = 20000;
+    double theo_peak_tflops = 67.0;
+    if (argc >= 2) iters = atoi(argv[1]);
+    if (argc >= 3) theo_peak_tflops = atof(argv[2]);
+
+    cudaDeviceProp prop;
+    CHECK_CUDA(cudaGetDeviceProperties(&prop, 0));
+    const int sm_count = prop.multiProcessorCount;
+    const int block = 256;
+    const int nblocks = sm_count * (2048 / block);   // fill every SM to its thread limit
+    const double threads = (double)nblocks * block;
+
+    // cudaDeviceProp::clockRate was removed in CUDA 13; the attribute query is
+    // the portable spelling.
+    int clock_khz = 0;
+    CHECK_CUDA(cudaDeviceGetAttribute(&clock_khz, cudaDevAttrClockRate, 0));
+
+    printf("GPU: %s | SMs: %d | max SM clock: %.2f GHz\n",
+           prop.name, sm_count, clock_khz / 1e6);
+    printf("Grid: %d blocks x %d threads = %.0f threads (2048 per SM)\n",
+           nblocks, block, threads);
+    printf("Each config: 5 runs x 50 reps, warmup 20; calibration uses the median\n");
+    printf("iters=%d  theo_peak_tflops=%.1f\n\n", iters, theo_peak_tflops);
+
+    // One slot per thread: the kernels store their accumulator unconditionally,
+    // so the sink has to be wide enough for all of them.
+    float* d_sink;
+    const size_t sink_bytes = (size_t)nblocks * block * sizeof(float);
+    CHECK_CUDA(cudaMalloc(&d_sink, sink_bytes));
+    CHECK_CUDA(cudaMemset(d_sink, 0, sink_bytes));
+
+    printf("op,ilp,block_size,best_ms,median_ms,worst_ms,stddev_pct,best_rate,median_rate,worst_rate,unit,pct_of_theo\n");
+
+    // ============================================================
+    // 1. fp32 FMA — primary calibration
+    //    Rate reported in TFLOP/s, counting an FMA as 2 FLOP.
+    // ============================================================
+    printf("# fp32 FMA (CUDA core) — primary calibration\n");
+    Grid g{nblocks, block, iters, threads, d_sink};
+    double peak_fma_tflops = 0.0;   // best median across the ILP sweep
+    peak_fma_tflops = std::max(peak_fma_tflops, sweep_fma<1>(g, theo_peak_tflops));
+    peak_fma_tflops = std::max(peak_fma_tflops, sweep_fma<2>(g, theo_peak_tflops));
+    peak_fma_tflops = std::max(peak_fma_tflops, sweep_fma<4>(g, theo_peak_tflops));
+    peak_fma_tflops = std::max(peak_fma_tflops, sweep_fma<8>(g, theo_peak_tflops));
+    peak_fma_tflops = std::max(peak_fma_tflops, sweep_fma<16>(g, theo_peak_tflops));
+
+    // ============================================================
+    // 2. MUFU (rsqrt.approx.ftz.f32) — reference, not used for calibration
+    //    Rate reported in Gop/s, counting one result per instruction.
+    // ============================================================
+    printf("# MUFU rsqrt.approx.ftz.f32 (special function unit) — reference\n");
+    double peak_mufu_gops = 0.0;
+    peak_mufu_gops = std::max(peak_mufu_gops, sweep_mufu<1>(g));
+    peak_mufu_gops = std::max(peak_mufu_gops, sweep_mufu<2>(g));
+    peak_mufu_gops = std::max(peak_mufu_gops, sweep_mufu<4>(g));
+    peak_mufu_gops = std::max(peak_mufu_gops, sweep_mufu<8>(g));
+
+    // ============================================================
+    // Derived quantities
+    // ============================================================
+    // An FMA-saturated SM issues FMA_LANES_PER_SM results per clock, so the
+    // measured rate divided by that product is the clock the GPU actually held
+    // — the difference from the boost ceiling above is the power cap at work.
+    double fma_per_s = peak_fma_tflops * 1e12 / 2.0;
+    double implied_ghz = fma_per_s / ((double)FMA_LANES_PER_SM * sm_count) / 1e9;
+    double mufu_ratio = (peak_mufu_gops > 0) ? fma_per_s / (peak_mufu_gops * 1e9) : 0.0;
+
+    printf("\n# derived\n");
+    printf("implied_sm_clock_ghz,%.3f\n", implied_ghz);
+    printf("fma_to_mufu_ratio,%.2f\n", mufu_ratio);
+
+    CHECK_CUDA(cudaFree(d_sink));
+    return 0;
+}

--- a/benchmarks/hardware/compute/fma_throughput.py
+++ b/benchmarks/hardware/compute/fma_throughput.py
@@ -1,0 +1,327 @@
+"""CUDA-Core FMA Throughput Benchmark — Python wrapper for fma_saturation.cu.
+
+Compiles and runs the CUDA microbenchmark, parses output, and prints the
+calibration factor for src/tileops/perf/profiles/.
+
+Calibration is derived from the fp32 FMA kernel: ILP independent FMA chains per
+thread, every operand in registers, memory touched once at the end.  What it
+measures is the issue rate of the CUDA cores — the compute axis of the roofline:
+
+    Williams, S., Waterman, A. & Patterson, D., 2009. "Roofline: An Insightful
+    Visual Performance Model for Multicore Architectures." CACM 52(4).
+
+This is the CUDA-core counterpart of memory/hbm_bandwidth.py.  The two together
+fix both axes, and their ratio is the arithmetic intensity at which a kernel
+stops being memory-bound.
+
+Usage:
+    python benchmarks/hardware/compute/fma_throughput.py [--profile h200] [--iters 20000]
+"""
+
+import argparse
+import statistics
+import subprocess
+import sys
+import tempfile
+import threading
+from pathlib import Path
+
+from tileops.perf import load_profile
+
+_CU_SRC = Path(__file__).parent / "fma_saturation.cu"
+
+# How much the SM clock may wander across a run before the result stops being a
+# locked-clock measurement.  One boost bin on sm_90 is 15 MHz.
+_CLOCK_STEADY_MHZ = 15.0
+
+# fp32 FMA lanes per SM per clock on compute capability 9.0, from the CUDA C
+# Programming Guide's native arithmetic throughput table.
+_FMA_LANES_PER_SM = 128
+
+
+def _compile(cu_path, binary_path, arch="sm_90"):
+    """Compile the CUDA source. Raises on failure."""
+    cmd = [
+        "nvcc",
+        "-O3",
+        f"-arch={arch}",
+        "-Wno-deprecated-gpu-targets",
+        "-o",
+        str(binary_path),
+        str(cu_path),
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"nvcc compilation failed:\n{result.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+
+class _ClockSampler(threading.Thread):
+    """Sample SM clock, power and temperature while the benchmark runs.
+
+    Without locked clocks a calibration number is only meaningful alongside the
+    clocks it was taken at: a saturating FMA loop pulls the SM clock well below
+    the boost ceiling, and how far it falls depends on the power cap, the
+    ambient temperature, and whoever else is using the board.  Recording the
+    distribution turns an unreproducible number into a conditional one.
+    """
+
+    def __init__(self, gpu_index, interval_ms=200):
+        super().__init__(daemon=True)
+        self.gpu_index = gpu_index
+        self.interval_ms = interval_ms
+        self.samples = []  # (sm_mhz, watts, celsius)
+        self._stopped = threading.Event()
+
+    def run(self):
+        cmd = [
+            "nvidia-smi",
+            f"--id={self.gpu_index}",
+            "--query-gpu=clocks.sm,power.draw,temperature.gpu",
+            "--format=csv,noheader,nounits",
+            f"-lms={self.interval_ms}",
+        ]
+        try:
+            proc = subprocess.Popen(
+                cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True
+            )
+        except OSError:
+            return  # no nvidia-smi: telemetry is best-effort
+        self._proc = proc
+        for line in proc.stdout:
+            if self._stopped.is_set():
+                break
+            parts = [x.strip() for x in line.split(",")]
+            if len(parts) != 3:
+                continue
+            try:
+                self.samples.append((float(parts[0]), float(parts[1]), float(parts[2])))
+            except ValueError:
+                continue
+        proc.terminate()
+
+    def stop(self):
+        self._stopped.set()
+        proc = getattr(self, "_proc", None)
+        if proc is not None:
+            proc.terminate()
+
+    def summary(self):
+        """Return (sm_min, sm_median, sm_max, watts_max, temp_max) or None."""
+        if not self.samples:
+            return None
+        sm = sorted(s[0] for s in self.samples)
+        return (
+            sm[0],
+            statistics.median(sm),
+            sm[-1],
+            max(s[1] for s in self.samples),
+            max(s[2] for s in self.samples),
+        )
+
+
+def _run(binary_path, iters, theo_peak_tflops, gpu_index):
+    """Run the benchmark binary and return (stdout lines, clock sampler)."""
+    cmd = [str(binary_path), str(iters), str(theo_peak_tflops)]
+    sampler = _ClockSampler(gpu_index)
+    sampler.start()
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=900)
+    finally:
+        sampler.stop()
+        sampler.join(timeout=5)
+    if result.returncode != 0:
+        print(f"Benchmark failed:\n{result.stderr}", file=sys.stderr)
+        sys.exit(1)
+    return result.stdout.strip().splitlines(), sampler
+
+
+# CSV layout emitted by fma_saturation.cu
+_COL_ILP, _COL_STDDEV, _COL_MEDIAN_RATE = 1, 6, 8
+
+
+def _parse_peak(lines, op):
+    """Return (median_rate, ilp, stddev_pct) for the best config of one op.
+
+    Selection is on the *median* of five runs, not the best of them: one lucky
+    run is not a rate the hardware sustains.  The sweep over ILP is still a
+    maximum — low ILP is latency-bound, and where the rate saturates moves with
+    the architecture — but each candidate is judged by its median.
+    """
+    best = (0.0, None, None)
+    for line in lines:
+        if not line.startswith(f"{op},"):
+            continue
+        parts = line.split(",")
+        if len(parts) <= _COL_MEDIAN_RATE:
+            continue
+        try:
+            rate = float(parts[_COL_MEDIAN_RATE])
+            ilp = int(parts[_COL_ILP])
+            stddev = float(parts[_COL_STDDEV])
+        except ValueError:
+            continue
+        if rate > best[0]:
+            best = (rate, ilp, stddev)
+    return best
+
+
+def _parse_device(lines):
+    """Pull (sm_count, max_clock_ghz) out of the benchmark's banner line."""
+    for line in lines:
+        if not line.startswith("GPU:"):
+            continue
+        sm_count = max_ghz = None
+        for field in line.split("|"):
+            field = field.strip()
+            if field.startswith("SMs:"):
+                sm_count = int(field.split(":")[1])
+            elif field.startswith("max SM clock:"):
+                max_ghz = float(field.split(":")[1].strip().split()[0])
+        return sm_count, max_ghz
+    return None, None
+
+
+def _parse_derived(lines, key):
+    """Extract a `key,value` line from the '# derived' block."""
+    for line in lines:
+        if line.startswith(f"{key},"):
+            try:
+                return float(line.split(",")[1])
+            except (IndexError, ValueError):
+                return None
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="CUDA-core fp32 FMA microbenchmark")
+    parser.add_argument("--profile", default="h200", help="GPU profile name")
+    parser.add_argument("--iters", type=int, default=20000, help="FMA iterations per chain")
+    parser.add_argument("--arch", default="sm_90", help="CUDA architecture")
+    parser.add_argument("--gpu-index", type=int, default=0, help="GPU to sample telemetry from")
+    parser.add_argument(
+        "--allow-unlocked-clocks",
+        action="store_true",
+        help="Emit a calibration factor even though the SM clock moved during the run",
+    )
+    args = parser.parse_args()
+
+    profile = load_profile(args.profile)
+    cuda_core = profile.get("cuda_core", {}).get("fp32")
+    if cuda_core is None:
+        print(
+            f"Profile '{args.profile}' has no cuda_core.fp32 section. "
+            "Add it with the datasheet fp32 (non-tensor) peak before calibrating.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    theo_peak_tflops = cuda_core["theoretical"] / 1e12
+
+    print(f"Profile: {args.profile}")
+    print(f"Theoretical fp32 FMA: {theo_peak_tflops:.1f} TFLOP/s")
+    print(f"Iterations per chain: {args.iters}")
+    print()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        binary = Path(tmpdir) / "fma_saturation"
+
+        print("Compiling fma_saturation.cu ...")
+        _compile(_CU_SRC, binary, arch=args.arch)
+
+        print("Running benchmark (5 runs x 50 reps per ILP, this takes a few minutes) ...\n")
+        lines, sampler = _run(binary, args.iters, theo_peak_tflops, args.gpu_index)
+
+    # Print raw output
+    for line in lines:
+        print(line)
+
+    measured_peak, fma_ilp, fma_stddev = _parse_peak(lines, "fma")
+    mufu_peak, mufu_ilp, _ = _parse_peak(lines, "mufu")
+    implied_ghz = _parse_derived(lines, "implied_sm_clock_ghz")
+    mufu_ratio = _parse_derived(lines, "fma_to_mufu_ratio")
+    telemetry = sampler.summary()
+
+    if measured_peak <= 0 or theo_peak_tflops <= 0:
+        return
+
+    calibration = measured_peak / theo_peak_tflops
+    print(f"\n{'=' * 60}")
+    print(
+        f"Measured peak (fp32 FMA):  {measured_peak:.2f} TFLOP/s"
+        f"  (median of 5, ILP={fma_ilp}, spread {fma_stddev:.2f}%)"
+    )
+    print(f"Theoretical:               {theo_peak_tflops:.1f} TFLOP/s")
+    print(f"Calibration:               {calibration:.4f}")
+    if implied_ghz is not None:
+        print(
+            f"Implied SM clock:          {implied_ghz:.3f} GHz"
+            f"  (assumes all {_FMA_LANES_PER_SM} lanes busy)"
+        )
+    if mufu_peak > 0:
+        print(f"MUFU (rsqrt.approx.ftz):   {mufu_peak:.2f} Gop/s (ILP={mufu_ilp})", end="")
+        print(f"  [{mufu_ratio:.1f} FMA per MUFU result]" if mufu_ratio else "")
+
+    # Telemetry, and the gate that depends on it.  An unlocked clock does not
+    # invalidate the measurement, but it does make it conditional — so the
+    # calibration line is withheld until the caller either locks the clock or
+    # says, on the record, that they accept an unlocked one.
+    clocks_steady = False
+    if telemetry is None:
+        print("\nSM clock:                  not sampled (nvidia-smi unavailable)")
+    else:
+        sm_min, sm_med, sm_max, watts, temp = telemetry
+        print(
+            f"\nSM clock during run:       {sm_min:.0f} / {sm_med:.0f} / {sm_max:.0f} MHz"
+            f"  (min / median / max)"
+        )
+        print(f"Peak power, temperature:   {watts:.0f} W, {temp:.0f} C")
+        clocks_steady = (sm_max - sm_min) <= _CLOCK_STEADY_MHZ
+
+        # With the clock actually measured, the peak stops being one number and
+        # splits into two independent factors.  Conflating them is how a site's
+        # clock policy ends up recorded as if it were a property of the GPU:
+        #
+        #   ceiling at this clock = 2 * lanes * SMs * clock   (what is reachable here)
+        #   lane utilisation      = measured / that ceiling   (what the kernel achieves)
+        #   clock headroom        = this clock / max clock    (what the site gave up)
+        #
+        # calibration = lane utilisation * clock headroom, and only the first is
+        # a property of the hardware plus the kernel.
+        sm_count, max_ghz = _parse_device(lines)
+        if sm_count and sm_med > 0:
+            ceiling = 2.0 * _FMA_LANES_PER_SM * sm_count * (sm_med * 1e6) / 1e12
+            lane_util = measured_peak / ceiling
+            print(
+                f"Ceiling at {sm_med:.0f} MHz:        {ceiling:.2f} TFLOP/s"
+                f"  ({_FMA_LANES_PER_SM} lanes x {sm_count} SMs)"
+            )
+            print(f"Lane utilisation:          {lane_util * 100:.1f}%")
+            if max_ghz and sm_med * 1e6 < max_ghz * 1e9 * 0.99:
+                headroom = (sm_med * 1e6) / (max_ghz * 1e9)
+                print(
+                    f"Clock headroom:            {headroom * 100:.1f}%"
+                    f" of the {max_ghz:.2f} GHz maximum — this board is not at boost."
+                )
+                print(
+                    f"  calibration {calibration:.4f}"
+                    f" = lane utilisation {lane_util:.4f} x clock headroom {headroom:.4f}"
+                )
+
+    if clocks_steady or args.allow_unlocked_clocks:
+        if not clocks_steady:
+            print("\nWARNING: the SM clock moved during this run; the calibration below is")
+            print("         conditional on the clocks recorded above, not on locked ones.")
+        print(f"\nUpdate src/tileops/perf/profiles/{args.profile}.yaml:")
+        print(f"  cuda_core.fp32.calibration: {calibration:.4f}")
+    else:
+        print(
+            f"\nNot emitting a calibration factor: the SM clock varied by"
+            f" {telemetry[2] - telemetry[0]:.0f} MHz during the run."
+        )
+        print("Lock the clocks (see benchmarks/hardware/README.md) and re-run, or pass")
+        print("--allow-unlocked-clocks to accept a calibration taken at the clocks above.")
+    print(f"{'=' * 60}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/hardware/compute/fma_throughput.py
+++ b/benchmarks/hardware/compute/fma_throughput.py
@@ -1,18 +1,8 @@
 """CUDA-Core FMA Throughput Benchmark — Python wrapper for fma_saturation.cu.
 
-Compiles and runs the CUDA microbenchmark, parses output, and prints the
-calibration factor for src/tileops/perf/profiles/.
-
-Calibration is derived from the fp32 FMA kernel: ILP independent FMA chains per
-thread, every operand in registers, memory touched once at the end.  What it
-measures is the issue rate of the CUDA cores — the compute axis of the roofline:
-
-    Williams, S., Waterman, A. & Patterson, D., 2009. "Roofline: An Insightful
-    Visual Performance Model for Multicore Architectures." CACM 52(4).
-
-This is the CUDA-core counterpart of memory/hbm_bandwidth.py.  The two together
-fix both axes, and their ratio is the arithmetic intensity at which a kernel
-stops being memory-bound.
+Compiles and runs the CUDA microbenchmark, parses its output, and prints the
+calibration factor for src/tileops/perf/profiles/.  The CUDA-core counterpart
+of memory/hbm_bandwidth.py: the two together fix both roofline axes.
 
 Usage:
     python benchmarks/hardware/compute/fma_throughput.py [--profile h200] [--iters 20000]
@@ -30,8 +20,7 @@ from tileops.perf import load_profile
 
 _CU_SRC = Path(__file__).parent / "fma_saturation.cu"
 
-# How much the SM clock may wander across a run before the result stops being a
-# locked-clock measurement.  One boost bin on sm_90 is 15 MHz.
+# One boost bin on sm_90; more clock movement than this is not a locked-clock run.
 _CLOCK_STEADY_MHZ = 15.0
 
 # fp32 FMA lanes per SM per clock on compute capability 9.0, from the CUDA C
@@ -59,11 +48,8 @@ def _compile(cu_path, binary_path, arch="sm_90"):
 class _ClockSampler(threading.Thread):
     """Sample SM clock, power and temperature while the benchmark runs.
 
-    Without locked clocks a calibration number is only meaningful alongside the
-    clocks it was taken at: a saturating FMA loop pulls the SM clock well below
-    the boost ceiling, and how far it falls depends on the power cap, the
-    ambient temperature, and whoever else is using the board.  Recording the
-    distribution turns an unreproducible number into a conditional one.
+    A calibration is only meaningful alongside the clocks it was taken at;
+    recording them turns an unreproducible number into a conditional one.
     """
 
     def __init__(self, gpu_index, interval_ms=200):
@@ -143,10 +129,8 @@ _COL_ILP, _COL_STDDEV, _COL_MEDIAN_RATE = 1, 6, 8
 def _parse_peak(lines, op):
     """Return (median_rate, ilp, stddev_pct) for the best config of one op.
 
-    Selection is on the *median* of five runs, not the best of them: one lucky
-    run is not a rate the hardware sustains.  The sweep over ILP is still a
-    maximum — low ILP is latency-bound, and where the rate saturates moves with
-    the architecture — but each candidate is judged by its median.
+    Best config across the ILP sweep, but each config judged by its median of
+    five runs — one lucky run is not a sustained rate.
     """
     best = (0.0, None, None)
     for line in lines:
@@ -261,10 +245,8 @@ def main():
         print(f"MUFU (rsqrt.approx.ftz):   {mufu_peak:.2f} Gop/s (ILP={mufu_ilp})", end="")
         print(f"  [{mufu_ratio:.1f} FMA per MUFU result]" if mufu_ratio else "")
 
-    # Telemetry, and the gate that depends on it.  An unlocked clock does not
-    # invalidate the measurement, but it does make it conditional — so the
-    # calibration line is withheld until the caller either locks the clock or
-    # says, on the record, that they accept an unlocked one.
+    # An unlocked clock makes the calibration conditional, so the update line is
+    # withheld until the caller locks the clock or passes --allow-unlocked-clocks.
     clocks_steady = False
     if telemetry is None:
         print("\nSM clock:                  not sampled (nvidia-smi unavailable)")
@@ -277,16 +259,9 @@ def main():
         print(f"Peak power, temperature:   {watts:.0f} W, {temp:.0f} C")
         clocks_steady = (sm_max - sm_min) <= _CLOCK_STEADY_MHZ
 
-        # With the clock actually measured, the peak stops being one number and
-        # splits into two independent factors.  Conflating them is how a site's
-        # clock policy ends up recorded as if it were a property of the GPU:
-        #
-        #   ceiling at this clock = 2 * lanes * SMs * clock   (what is reachable here)
-        #   lane utilisation      = measured / that ceiling   (what the kernel achieves)
-        #   clock headroom        = this clock / max clock    (what the site gave up)
-        #
-        # calibration = lane utilisation * clock headroom, and only the first is
-        # a property of the hardware plus the kernel.
+        # calibration = lane utilisation * clock headroom:
+        #   lane utilisation = measured / (2 * lanes * SMs * clock)  — hardware + kernel
+        #   clock headroom   = held clock / max clock                — the site's policy
         sm_count, max_ghz = _parse_device(lines)
         if sm_count and sm_med > 0:
             ceiling = 2.0 * _FMA_LANES_PER_SM * sm_count * (sm_med * 1e6) / 1e12

--- a/benchmarks/hardware/compute/fma_throughput.py
+++ b/benchmarks/hardware/compute/fma_throughput.py
@@ -91,6 +91,11 @@ class _ClockSampler(threading.Thread):
         proc = getattr(self, "_proc", None)
         if proc is not None:
             proc.terminate()
+            try:
+                proc.wait(timeout=5)  # reap; terminate alone leaves a zombie
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()
 
     def summary(self):
         """Return (sm_min, sm_median, sm_max, watts_max, temp_max) or None."""
@@ -288,6 +293,10 @@ def main():
             print("         conditional on the clocks recorded above, not on locked ones.")
         print(f"\nUpdate src/tileops/perf/profiles/{args.profile}.yaml:")
         print(f"  cuda_core.fp32.calibration: {calibration:.4f}")
+    elif telemetry is None:
+        print("\nNot emitting a calibration factor: the SM clock could not be sampled,")
+        print("so a locked clock cannot be verified. Pass --allow-unlocked-clocks to")
+        print("accept a calibration taken at unknown clocks.")
     else:
         print(
             f"\nNot emitting a calibration factor: the SM clock varied by"

--- a/benchmarks/hardware/compute/gemm_throughput.py
+++ b/benchmarks/hardware/compute/gemm_throughput.py
@@ -219,8 +219,20 @@ def main():
         if section is None:
             continue
         theo_tflops = section["theoretical"] / 1e12
+
+        # Probe once: fp8 in particular needs hardware and torch support the
+        # profile alone cannot promise.
+        try:
+            probe, _ = _make_gemm(dtype_name, 256, device)
+            probe()
+            torch.cuda.synchronize()
+            del probe
+        except (RuntimeError, NotImplementedError, AttributeError) as exc:
+            print(f"{dtype_name}: skipped, not supported here ({exc})", flush=True)
+            continue
+
         best = (0.0, None, None)  # (median_tflops, n, spread)
-        configs = []  # (n, launch, flops, ms_per_launch, med, spread)
+        configs = []  # (n, flops, ms_per_launch, med, spread, settled)
         sampler = _ClockSampler(gpu_index) if gpu_index is not None else None
         if sampler:
             sampler.start()
@@ -229,9 +241,11 @@ def main():
                 launch, flops = _make_gemm(dtype_name, n, device)
                 settled = _settle(launch, sampler)
                 med, spread, ms_per_launch = _time_gemm(launch, flops)
-                configs.append((n, launch, flops, ms_per_launch, med, spread, settled))
+                configs.append((n, flops, ms_per_launch, med, spread, settled))
                 if med > best[0]:
                     best = (med, n, spread)
+                del launch
+                torch.cuda.empty_cache()
         finally:
             # Stop before the bursts: their idle gaps would drag the dtype's
             # clock summary below what the sustained measurement ran at.
@@ -240,8 +254,12 @@ def main():
                 sampler.join(timeout=5)
 
         best_burst = 0.0
-        for n, launch, flops, ms_per_launch, med, spread, settled in configs:
+        for n, flops, ms_per_launch, med, spread, settled in configs:
+            # Rebuilt per size so only one size's tensors are alive at a time.
+            launch, _ = _make_gemm(dtype_name, n, device)
             burst = _burst_gemm(launch, flops, ms_per_launch)
+            del launch
+            torch.cuda.empty_cache()
             best_burst = max(best_burst, burst)
             settled_s = f"{settled:.0f}" if settled is not None else "-"
             print(
@@ -249,14 +267,20 @@ def main():
                 f"{med / theo_tflops * 100:.1f}",
                 flush=True,
             )
-        del configs
-        torch.cuda.empty_cache()
         results[dtype_name] = (
             best,
             best_burst,
             theo_tflops,
             sampler.summary() if sampler else None,
         )
+
+    if not results:
+        print(
+            f"Profile '{args.profile}' tensor_core section has none of the dtypes"
+            " this benchmark measures (fp16/bf16/tf32/fp8).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     # A tf32 rate at or below the non-tensor fp32 ceiling means TF32 never
     # engaged and the row is IEEE fp32 GEMM against a TF32 theoretical.

--- a/benchmarks/hardware/compute/gemm_throughput.py
+++ b/benchmarks/hardware/compute/gemm_throughput.py
@@ -1,0 +1,243 @@
+"""Tensor-core GEMM throughput via cuBLAS — calibrates tensor_core.* in profiles.
+
+Times torch.matmul (cuBLAS) for fp16/bf16/tf32 and torch._scaled_mm (cuBLASLt)
+for fp8, sweeping square sizes, and prints one calibration factor per dtype for
+src/tileops/perf/profiles/.  The tensor-core counterpart of fma_throughput.py.
+
+Unlike the FMA benchmark, clock locking cannot hold here: a saturating GEMM
+drives an H200 into its power cap, so the SM clock is set by the cap, not the
+lock.  Each dtype therefore gets its own telemetry window and its calibration
+is reported next to the clocks it was taken at.
+
+Usage:
+    python benchmarks/hardware/compute/gemm_throughput.py [--profile h200]
+"""
+
+import argparse
+import statistics
+import subprocess
+import sys
+
+import torch
+from fma_throughput import _ClockSampler
+
+from tileops.perf import load_profile
+
+# Square GEMMs large enough to saturate the tensor cores; the sweep exists
+# because the cuBLAS-peak size moves with dtype and architecture.
+_SIZES = (4096, 8192, 16384)
+
+_RUNS = 5
+# Long enough to average over several power-cap clock oscillations; short runs
+# sample one slice of the cycle and spread by >10% run to run.
+_TARGET_RUN_MS = 4000.0
+
+# Warmup ends when two consecutive windows agree on the SM clock to within one
+# sm_90 boost bin (15 MHz) — a fixed duration only rides the power-cap ramp.
+_SETTLE_WINDOW_MS = 2000.0
+_SETTLE_TOL_MHZ = 15.0
+_SETTLE_CAP_MS = 30000.0
+
+
+def _telemetry_index():
+    """Map the torch device to its nvidia-smi index via the device UUID."""
+    uuid = str(torch.cuda.get_device_properties(torch.cuda.current_device()).uuid)
+    try:
+        out = subprocess.run(
+            ["nvidia-smi", "--query-gpu=index,uuid", "--format=csv,noheader"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        ).stdout
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    for line in out.splitlines():
+        index, _, smi_uuid = line.partition(",")
+        if uuid in smi_uuid:
+            return int(index)
+    return None
+
+
+def _make_gemm(dtype_name, n, device):
+    """Return (launch, flops_per_launch) for one dtype at size n."""
+    if dtype_name in ("fp16", "bf16", "tf32"):
+        dt = {"fp16": torch.float16, "bf16": torch.bfloat16, "tf32": torch.float32}[dtype_name]
+        a = torch.randn(n, n, device=device, dtype=dt)
+        b = torch.randn(n, n, device=device, dtype=dt)
+        out = torch.empty(n, n, device=device, dtype=dt)
+        return lambda: torch.matmul(a, b, out=out), 2.0 * n**3
+
+    if dtype_name == "fp8":
+        a = torch.randn(n, n, device=device).to(torch.float8_e4m3fn)
+        # cuBLASLt wants the second operand column-major.
+        b = torch.randn(n, n, device=device).to(torch.float8_e4m3fn).t().contiguous().t()
+        scale = torch.ones((), device=device)
+        out = torch.empty(n, n, device=device, dtype=torch.bfloat16)
+        return (
+            lambda: torch._scaled_mm(
+                a, b, scale_a=scale, scale_b=scale, out_dtype=torch.bfloat16, out=out
+            ),
+            2.0 * n**3,
+        )
+
+    raise ValueError(f"unknown dtype {dtype_name}")
+
+
+def _settle(launch, sampler):
+    """Run under load until the SM clock holds steady; return the settled MHz.
+
+    The clocks come from *sampler*, whose thread reads nvidia-smi while the
+    launch loop keeps the GPU busy — a one-shot read here would see the clock
+    after the queue drained, not the clock under load.
+    """
+    start, end = torch.cuda.Event(enable_timing=True), torch.cuda.Event(enable_timing=True)
+    start.record()
+    elapsed, window_start, prev_mhz, mhz = 0.0, 0.0, None, None
+    mark = len(sampler.samples) if sampler else 0
+    while elapsed < _SETTLE_CAP_MS:
+        for _ in range(5):
+            launch()
+        end.record()
+        end.synchronize()
+        elapsed = start.elapsed_time(end)
+        if elapsed - window_start < _SETTLE_WINDOW_MS:
+            continue
+        window_start = elapsed
+        if sampler is None:
+            if elapsed >= 5000.0:  # no telemetry: fall back to a fixed warmup
+                return None
+            continue
+        window = [s[0] for s in sampler.samples[mark:]]
+        mark = len(sampler.samples)
+        if not window:
+            continue
+        mhz = statistics.median(window)
+        if prev_mhz is not None and abs(mhz - prev_mhz) <= _SETTLE_TOL_MHZ:
+            return mhz
+        prev_mhz = mhz
+    return mhz
+
+
+def _time_gemm(launch, flops):
+    """Median TFLOP/s over _RUNS timed runs, plus the run-to-run spread."""
+    start, end = torch.cuda.Event(enable_timing=True), torch.cuda.Event(enable_timing=True)
+
+    start.record()
+    for _ in range(3):
+        launch()
+    end.record()
+    end.synchronize()
+    reps = max(1, int(_TARGET_RUN_MS / max(start.elapsed_time(end) / 3, 1e-3)))
+
+    ms_per_launch = []
+    for _ in range(_RUNS):
+        start.record()
+        for _ in range(reps):
+            launch()
+        end.record()
+        end.synchronize()
+        ms_per_launch.append(start.elapsed_time(end) / reps)
+
+    tflops = sorted(flops / (ms * 1e-3) / 1e12 for ms in ms_per_launch)
+    spread = (tflops[-1] - tflops[0]) / tflops[len(tflops) // 2] * 100.0
+    return tflops[len(tflops) // 2], spread
+
+
+def _enable_tf32():
+    if hasattr(torch.backends.cuda.matmul, "fp32_precision"):
+        torch.backends.cuda.matmul.fp32_precision = "tf32"
+    else:
+        torch.backends.cuda.matmul.allow_tf32 = True
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Tensor-core GEMM throughput via cuBLAS")
+    parser.add_argument("--profile", default="h200", help="GPU profile name")
+    args = parser.parse_args()
+
+    profile = load_profile(args.profile)
+    tensor_core = profile.get("tensor_core", {})
+    if not tensor_core:
+        print(f"Profile '{args.profile}' has no tensor_core section.", file=sys.stderr)
+        sys.exit(1)
+    fp32_ceiling_tflops = profile.get("cuda_core", {}).get("fp32", {}).get("theoretical", 0) / 1e12
+    if "tf32" in tensor_core and not fp32_ceiling_tflops:
+        print(
+            f"Profile '{args.profile}' has tensor_core.tf32 but no cuda_core.fp32.theoretical;"
+            " the tf32 guard needs that ceiling. Add it before calibrating.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    _enable_tf32()
+    device = torch.device("cuda")
+    gpu_index = _telemetry_index()
+    print(
+        f"Profile: {args.profile} | GPU: {torch.cuda.get_device_name(device)} (smi index {gpu_index})"
+    )
+    print(f"torch {torch.__version__}, CUDA {torch.version.cuda}")
+    print(f"Each config: settle to steady clock, then {_RUNS} runs; calibration uses the median\n")
+    print("dtype,n,median_tflops,spread_pct,settled_mhz,pct_of_theo")
+
+    results = {}
+    for dtype_name in ("fp16", "bf16", "tf32", "fp8"):
+        section = tensor_core.get(dtype_name)
+        if section is None:
+            continue
+        theo_tflops = section["theoretical"] / 1e12
+        best = (0.0, None, None)  # (median_tflops, n, spread)
+        sampler = _ClockSampler(gpu_index) if gpu_index is not None else None
+        if sampler:
+            sampler.start()
+        try:
+            for n in _SIZES:
+                launch, flops = _make_gemm(dtype_name, n, device)
+                settled = _settle(launch, sampler)
+                med, spread = _time_gemm(launch, flops)
+                settled_s = f"{settled:.0f}" if settled is not None else "-"
+                print(
+                    f"{dtype_name},{n},{med:.1f},{spread:.2f},{settled_s},"
+                    f"{med / theo_tflops * 100:.1f}",
+                    flush=True,
+                )
+                if med > best[0]:
+                    best = (med, n, spread)
+                del launch
+                torch.cuda.empty_cache()
+        finally:
+            if sampler:
+                sampler.stop()
+                sampler.join(timeout=5)
+        results[dtype_name] = (best, theo_tflops, sampler.summary() if sampler else None)
+
+    # A tf32 rate at or below the non-tensor fp32 ceiling means TF32 never
+    # engaged and the row is IEEE fp32 GEMM against a TF32 theoretical.
+    if "tf32" in results and results["tf32"][0][0] <= fp32_ceiling_tflops:
+        print(
+            f"\nERROR: tf32 measured {results['tf32'][0][0]:.1f} TFLOP/s, at or below the"
+            f" {fp32_ceiling_tflops:.1f} TFLOP/s non-tensor fp32 ceiling — TF32 is not"
+            " enabled; not emitting calibrations.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    print(f"\n{'=' * 60}")
+    for dtype_name, ((med, n, spread), theo, telemetry) in results.items():
+        clocks = ""
+        if telemetry:
+            sm_min, sm_med, sm_max, watts, _ = telemetry
+            clocks = f"  clock {sm_min:.0f}/{sm_med:.0f}/{sm_max:.0f} MHz, {watts:.0f} W peak"
+        print(
+            f"{dtype_name}: {med:8.1f} TFLOP/s at n={n} (spread {spread:.2f}%)"
+            f"  calibration {med / theo:.4f}{clocks}"
+        )
+
+    print(f"\nUpdate src/tileops/perf/profiles/{args.profile}.yaml:")
+    for dtype_name, ((med, _, _), theo, _) in results.items():
+        print(f"  tensor_core.{dtype_name}.calibration: {med / theo:.4f}")
+    print("These rates are power-cap limited; record the clocks above with the numbers.")
+    print(f"{'=' * 60}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/hardware/compute/gemm_throughput.py
+++ b/benchmarks/hardware/compute/gemm_throughput.py
@@ -1,13 +1,14 @@
 """Tensor-core GEMM throughput via cuBLAS — calibrates tensor_core.* in profiles.
 
 Times torch.matmul (cuBLAS) for fp16/bf16/tf32 and torch._scaled_mm (cuBLASLt)
-for fp8, sweeping square sizes, and prints one calibration factor per dtype for
-src/tileops/perf/profiles/.  The tensor-core counterpart of fma_throughput.py.
+for fp8, sweeping square sizes, and prints two factors per dtype for
+src/tileops/perf/profiles/: `calibration` (sustained) and `calibration_burst`.
+The tensor-core counterpart of fma_throughput.py.
 
 Unlike the FMA benchmark, clock locking cannot hold here: a saturating GEMM
 drives an H200 into its power cap, so the SM clock is set by the cap, not the
-lock.  Each dtype therefore gets its own telemetry window and its calibration
-is reported next to the clocks it was taken at.
+lock.  Each dtype gets its own telemetry window, and the sustained factor is
+reported next to the clocks it was taken at; burst is the pre-cap rate.
 
 Usage:
     python benchmarks/hardware/compute/gemm_throughput.py [--profile h200]
@@ -17,6 +18,7 @@ import argparse
 import statistics
 import subprocess
 import sys
+import time
 
 import torch
 from fma_throughput import _ClockSampler
@@ -31,6 +33,15 @@ _RUNS = 5
 # Long enough to average over several power-cap clock oscillations; short runs
 # sample one slice of the cycle and spread by >10% run to run.
 _TARGET_RUN_MS = 4000.0
+
+# Burst: rate over the first short slice of load after _COOLDOWN_S of idle,
+# before the power cap engages.  Reps are sized from the sustained per-launch
+# time, so at burst clocks the timed slice is somewhat shorter than the
+# nominal window.  The idle is under the board's clock policy as-is; no
+# power or temperature floor is verified.
+_BURST_WINDOW_MS = 200.0
+_BURST_ATTEMPTS = 3
+_COOLDOWN_S = 5.0
 
 # Warmup ends when two consecutive windows agree on the SM clock to within one
 # sm_90 boost bin (15 MHz) — a fixed duration only rides the power-cap ramp.
@@ -140,7 +151,30 @@ def _time_gemm(launch, flops):
 
     tflops = sorted(flops / (ms * 1e-3) / 1e12 for ms in ms_per_launch)
     spread = (tflops[-1] - tflops[0]) / tflops[len(tflops) // 2] * 100.0
-    return tflops[len(tflops) // 2], spread
+    return tflops[len(tflops) // 2], spread, statistics.median(ms_per_launch)
+
+
+def _burst_gemm(launch, flops, ms_per_launch):
+    """Median burst TFLOP/s: a short window timed from a cooled-down clock.
+
+    Sustained rates sit at the power-cap clock; a kernel that starts with power
+    headroom (after idle, or between memory-bound phases) runs at boost clocks
+    until the cap engages.  Each attempt drains the queue, idles the board, and
+    times only the first _BURST_WINDOW_MS of load.
+    """
+    start, end = torch.cuda.Event(enable_timing=True), torch.cuda.Event(enable_timing=True)
+    reps = max(1, int(_BURST_WINDOW_MS / max(ms_per_launch, 1e-3)))
+    rates = []
+    for _ in range(_BURST_ATTEMPTS):
+        torch.cuda.synchronize()
+        time.sleep(_COOLDOWN_S)
+        start.record()
+        for _ in range(reps):
+            launch()
+        end.record()
+        end.synchronize()
+        rates.append(flops * reps / (start.elapsed_time(end) * 1e-3) / 1e12)
+    return statistics.median(rates)
 
 
 def _enable_tf32():
@@ -177,7 +211,7 @@ def main():
     )
     print(f"torch {torch.__version__}, CUDA {torch.version.cuda}")
     print(f"Each config: settle to steady clock, then {_RUNS} runs; calibration uses the median\n")
-    print("dtype,n,median_tflops,spread_pct,settled_mhz,pct_of_theo")
+    print("dtype,n,median_tflops,spread_pct,burst_tflops,settled_mhz,pct_of_theo")
 
     results = {}
     for dtype_name in ("fp16", "bf16", "tf32", "fp8"):
@@ -186,6 +220,7 @@ def main():
             continue
         theo_tflops = section["theoretical"] / 1e12
         best = (0.0, None, None)  # (median_tflops, n, spread)
+        configs = []  # (n, launch, flops, ms_per_launch, med, spread)
         sampler = _ClockSampler(gpu_index) if gpu_index is not None else None
         if sampler:
             sampler.start()
@@ -193,22 +228,35 @@ def main():
             for n in _SIZES:
                 launch, flops = _make_gemm(dtype_name, n, device)
                 settled = _settle(launch, sampler)
-                med, spread = _time_gemm(launch, flops)
-                settled_s = f"{settled:.0f}" if settled is not None else "-"
-                print(
-                    f"{dtype_name},{n},{med:.1f},{spread:.2f},{settled_s},"
-                    f"{med / theo_tflops * 100:.1f}",
-                    flush=True,
-                )
+                med, spread, ms_per_launch = _time_gemm(launch, flops)
+                configs.append((n, launch, flops, ms_per_launch, med, spread, settled))
                 if med > best[0]:
                     best = (med, n, spread)
-                del launch
-                torch.cuda.empty_cache()
         finally:
+            # Stop before the bursts: their idle gaps would drag the dtype's
+            # clock summary below what the sustained measurement ran at.
             if sampler:
                 sampler.stop()
                 sampler.join(timeout=5)
-        results[dtype_name] = (best, theo_tflops, sampler.summary() if sampler else None)
+
+        best_burst = 0.0
+        for n, launch, flops, ms_per_launch, med, spread, settled in configs:
+            burst = _burst_gemm(launch, flops, ms_per_launch)
+            best_burst = max(best_burst, burst)
+            settled_s = f"{settled:.0f}" if settled is not None else "-"
+            print(
+                f"{dtype_name},{n},{med:.1f},{spread:.2f},{burst:.1f},{settled_s},"
+                f"{med / theo_tflops * 100:.1f}",
+                flush=True,
+            )
+        del configs
+        torch.cuda.empty_cache()
+        results[dtype_name] = (
+            best,
+            best_burst,
+            theo_tflops,
+            sampler.summary() if sampler else None,
+        )
 
     # A tf32 rate at or below the non-tensor fp32 ceiling means TF32 never
     # engaged and the row is IEEE fp32 GEMM against a TF32 theoretical.
@@ -222,20 +270,21 @@ def main():
         sys.exit(1)
 
     print(f"\n{'=' * 60}")
-    for dtype_name, ((med, n, spread), theo, telemetry) in results.items():
+    for dtype_name, ((med, n, spread), burst, _theo, telemetry) in results.items():
         clocks = ""
         if telemetry:
             sm_min, sm_med, sm_max, watts, _ = telemetry
             clocks = f"  clock {sm_min:.0f}/{sm_med:.0f}/{sm_max:.0f} MHz, {watts:.0f} W peak"
         print(
-            f"{dtype_name}: {med:8.1f} TFLOP/s at n={n} (spread {spread:.2f}%)"
-            f"  calibration {med / theo:.4f}{clocks}"
+            f"{dtype_name}: {med:8.1f} TFLOP/s sustained at n={n} (spread {spread:.2f}%),"
+            f" {burst:8.1f} burst{clocks}"
         )
 
     print(f"\nUpdate src/tileops/perf/profiles/{args.profile}.yaml:")
-    for dtype_name, ((med, _, _), theo, _) in results.items():
+    for dtype_name, ((med, _, _), burst, theo, _) in results.items():
         print(f"  tensor_core.{dtype_name}.calibration: {med / theo:.4f}")
-    print("These rates are power-cap limited; record the clocks above with the numbers.")
+        print(f"  tensor_core.{dtype_name}.calibration_burst: {burst / theo:.4f}")
+    print("Sustained rates are power-cap limited; record the clocks above with the numbers.")
     print(f"{'=' * 60}")
 
 

--- a/src/tileops/manifest/__init__.py
+++ b/src/tileops/manifest/__init__.py
@@ -101,7 +101,7 @@ WORKLOAD_RESERVED_KEYS: frozenset[str] = frozenset({"dtypes", "label"})
 def single_input_workload_contract(
     signature: dict[str, Any],
 ) -> tuple[str, frozenset[str]] | None:
-    """Return $[shape\_key \\times allowed\_workload\_keys]$ for a signature with
+    r"""Return $[shape\_key \times allowed\_workload\_keys]$ for a signature with
     exactly one tensor input; ``None`` for any other input arity.
 
     The shape key is ``{input}_shape``; allowed keys are the shape key,

--- a/src/tileops/perf/profile.py
+++ b/src/tileops/perf/profile.py
@@ -56,14 +56,15 @@ def _coerce_numeric_strings(obj, key=None):
 
 
 def _inject_effective(profile):
-    """Compute effective = theoretical * calibration for hbm and tensor_core."""
+    """Compute effective = theoretical * calibration for hbm and the compute sections."""
     hbm = profile.get("hbm")
     if hbm and "effective" not in hbm:
         hbm["effective"] = hbm["theoretical"] * hbm["calibration"]
 
-    for section in profile.get("tensor_core", {}).values():
-        if isinstance(section, dict) and "effective" not in section:
-            section["effective"] = section["theoretical"] * section["calibration"]
+    for group in ("tensor_core", "cuda_core"):
+        for section in profile.get(group, {}).values():
+            if isinstance(section, dict) and "effective" not in section:
+                section["effective"] = section["theoretical"] * section["calibration"]
 
 
 def load_profile(gpu_name: str) -> dict:

--- a/src/tileops/perf/profile.py
+++ b/src/tileops/perf/profile.py
@@ -56,15 +56,17 @@ def _coerce_numeric_strings(obj, key=None):
 
 
 def _inject_effective(profile):
-    """Compute effective = theoretical * calibration for hbm and the compute sections."""
-    hbm = profile.get("hbm")
-    if hbm and "effective" not in hbm:
-        hbm["effective"] = hbm["theoretical"] * hbm["calibration"]
+    """Compute effective = theoretical * calibration for hbm and the compute sections.
 
+    A section with only ``theoretical`` is left alone: profiles are created from
+    datasheet numbers first and calibrated by benchmarks/hardware/ afterwards.
+    """
+    sections = [profile.get("hbm")]
     for group in ("tensor_core", "cuda_core"):
-        for section in profile.get(group, {}).values():
-            if isinstance(section, dict) and "effective" not in section:
-                section["effective"] = section["theoretical"] * section["calibration"]
+        sections.extend(profile.get(group, {}).values())
+    for section in sections:
+        if isinstance(section, dict) and "effective" not in section and "calibration" in section:
+            section["effective"] = section["theoretical"] * section["calibration"]
 
 
 def load_profile(gpu_name: str) -> dict:

--- a/src/tileops/perf/profile.py
+++ b/src/tileops/perf/profile.py
@@ -15,7 +15,7 @@ _PROFILES_DIR = Path(__file__).parent / "profiles"
 
 # Keys whose values are numeric but arrive as strings from PyYAML
 # (scientific notation like 4800e9 is not YAML-native float syntax).
-_NUMERIC_KEYS = frozenset({"theoretical", "calibration", "effective"})
+_NUMERIC_KEYS = frozenset({"theoretical", "calibration", "calibration_burst", "effective"})
 
 
 def get_profile_path(gpu_name: str) -> Path:

--- a/src/tileops/perf/profiles/h200.yaml
+++ b/src/tileops/perf/profiles/h200.yaml
@@ -15,13 +15,9 @@ hbm:
 cuda_core:
   fp32:
     theoretical: 67.0e12     # FLOPS, spec sheet (non-tensor FMA, 2 FLOP per FMA, 1.98 GHz boost)
-    # FMA saturation, from benchmarks/hardware/compute/fma_throughput.py.
-    # Taken with clocks locked (nvidia-smi -lgc 1830,1980); the board holds
-    # 1830 MHz under a saturating FMA load and does not reach the 1.98 GHz the
-    # datasheet figure assumes, at 339 W against a 700 W cap.  The factor splits
-    # into 0.9261 lane utilisation x 0.9242 clock, and only the first is a
-    # property of the silicon: lane utilisation measured 0.926 / 0.924 / 0.926
-    # across 1500 MHz unlocked, 1830 MHz unlocked, and 1830 MHz locked.
+    # From benchmarks/hardware/compute/fma_throughput.py, clocks locked
+    # (-lgc 1830,1980; the board holds 1830 MHz under saturating FMA).
+    # Splits into 0.9261 lane utilisation x 0.9242 clock headroom.
     calibration: 0.8548
 
 tensor_core:

--- a/src/tileops/perf/profiles/h200.yaml
+++ b/src/tileops/perf/profiles/h200.yaml
@@ -2,7 +2,7 @@
 # Source: NVIDIA H200 datasheet (dense, no sparsity)
 # Calibration: benchmarks/hardware/ microbenchmarks
 #
-# Only store theoretical + calibration here.
+# Only store measured values here (theoretical, calibration, calibration_burst).
 # effective = theoretical × calibration is computed by load_profile().
 
 gpu: NVIDIA H200
@@ -21,18 +21,27 @@ cuda_core:
     calibration: 0.8548
 
 # From benchmarks/hardware/compute/gemm_throughput.py (cuBLAS peak, best of
-# n=4096/8192/16384 square). Power-cap limited: the GEMMs hold the 700 W cap
-# and the SM clock sits near 1.2-1.4 GHz, so locking cannot pin the clock here.
+# n=4096/8192/16384 square). Two regimes per dtype:
+#   calibration       — sustained: the GEMMs hold the 700 W cap and the SM
+#                       clock sits near 1.2-1.4 GHz; locking cannot pin it.
+#                       This is what load_profile() turns into `effective`.
+#   calibration_burst — first 200 ms from a cooled-down clock, before the cap
+#                       engages; what a short kernel between memory-bound
+#                       phases can reach.
 tensor_core:
   fp16:
     theoretical: 989.5e12    # FLOPS, spec sheet (dense)
-    calibration: 0.6742
+    calibration: 0.6677
+    calibration_burst: 0.7379
   bf16:
     theoretical: 989.5e12
-    calibration: 0.6996
+    calibration: 0.7078
+    calibration_burst: 0.7663
   tf32:
     theoretical: 494.7e12
-    calibration: 0.7293
+    calibration: 0.7242
+    calibration_burst: 0.7873
   fp8:
     theoretical: 1979.0e12
-    calibration: 0.6295
+    calibration: 0.6302
+    calibration_burst: 0.6962

--- a/src/tileops/perf/profiles/h200.yaml
+++ b/src/tileops/perf/profiles/h200.yaml
@@ -20,16 +20,19 @@ cuda_core:
     # Splits into 0.9261 lane utilisation x 0.9242 clock headroom.
     calibration: 0.8548
 
+# From benchmarks/hardware/compute/gemm_throughput.py (cuBLAS peak, best of
+# n=4096/8192/16384 square). Power-cap limited: the GEMMs hold the 700 W cap
+# and the SM clock sits near 1.2-1.4 GHz, so locking cannot pin the clock here.
 tensor_core:
   fp16:
     theoretical: 989.5e12    # FLOPS, spec sheet (dense)
-    calibration: 0.75        # from benchmarks/hardware/compute/gemm_throughput.py (cuBLAS peak)
+    calibration: 0.6742
   bf16:
     theoretical: 989.5e12
-    calibration: 0.75
+    calibration: 0.6996
   tf32:
     theoretical: 494.7e12
-    calibration: 0.75        # placeholder — not yet measured
+    calibration: 0.7293
   fp8:
     theoretical: 1979.0e12
-    calibration: 0.75        # placeholder — not yet measured
+    calibration: 0.6295

--- a/src/tileops/perf/profiles/h200.yaml
+++ b/src/tileops/perf/profiles/h200.yaml
@@ -12,6 +12,18 @@ hbm:
   theoretical: 4800e9        # bytes/s, spec sheet
   calibration: 0.848         # STREAM Triad, from benchmarks/hardware/memory/hbm_bandwidth.py
 
+cuda_core:
+  fp32:
+    theoretical: 67.0e12     # FLOPS, spec sheet (non-tensor FMA, 2 FLOP per FMA, 1.98 GHz boost)
+    # FMA saturation, from benchmarks/hardware/compute/fma_throughput.py.
+    # Taken with clocks locked (nvidia-smi -lgc 1830,1980); the board holds
+    # 1830 MHz under a saturating FMA load and does not reach the 1.98 GHz the
+    # datasheet figure assumes, at 339 W against a 700 W cap.  The factor splits
+    # into 0.9261 lane utilisation x 0.9242 clock, and only the first is a
+    # property of the silicon: lane utilisation measured 0.926 / 0.924 / 0.926
+    # across 1500 MHz unlocked, 1830 MHz unlocked, and 1830 MHz locked.
+    calibration: 0.8548
+
 tensor_core:
   fp16:
     theoretical: 989.5e12    # FLOPS, spec sheet (dense)

--- a/src/tileops/perf/profiles/h200.yaml
+++ b/src/tileops/perf/profiles/h200.yaml
@@ -20,14 +20,10 @@ cuda_core:
     # Splits into 0.9261 lane utilisation x 0.9242 clock headroom.
     calibration: 0.8548
 
-# From benchmarks/hardware/compute/gemm_throughput.py (cuBLAS peak, best of
-# n=4096/8192/16384 square). Two regimes per dtype:
-#   calibration       — sustained: the GEMMs hold the 700 W cap and the SM
-#                       clock sits near 1.2-1.4 GHz; locking cannot pin it.
-#                       This is what load_profile() turns into `effective`.
-#   calibration_burst — first 200 ms from a cooled-down clock, before the cap
-#                       engages; what a short kernel between memory-bound
-#                       phases can reach.
+# From benchmarks/hardware/compute/gemm_throughput.py (cuBLAS peak).
+# calibration is sustained — the GEMMs hold the 700 W cap at ~1.2-1.4 GHz —
+# and feeds `effective`; calibration_burst is the pre-cap rate a short
+# kernel between memory-bound phases can reach.
 tensor_core:
   fp16:
     theoretical: 989.5e12    # FLOPS, spec sheet (dense)

--- a/src/tileops/perf/profiles/h200.yaml
+++ b/src/tileops/perf/profiles/h200.yaml
@@ -20,24 +20,25 @@ cuda_core:
     # Splits into 0.9261 lane utilisation x 0.9242 clock headroom.
     calibration: 0.8548
 
-# From benchmarks/hardware/compute/gemm_throughput.py (cuBLAS peak).
+# From benchmarks/hardware/compute/gemm_throughput.py (cuBLAS peak); each
+# value is the median across repeated runs on one board (run band <= 1.5%).
 # calibration is sustained — the GEMMs hold the 700 W cap at ~1.2-1.4 GHz —
 # and feeds `effective`; calibration_burst is the pre-cap rate a short
 # kernel between memory-bound phases can reach.
 tensor_core:
   fp16:
     theoretical: 989.5e12    # FLOPS, spec sheet (dense)
-    calibration: 0.6677
-    calibration_burst: 0.7379
+    calibration: 0.6684
+    calibration_burst: 0.7370
   bf16:
     theoretical: 989.5e12
-    calibration: 0.7078
-    calibration_burst: 0.7663
+    calibration: 0.7077
+    calibration_burst: 0.7680
   tf32:
     theoretical: 494.7e12
-    calibration: 0.7242
-    calibration_burst: 0.7873
+    calibration: 0.7249
+    calibration_burst: 0.7899
   fp8:
     theoretical: 1979.0e12
-    calibration: 0.6302
-    calibration_burst: 0.6962
+    calibration: 0.6303
+    calibration_burst: 0.6977

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -2874,10 +2874,11 @@ class TestResolveOpClass:
 
     def test_single_class_file_rejects_mismatched_name(self, validator):
         """Single-class files reject mismatched manifest keys — no bypass."""
-        result = validator._resolve_op_class(
-            "tileops/ops/reduction/softmax.py",
-            "SoftmaxBwdOp",
-        )
+        with pytest.warns(UserWarning, match="No class named 'SoftmaxBwdOp'"):
+            result = validator._resolve_op_class(
+                "tileops/ops/reduction/softmax.py",
+                "SoftmaxBwdOp",
+            )
         assert result.cls is None
         assert result.warning is not None
 


### PR DESCRIPTION
## Problems

- Only the bandwidth axis is calibrated: `h200.yaml` has no CUDA-core entry, and the four `tensor_core` factors are 0.75 placeholders pointing at a benchmark that does not exist.
- The README clock-locking recipe no longer works on 595.x drivers.
- Importing `tileops.manifest` raises SyntaxWarning; one validator test leaks a UserWarning.

## Changes

- Add `compute/fma_throughput.py` (+ `fma_saturation.cu`): register-only fp32 FMA chains, best ILP of 1..16, median of 5; withholds the factor if the SM clock moved while unlocked.
- Add `compute/gemm_throughput.py`: cuBLAS GEMM peak per tensor-core dtype, best n of 4096/8192/16384; settles to a steady clock, then ~4 s timed runs to average over power-cap clock oscillation. Records sustained (`calibration`, feeds `effective`) and pre-cap burst (`calibration_burst`).
- Record the measured factors in `h200.yaml` (medians across repeated runs, band ≤ 1.5%; sustained rates hold the 700 W cap at ~1.2-1.4 GHz):

| | fp32 | fp16 | bf16 | tf32 | fp8 |
| --- | --- | --- | --- | --- | --- |
| calibration | 0.8548 | 0.6684 | 0.7077 | 0.7249 | 0.6303 |
| calibration_burst | — | 0.7370 | 0.7680 | 0.7899 | 0.6977 |

- `load_profile()` tolerates a section with only `theoretical` (create the yaml first, calibrate after) and coerces `calibration_burst`.
- Reduce the README to run commands and a method table; fix the lock recipe.
- Fix the SyntaxWarning (raw-string the docstring) and the leaked UserWarning (`pytest.warns`).