### PR TITLE
[Perf][kernels] Read edge-axes and product reductions in the tensor's own layout

### DIFF
--- a/src/tileops/kernels/reduction/reduce.py
+++ b/src/tileops/kernels/reduction/reduce.py
@@ -2,6 +2,7 @@
 
 import functools
 from dataclasses import dataclass
+from math import prod
 from typing import Optional
 
 import tilelang
@@ -12,6 +13,7 @@ from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.reduction._primitives import (
     DEFAULT_ALIGNMENT,
     DEFAULT_THREADS,
+    VECTOR_ACCESS_BYTES,
     BlockConfigPlanner,
     align_up,
     ceildiv_int,
@@ -55,6 +57,11 @@ class ProductReducePolicy:
 
     cols_per_thread: int = 8
 
+    # Rows below this leave the grid too small to hide the vectorized path's
+    # per-thread latency; the shared staging keeps more loads in flight there.
+    # Measured on H200 at (64, 32768) bf16: staged 0.96 TB/s, vectorized 0.85.
+    min_rows_for_vectorized: int = 256
+
 
 _LEADING_POLICY = LeadingAxisReducePolicy()
 _PROD_POLICY = ProductReducePolicy()
@@ -76,7 +83,7 @@ def _pad_value_for_op(op_kind: str) -> float:
 
 
 @functools.lru_cache(maxsize=32)
-def _simple_reduce_kernel(M, N, op_kind, dtype):
+def _simple_reduce_kernel(M, N, op_kind, dtype, out_dtype=None):
     """Build a simple reduce kernel for sum/mean/amax/amin.
 
     Accepts an ``(M, N)`` input tensor.  When ``N`` is not a multiple of
@@ -84,23 +91,27 @@ def _simple_reduce_kernel(M, N, op_kind, dtype):
     loads that substitute the identity element for out-of-bounds columns
     (kernel-side boundary handling).  When ``N`` is already aligned, the
     fast ``T.copy`` path is used.
+
+    ``out_dtype`` overrides the output element type; an edge-axes reduction
+    writes fp32 partials so nothing narrows before its second pass.
     """
     N_padded = align_up(N, DEFAULT_ALIGNMENT)
     _needs_pad = N_padded != N
     _pad_val = _pad_value_for_op(op_kind)
+    out_dtype = out_dtype or dtype
 
     @tilelang.jit(out_idx=[1])
     def _func(block_m, threads):
         @T.prim_func
         def main(
             x: T.Tensor[(M, N), dtype],
-            out: T.Tensor[(M,), dtype],
+            out: T.Tensor[(M,), out_dtype],
         ):
             with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
                 shared_buf = T.alloc_shared((block_m, N_padded), dtype)
                 x_f32 = T.alloc_fragment((block_m, N_padded), "float32")
                 acc = T.alloc_fragment((block_m,), "float32")
-                out_local = T.alloc_fragment((block_m,), dtype)
+                out_local = T.alloc_fragment((block_m,), out_dtype)
 
                 if _needs_pad:
                     # Kernel-side boundary handling: element-wise load
@@ -142,7 +153,7 @@ def _simple_reduce_kernel(M, N, op_kind, dtype):
 
                 # Cast back to output dtype
                 for i in T.Parallel(block_m):
-                    out_local[i] = T.cast(acc[i], dtype)
+                    out_local[i] = T.cast(acc[i], out_dtype)
 
                 # Write output
                 T.copy(out_local, out[pid_m * block_m])
@@ -153,7 +164,7 @@ def _simple_reduce_kernel(M, N, op_kind, dtype):
 
 
 @functools.lru_cache(maxsize=32)
-def _simple_reduce_kernel_tiled(M, N, op_kind, dtype, tile_n):
+def _simple_reduce_kernel_tiled(M, N, op_kind, dtype, tile_n, out_dtype=None):
     """Tiled simple reduce for N_padded > MAX_SINGLE_TILE_COLS.
 
     Iterates over N in chunks of ``tile_n`` columns, accumulating
@@ -165,20 +176,21 @@ def _simple_reduce_kernel_tiled(M, N, op_kind, dtype, tile_n):
     total_cols = num_tiles * tile_n
     _needs_mask = total_cols > N
     _pad_val = _pad_value_for_op(op_kind)
+    out_dtype = out_dtype or dtype
 
     @tilelang.jit(out_idx=[1])
     def _func(block_m, threads):
         @T.prim_func
         def main(
             x: T.Tensor[(M, N), dtype],
-            out: T.Tensor[(M,), dtype],
+            out: T.Tensor[(M,), out_dtype],
         ):
             with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
                 shared_buf = T.alloc_shared((block_m, tile_n), dtype)
                 tile_f32 = T.alloc_fragment((block_m, tile_n), "float32")
                 acc = T.alloc_fragment((block_m,), "float32")
                 tile_acc = T.alloc_fragment((block_m,), "float32")
-                out_local = T.alloc_fragment((block_m,), dtype)
+                out_local = T.alloc_fragment((block_m,), out_dtype)
 
                 # Initialize accumulator
                 if op_kind in ("sum", "mean"):
@@ -237,10 +249,10 @@ def _simple_reduce_kernel_tiled(M, N, op_kind, dtype, tile_n):
                 # Finalize
                 if op_kind == "mean":
                     for i in T.Parallel(block_m):
-                        out_local[i] = T.cast(acc[i] / float(N), dtype)
+                        out_local[i] = T.cast(acc[i] / float(N), out_dtype)
                 else:
                     for i in T.Parallel(block_m):
-                        out_local[i] = T.cast(acc[i], dtype)
+                        out_local[i] = T.cast(acc[i], out_dtype)
 
                 T.copy(out_local, out[pid_m * block_m])
 
@@ -274,6 +286,29 @@ def reduces_leading_axes(ndim: int, axes: "tuple[int, ...]") -> bool:
     return 0 < len(axes) < ndim and tuple(axes) == tuple(range(len(axes)))
 
 
+def edge_axis_split(ndim: int, axes: "tuple[int, ...]") -> "tuple[int, int]":
+    """Split *axes* into ``(leading, trailing)`` counts when they hug both edges.
+
+    Returns ``(0, 0)`` unless *axes* is a non-empty prefix plus a non-empty
+    suffix with at least one kept axis in between. Such a reduction runs as two
+    passes in the tensor's own layout — trailing axes as contiguous rows, then
+    the leading axes down the columns of the partials — where a single pass
+    would first permute the reduced axes together, reading and writing the
+    whole tensor before reducing anything.
+    """
+    k = 0
+    while k < len(axes) and axes[k] == k:
+        k += 1
+    j = len(axes) - k
+    if k == 0 or j == 0:
+        return (0, 0)
+    if tuple(axes[k:]) != tuple(range(ndim - j, ndim)):
+        return (0, 0)
+    if k + j >= ndim:
+        return (0, 0)
+    return (k, j)
+
+
 def leading_row_splits(reduced: int, kept: int, threads: int) -> int:
     """How many ways to split the reduced axis so the grid fills the device."""
     block_b = threads * _LEADING_POLICY.cols_per_thread
@@ -303,11 +338,11 @@ def _make_leading_reduce_ops(op_kind: str, divisor: float, out_dtype: str):
             acc[slot] = acc[slot] + value
 
     @T.macro
-    def finish(out_local, slot, accumulated):
+    def finish(done, slot, accumulated):
         if divisor:
-            out_local[slot] = T.cast(accumulated / divisor, out_dtype)
+            done[slot] = T.cast(accumulated / divisor, out_dtype)
         else:
-            out_local[slot] = T.cast(accumulated, out_dtype)
+            done[slot] = T.cast(accumulated, out_dtype)
 
     return init, combine, finish
 
@@ -397,13 +432,93 @@ def _leading_reduce_kernel(
     return _func
 
 
+def _reduce_down_rows(
+    flat: torch.Tensor,
+    op_kind: str,
+    in_dtype: str,
+    out_dtype: str,
+    divisor: float,
+) -> torch.Tensor:
+    """Reduce an ``(A, B)`` buffer down its rows, writing one *out_dtype* row.
+
+    Splitting the reduced axis is what fills the grid, and each slice leaves an
+    fp32 partial row; a second call over those rows finishes the op. The partials
+    are a few thousand values against the millions the first pass reads, so the
+    second call costs about nothing.
+    """
+    reduced, kept = flat.shape
+    # An input smaller than one grid's worth of work cannot amortize the
+    # extra pass a split costs; reduce it in a single call.
+    grid_work = (
+        _LEADING_POLICY.threads * _LEADING_POLICY.cols_per_thread * _LEADING_POLICY.target_blocks
+    )
+    if reduced * kept <= grid_work:
+        splits = 1
+    else:
+        splits = leading_row_splits(reduced, kept, _LEADING_POLICY.threads)
+    if splits == 1:
+        single = _leading_reduce_kernel(
+            reduced,
+            kept,
+            op_kind,
+            in_dtype,
+            out_dtype,
+            _LEADING_POLICY.threads,
+            1,
+            divisor,
+        )
+        return single()(flat)
+    partials = _leading_reduce_kernel(
+        reduced,
+        kept,
+        op_kind,
+        in_dtype,
+        "float32",
+        _LEADING_POLICY.threads,
+        splits,
+        0.0,
+    )()(flat)
+    # Partials are summed even for mean, whose divisor is the whole row count.
+    finish = _leading_reduce_kernel(
+        splits,
+        kept,
+        "sum" if op_kind == "mean" else op_kind,
+        "float32",
+        out_dtype,
+        _LEADING_POLICY.threads,
+        1,
+        divisor,
+    )
+    return finish()(partials.reshape(splits, kept))
+
+
 @functools.lru_cache(maxsize=32)
 def _prod_reduce_kernel(M: int, N: int, dtype: str, threads: int):
-    """Build a product reduce: one block per row, multiplying in fp32."""
+    """Build a product reduce: one block per row, multiplying in fp32.
+
+    With enough rows to fill the device, each thread owns ``cols_per_thread``
+    consecutive elements per tile and reads them with one vectorized access, so
+    a warp's loads stay contiguous and every fetched sector is used in full. At
+    this small per-thread width the vectorized blocked read beats a
+    shared-memory staging pass, which costs a sync each way and reads back at a
+    bank-conflicting stride.
+
+    Below ``min_rows_for_vectorized`` rows, or when the tile does not divide the
+    row, the row is staged through shared memory instead and consumed from
+    there. The staging also sidesteps a compiler limit: a ``T.vectorized`` loop
+    and a guarded tail load in one body trip PointerValueTypeRewrite
+    ("Can't fetch the lanes of a scalable vector").
+    """
     chunk = threads * _PROD_POLICY.cols_per_thread
+    vectorized = N % chunk == 0 and _PROD_POLICY.min_rows_for_vectorized <= M
+    full_tiles = N // chunk if vectorized else 0
     tiles = ceildiv_int(N, chunk)
     exact = tiles * chunk == N
     num_warps = threads // _WARP_LANES
+    # One vector access is at most 16 bytes; wider per-thread spans split into
+    # several back-to-back vector loads.
+    vec_elems = min(_PROD_POLICY.cols_per_thread, VECTOR_ACCESS_BYTES // torch_dtype_nbytes(dtype))
+    vec_groups = _PROD_POLICY.cols_per_thread // vec_elems
 
     @tilelang.jit(out_idx=[1])
     def _func():
@@ -416,23 +531,47 @@ def _prod_reduce_kernel(M: int, N: int, dtype: str, threads: int):
                 tx = T.get_thread_binding()
                 running = T.alloc_local((1,), "float32")
                 warp_prod = T.alloc_shared((num_warps,), "float32")
-                staged = T.alloc_shared((chunk,), dtype)
+                held = T.alloc_local((_PROD_POLICY.cols_per_thread,), dtype)
+                staged = T.alloc_shared((1 if vectorized else chunk,), dtype)
+                # One chain per slot: a single running product serializes every
+                # multiply behind the previous one, which is what binds a
+                # low-block-count launch, not bandwidth.
+                slots = T.alloc_local((_PROD_POLICY.cols_per_thread,), "float32")
 
-                running[0] = T.cast(1.0, "float32")
-                for t in T.serial(tiles):
-                    for i in T.Parallel(chunk):
-                        staged[i] = x[row, t * chunk + i]
-                    T.sync_threads()
-                    for c in T.serial(_PROD_POLICY.cols_per_thread):
-                        held = staged[tx * _PROD_POLICY.cols_per_thread + c]
-                        if exact:
-                            running[0] = running[0] * T.cast(held, "float32")
-                        else:
-                            col = (t * threads + tx) * _PROD_POLICY.cols_per_thread + c
-                            running[0] = running[0] * T.if_then_else(
-                                col < N, T.cast(held, "float32"), T.cast(1.0, "float32")
-                            )
-                    T.sync_threads()
+                for c in T.serial(_PROD_POLICY.cols_per_thread):
+                    slots[c] = T.cast(1.0, "float32")
+                if vectorized:
+                    for t in T.serial(full_tiles):
+                        for g in T.serial(vec_groups):
+                            for c in T.vectorized(vec_elems):
+                                held[g * vec_elems + c] = x[
+                                    row,
+                                    t * chunk
+                                    + tx * _PROD_POLICY.cols_per_thread
+                                    + g * vec_elems
+                                    + c,
+                                ]
+                        for c in T.serial(_PROD_POLICY.cols_per_thread):
+                            slots[c] = slots[c] * T.cast(held[c], "float32")
+                else:
+                    for t in T.serial(tiles):
+                        for i in T.Parallel(chunk):
+                            staged[i] = x[row, t * chunk + i]
+                        T.sync_threads()
+                        for c in T.serial(_PROD_POLICY.cols_per_thread):
+                            kept = staged[tx * _PROD_POLICY.cols_per_thread + c]
+                            if exact:
+                                slots[c] = slots[c] * T.cast(kept, "float32")
+                            else:
+                                col = (t * threads + tx) * _PROD_POLICY.cols_per_thread + c
+                                slots[c] = slots[c] * T.if_then_else(
+                                    col < N, T.cast(kept, "float32"), T.cast(1.0, "float32")
+                                )
+                        T.sync_threads()
+
+                running[0] = slots[0]
+                for c in T.serial(1, _PROD_POLICY.cols_per_thread):
+                    running[0] = running[0] * slots[c]
 
                 for stage in T.serial(_WARP_STAGES):
                     running[0] = running[0] * T.shfl_xor(
@@ -901,6 +1040,11 @@ class ReduceKernel(Kernel):
         self._leading_axis_kind = op_kind in _LEADING_AXIS_KINDS and self.reduce_axes == tuple(
             range(len(self.reduce_axes))
         )
+        # Axes hugging both edges also run in the tensor's own layout; the rank
+        # check again waits for forward.
+        self._edge_axis_kind = op_kind in _LEADING_AXIS_KINDS
+        # Planner per edge-axes shape; the kernels themselves are lru-cached.
+        self._edge_stages: dict[tuple, BlockConfigPlanner] = {}
         self._elem_bytes = torch_dtype_nbytes(dtype)
         self._smem_budget = device_smem_budget(device_index)
         self._planner = BlockConfigPlanner(
@@ -986,6 +1130,11 @@ class ReduceKernel(Kernel):
         if self._leading_axis_kind and reduces_leading_axes(x.ndim, self.reduce_axes):
             columns = self._reduce_leading_axes(x)
             return restore_reduced(columns, in_shape, self.reduce_axes, self.keepdim)
+        if self._edge_axis_kind:
+            k, j = edge_axis_split(x.ndim, self.reduce_axes)
+            if k:
+                y = self._reduce_edge_axes(x, k, j)
+                return restore_reduced(y, in_shape, self.reduce_axes, self.keepdim)
         rows = rows_for_axes(x, self.reduce_axes)
         result = self._reduce_rows(rows)
         if self.op_kind == "var_mean":
@@ -996,52 +1145,74 @@ class ReduceKernel(Kernel):
             )
         return restore_reduced(result, in_shape, self.reduce_axes, self.keepdim)
 
-    def _reduce_leading_axes(self, x: torch.Tensor) -> torch.Tensor:
-        """Reduce the leading axes of *x* down to one value per kept column.
+    def _reduce_edge_axes(self, x: torch.Tensor, k: int, j: int) -> torch.Tensor:
+        """Reduce a prefix and a suffix of the axes without permuting the tensor.
 
-        Splitting the reduced axis is what fills the grid, and each slice leaves an
-        fp32 partial row; a second call over those rows finishes the op. The partials
-        are a few thousand values against the millions the first pass reads, so the
-        second call costs about nothing.
+        Two passes in the tensor's own layout: the trailing axes reduce as
+        contiguous rows into fp32 partials, then the leading axes reduce down
+        the columns of those partials. The partials are ``lead * kept`` values
+        against the ``lead * kept * trail`` the first pass reads, so the second
+        pass costs about nothing — where the permute a single pass needs reads
+        and writes the whole tensor before reducing anything.
+
+        Everything between the loads and the one cast at the end stays fp32,
+        like the single-pass kernels. ``mean`` runs the first pass as ``sum``
+        and divides in the second by the full reduced count.
         """
-        reduced, kept = leading_axis_split(tuple(x.shape), self.reduce_axes)
-        flat = x.reshape(reduced, kept)
-        splits = leading_row_splits(reduced, kept, _LEADING_POLICY.threads)
-        divisor = float(reduced) if self.op_kind == "mean" else 0.0
-        if splits == 1:
-            single = _leading_reduce_kernel(
-                reduced,
-                kept,
-                self.op_kind,
-                self.dtype_str,
-                self.dtype_str,
-                _LEADING_POLICY.threads,
-                1,
-                divisor,
+        shape = tuple(x.shape)
+        lead = prod(shape[:k])
+        kept = prod(shape[k : x.ndim - j])
+        trail = prod(shape[x.ndim - j :])
+        inner_kind = "sum" if self.op_kind == "mean" else self.op_kind
+        key = (lead, kept, trail)
+        if key not in self._edge_stages:
+            planner = BlockConfigPlanner(
+                align_up(trail, DEFAULT_ALIGNMENT),
+                self._elem_bytes,
+                self._smem_budget,
             )
-            return single()(flat)
-        partials = _leading_reduce_kernel(
-            reduced,
-            kept,
+            self._edge_stages[key] = planner
+        planner = self._edge_stages[key]
+        cfg = planner.default_config()
+        if planner.needs_tiling:
+            rows_stage = _simple_reduce_kernel_tiled(
+                lead * kept,
+                trail,
+                inner_kind,
+                self.dtype_str,
+                cfg["tile_n"],
+                "float32",
+            )
+        else:
+            rows_stage = _simple_reduce_kernel(
+                lead * kept,
+                trail,
+                inner_kind,
+                self.dtype_str,
+                "float32",
+            )
+        partials = rows_stage(cfg["block_m"], cfg["threads"])(x.reshape(lead * kept, trail))
+        divisor = float(lead * trail) if self.op_kind == "mean" else 0.0
+        y = _reduce_down_rows(
+            partials.reshape(lead, kept),
             self.op_kind,
-            self.dtype_str,
             "float32",
-            _LEADING_POLICY.threads,
-            splits,
-            0.0,
-        )()(flat)
-        # Partials are summed even for mean, whose divisor is the whole row count.
-        finish = _leading_reduce_kernel(
-            splits,
-            kept,
-            "sum" if self.op_kind == "mean" else self.op_kind,
             "float32",
-            self.dtype_str,
-            _LEADING_POLICY.threads,
-            1,
             divisor,
         )
-        return finish()(partials.reshape(splits, kept))
+        return y.to(x.dtype)
+
+    def _reduce_leading_axes(self, x: torch.Tensor) -> torch.Tensor:
+        """Reduce the leading axes of *x* down to one value per kept column."""
+        reduced, kept = leading_axis_split(tuple(x.shape), self.reduce_axes)
+        divisor = float(reduced) if self.op_kind == "mean" else 0.0
+        return _reduce_down_rows(
+            x.reshape(reduced, kept),
+            self.op_kind,
+            self.dtype_str,
+            self.dtype_str,
+            divisor,
+        )
 
     def _reduce_rows(self, x: torch.Tensor) -> object:
         """Reduce the trailing axis of an ``(M, N)`` buffer."""

--- a/src/tileops/kernels/reduction/reduce.py
+++ b/src/tileops/kernels/reduction/reduce.py
@@ -59,7 +59,6 @@ class ProductReducePolicy:
 
     # Rows below this leave the grid too small to hide the vectorized path's
     # per-thread latency; the shared staging keeps more loads in flight there.
-    # Measured on H200 at (64, 32768) bf16: staged 0.96 TB/s, vectorized 0.85.
     min_rows_for_vectorized: int = 256
 
 
@@ -92,8 +91,8 @@ def _simple_reduce_kernel(M, N, op_kind, dtype, out_dtype=None):
     (kernel-side boundary handling).  When ``N`` is already aligned, the
     fast ``T.copy`` path is used.
 
-    ``out_dtype`` overrides the output element type; an edge-axes reduction
-    writes fp32 partials so nothing narrows before its second pass.
+    ``out_dtype`` overrides the output element type, for a caller that keeps
+    fp32 partials across a second pass.
     """
     N_padded = align_up(N, DEFAULT_ALIGNMENT)
     _needs_pad = N_padded != N
@@ -290,11 +289,8 @@ def edge_axis_split(ndim: int, axes: "tuple[int, ...]") -> "tuple[int, int]":
     """Split *axes* into ``(leading, trailing)`` counts when they hug both edges.
 
     Returns ``(0, 0)`` unless *axes* is a non-empty prefix plus a non-empty
-    suffix with at least one kept axis in between. Such a reduction runs as two
-    passes in the tensor's own layout — trailing axes as contiguous rows, then
-    the leading axes down the columns of the partials — where a single pass
-    would first permute the reduced axes together, reading and writing the
-    whole tensor before reducing anything.
+    suffix with at least one kept axis in between — the layout
+    ``ReduceKernel._reduce_edge_axes`` handles without permuting the tensor.
     """
     k = 0
     while k < len(axes) and axes[k] == k:
@@ -338,11 +334,11 @@ def _make_leading_reduce_ops(op_kind: str, divisor: float, out_dtype: str):
             acc[slot] = acc[slot] + value
 
     @T.macro
-    def finish(done, slot, accumulated):
+    def finish(out_local, slot, accumulated):
         if divisor:
-            done[slot] = T.cast(accumulated / divisor, out_dtype)
+            out_local[slot] = T.cast(accumulated / divisor, out_dtype)
         else:
-            done[slot] = T.cast(accumulated, out_dtype)
+            out_local[slot] = T.cast(accumulated, out_dtype)
 
     return init, combine, finish
 
@@ -496,18 +492,13 @@ def _reduce_down_rows(
 def _prod_reduce_kernel(M: int, N: int, dtype: str, threads: int):
     """Build a product reduce: one block per row, multiplying in fp32.
 
-    With enough rows to fill the device, each thread owns ``cols_per_thread``
-    consecutive elements per tile and reads them with one vectorized access, so
-    a warp's loads stay contiguous and every fetched sector is used in full. At
-    this small per-thread width the vectorized blocked read beats a
-    shared-memory staging pass, which costs a sync each way and reads back at a
-    bank-conflicting stride.
-
-    Below ``min_rows_for_vectorized`` rows, or when the tile does not divide the
-    row, the row is staged through shared memory instead and consumed from
-    there. The staging also sidesteps a compiler limit: a ``T.vectorized`` loop
-    and a guarded tail load in one body trip PointerValueTypeRewrite
-    ("Can't fetch the lanes of a scalable vector").
+    With enough rows to fill the device, each thread reads its
+    ``cols_per_thread`` consecutive elements per tile with vectorized accesses
+    straight into registers. Below ``min_rows_for_vectorized`` rows, or when
+    the tile does not divide the row, the row is staged through shared memory
+    instead. The two bodies cannot be merged: TileLang rejects a
+    ``T.vectorized`` loop and a guarded tail load of the same buffer in one
+    kernel.
     """
     chunk = threads * _PROD_POLICY.cols_per_thread
     vectorized = N % chunk == 0 and _PROD_POLICY.min_rows_for_vectorized <= M
@@ -533,9 +524,8 @@ def _prod_reduce_kernel(M: int, N: int, dtype: str, threads: int):
                 warp_prod = T.alloc_shared((num_warps,), "float32")
                 held = T.alloc_local((_PROD_POLICY.cols_per_thread,), dtype)
                 staged = T.alloc_shared((1 if vectorized else chunk,), dtype)
-                # One chain per slot: a single running product serializes every
-                # multiply behind the previous one, which is what binds a
-                # low-block-count launch, not bandwidth.
+                # One independent fp32 chain per slot; a single running product
+                # would serialize every multiply behind the previous one.
                 slots = T.alloc_local((_PROD_POLICY.cols_per_thread,), "float32")
 
                 for c in T.serial(_PROD_POLICY.cols_per_thread):
@@ -1043,8 +1033,6 @@ class ReduceKernel(Kernel):
         # Axes hugging both edges also run in the tensor's own layout; the rank
         # check again waits for forward.
         self._edge_axis_kind = op_kind in _LEADING_AXIS_KINDS
-        # Planner per edge-axes shape; the kernels themselves are lru-cached.
-        self._edge_stages: dict[tuple, BlockConfigPlanner] = {}
         self._elem_bytes = torch_dtype_nbytes(dtype)
         self._smem_budget = device_smem_budget(device_index)
         self._planner = BlockConfigPlanner(
@@ -1150,10 +1138,10 @@ class ReduceKernel(Kernel):
 
         Two passes in the tensor's own layout: the trailing axes reduce as
         contiguous rows into fp32 partials, then the leading axes reduce down
-        the columns of those partials. The partials are ``lead * kept`` values
-        against the ``lead * kept * trail`` the first pass reads, so the second
-        pass costs about nothing — where the permute a single pass needs reads
-        and writes the whole tensor before reducing anything.
+        the columns of those partials. The permute a single pass needs would
+        read and write the whole tensor before reducing anything; the partials
+        here are ``lead * kept`` values against the ``lead * kept * trail`` the
+        first pass reads.
 
         Everything between the loads and the one cast at the end stays fp32,
         like the single-pass kernels. ``mean`` runs the first pass as ``sum``
@@ -1164,15 +1152,11 @@ class ReduceKernel(Kernel):
         kept = prod(shape[k : x.ndim - j])
         trail = prod(shape[x.ndim - j :])
         inner_kind = "sum" if self.op_kind == "mean" else self.op_kind
-        key = (lead, kept, trail)
-        if key not in self._edge_stages:
-            planner = BlockConfigPlanner(
-                align_up(trail, DEFAULT_ALIGNMENT),
-                self._elem_bytes,
-                self._smem_budget,
-            )
-            self._edge_stages[key] = planner
-        planner = self._edge_stages[key]
+        planner = BlockConfigPlanner(
+            align_up(trail, DEFAULT_ALIGNMENT),
+            self._elem_bytes,
+            self._smem_budget,
+        )
         cfg = planner.default_config()
         if planner.needs_tiling:
             rows_stage = _simple_reduce_kernel_tiled(

--- a/tests/ops/test_reduce_multidim.py
+++ b/tests/ops/test_reduce_multidim.py
@@ -112,6 +112,21 @@ def test_mean_multidim(
     assert torch.allclose(y, ref, **tol), f"max err: {(y - ref).abs().max()}"
 
 
+@pytest.mark.smoke
+def test_mean_edge_axes_fp16_keeps_fp32_intermediates() -> None:
+    """A mean over edge axes must not narrow its partial sums to the storage dtype.
+
+    fp16 rows of 100.0 sum to 409600 per row — past fp16's max — so any pass
+    that casts an undivided sum back to fp16 answers inf instead of 100.
+    """
+    from tileops.ops.reduction.reduce import MeanFwdOp
+
+    x = torch.full((4, 8, 1024), 100.0, dtype=torch.float16, device="cuda")
+    y = MeanFwdOp(dim=[0, 2])(x)
+    assert torch.isfinite(y).all(), "edge-axes mean overflowed an intermediate"
+    assert torch.allclose(y, torch.full_like(y, 100.0))
+
+
 @MultiDimFixture
 def test_amax_multidim(
     shape: tuple,


### PR DESCRIPTION
Applies the coalescing section of the memory-bound-kernels guide to the reduction kernels.

## problems

- A `dim=[0, 2]`-style reduction permuted the whole tensor to rows before reducing; every kind lost to torch eager on the 3d workload.
- The product reduce staged every tile through an unpadded shared buffer and consumed it at a bank-conflicting stride.
- A leading-axes reduce split its rows even when the input was smaller than one grid of work.

## changes

- `dim=[0, 2]` (sum/mean/amax/amin) runs as two passes in the tensor's own layout: trailing rows into fp32 partials, then the leading axes; one cast at the end. A regression test pins the fp16 mean-overflow case. Test node delta: +1 on an existing file.
- The product reduce takes vectorized blocked reads straight into registers when the rows fill the device; small grids and ragged rows keep the staging, which measures faster there.
- `_reduce_down_rows` extracted from `_reduce_leading_axes`; a row split is declined under one grid of work.

## measured

H200, image `cu132-torch2.13-tl-afcebed1`, `bench_reduce.py`, before = main.

| row | before TB/s | after TB/s | speedup |
| --- | --- | --- | --- |
| sum / mean / amax / amin `3d-multidim` | 0.371 | 0.72-0.74 | 1.95-1.98 |
| prod `hidden-state` fp16 / bf16 | 2.12 / 2.24 | 2.27 / 2.27 | 1.07 / 1.01 |
| other 28 reduce rows | — | — | 0.99-1.01 |

875 family tests pass in the runner image.