### PR TITLE
[Perf][FFT] Reuse twiddle LUT in complex128 SMEM stages

### DIFF
--- a/src/tileops/kernels/fft.py
+++ b/src/tileops/kernels/fft.py
@@ -29,8 +29,10 @@ def _fft_c2c_kernel(n: int, batch_size: int = 1, dtype: str = "complex64") -> Ca
       Each block reads input elements at their bit-reversed positions directly
       into shared memory, eliminating the separate bit-reversal kernel.  It
       then performs all log2(min(n, 2*threads)) butterfly stages entirely in
-      SMEM using on-the-fly trig.  Result: one global-memory read + one write
-      for the entire SMEM phase, regardless of how many stages it covers.
+      SMEM.  Complex128 uses the pre-computed twiddle LUT; complex64 retains
+      inline trig because its FP32 trig is cheaper than the extra LUT loads.
+      Result: one global-memory read + one write for the entire SMEM phase,
+      regardless of how many stages it covers.
 
     Phase 2 — LUT stages (remaining stages, one kernel each):
       For stages where butterfly strides exceed the SMEM chunk size, each
@@ -117,6 +119,8 @@ def _fft_c2c_kernel(n: int, batch_size: int = 1, dtype: str = "complex64") -> Ca
         def fused_bitrev_smem_stages(
             x_real: T.Tensor((B, n), real_dtype),
             x_imag: T.Tensor((B, n), real_dtype),
+            lut_real: T.Tensor((lut_size,), real_dtype),
+            lut_imag: T.Tensor((lut_size,), real_dtype),
             y_real: T.Tensor((B, n), real_dtype),
             y_imag: T.Tensor((B, n), real_dtype),
             y_pair: T.Tensor((B, n, 2), real_dtype),
@@ -166,6 +170,7 @@ def _fft_c2c_kernel(n: int, batch_size: int = 1, dtype: str = "complex64") -> Ca
                 for s in range(smem_stages):
                     m_s = 1 << (s + 1)  # compile-time constant
                     half_m_s = 1 << s  # compile-time constant
+                    lut_base_s = half_m_s - 1
 
                     for i in T.Parallel(threads):
                         if i < smem_per_block // 2:
@@ -174,9 +179,16 @@ def _fft_c2c_kernel(n: int, batch_size: int = 1, dtype: str = "complex64") -> Ca
                             j_idx = group * m_s + k
                             l_idx = j_idx + half_m_s
 
-                            angle = -2.0 * _PI * T.cast(k, "float64") / T.cast(m_s, "float64")
-                            tw_r = T.cos(T.cast(angle, accum_dtype))
-                            tw_i = T.sin(T.cast(angle, accum_dtype))
+                            if dtype == "complex128":
+                                # Reuse the pre-built LUT instead of evaluating
+                                # expensive FP64 cos/sin. Its stage layout is
+                                # LUT[half_m - 1 + k] = exp(-2pi*i*k/m).
+                                tw_r = T.cast(lut_real[lut_base_s + k], accum_dtype)
+                                tw_i = T.cast(lut_imag[lut_base_s + k], accum_dtype)
+                            else:
+                                angle = -2.0 * _PI * T.cast(k, "float64") / T.cast(m_s, "float64")
+                                tw_r = T.cos(T.cast(angle, accum_dtype))
+                                tw_i = T.sin(T.cast(angle, accum_dtype))
 
                             u_r = T.cast(smem_r[j_idx], accum_dtype)
                             u_i = T.cast(smem_i[j_idx], accum_dtype)
@@ -563,7 +575,15 @@ def _fft_c2c_kernel(n: int, batch_size: int = 1, dtype: str = "complex64") -> Ca
         ) -> None:
             # Fused bit-reversal + SMEM butterfly stages: single kernel launch,
             # one global-memory read of x, one write of y for all SMEM stages.
-            fused_bitrev_smem_stages(x_real, x_imag, y_real, y_imag, y_pair)
+            fused_bitrev_smem_stages(
+                x_real,
+                x_imag,
+                lut_real,
+                lut_imag,
+                y_real,
+                y_imag,
+                y_pair,
+            )
 
             # LUT stages: use radix-8 (fused triples) where possible,
             # then radix-4 or radix-2 for the remainder.
@@ -651,9 +671,10 @@ class FFTC2CKernel(Kernel):
 
     2. Pre-computed twiddle LUT: the remaining large-stride stages look up
        twiddle factors from a GPU-resident LUT (built by FFTC2CFwdOp at
-       construction time), eliminating repeated sin/cos evaluation.
+       construction time), and complex128 SMEM stages use the same LUT to
+       avoid expensive FP64 sin/cos evaluation.
 
-    Together these match cuFFT-level performance on modern NVIDIA GPUs.
+    Together these reduce global memory traffic and runtime trigonometric work.
 
     Args:
         x_real:    Real part of input, shape (n,), float32 or float64.

--- a/tests/kernels/test_fft_output_layout.py
+++ b/tests/kernels/test_fft_output_layout.py
@@ -1,3 +1,9 @@
+"""Kernel-level coverage for FFT's interleaved output layout.
+
+The public Op converts the internal ``(batch, n, 2)`` buffer to a complex
+view, so its layout requires direct kernel coverage.
+"""
+
 import pytest
 import torch
 

--- a/tests/ops/test_fft.py
+++ b/tests/ops/test_fft.py
@@ -23,6 +23,7 @@ class FFTFixture(FixtureBase):
                 pytest.param(512, torch.complex64, False, (16,), marks=pytest.mark.full),
                 pytest.param(1024, torch.complex64, False, (), marks=pytest.mark.full),
                 pytest.param(1024, torch.complex64, False, (2, 4), marks=pytest.mark.full),
+                pytest.param(4096, torch.complex64, False, (), marks=pytest.mark.full),
                 pytest.param(128, torch.complex128, False, (4,), marks=pytest.mark.full),
             ],
         ),


### PR DESCRIPTION
## Summary

This is a follow-up to [#1884](https://github.com/tile-ai/TileOPs/pull/1884), which fused complex output packing into the final FFT butterfly. This PR adds the remaining shared-memory twiddle optimization that was not part of the merged implementation.

- `complex128` shared-memory butterfly stages now read twiddles from the pre-computed GPU LUT instead of evaluating FP64 `sin`/`cos` at runtime.
- `complex64` intentionally retains inline FP32 `sin`/`cos`: measurements show that the extra LUT loads do not improve FP32 latency.
- The public `FFTC2CFwdOp` API, split-input kernel contract, output layout, and existing scratch buffers are unchanged.

## Performance

Measured on an NVIDIA H200 with the official CUDA 13.2 runner:

| Item | Value |
| --- | --- |
| PyTorch | 2.13.0+cu132 |
| CUDA | 13.2 |
| TileLang | 0.1.11+cu132.gitafcebed1 |
| Timer | Native CUPTI |
| CUPTI fallback | Disabled |
| Comparison | Four alternating candidate/baseline rounds |
| Metric | `device_busy_ms` |

The baseline is current `main` (which already contains the output-packing fusion from #1884). Speedup is `baseline / candidate`.

| Workload | Baseline mean (ms) | Candidate mean (ms) | Speedup |
| --- | ---: | ---: | ---: |
| c64, unbatched | 0.0074 | 0.0074 | **1.003x** |
| c64, batch 64 | 0.0149 | 0.0144 | **1.029x** |
| c128, batch 64 | 0.0267 | 0.0186 | **1.438x** |

The autotuner selects different configurations between some very short runs. A fixed `{"block_size": 512, "threads": 512}` native-CUPTI comparison isolates the kernel change:

| Workload | Baseline (ms) | Candidate (ms) | Speedup |
| --- | ---: | ---: | ---: |
| c64, unbatched | 0.007904 | 0.007841 | **1.008x** |
| c64, batch 64 | 0.012672 | 0.012640 | **1.002x** |
| c128, batch 64 | 0.026816 | 0.017984 | **1.491x** |

These measurements show that the optimization is neutral for FP32 and provides a substantial FP64 gain. The dtype-specific dispatch avoids turning the LUT trade-off into a c64 regression.

## Correctness and checks

- 14 FFT correctness tests pass, including a new `N=4096` Op-level case that reaches the final LUT stage.
- The kernel-level layout test continues to cover the radix-specific final-stage paths for both dtypes.
- `ruff check` passes.
- `ruff format --check` passes.
- `compileall` passes.
- `git diff --check` passes.
- Test-node delta:

  ```text
  tests/kernels/test_fft_output_layout.py   4 -> 4   +0
  tests/ops/test_fft.py                     9 -> 10  +1
  TOTAL                                    13 -> 14  +1
  ```

## Scope and limitations

- No public API or benchmark infrastructure changes are included.
- Input split-copy removal and scratch-buffer elimination are intentionally left for separate follow-up work.
- PyTorch cuFFT remains faster; this PR optimizes the TileOPs implementation relative to the current TileOPs baseline.