### PR TITLE
[CI][Nightly] Draw perf verdicts from row noise, the window median, and the previous run

### DIFF
--- a/scripts/nightly_report.py
+++ b/scripts/nightly_report.py
@@ -26,9 +26,7 @@ from typing import NamedTuple
 
 REGRESSION_THRESHOLD = 0.10  # 10% latency change => regression or improvement
 NOISE_MULTIPLE = 2.5  # a delta within 2.5x the row's p90-p10 spread is noise
-# Verdict floor for rows measured before percentiles were recorded; rows with a
-# p10/p90 spread gate on NOISE_MULTIPLE x spread instead.
-REGRESSION_ABS_MIN = 0.01
+REGRESSION_ABS_MIN = 0.01  # noise floor for rows recorded without percentiles
 
 # Measurement properties carried from the benchmark XML through to the report.
 # Parsing and aggregation must read the same set.
@@ -391,12 +389,10 @@ def _spread(props: dict) -> float | None:
 def _alias_name(runs: list[dict], op: str, config_name: str, work: _WorkCounts) -> str | None:
     """The unique prior display name of this row in history, or None.
 
-    A parametrized test's display name can change while the row's workload does
-    not, which would orphan the history recorded under the old name. A
-    historical name is adopted only when its recorded FLOP and byte counts
-    equal the current row's exactly and it never shares a run with the current
-    name: a renamed row and its new name never co-occur, while a different
-    variant of the same workload does.
+    A name is adopted only when its recorded FLOP and byte counts equal the
+    current row's exactly and it never shares a run with the current name: a
+    renamed row and its new name never co-occur, while another variant of the
+    same workload does.
     """
     if not work.flops_recorded or work.flops is None or work.nbytes is None:
         return None
@@ -409,8 +405,6 @@ def _alias_name(runs: list[dict], op: str, config_name: str, work: _WorkCounts) 
             if name == config_name:
                 continue
             if has_current:
-                # Co-occurrence disqualifies at any counts: a rename never
-                # leaves both names in one run, so this name is another row.
                 excluded.add(name)
                 continue
             tileops_data = entry.get("tileops", {})
@@ -425,7 +419,7 @@ def _alias_name(runs: list[dict], op: str, config_name: str, work: _WorkCounts) 
 def _config_readings(
     runs: list[dict], op: str, config_name: str, key: str, work: _WorkCounts
 ) -> list[_Reading]:
-    """Workload-matched readings for one row, oldest first.
+    """Workload-matched positive readings for one row, oldest first.
 
     Per run the current display name wins; a run that recorded the row only
     under its prior name (see ``_alias_name``) contributes that reading.
@@ -439,31 +433,31 @@ def _config_readings(
                 continue
             tileops_data = cfgs[name].get("tileops", {})
             ms = tileops_data.get(key)
-            if ms is None or not _same_workload(work, _work_counts(tileops_data, ms)):
+            if ms is None or ms <= 0 or not _same_workload(work, _work_counts(tileops_data, ms)):
                 continue
             readings.append(_Reading(ms, _spread(tileops_data)))
             break
     return readings
 
 
-def _significant(delta_abs: float, curr_spread: float | None, base_spread: float | None) -> bool:
-    """Whether a delta clears the row's measurement noise.
+def _reportable(delta_ms: float, base: _Reading, curr_spread: float | None) -> bool:
+    """Whether a move of ``delta_ms`` against ``base`` clears both gates.
 
-    The gate is ``NOISE_MULTIPLE`` times the wider of the two runs' p90-p10
-    spreads. Rows measured before percentiles were recorded fall back to the
-    fixed ``REGRESSION_ABS_MIN`` floor.
+    Relative gate: ``REGRESSION_THRESHOLD`` of the baseline. Noise gate:
+    ``NOISE_MULTIPLE`` times the wider of the two runs' p90-p10 spreads, or
+    ``REGRESSION_ABS_MIN`` when neither run recorded percentiles.
     """
-    spreads = [s for s in (curr_spread, base_spread) if s is not None]
+    spreads = [s for s in (curr_spread, base.spread) if s is not None]
     floor = NOISE_MULTIPLE * max(spreads) if spreads else REGRESSION_ABS_MIN
-    return delta_abs > floor
+    return delta_ms / base.ms > REGRESSION_THRESHOLD and delta_ms > floor
 
 
 def _verdict_inputs(bench_ops: dict, history_runs: list[dict]):
-    """Yield one verdict input per config that has both a reading and history."""
+    """Yield one verdict input per config with a positive reading and history."""
     for op, data in bench_ops.items():
         for cfg in data["configs"]:
             lat, key = _conclusion(cfg)
-            if lat is None:
+            if lat is None or lat <= 0:
                 continue
             props = {k.removeprefix("tileops_"): v for k, v in cfg.items()}
             work = _work_counts(props, lat)
@@ -486,19 +480,13 @@ def _record(op: str, cfg: dict, base_ms: float, curr_ms: float) -> dict:
 def detect_regressions(bench_ops: dict, history_runs: list[dict]) -> list[dict]:
     """Rows slower than their 14-day median by the threshold and the noise gate.
 
-    The median, not the minimum: the minimum of one-sample-per-night readings
-    is an optimistic extremum, and comparing against it reports a regression
-    whenever one past night got lucky. The lower median keeps the baseline an
-    actual reading.
+    Why the median: the window minimum is a lucky extremum of one-sample
+    nights and would alarm on every later normal night.
     """
     out = []
     for op, cfg, lat, curr_spread, readings in _verdict_inputs(bench_ops, history_runs):
         base = sorted(readings, key=lambda r: r.ms)[(len(readings) - 1) // 2]
-        if base.ms <= 0:
-            continue
-        if (lat - base.ms) / base.ms > REGRESSION_THRESHOLD and _significant(
-            lat - base.ms, curr_spread, base.spread
-        ):
+        if _reportable(lat - base.ms, base, curr_spread):
             out.append(_record(op, cfg, base.ms, lat))
     return out
 
@@ -508,11 +496,7 @@ def detect_improvements(bench_ops: dict, history_runs: list[dict]) -> list[dict]
     out = []
     for op, cfg, lat, curr_spread, readings in _verdict_inputs(bench_ops, history_runs):
         base = min(readings, key=lambda r: r.ms)
-        if base.ms <= 0:
-            continue
-        if (base.ms - lat) / base.ms > REGRESSION_THRESHOLD and _significant(
-            base.ms - lat, curr_spread, base.spread
-        ):
+        if _reportable(base.ms - lat, base, curr_spread):
             out.append(_record(op, cfg, base.ms, lat))
     return out
 
@@ -526,11 +510,7 @@ def detect_previous_run_shifts(bench_ops: dict, history_runs: list[dict]) -> lis
     out = []
     for op, cfg, lat, curr_spread, readings in _verdict_inputs(bench_ops, history_runs):
         base = readings[-1]
-        if base.ms <= 0:
-            continue
-        if abs(lat - base.ms) / base.ms > REGRESSION_THRESHOLD and _significant(
-            abs(lat - base.ms), curr_spread, base.spread
-        ):
+        if _reportable(abs(lat - base.ms), base, curr_spread):
             out.append(_record(op, cfg, base.ms, lat))
     return out
 

--- a/scripts/nightly_report.py
+++ b/scripts/nightly_report.py
@@ -25,7 +25,10 @@ from typing import NamedTuple
 # ---------------------------------------------------------------------------
 
 REGRESSION_THRESHOLD = 0.10  # 10% latency change => regression or improvement
-REGRESSION_ABS_MIN = 0.01  # ignore regressions < 0.01 ms
+NOISE_MULTIPLE = 2.5  # a delta within 2.5x the row's p90-p10 spread is noise
+# Verdict floor for rows measured before percentiles were recorded; rows with a
+# p10/p90 spread gate on NOISE_MULTIPLE x spread instead.
+REGRESSION_ABS_MIN = 0.01
 
 # Measurement properties carried from the benchmark XML through to the report.
 # Parsing and aggregation must read the same set.
@@ -375,75 +378,161 @@ def _same_workload(current: _WorkCounts, historical: _WorkCounts) -> bool:
     )
 
 
-def find_best_latency(
-    runs: list[dict],
-    op: str,
-    config_name: str,
-    key: str = _CONCLUSION_KEY,
-    work: _WorkCounts | None = None,
-) -> float | None:
-    """Find the best (lowest) tileops reading for an op+config across history."""
-    best = None
-    for run in runs:
-        tileops_data = run.get("ops", {}).get(op, {}).get(config_name, {}).get("tileops", {})
-        lat = tileops_data.get(key)
-        if lat is None:
-            continue
-        if work is not None and not _same_workload(work, _work_counts(tileops_data, lat)):
-            continue
-        if best is None or lat < best:
-            best = lat
-    return best
+class _Reading(NamedTuple):
+    ms: float
+    spread: float | None  # p90 - p10 of the run that produced ``ms``
 
 
-def _history_deltas(bench_ops: dict, history_runs: list[dict]):
-    """Yield ``(record, delta)`` per config with both a reading and a history best.
+def _spread(props: dict) -> float | None:
+    lo, hi = props.get("device_busy_p10_ms"), props.get("device_busy_p90_ms")
+    return hi - lo if lo is not None and hi is not None else None
 
-    ``delta`` is the fractional change against that best: positive is slower.
+
+def _alias_name(runs: list[dict], op: str, config_name: str, work: _WorkCounts) -> str | None:
+    """The unique prior display name of this row in history, or None.
+
+    A parametrized test's display name can change while the row's workload does
+    not, which would orphan the history recorded under the old name. A
+    historical name is adopted only when its recorded FLOP and byte counts
+    equal the current row's exactly and it never shares a run with the current
+    name: a renamed row and its new name never co-occur, while a different
+    variant of the same workload does.
     """
+    if not work.flops_recorded or work.flops is None or work.nbytes is None:
+        return None
+    candidates: set[str] = set()
+    excluded: set[str] = set()
+    for run in runs:
+        cfgs = run.get("ops", {}).get(op, {})
+        has_current = config_name in cfgs
+        for name, entry in cfgs.items():
+            if name == config_name:
+                continue
+            if has_current:
+                # Co-occurrence disqualifies at any counts: a rename never
+                # leaves both names in one run, so this name is another row.
+                excluded.add(name)
+                continue
+            tileops_data = entry.get("tileops", {})
+            ms = tileops_data.get(_CONCLUSION_KEY, tileops_data.get("latency_ms"))
+            hist = _work_counts(tileops_data, ms)
+            if hist.flops_recorded and hist.flops == work.flops and hist.nbytes == work.nbytes:
+                candidates.add(name)
+    candidates -= excluded
+    return candidates.pop() if len(candidates) == 1 else None
+
+
+def _config_readings(
+    runs: list[dict], op: str, config_name: str, key: str, work: _WorkCounts
+) -> list[_Reading]:
+    """Workload-matched readings for one row, oldest first.
+
+    Per run the current display name wins; a run that recorded the row only
+    under its prior name (see ``_alias_name``) contributes that reading.
+    """
+    alias = _alias_name(runs, op, config_name, work)
+    readings = []
+    for run in runs:
+        cfgs = run.get("ops", {}).get(op, {})
+        for name in (config_name, alias):
+            if name is None or name not in cfgs:
+                continue
+            tileops_data = cfgs[name].get("tileops", {})
+            ms = tileops_data.get(key)
+            if ms is None or not _same_workload(work, _work_counts(tileops_data, ms)):
+                continue
+            readings.append(_Reading(ms, _spread(tileops_data)))
+            break
+    return readings
+
+
+def _significant(delta_abs: float, curr_spread: float | None, base_spread: float | None) -> bool:
+    """Whether a delta clears the row's measurement noise.
+
+    The gate is ``NOISE_MULTIPLE`` times the wider of the two runs' p90-p10
+    spreads. Rows measured before percentiles were recorded fall back to the
+    fixed ``REGRESSION_ABS_MIN`` floor.
+    """
+    spreads = [s for s in (curr_spread, base_spread) if s is not None]
+    floor = NOISE_MULTIPLE * max(spreads) if spreads else REGRESSION_ABS_MIN
+    return delta_abs > floor
+
+
+def _verdict_inputs(bench_ops: dict, history_runs: list[dict]):
+    """Yield one verdict input per config that has both a reading and history."""
     for op, data in bench_ops.items():
         for cfg in data["configs"]:
             lat, key = _conclusion(cfg)
             if lat is None:
                 continue
-            work = _work_counts(
-                {k.removeprefix("tileops_"): v for k, v in cfg.items()},
-                lat,
-            )
-            best = find_best_latency(history_runs, op, cfg["name"], key, work)
-            if not best:  # a zero is not something to measure against
-                continue
-            yield (
-                {
-                    "op": op,
-                    "config": cfg["name"],
-                    "best_ms": best,
-                    "curr_ms": lat,
-                    "delta_pct": (lat - best) / best * 100,
-                    "tflops": cfg.get("tileops_tflops"),
-                },
-                (lat - best) / best,
-            )
+            props = {k.removeprefix("tileops_"): v for k, v in cfg.items()}
+            work = _work_counts(props, lat)
+            readings = _config_readings(history_runs, op, cfg["name"], key, work)
+            if readings:
+                yield op, cfg, lat, _spread(props), readings
+
+
+def _record(op: str, cfg: dict, base_ms: float, curr_ms: float) -> dict:
+    return {
+        "op": op,
+        "config": cfg["name"],
+        "base_ms": base_ms,
+        "curr_ms": curr_ms,
+        "delta_pct": (curr_ms - base_ms) / base_ms * 100,
+        "tflops": cfg.get("tileops_tflops"),
+    }
 
 
 def detect_regressions(bench_ops: dict, history_runs: list[dict]) -> list[dict]:
-    """Detect performance regressions vs 14-day best."""
-    return [
-        record
-        for record, delta in _history_deltas(bench_ops, history_runs)
-        if delta > REGRESSION_THRESHOLD
-        and (record["curr_ms"] - record["best_ms"]) > REGRESSION_ABS_MIN
-    ]
+    """Rows slower than their 14-day median by the threshold and the noise gate.
+
+    The median, not the minimum: the minimum of one-sample-per-night readings
+    is an optimistic extremum, and comparing against it reports a regression
+    whenever one past night got lucky. The lower median keeps the baseline an
+    actual reading.
+    """
+    out = []
+    for op, cfg, lat, curr_spread, readings in _verdict_inputs(bench_ops, history_runs):
+        base = sorted(readings, key=lambda r: r.ms)[(len(readings) - 1) // 2]
+        if base.ms <= 0:
+            continue
+        if (lat - base.ms) / base.ms > REGRESSION_THRESHOLD and _significant(
+            lat - base.ms, curr_spread, base.spread
+        ):
+            out.append(_record(op, cfg, base.ms, lat))
+    return out
 
 
 def detect_improvements(bench_ops: dict, history_runs: list[dict]) -> list[dict]:
-    """Detect performance improvements vs 14-day best, on the regression's absolute floor."""
-    return [
-        record
-        for record, delta in _history_deltas(bench_ops, history_runs)
-        if delta < -REGRESSION_THRESHOLD
-        and (record["best_ms"] - record["curr_ms"]) > REGRESSION_ABS_MIN
-    ]
+    """Rows faster than every 14-day reading by the threshold and the noise gate."""
+    out = []
+    for op, cfg, lat, curr_spread, readings in _verdict_inputs(bench_ops, history_runs):
+        base = min(readings, key=lambda r: r.ms)
+        if base.ms <= 0:
+            continue
+        if (base.ms - lat) / base.ms > REGRESSION_THRESHOLD and _significant(
+            base.ms - lat, curr_spread, base.spread
+        ):
+            out.append(_record(op, cfg, base.ms, lat))
+    return out
+
+
+def detect_previous_run_shifts(bench_ops: dict, history_runs: list[dict]) -> list[dict]:
+    """Rows that moved either way since their most recent comparable reading.
+
+    A fix that returns a row to its old level reads as 0% against the 14-day
+    best; this lens reports it.
+    """
+    out = []
+    for op, cfg, lat, curr_spread, readings in _verdict_inputs(bench_ops, history_runs):
+        base = readings[-1]
+        if base.ms <= 0:
+            continue
+        if abs(lat - base.ms) / base.ms > REGRESSION_THRESHOLD and _significant(
+            abs(lat - base.ms), curr_spread, base.spread
+        ):
+            out.append(_record(op, cfg, base.ms, lat))
+    return out
 
 
 def detect_baseline_alerts(bench_ops: dict) -> list[dict]:
@@ -508,7 +597,13 @@ def build_history_entry(bench_ops: dict, coverage: list[dict] | None = None) -> 
                 for key, value in (("latency_ms", lat), (_CONCLUSION_KEY, busy)):
                     if value is not None:
                         entry["tileops"][key] = value
-                for name in ("tflops", "flops", "bytes"):
+                for name in (
+                    "tflops",
+                    "flops",
+                    "bytes",
+                    "device_busy_p10_ms",
+                    "device_busy_p90_ms",
+                ):
                     value = cfg.get(f"tileops_{name}")
                     if value is not None:
                         entry["tileops"][name] = value
@@ -637,6 +732,7 @@ def generate_report(
     coverage: list[dict] | None = None,
     coverage_prev: dict | None = None,
     bench_skips: int = 0,
+    previous_run_shifts: list[dict] | None = None,
 ) -> str:
     """Generate markdown report."""
     lines = []
@@ -674,10 +770,12 @@ def generate_report(
     )
     lines.append(f"| **Benchmarked Ops** | {n_bench_ops} |")
     lines.append(f"| **Benchmark Failures** | {bench_fail_icon} |")
-    lines.append(f"| **Regressions** (vs 14-day best) | {reg_icon} |")
+    lines.append(f"| **Regressions** (vs 14-day median) | {reg_icon} |")
     lines.append(f"| **Baseline Alerts** (< {BASELINE_RATIO_ALERT:.0%}) | {alert_icon} |")
     if improvements:
         lines.append(f"| **Improvements** (vs 14-day best) | {_PARTY} {len(improvements)} |")
+    if previous_run_shifts:
+        lines.append(f"| **Moved since previous run** | {_BLUE} {len(previous_run_shifts)} |")
     if coverage:
         # Repeated here because the Coverage section sits below the benchmark
         # tables, which run to hundreds of rows. One row per concern: a single
@@ -764,15 +862,15 @@ def generate_report(
 
     # ── Regressions ───────────────────────────────────────────────────────
     if regressions:
-        lines.append(f"## {_WARN} Performance Regressions (vs 14-day best)")
+        lines.append(f"## {_WARN} Performance Regressions (vs 14-day median)")
         lines.append("")
-        lines.append("| Op | Config | Best (ms) | Current (ms) | Delta | TFLOPS |")
-        lines.append("|:---|:-------|----------:|-----------:|------:|-------:|")
+        lines.append("| Op | Config | Median (ms) | Current (ms) | Delta | TFLOPS |")
+        lines.append("|:---|:-------|------------:|-----------:|------:|-------:|")
         for r in sorted(regressions, key=lambda x: -x["delta_pct"]):
             tflops_str = f"{r['tflops']:.2f}" if r.get("tflops") else "-"
             lines.append(
                 f"| **{r['op']}** | {r['config']} "
-                f"| {r['best_ms']:.4f} | {r['curr_ms']:.4f} "
+                f"| {r['base_ms']:.4f} | {r['curr_ms']:.4f} "
                 f"| +{r['delta_pct']:.1f}% | {tflops_str} |"
             )
         lines.append("")
@@ -787,8 +885,28 @@ def generate_report(
             tflops_str = f"{r['tflops']:.2f}" if r.get("tflops") else "-"
             lines.append(
                 f"| **{r['op']}** | {r['config']} "
-                f"| {r['best_ms']:.4f} | {r['curr_ms']:.4f} "
+                f"| {r['base_ms']:.4f} | {r['curr_ms']:.4f} "
                 f"| {r['delta_pct']:.1f}% | {tflops_str} |"
+            )
+        lines.append("")
+
+    # ── Moves since the previous run ──────────────────────────────────────
+    if previous_run_shifts:
+        lines.append(f"## {_BLUE} Moved Since Previous Run")
+        lines.append("")
+        lines.append(
+            "> Moves against the most recent reading. A row restored to its"
+            " old level appears only here: returning is not a new 14-day record."
+        )
+        lines.append("")
+        lines.append("| Op | Config | Previous (ms) | Current (ms) | Delta | TFLOPS |")
+        lines.append("|:---|:-------|--------------:|-----------:|------:|-------:|")
+        for r in sorted(previous_run_shifts, key=lambda x: x["delta_pct"]):
+            tflops_str = f"{r['tflops']:.2f}" if r.get("tflops") else "-"
+            lines.append(
+                f"| **{r['op']}** | {r['config']} "
+                f"| {r['base_ms']:.4f} | {r['curr_ms']:.4f} "
+                f"| {r['delta_pct']:+.1f}% | {tflops_str} |"
             )
         lines.append("")
 
@@ -1049,10 +1167,11 @@ def main():
 
     # Prune first: the carried-over artifact can hold entries older than the
     # window when a run gap exceeds the retention period, and the verdicts below
-    # are labelled "vs 14-day best".
+    # are labelled with the 14-day window.
     history_runs = prune_history(load_history(args.history))
     regressions = detect_regressions(bench_ops, history_runs) if bench_ops else []
     improvements = detect_improvements(bench_ops, history_runs) if bench_ops else []
+    previous_run_shifts = detect_previous_run_shifts(bench_ops, history_runs) if bench_ops else []
     baseline_alerts = detect_baseline_alerts(bench_ops) if bench_ops else []
 
     coverage = None
@@ -1072,6 +1191,7 @@ def main():
         coverage,
         coverage_prev,
         bench_skips,
+        previous_run_shifts,
     )
     Path(args.output).write_text(report)
     print(f"Report written to {args.output}")

--- a/src/tileops/ops/attention/gqa.py
+++ b/src/tileops/ops/attention/gqa.py
@@ -149,9 +149,9 @@ class GroupedQueryAttentionDenseFwdOp(Op):
     For FP8 inputs, each query head uses the scale of its KV group:
 
     $$
-    \hat q_{bih} = q_{bih} qscale_{b,r(h)},\quad
-    \hat k_{bjr} = k_{bjr} kscale_{b,r},\quad
-    \hat v_{bjr} = v_{bjr} vscale_{b,r}.
+    \hat q_{bih} = q_{bih} \mathrm{qscale}_{b,r(h)},\quad
+    \hat k_{bjr} = k_{bjr} \mathrm{kscale}_{b,r},\quad
+    \hat v_{bjr} = v_{bjr} \mathrm{vscale}_{b,r}.
     $$
 
     With ``alpha = sm_scale`` (default ``1 / sqrt(D)``), scores are

--- a/tests/test_nightly_report.py
+++ b/tests/test_nightly_report.py
@@ -1,7 +1,7 @@
 """Tests for scripts/nightly_report.py.
 
-Covers the history comparison a workload change can mislead: a config keeps its
-name when its shape moves, so the reading before the change is not a baseline.
+Covers the verdict rules a wrong comparison can mislead: workload identity,
+baseline choice, the noise gate, rename recovery, and the previous-run lens.
 """
 
 import importlib.util
@@ -27,12 +27,19 @@ def report():
     return mod
 
 
-def _history_run(busy_ms, **counts):
-    return {"ops": {_OP: {_CONFIG: {"tileops": {"device_busy_ms": busy_ms, **counts}}}}}
+def _history_run(busy_ms, name=_CONFIG, p10=None, p90=None, **counts):
+    tileops = {"device_busy_ms": busy_ms, **counts}
+    if p10 is not None:
+        tileops["device_busy_p10_ms"] = p10
+        tileops["device_busy_p90_ms"] = p90
+    return {"ops": {_OP: {name: {"tileops": tileops}}}}
 
 
-def _bench_ops(busy_ms, **counts):
+def _bench_ops(busy_ms, p10=None, p90=None, **counts):
     config = {"name": _CONFIG, "tileops_device_busy_ms": busy_ms}
+    if p10 is not None:
+        config["tileops_device_busy_p10_ms"] = p10
+        config["tileops_device_busy_p90_ms"] = p90
     config.update({f"tileops_{k}": v for k, v in counts.items()})
     return {_OP: {"configs": [config]}}
 
@@ -47,7 +54,7 @@ def test_history_reading_at_the_same_work_size_still_compares(report):
     """The same counts keep their history: this is where a regression shows."""
     runs = [_history_run(0.1, flops=5e9, bytes=1e6)]
     (found,) = report.detect_regressions(_bench_ops(0.4, flops=5e9, bytes=1e6), runs)
-    assert found["best_ms"] == 0.1
+    assert found["base_ms"] == 0.1
 
 
 def test_history_reading_of_another_dtype_at_equal_flops_is_not_a_baseline(report):
@@ -60,10 +67,82 @@ def test_history_reading_without_counts_falls_back_to_tflops(report):
     """A reading carrying only ``tflops`` still recovers a comparable FLOP count."""
     runs = [_history_run(0.1, tflops=50.0)]
     (found,) = report.detect_regressions(_bench_ops(0.4, flops=5e9), runs)
-    assert found["best_ms"] == 0.1
+    assert found["base_ms"] == 0.1
 
 
 def test_history_reading_without_counts_at_another_work_size_is_not_a_baseline(report):
     """A FLOP count recovered from ``tflops`` separates workloads too."""
     runs = [_history_run(0.1, tflops=50.0)]
     assert report.detect_regressions(_bench_ops(0.4, flops=2e10), runs) == []
+
+
+def test_sub_floor_change_with_percentiles_is_reported(report):
+    """Once a spread is recorded, the noise gate replaces the fixed floor."""
+    runs = [_history_run(0.010, p10=0.0099, p90=0.0101)]
+    (found,) = report.detect_improvements(_bench_ops(0.005, p10=0.0049, p90=0.0051), runs)
+    assert found["base_ms"] == 0.010
+
+
+def test_change_within_noise_spread_is_not_reported(report):
+    """A 20% move inside 2.5x the row's p90-p10 spread is noise."""
+    runs = [_history_run(0.0010, p10=0.0009, p90=0.0011)]
+    assert report.detect_regressions(_bench_ops(0.0012), runs) == []
+
+
+def test_row_without_percentiles_keeps_the_absolute_floor(report):
+    """Legacy rows with no spread on either side gate on the fixed floor."""
+    runs = [_history_run(0.010)]
+    assert report.detect_regressions(_bench_ops(0.015), runs) == []
+
+
+def test_regression_baseline_is_the_median_not_the_minimum(report):
+    """One lucky fast night must not alarm every later night."""
+    runs = [_history_run(0.10), _history_run(0.20), _history_run(0.21)]
+    assert report.detect_regressions(_bench_ops(0.21), runs) == []
+
+
+def test_improvement_baseline_stays_the_minimum(report):
+    """An improvement is a new record, not a move against the typical night."""
+    runs = [_history_run(0.10), _history_run(0.20), _history_run(0.21)]
+    assert report.detect_improvements(_bench_ops(0.15), runs) == []
+    (found,) = report.detect_improvements(_bench_ops(0.05), runs)
+    assert found["base_ms"] == 0.10
+
+
+def test_restored_row_shows_as_moved_since_previous_run(report):
+    """A fix back to the old level is no new record; the previous-run lens reports it."""
+    runs = [_history_run(0.066), _history_run(0.082)]
+    assert report.detect_improvements(_bench_ops(0.066), runs) == []
+    (found,) = report.detect_previous_run_shifts(_bench_ops(0.066), runs)
+    assert found["base_ms"] == 0.082
+
+
+def test_renamed_row_keeps_its_history(report):
+    """History under the row's prior display name still baselines it."""
+    runs = [_history_run(0.1, name="test_foo_bench[old-bfloat16]", flops=5e9, bytes=1e6)]
+    (found,) = report.detect_regressions(_bench_ops(0.4, flops=5e9, bytes=1e6), runs)
+    assert found["base_ms"] == 0.1
+
+
+def test_name_that_ever_shared_a_run_with_the_current_name_is_not_a_rename(report):
+    """Co-occurrence disqualifies a prior name even when its counts differ there."""
+    shared_run = {
+        "ops": {
+            _OP: {
+                _CONFIG: {"tileops": {"device_busy_ms": 0.39, "flops": 5e9, "bytes": 1e6}},
+                "test_foo_bench[other]": {
+                    "tileops": {"device_busy_ms": 0.20, "flops": 9e9, "bytes": 9e6}
+                },
+            }
+        }
+    }
+    runs = [_history_run(0.10, name="test_foo_bench[other]", flops=5e9, bytes=1e6), shared_run]
+    assert report.detect_regressions(_bench_ops(0.40, flops=5e9, bytes=1e6), runs) == []
+
+
+def test_history_entry_records_the_percentiles(report):
+    """The noise gate needs each run's spread persisted with its reading."""
+    entry = report.build_history_entry(_bench_ops(0.010, p10=0.0099, p90=0.0101))
+    tileops = entry["ops"][_OP][_CONFIG]["tileops"]
+    assert tileops["device_busy_p10_ms"] == 0.0099
+    assert tileops["device_busy_p90_ms"] == 0.0101

--- a/tests/test_nightly_report.py
+++ b/tests/test_nightly_report.py
@@ -117,6 +117,12 @@ def test_restored_row_shows_as_moved_since_previous_run(report):
     assert found["base_ms"] == 0.082
 
 
+def test_non_positive_reading_is_not_a_measurement(report):
+    """A zero on either side is rejected, not reported as a 100% move."""
+    assert report.detect_improvements(_bench_ops(0.0), [_history_run(0.10)]) == []
+    assert report.detect_regressions(_bench_ops(0.4), [_history_run(0.0)]) == []
+
+
 def test_renamed_row_keeps_its_history(report):
     """History under the row's prior display name still baselines it."""
     runs = [_history_run(0.1, name="test_foo_bench[old-bfloat16]", flops=5e9, bytes=1e6)]


### PR DESCRIPTION
## problems

- Every verdict gates on a fixed 0.01 ms absolute floor; 813 of 1137 bench rows run under 0.1 ms, where a 10% change never clears it. On the 2026-08-25 nightly this hid a 2x reduce improvement and a 26% logsumexp regression.
- Regressions compare against the 14-day minimum, an optimistic extremum of one-sample-per-night readings.
- There is no comparison against the previous run: a fix restoring a regressed row reads as 0% vs the 14-day best and never shows.
- History is keyed by the pytest display name; a rename silently orphans the row's history.
- Each row's p10/p90 is measured and parsed but never persisted or used.

## changes

- Verdicts require `delta > 10%` and `delta > 2.5 x (p90 - p10)` of the wider side; the 0.01 ms floor remains only for history entries recorded without percentiles.
- Regressions compare against the window's lower median; improvements keep the minimum (new-record semantics).
- New "Moved Since Previous Run" section lists moves either way against the most recent comparable reading.
- A renamed row adopts history under a unique prior name whose recorded flops and bytes match exactly and that never shares a run with the current name.
- p10/p90 persist into history entries.
- Replayed on the 2026-08-25 nightly artifacts (H200, run 32884970678): 1 regression, 9 improvements, 15 previous-run moves; the shipped report listed 0 and 2.
- Non-positive readings are rejected where readings enter the verdicts; the relative and noise gates live in one shared predicate.
- Test node delta: +10 on `tests/test_nightly_report.py`, one node per new verdict rule.

- Rider: the dense GQA docstring sets `qscale`/`kscale`/`vscale` in `\mathrm` so the FP8 math renders them as names, not letter products.

