### PR TITLE
[Perf][kernels] Own-layout edge reductions, row broadcasts, and split-row softmax

### DIFF
--- a/src/tileops/kernels/elementwise/_broadcast.py
+++ b/src/tileops/kernels/elementwise/_broadcast.py
@@ -88,8 +88,8 @@ def _is_contiguous_same_shape(coalesced_shape, a_strides, b_strides):
     )
 
 
-# One grid axis carries the rows, and CUDA caps grid.y at 65535.
-_MAX_ROW_GRID = 65535
+# CUDA caps grid.y at 65535, and one grid axis carries the rows.
+_CUDA_MAX_GRID_Y = 65535
 
 
 def row_broadcast_split(coalesced_shape, a_strides, b_strides):
@@ -109,7 +109,7 @@ def row_broadcast_split(coalesced_shape, a_strides, b_strides):
     rows = 1
     for d in coalesced_shape[:-1]:
         rows *= d
-    if rows > _MAX_ROW_GRID:
+    if rows > _CUDA_MAX_GRID_Y:
         return None
     return rows, inner
 

--- a/src/tileops/kernels/elementwise/_broadcast.py
+++ b/src/tileops/kernels/elementwise/_broadcast.py
@@ -88,6 +88,32 @@ def _is_contiguous_same_shape(coalesced_shape, a_strides, b_strides):
     )
 
 
+# One grid axis carries the rows, and CUDA caps grid.y at 65535.
+_MAX_ROW_GRID = 65535
+
+
+def row_broadcast_split(coalesced_shape, a_strides, b_strides):
+    """``(rows, inner)`` when the innermost coalesced dim reads at stride 0 or 1.
+
+    That layout gives every row a constant offset into each operand, so a
+    kernel can pay the divmod chain once per block and keep the inner loop
+    affine — which is what lets it vectorize. Returns ``None`` for layouts
+    this does not cover (an inner dim read at a wider stride, or more rows
+    than a grid axis holds), which keep the per-element offset path.
+    """
+    if len(coalesced_shape) < 2:
+        return None
+    if a_strides[-1] not in (0, 1) or b_strides[-1] not in (0, 1):
+        return None
+    inner = coalesced_shape[-1]
+    rows = 1
+    for d in coalesced_shape[:-1]:
+        rows *= d
+    if rows > _MAX_ROW_GRID:
+        return None
+    return rows, inner
+
+
 @dataclass(frozen=True)
 class BroadcastPlan:
     """The coalesced shape and per-operand strides a binary kernel indexes with."""

--- a/src/tileops/kernels/elementwise/_builders.py
+++ b/src/tileops/kernels/elementwise/_builders.py
@@ -5,7 +5,12 @@ import functools
 import tilelang
 import tilelang.language as T
 
-from ._broadcast import _compute_broadcast_offsets, _is_contiguous_same_shape, broadcast_plan_for
+from ._broadcast import (
+    _compute_broadcast_offsets,
+    _is_contiguous_same_shape,
+    broadcast_plan_for,
+    row_broadcast_split,
+)
 from ._op_body import op_func_for
 
 
@@ -90,6 +95,64 @@ def _make_unary_regcopy(N, dtype, op_name, output_dtype=None, threads=256, num_p
     return kernel
 
 
+def _row_broadcast_prim(
+    N_total, dtype, out_dtype, op_name, plan_name, a_numel, b_numel, threads, num_per_thread
+):
+    """PrimFunc for a broadcast whose innermost coalesced dim reads at stride 0 or 1.
+
+    One grid row per output row: the divmod chain that locates each operand
+    runs once per block, and the inner loop indexes affinely, so it vectorizes.
+    The generic path pays that chain per element and every access is a gather.
+    A ragged inner extent splits at trace time: full blocks run unguarded, the
+    one tail block guards each lane.
+    """
+    op_func = op_func_for(op_name)
+    ndim, divisors, a_strides, b_strides = _broadcast_index_terms(plan_name)
+    plan = broadcast_plan_for(plan_name)
+    inner = plan.coalesced_shape[-1]
+    rows = N_total // inner
+    a_inner = plan.a_strides[-1]
+    b_inner = plan.b_strides[-1]
+    block_cols = threads * num_per_thread
+    full_blocks = inner // block_cols
+    exact = full_blocks * block_cols == inner
+
+    @T.prim_func
+    def main(
+        a: T.Tensor((a_numel,), dtype),
+        b: T.Tensor((b_numel,), dtype),
+        y: T.Tensor((N_total,), out_dtype),
+    ):
+        with T.Kernel(T.ceildiv(inner, block_cols), rows, threads=threads) as (bx, by):
+            a_base, b_base = _compute_broadcast_offsets(
+                by * inner, ndim, divisors, a_strides, b_strides
+            )
+            if exact:
+                for i, j in T.Parallel(threads, num_per_thread):
+                    col = (bx * threads + i) * num_per_thread + j
+                    y[by * inner + col] = op_func(
+                        a[a_base + col * a_inner], b[b_base + col * b_inner]
+                    )
+            else:
+                with T.If(bx < full_blocks):
+                    with T.Then():
+                        for i, j in T.Parallel(threads, num_per_thread):
+                            col = (bx * threads + i) * num_per_thread + j
+                            y[by * inner + col] = op_func(
+                                a[a_base + col * a_inner], b[b_base + col * b_inner]
+                            )
+                    with T.Else():
+                        for i, j in T.Parallel(threads, num_per_thread):
+                            col = (bx * threads + i) * num_per_thread + j
+                            with T.If(col < inner):  # noqa: SIM117
+                                with T.Then():
+                                    y[by * inner + col] = op_func(
+                                        a[a_base + col * a_inner], b[b_base + col * b_inner]
+                                    )
+
+    return main
+
+
 @functools.lru_cache(maxsize=32)
 def _make_binary_register_copy(
     N_total,
@@ -165,6 +228,16 @@ def _make_binary_direct(
 
         return kernel
 
+    if row_broadcast_split(plan.coalesced_shape, plan.a_strides, plan.b_strides):
+
+        @tilelang.jit(out_idx=[2])
+        def kernel(threads):
+            return _row_broadcast_prim(
+                N_total, dtype, out_dtype, op_name, plan_name, a_numel, b_numel, threads, 1
+            )
+
+        return kernel
+
     @tilelang.jit(out_idx=[2])
     def kernel(threads):
         op_func = op_func_for(op_name)
@@ -208,6 +281,24 @@ def _make_binary_explicit(
     """Binary explicit_parallel: N elements per thread with stride-based broadcast."""
     out_dtype = output_dtype or dtype
     plan = broadcast_plan_for(plan_name)
+
+    if row_broadcast_split(plan.coalesced_shape, plan.a_strides, plan.b_strides):
+
+        @tilelang.jit(out_idx=[2])
+        def kernel(threads, num_per_thread):
+            return _row_broadcast_prim(
+                N_total,
+                dtype,
+                out_dtype,
+                op_name,
+                plan_name,
+                a_numel,
+                b_numel,
+                threads,
+                num_per_thread,
+            )
+
+        return kernel
 
     if _is_contiguous_same_shape(plan.coalesced_shape, plan.a_strides, plan.b_strides):
 

--- a/src/tileops/kernels/elementwise/_builders.py
+++ b/src/tileops/kernels/elementwise/_builders.py
@@ -117,6 +117,10 @@ def _row_broadcast_prim(
     full_blocks = inner // block_cols
     exact = full_blocks * block_cols == inner
 
+    @T.macro
+    def write_col(a, b, y, a_base, b_base, by, col):
+        y[by * inner + col] = op_func(a[a_base + col * a_inner], b[b_base + col * b_inner])
+
     @T.prim_func
     def main(
         a: T.Tensor((a_numel,), dtype),
@@ -129,26 +133,26 @@ def _row_broadcast_prim(
             )
             if exact:
                 for i, j in T.Parallel(threads, num_per_thread):
-                    col = (bx * threads + i) * num_per_thread + j
-                    y[by * inner + col] = op_func(
-                        a[a_base + col * a_inner], b[b_base + col * b_inner]
-                    )
+                    write_col(a, b, y, a_base, b_base, by, (bx * threads + i) * num_per_thread + j)
             else:
                 with T.If(bx < full_blocks):
                     with T.Then():
                         for i, j in T.Parallel(threads, num_per_thread):
-                            col = (bx * threads + i) * num_per_thread + j
-                            y[by * inner + col] = op_func(
-                                a[a_base + col * a_inner], b[b_base + col * b_inner]
+                            write_col(
+                                a,
+                                b,
+                                y,
+                                a_base,
+                                b_base,
+                                by,
+                                (bx * threads + i) * num_per_thread + j,
                             )
                     with T.Else():
                         for i, j in T.Parallel(threads, num_per_thread):
                             col = (bx * threads + i) * num_per_thread + j
                             with T.If(col < inner):  # noqa: SIM117
                                 with T.Then():
-                                    y[by * inner + col] = op_func(
-                                        a[a_base + col * a_inner], b[b_base + col * b_inner]
-                                    )
+                                    write_col(a, b, y, a_base, b_base, by, col)
 
     return main
 

--- a/src/tileops/kernels/elementwise/arithmetic.py
+++ b/src/tileops/kernels/elementwise/arithmetic.py
@@ -280,7 +280,9 @@ class MaximumFwdKernel(BinaryKernel):
             return result
         # Float path: T.max handles signed-zero correctly but does NOT
         # propagate NaN -- it returns the non-NaN operand. Cast to fp32
-        # for isnan (bfloat16 lacks native isnan).
+        # for isnan (bfloat16 lacks native isnan). A self-compare is not
+        # a guard here: TileLang lowers ``!=`` as an ordered compare, so
+        # ``x != x`` is false for NaN.
         a_is_nan = T.isnan(T.Cast("float32", a))
         b_is_nan = T.isnan(T.Cast("float32", b))
         result = T.if_then_else(b_is_nan, b, result)

--- a/src/tileops/kernels/reduction/_primitives.py
+++ b/src/tileops/kernels/reduction/_primitives.py
@@ -1117,16 +1117,18 @@ def _down_rows_kernel(
                         )
                         combine(acc, j, val)
 
-                for j in T.Parallel(block_b):
-                    finish(out_local, j, acc[j])
-
                 if exact:
+                    for j in T.Parallel(block_b):
+                        finish(out_local, j, acc[j])
                     T.copy(out_local, out[pid_a * B + pid_b * block_b])
                 else:
+                    # Finish only stored lanes: a masked lane holds the identity
+                    # (e.g. +inf), which an integer output dtype cannot take.
                     for j in T.Parallel(block_b):
                         # TileLang requires T.If/T.Then as nested context managers.
                         with T.If(pid_b * block_b + j < B):  # noqa: SIM117
                             with T.Then():
+                                finish(out_local, j, acc[j])
                                 out[pid_a * B + pid_b * block_b + j] = out_local[j]
 
         return main

--- a/src/tileops/kernels/reduction/_primitives.py
+++ b/src/tileops/kernels/reduction/_primitives.py
@@ -27,18 +27,19 @@ __all__ = [
     "AUTOTUNE_THREADS",
     "DEFAULT_ALIGNMENT",
     "DEFAULT_THREADS",
+    "FP32_EXACT_INT_LIMIT",
+    "FRAGMENT_ELEMS_PER_THREAD",
     "MAX_SINGLE_TILE_COLS",
     "SHARED_MEMORY_BUDGET_BYTES",
     "VECTOR_ACCESS_BYTES",
     "BlockConfigPlanner",
-    "LeadingAxisReducePolicy",
     "RowTiledAutotuneMixin",
     "align_up",
     "ceildiv_int",
     "compute_tile_n",
     "device_smem_budget",
+    "edge_axis_plan",
     "edge_axis_split",
-    "leading_row_splits",
     "make_cumulative_scan",
     "make_reduce_epilogue",
     "make_softmax_epilogue",
@@ -965,7 +966,7 @@ class RowTiledAutotuneMixin:
 
 
 @dataclass(frozen=True)
-class LeadingAxisReducePolicy:
+class _LeadingAxisReducePolicy:
     """Launch heuristics for reductions down contiguous leading axes."""
 
     cols_per_thread: int = 8
@@ -975,7 +976,39 @@ class LeadingAxisReducePolicy:
     target_blocks: int = 512
 
 
-_LEADING_POLICY = LeadingAxisReducePolicy()
+_LEADING_POLICY = _LeadingAxisReducePolicy()
+
+
+# Largest integer count fp32 carries exactly; a statistic folded through
+# fp32 counts or weights is trusted only below it.
+FP32_EXACT_INT_LIMIT = 1 << 24
+
+
+def edge_axis_plan(
+    shape: "tuple[int, ...]",
+    k: int,
+    j: int,
+    elem_bytes: int,
+    smem_budget: int,
+    **planner_kwargs,
+):
+    """Split *shape* for an edge-axis reduction and plan its rows pass.
+
+    Returns ``(lead, kept, trail, planner, cfg)``: the leading and trailing
+    reduced element counts, the kept middle, and the ``BlockConfigPlanner``
+    with its default config for rows of ``trail`` elements.
+    """
+    ndim = len(shape)
+    lead = prod(shape[:k])
+    kept = prod(shape[k : ndim - j])
+    trail = prod(shape[ndim - j :])
+    planner = BlockConfigPlanner(
+        align_up(trail, DEFAULT_ALIGNMENT),
+        elem_bytes,
+        smem_budget,
+        **planner_kwargs,
+    )
+    return lead, kept, trail, planner, planner.default_config()
 
 
 def edge_axis_split(ndim: int, axes: "tuple[int, ...]") -> "tuple[int, int]":
@@ -998,7 +1031,7 @@ def edge_axis_split(ndim: int, axes: "tuple[int, ...]") -> "tuple[int, int]":
     return (k, j)
 
 
-def leading_row_splits(reduced: int, kept: int, threads: int) -> int:
+def _leading_row_splits(reduced: int, kept: int, threads: int) -> int:
     """How many ways to split the reduced axis so the grid fills the device."""
     block_b = threads * _LEADING_POLICY.cols_per_thread
     column_blocks = ceildiv_int(kept, block_b)
@@ -1161,7 +1194,7 @@ def reduce_down_rows(
     if reduced * kept <= grid_work:
         splits = 1
     else:
-        splits = leading_row_splits(reduced, kept, _LEADING_POLICY.threads)
+        splits = _leading_row_splits(reduced, kept, _LEADING_POLICY.threads)
     if splits == 1:
         single = _down_rows_kernel(
             reduced,

--- a/src/tileops/kernels/reduction/_primitives.py
+++ b/src/tileops/kernels/reduction/_primitives.py
@@ -12,9 +12,12 @@ reduction runs over — which forms an empty ``dim`` takes, and which ranks it m
 the op's contract rather than a kernel's.
 """
 
+import functools
 import itertools
+from dataclasses import dataclass
 from math import prod
 
+import tilelang
 import tilelang.language as T
 import torch
 
@@ -28,16 +31,20 @@ __all__ = [
     "SHARED_MEMORY_BUDGET_BYTES",
     "VECTOR_ACCESS_BYTES",
     "BlockConfigPlanner",
+    "LeadingAxisReducePolicy",
     "RowTiledAutotuneMixin",
     "align_up",
     "ceildiv_int",
     "compute_tile_n",
     "device_smem_budget",
+    "edge_axis_split",
+    "leading_row_splits",
     "make_cumulative_scan",
     "make_reduce_epilogue",
     "make_softmax_epilogue",
     "make_welford_update",
     "reduce_column_alignment",
+    "reduce_down_rows",
     "restore_reduced",
     "restore_same_shape",
     "rows_for_axes",
@@ -948,3 +955,245 @@ class RowTiledAutotuneMixin:
             configs = [{"block_m": 1, "threads": 256, "tile_n": self._tile_n}]
 
         return configs
+
+
+# ---------------------------------------------------------------------------
+# Reducing an (A, B) buffer down its rows: the outer pass every edge-axis
+# reduction shares. The inner pass is each kernel class's own; this engine
+# takes its partials and reduces them down the lead axis.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LeadingAxisReducePolicy:
+    """Launch heuristics for reductions down contiguous leading axes."""
+
+    cols_per_thread: int = 8
+
+    threads: int = 64
+
+    target_blocks: int = 512
+
+
+_LEADING_POLICY = LeadingAxisReducePolicy()
+
+
+def edge_axis_split(ndim: int, axes: "tuple[int, ...]") -> "tuple[int, int]":
+    """Split *axes* into ``(leading, trailing)`` counts when they hug both edges.
+
+    Returns ``(0, 0)`` unless *axes* is a non-empty prefix plus a non-empty
+    suffix with at least one kept axis in between — the layout an edge-axis
+    reduction handles without permuting the tensor.
+    """
+    k = 0
+    while k < len(axes) and axes[k] == k:
+        k += 1
+    j = len(axes) - k
+    if k == 0 or j == 0:
+        return (0, 0)
+    if tuple(axes[k:]) != tuple(range(ndim - j, ndim)):
+        return (0, 0)
+    if k + j >= ndim:
+        return (0, 0)
+    return (k, j)
+
+
+def leading_row_splits(reduced: int, kept: int, threads: int) -> int:
+    """How many ways to split the reduced axis so the grid fills the device."""
+    block_b = threads * _LEADING_POLICY.cols_per_thread
+    column_blocks = ceildiv_int(kept, block_b)
+    return max(1, min(reduced, ceildiv_int(_LEADING_POLICY.target_blocks, column_blocks)))
+
+
+def _down_rows_identity(op_kind: str) -> float:
+    """The identity element a masked lane contributes."""
+    if op_kind == "amin":
+        return float("inf")
+    if op_kind == "amax":
+        return float("-inf")
+    return 0.0
+
+
+def _make_down_rows_ops(op_kind: str, divisor: float, out_dtype: str, epilogue: str):
+    """Create the per-op macros used by the down-rows reduction."""
+
+    @T.macro
+    def init(acc):
+        if op_kind == "amax":
+            T.fill(acc, -T.infinity("float32"))
+        elif op_kind == "amin":
+            T.fill(acc, T.infinity("float32"))
+        else:
+            T.fill(acc, 0.0)
+
+    @T.macro
+    def combine(acc, slot, value):
+        if op_kind == "amax":
+            acc[slot] = T.max(acc[slot], value)
+        elif op_kind == "amin":
+            acc[slot] = T.min(acc[slot], value)
+        else:
+            acc[slot] = acc[slot] + value
+
+    @T.macro
+    def finish(out_local, slot, accumulated):
+        if divisor and epilogue == "sqrt":
+            out_local[slot] = T.cast(T.sqrt(accumulated / divisor), out_dtype)
+        elif divisor:
+            out_local[slot] = T.cast(accumulated / divisor, out_dtype)
+        elif epilogue == "sqrt":
+            out_local[slot] = T.cast(T.sqrt(accumulated), out_dtype)
+        else:
+            out_local[slot] = T.cast(accumulated, out_dtype)
+
+    return init, combine, finish
+
+
+@functools.lru_cache(maxsize=32)
+def _down_rows_kernel(
+    A: int,
+    B: int,
+    op_kind: str,
+    in_dtype: str,
+    out_dtype: str,
+    threads: int,
+    splits: int,
+    divisor: float,
+    epilogue: str,
+):
+    """Build a reduce down the leading axis of an ``(A, B)`` buffer.
+
+    One accumulator per output column, walked down the rows the block owns. Adjacent
+    threads take adjacent columns, so every row of the walk is one coalesced pass and
+    the buffer is read once in the layout it already has.
+
+    The grid is ``(column blocks, splits)``: a leading-axis reduction has only as many
+    output columns as the axes it keeps, and one block per column tile would leave an
+    H200 running four of them.
+
+    Args:
+        A: Elements the reduction consumes per output column.
+        B: Output columns.
+        op_kind: One of ``sum`` / ``mean`` / ``amax`` / ``amin``.
+        in_dtype: TileLang dtype string of the input.
+        out_dtype: TileLang dtype string of the output. A split pass writes fp32
+            partials whatever it read; the pass that finishes writes the declared dtype.
+        threads: Threads per block.
+        splits: Row slices, each its own block row. Above 1 the output is one row of
+            partials per slice, for a second call with ``splits=1`` to finish.
+        divisor: What the accumulator is divided by before the output cast, or 0 for
+            none. Mean's divisor is the row count of the whole reduction, which a
+            second pass over partials can no longer see.
+        epilogue: ``"sqrt"`` applies a square root before the output cast, for a
+            caller whose outer pass finishes a sum-of-squares; ``""`` for none.
+    """
+    block_b = threads * _LEADING_POLICY.cols_per_thread
+    rows_per_split = ceildiv_int(A, splits)
+    exact = B % block_b == 0
+    init_acc, combine, finish = _make_down_rows_ops(op_kind, divisor, out_dtype, epilogue)
+
+    @tilelang.jit(out_idx=[1])
+    def _func():
+        @T.prim_func
+        def main(
+            x: T.Tensor[(A, B), in_dtype],
+            out: T.Tensor[(splits * B,), out_dtype],
+        ):
+            with T.Kernel(T.ceildiv(B, block_b), splits, threads=threads) as (pid_b, pid_a):
+                acc = T.alloc_fragment((block_b,), "float32")
+                out_local = T.alloc_fragment((block_b,), out_dtype)
+
+                init_acc(acc)
+
+                for step in T.serial(rows_per_split):
+                    row = pid_a * rows_per_split + step
+                    for j in T.Parallel(block_b):
+                        col = pid_b * block_b + j
+                        in_range = row < A if exact else T.And(row < A, col < B)
+                        val = T.if_then_else(
+                            in_range,
+                            T.cast(x[row, col], "float32"),
+                            T.cast(_down_rows_identity(op_kind), "float32"),
+                        )
+                        combine(acc, j, val)
+
+                for j in T.Parallel(block_b):
+                    finish(out_local, j, acc[j])
+
+                if exact:
+                    T.copy(out_local, out[pid_a * B + pid_b * block_b])
+                else:
+                    for j in T.Parallel(block_b):
+                        # TileLang requires T.If/T.Then as nested context managers.
+                        with T.If(pid_b * block_b + j < B):  # noqa: SIM117
+                            with T.Then():
+                                out[pid_a * B + pid_b * block_b + j] = out_local[j]
+
+        return main
+
+    return _func
+
+
+def reduce_down_rows(
+    flat: torch.Tensor,
+    op_kind: str,
+    in_dtype: str,
+    out_dtype: str,
+    divisor: float,
+    epilogue: str = "",
+) -> torch.Tensor:
+    """Reduce an ``(A, B)`` buffer down its rows, writing one *out_dtype* row.
+
+    Splitting the reduced axis is what fills the grid, and each slice leaves an
+    fp32 partial row; a second call over those rows finishes the op. The partials
+    are a few thousand values against the millions the first pass reads, so the
+    second call costs about nothing. ``divisor`` and ``epilogue`` apply only at
+    the finishing call.
+    """
+    reduced, kept = flat.shape
+    # An input smaller than one grid's worth of work cannot amortize the
+    # extra pass a split costs; reduce it in a single call.
+    grid_work = (
+        _LEADING_POLICY.threads * _LEADING_POLICY.cols_per_thread * _LEADING_POLICY.target_blocks
+    )
+    if reduced * kept <= grid_work:
+        splits = 1
+    else:
+        splits = leading_row_splits(reduced, kept, _LEADING_POLICY.threads)
+    if splits == 1:
+        single = _down_rows_kernel(
+            reduced,
+            kept,
+            op_kind,
+            in_dtype,
+            out_dtype,
+            _LEADING_POLICY.threads,
+            1,
+            divisor,
+            epilogue,
+        )
+        return single()(flat)
+    partials = _down_rows_kernel(
+        reduced,
+        kept,
+        op_kind,
+        in_dtype,
+        "float32",
+        _LEADING_POLICY.threads,
+        splits,
+        0.0,
+        "",
+    )()(flat)
+    # Partials are summed even for mean, whose divisor is the whole row count.
+    finish = _down_rows_kernel(
+        splits,
+        kept,
+        "sum" if op_kind == "mean" else op_kind,
+        "float32",
+        out_dtype,
+        _LEADING_POLICY.threads,
+        1,
+        divisor,
+        epilogue,
+    )
+    return finish()(partials.reshape(splits, kept))

--- a/src/tileops/kernels/reduction/_split_softmax.py
+++ b/src/tileops/kernels/reduction/_split_softmax.py
@@ -1,11 +1,9 @@
 """Split-row softmax statistics, shared by softmax, log_softmax, and logsumexp.
 
-A handful of long rows cannot fill the device one block per row. The split
-gives every row ``ceildiv(N, seg_n)`` blocks: one pass writes each segment's
-fp32 ``(max, sum)``, and a fold combines them — softmax and log_softmax then
-re-read their segment to write it normalized, logsumexp folds straight to its
-scalar. This module holds the gate, the statistics pass, and the fold; the
-pass that writes each op's output stays in that op's module.
+A handful of long rows cannot fill the device one block per row; the split
+gives every row one block per segment. This module holds the gate, the
+fp32 ``(max, sum)`` statistics pass, and the fold; the pass that writes each
+op's output stays in that op's module.
 """
 
 import functools

--- a/src/tileops/kernels/reduction/_split_softmax.py
+++ b/src/tileops/kernels/reduction/_split_softmax.py
@@ -1,0 +1,149 @@
+"""Split-row softmax statistics, shared by softmax, log_softmax, and logsumexp.
+
+A handful of long rows cannot fill the device one block per row. The split
+gives every row ``ceildiv(N, seg_n)`` blocks: one pass writes each segment's
+fp32 ``(max, sum)``, and a fold combines them — softmax and log_softmax then
+re-read their segment to write it normalized, logsumexp folds straight to its
+scalar. This module holds the gate, the statistics pass, and the fold; the
+pass that writes each op's output stays in that op's module.
+"""
+
+import functools
+
+import tilelang
+import tilelang.language as T
+import torch
+
+from tileops.kernels.reduction._primitives import (
+    DEFAULT_ALIGNMENT,
+    DEFAULT_THREADS,
+    FRAGMENT_ELEMS_PER_THREAD,
+    align_up,
+    ceildiv_int,
+)
+
+__all__ = [
+    "make_split_fold",
+    "softmax_split_partials_kernel",
+    "split_seg_n",
+    "split_target_blocks",
+]
+
+# Blocks per SM a split aims for; under this the grid runs the device empty.
+_OCCUPANCY_FACTOR = 2
+
+# Rows shorter than this cannot amortize the fold pass. Measured threshold,
+# not derived: below it the second launch outweighs the extra blocks.
+_SPLIT_MIN_AMORTIZED_COLS = 16384
+
+# Widest segment a partials block holds in its fragment.
+_SPLIT_MAX_SEG_COLS = FRAGMENT_ELEMS_PER_THREAD * DEFAULT_THREADS
+
+
+def split_target_blocks(device_index: "int | None" = None) -> int:
+    """The block count a split aims for: ``_OCCUPANCY_FACTOR`` per SM.
+
+    ``None`` reads the current device; without CUDA it falls back to an H200's
+    SM count, mirroring ``device_smem_budget``'s auto-detect fallback.
+    """
+    try:
+        if not torch.cuda.is_available():
+            return _OCCUPANCY_FACTOR * 132
+        if device_index is None:
+            device_index = torch.cuda.current_device()
+        return (
+            _OCCUPANCY_FACTOR * torch.cuda.get_device_properties(device_index).multi_processor_count
+        )
+    except (RuntimeError, AssertionError):
+        return _OCCUPANCY_FACTOR * 132
+
+
+def split_seg_n(M: int, N: int, block_m: int, target_blocks: int) -> int:
+    """The split-row segment width, or 0 when one block per row is enough.
+
+    Applies when the row grid leaves the device under-filled and a row is
+    long enough to amortize the fold pass; the segment count targets
+    *target_blocks* and the width stays aligned and within the fragment cap.
+    """
+    if align_up(N, DEFAULT_ALIGNMENT) < _SPLIT_MIN_AMORTIZED_COLS:
+        return 0
+    if ceildiv_int(M, block_m) >= target_blocks:
+        return 0
+    num_segs = max(1, ceildiv_int(target_blocks, M))
+    seg_n = min(align_up(ceildiv_int(N, num_segs), DEFAULT_ALIGNMENT), _SPLIT_MAX_SEG_COLS)
+    if ceildiv_int(N, seg_n) < 2:
+        return 0
+    return seg_n
+
+
+@functools.lru_cache(maxsize=64)
+def softmax_split_partials_kernel(M: int, N: int, seg_n: int, dtype: str, threads: int):
+    """Per-segment softmax statistics: fp32 ``(max, sum)`` for a later fold.
+
+    One block owns one ``seg_n``-column segment of one row and writes the
+    segment's max and its sum of ``exp(x - max)``. With a finite segment max,
+    a masked lane contributes ``exp(-inf) = 0``; a segment whose max is
+    ``-inf`` (all lanes masked ``-inf``) writes an explicit zero sum, since
+    ``exp(-inf - -inf)`` is NaN.
+    """
+    num_segs = ceildiv_int(N, seg_n)
+
+    @tilelang.jit(out_idx=[1, 2])
+    def _func():
+        @T.prim_func
+        def main(
+            x: T.Tensor[(M, N), dtype],
+            seg_max: T.Tensor[(M * num_segs,), "float32"],  # noqa: F821
+            seg_sum: T.Tensor[(M * num_segs,), "float32"],  # noqa: F821
+        ):
+            with T.Kernel(num_segs, M, threads=threads) as (pid_s, pid_m):
+                x_f32 = T.alloc_fragment((1, seg_n), "float32")
+                m_s = T.alloc_fragment((1,), "float32")
+                s_s = T.alloc_fragment((1,), "float32")
+
+                for _, j in T.Parallel(1, seg_n):
+                    x_f32[0, j] = T.if_then_else(
+                        pid_s * seg_n + j < N,
+                        T.cast(x[pid_m, pid_s * seg_n + j], "float32"),
+                        -T.infinity("float32"),
+                    )
+                T.fill(m_s, -T.infinity("float32"))
+                T.reduce_max(x_f32, m_s, dim=1, clear=False)
+                for _, j in T.Parallel(1, seg_n):
+                    x_f32[0, j] = T.exp(x_f32[0, j] - m_s[0])
+                T.reduce_sum(x_f32, s_s, dim=1)
+
+                seg_max[pid_m * num_segs + pid_s] = m_s[0]
+                seg_sum[pid_m * num_segs + pid_s] = T.if_then_else(
+                    m_s[0] == -T.infinity("float32"), T.cast(0.0, "float32"), s_s[0]
+                )
+
+        return main
+
+    return _func
+
+
+def make_split_fold(num_segs: int):
+    """Create the macro folding one row's segment statistics.
+
+    Reads ``num_segs`` fp32 pairs starting at *base* and leaves the row's max
+    and rescaled sum in two scalar locals. An all--inf segment contributes
+    nothing; folding it through ``exp(-inf - row_max)`` would turn NaN when
+    ``row_max`` is -inf too. An all--inf row leaves ``(-inf, 0)``, which reads
+    as torch's NaN softmax and -inf logsumexp downstream.
+    """
+
+    @T.macro
+    def fold(seg_max, seg_sum, base, row_max, row_sum):
+        row_max[0] = -T.infinity("float32")
+        for s in T.serial(num_segs):
+            row_max[0] = T.max(row_max[0], seg_max[base + s])
+        row_sum[0] = 0.0
+        for s in T.serial(num_segs):
+            row_sum[0] = row_sum[0] + T.if_then_else(
+                seg_max[base + s] == -T.infinity("float32"),
+                T.cast(0.0, "float32"),
+                seg_sum[base + s] * T.exp(seg_max[base + s] - row_max[0]),
+            )
+
+    return fold

--- a/src/tileops/kernels/reduction/_split_softmax.py
+++ b/src/tileops/kernels/reduction/_split_softmax.py
@@ -127,23 +127,26 @@ def make_split_fold(num_segs: int):
     """Create the macro folding one row's segment statistics.
 
     Reads ``num_segs`` fp32 pairs starting at *base* and leaves the row's max
-    and rescaled sum in two scalar locals. An all--inf segment contributes
+    and rescaled sum in two scalar locals; *held* is a caller-allocated fp32
+    scalar, since a macro argument is substituted per mention and an indexed
+    read spelled twice would load twice. An all--inf segment contributes
     nothing; folding it through ``exp(-inf - row_max)`` would turn NaN when
     ``row_max`` is -inf too. An all--inf row leaves ``(-inf, 0)``, which reads
     as torch's NaN softmax and -inf logsumexp downstream.
     """
 
     @T.macro
-    def fold(seg_max, seg_sum, base, row_max, row_sum):
+    def fold(seg_max, seg_sum, base, row_max, row_sum, held):
         row_max[0] = -T.infinity("float32")
         for s in T.serial(num_segs):
             row_max[0] = T.max(row_max[0], seg_max[base + s])
         row_sum[0] = 0.0
         for s in T.serial(num_segs):
+            held[0] = seg_max[base + s]
             row_sum[0] = row_sum[0] + T.if_then_else(
-                seg_max[base + s] == -T.infinity("float32"),
+                held[0] == -T.infinity("float32"),
                 T.cast(0.0, "float32"),
-                seg_sum[base + s] * T.exp(seg_max[base + s] - row_max[0]),
+                seg_sum[base + s] * T.exp(held[0] - row_max[0]),
             )
 
     return fold

--- a/src/tileops/kernels/reduction/logical_reduce.py
+++ b/src/tileops/kernels/reduction/logical_reduce.py
@@ -25,9 +25,11 @@ from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.reduction._primitives import (
     DEFAULT_ALIGNMENT,
     DEFAULT_THREADS,
+    FP32_EXACT_INT_LIMIT,
     BlockConfigPlanner,
     align_up,
     device_smem_budget,
+    edge_axis_plan,
     edge_axis_split,
     reduce_down_rows,
     restore_reduced,
@@ -424,7 +426,7 @@ class LogicalReduceKernel(Kernel):
         # A count is carried in fp32 across the two passes: exact while the
         # elements each output reduces stay within fp32's integer range.
         reduced_count = x.numel() // prod(x.shape[k : x.ndim - j]) if k else 0
-        if k and (self.op_kind != "count_nonzero" or reduced_count <= 2**24):
+        if k and (self.op_kind != "count_nonzero" or reduced_count <= FP32_EXACT_INT_LIMIT):
             y = self._reduce_edge_axes(x, k, j)
             return restore_reduced(y, in_shape, self.reduce_axes, self.keepdim)
         rows = rows_for_axes(x, self.reduce_axes)
@@ -439,17 +441,10 @@ class LogicalReduceKernel(Kernel):
         leading axes fold down the columns of those partials — or/and are max/
         min over 0 and 1, a count is a sum.
         """
-        shape = tuple(x.shape)
-        lead = prod(shape[:k])
-        kept = prod(shape[k : x.ndim - j])
-        trail = prod(shape[x.ndim - j :])
-        dtype_str = self.dtype_to_str(self._kernel_dtype)
-        planner = BlockConfigPlanner(
-            align_up(trail, DEFAULT_ALIGNMENT),
-            self._elem_bytes,
-            self._smem_budget,
+        lead, kept, trail, planner, cfg = edge_axis_plan(
+            tuple(x.shape), k, j, self._elem_bytes, self._smem_budget
         )
-        cfg = planner.default_config()
+        dtype_str = self.dtype_to_str(self._kernel_dtype)
         if planner.needs_tiling:
             stage = _logical_reduce_kernel_tiled(
                 lead * kept, trail, self.op_kind, dtype_str, cfg["tile_n"], partial=True

--- a/src/tileops/kernels/reduction/logical_reduce.py
+++ b/src/tileops/kernels/reduction/logical_reduce.py
@@ -421,8 +421,10 @@ class LogicalReduceKernel(Kernel):
         if x.dtype in _UNSUPPORTED_STORAGE_DTYPES:
             x = to_logical_storage(x)
         k, j = edge_axis_split(x.ndim, self.reduce_axes)
-        # A count is carried in fp32 across the two passes, exact below 2^24.
-        if k and (self.op_kind != "count_nonzero" or x.numel() < 2**24):
+        # A count is carried in fp32 across the two passes: exact while the
+        # elements each output reduces stay within fp32's integer range.
+        reduced_count = x.numel() // prod(x.shape[k : x.ndim - j]) if k else 0
+        if k and (self.op_kind != "count_nonzero" or reduced_count <= 2**24):
             y = self._reduce_edge_axes(x, k, j)
             return restore_reduced(y, in_shape, self.reduce_axes, self.keepdim)
         rows = rows_for_axes(x, self.reduce_axes)

--- a/src/tileops/kernels/reduction/logical_reduce.py
+++ b/src/tileops/kernels/reduction/logical_reduce.py
@@ -14,6 +14,7 @@ any/all, int64 for count_nonzero.
 """
 
 import functools
+from math import prod
 from typing import Optional
 
 import tilelang
@@ -27,6 +28,8 @@ from tileops.kernels.reduction._primitives import (
     BlockConfigPlanner,
     align_up,
     device_smem_budget,
+    edge_axis_split,
+    reduce_down_rows,
     restore_reduced,
     rows_for_axes,
     tune_by_forward,
@@ -86,8 +89,19 @@ def _pad_value_for_op(op_kind: str) -> float:
 # Logical reduce kernel
 
 
+def _logical_out_dtype(op_kind: str, partial: bool) -> str:
+    """The dtype a logical reduce writes: 0/1 stays int8, a count widens.
+
+    A count written for an outer pass stays fp32, exact below 2^24, so the
+    down-rows engine can sum it without an int accumulator.
+    """
+    if op_kind != "count_nonzero":
+        return "int8"
+    return "float32" if partial else "int64"
+
+
 @functools.lru_cache(maxsize=32)
-def _logical_reduce_kernel(M: int, N: int, op_kind: str, dtype: str):
+def _logical_reduce_kernel(M: int, N: int, op_kind: str, dtype: str, partial: bool = False):
     """Build a TileLang any/all/count_nonzero kernel.
 
     Cast input to bool (0.0 or 1.0 in float32), then:
@@ -100,6 +114,8 @@ def _logical_reduce_kernel(M: int, N: int, op_kind: str, dtype: str):
         N: Original hidden dimension (last dim, before padding).
         op_kind: One of "any", "all", "count_nonzero".
         dtype: TileLang dtype string (e.g. "float16", "bfloat16", "float32").
+        partial: Write partials for an outer pass; only the count changes,
+            staying fp32 instead of widening to int64.
 
     Returns:
         A TileLang JIT-compiled kernel factory accepting (block_m, threads).
@@ -107,21 +123,20 @@ def _logical_reduce_kernel(M: int, N: int, op_kind: str, dtype: str):
     N_padded = align_up(N, DEFAULT_ALIGNMENT)
     _needs_pad = N_padded != N
     _pad_val = _pad_value_for_op(op_kind)
+    out_dtype = _logical_out_dtype(op_kind, partial)
 
     @tilelang.jit(out_idx=[1])
     def _func(block_m, threads):
         @T.macro
         def compute(
             x: T.Tensor[(M, N), dtype],
-            out: T.Tensor[(M,), "int8" if op_kind != "count_nonzero" else "int64"],  # noqa: F821
+            out: T.Tensor[(M,), out_dtype],
         ):
             with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
                 shared_buf = T.alloc_shared((block_m, N_padded), dtype)
                 bool_vals = T.alloc_fragment((block_m, N_padded), "float32")
                 result = T.alloc_fragment((block_m,), "float32")
-                out_local = T.alloc_fragment(
-                    (block_m,), "int8" if op_kind != "count_nonzero" else "int64"
-                )
+                out_local = T.alloc_fragment((block_m,), out_dtype)
 
                 # Truthiness is decided at the load, so a tile costs one fragment.
                 if _needs_pad:
@@ -155,7 +170,7 @@ def _logical_reduce_kernel(M: int, N: int, op_kind: str, dtype: str):
 
                 if op_kind == "count_nonzero":
                     for i in T.Parallel(block_m):
-                        out_local[i] = T.cast(result[i], "int64")
+                        out_local[i] = T.cast(result[i], out_dtype)
                 else:
                     # Cast result to int8 (bool representation: 0 or 1)
                     for i in T.Parallel(block_m):
@@ -167,7 +182,7 @@ def _logical_reduce_kernel(M: int, N: int, op_kind: str, dtype: str):
         @T.prim_func
         def main(
             x: T.Tensor[(M, N), dtype],
-            out: T.Tensor[(M,), "int8" if op_kind != "count_nonzero" else "int64"],  # noqa: F821
+            out: T.Tensor[(M,), out_dtype],
         ):
             compute(x, out)
 
@@ -177,16 +192,19 @@ def _logical_reduce_kernel(M: int, N: int, op_kind: str, dtype: str):
 
 
 @functools.lru_cache(maxsize=32)
-def _logical_reduce_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_n: int):
+def _logical_reduce_kernel_tiled(
+    M: int, N: int, op_kind: str, dtype: str, tile_n: int, partial: bool = False
+):
     """Build a tiled TileLang any/all/count_nonzero kernel.
 
     Iterates over the reduction dimension in chunks of ``tile_n`` columns, for the
-    rows a single pass cannot hold.
+    rows a single pass cannot hold. ``partial`` as in ``_logical_reduce_kernel``.
     """
     N_padded = align_up(N, DEFAULT_ALIGNMENT)
     num_tiles = (N_padded + tile_n - 1) // tile_n
     _pad_val = _pad_value_for_op(op_kind)
     _past_n = num_tiles * tile_n > N
+    out_dtype = _logical_out_dtype(op_kind, partial)
 
     @tilelang.jit(out_idx=[1])
     def _func(block_m, threads):
@@ -196,16 +214,14 @@ def _logical_reduce_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_
         @T.macro
         def compute(
             x: T.Tensor[(M, N), dtype],
-            out: T.Tensor[(M,), "int8" if op_kind != "count_nonzero" else "int64"],  # noqa: F821
+            out: T.Tensor[(M,), out_dtype],
         ):
             with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
                 shared_buf = T.alloc_shared((block_m, tile_n), dtype)
                 bool_vals = T.alloc_fragment((block_m, tile_n), "float32")
                 acc = T.alloc_fragment((block_m,), "float32")
                 tile_acc = T.alloc_fragment((block_m,), "float32")
-                out_local = T.alloc_fragment(
-                    (block_m,), "int8" if op_kind != "count_nonzero" else "int64"
-                )
+                out_local = T.alloc_fragment((block_m,), out_dtype)
 
                 if op_kind == "all":
                     T.fill(acc, 1.0)
@@ -262,7 +278,7 @@ def _logical_reduce_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_
 
                 if op_kind == "count_nonzero":
                     for i in T.Parallel(block_m):
-                        out_local[i] = T.cast(acc[i], "int64")
+                        out_local[i] = T.cast(acc[i], out_dtype)
                 else:
                     for i in T.Parallel(block_m):
                         out_local[i] = T.cast(acc[i] > 0.5, "int8")
@@ -273,7 +289,7 @@ def _logical_reduce_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_
         @T.prim_func
         def main(
             x: T.Tensor[(M, N), dtype],
-            out: T.Tensor[(M,), "int8" if op_kind != "count_nonzero" else "int64"],  # noqa: F821
+            out: T.Tensor[(M,), out_dtype],
         ):
             compute(x, out)
 
@@ -404,9 +420,48 @@ class LogicalReduceKernel(Kernel):
         in_shape = tuple(x.shape)
         if x.dtype in _UNSUPPORTED_STORAGE_DTYPES:
             x = to_logical_storage(x)
+        k, j = edge_axis_split(x.ndim, self.reduce_axes)
+        # A count is carried in fp32 across the two passes, exact below 2^24.
+        if k and (self.op_kind != "count_nonzero" or x.numel() < 2**24):
+            y = self._reduce_edge_axes(x, k, j)
+            return restore_reduced(y, in_shape, self.reduce_axes, self.keepdim)
         rows = rows_for_axes(x, self.reduce_axes)
         y = self._reduce_rows(rows)
         return restore_reduced(y, in_shape, self.reduce_axes, self.keepdim)
+
+    def _reduce_edge_axes(self, x: torch.Tensor, k: int, j: int) -> torch.Tensor:
+        """Reduce a prefix and a suffix of the axes without permuting the tensor.
+
+        Two passes in the tensor's own layout: the trailing axes reduce as
+        contiguous rows into 0/1 int8 (or fp32 count) partials, then the
+        leading axes fold down the columns of those partials — or/and are max/
+        min over 0 and 1, a count is a sum.
+        """
+        shape = tuple(x.shape)
+        lead = prod(shape[:k])
+        kept = prod(shape[k : x.ndim - j])
+        trail = prod(shape[x.ndim - j :])
+        dtype_str = self.dtype_to_str(self._kernel_dtype)
+        planner = BlockConfigPlanner(
+            align_up(trail, DEFAULT_ALIGNMENT),
+            self._elem_bytes,
+            self._smem_budget,
+        )
+        cfg = planner.default_config()
+        if planner.needs_tiling:
+            stage = _logical_reduce_kernel_tiled(
+                lead * kept, trail, self.op_kind, dtype_str, cfg["tile_n"], partial=True
+            )
+        else:
+            stage = _logical_reduce_kernel(
+                lead * kept, trail, self.op_kind, dtype_str, partial=True
+            )
+        partials = stage(cfg["block_m"], cfg["threads"])(x.reshape(lead * kept, trail))
+        partials = partials.reshape(lead, kept)
+        if self.op_kind == "count_nonzero":
+            return reduce_down_rows(partials, "sum", "float32", "float32", 0.0).to(torch.int64)
+        outer_kind = "amax" if self.op_kind == "any" else "amin"
+        return reduce_down_rows(partials, outer_kind, "int8", "int8", 0.0).view(torch.bool)
 
     def _reduce_rows(self, x: torch.Tensor) -> torch.Tensor:
         """Reduce the trailing axis of an ``(M, N)`` buffer.

--- a/src/tileops/kernels/reduction/logsumexp.py
+++ b/src/tileops/kernels/reduction/logsumexp.py
@@ -28,16 +28,56 @@ from tileops.kernels.reduction._primitives import (
     BlockConfigPlanner,
     RowTiledAutotuneMixin,
     align_up,
+    ceildiv_int,
     device_smem_budget,
     restore_reduced,
     rows_for_axes,
 )
+from tileops.kernels.reduction.softmax import _softmax_split_partials_kernel, split_seg_n
 
 # These two kernels bake tile_n in at build time and default to the wider
 # thread block; AUTOTUNE_THREADS still bounds what the sweep explores.
 _DEFAULT_TUNE_THREADS = 256
 
 __all__ = ["LogSumExpKernel"]
+
+
+@functools.lru_cache(maxsize=64)
+def _logsumexp_split_fold_kernel(M: int, N: int, dtype: str, seg_n: int):
+    """Fold per-segment ``(max, sum)`` into one logsumexp per row.
+
+    The fold is over a few hundred fp32 pairs, so one warp per row is enough;
+    unlike softmax there is no second pass over the input.
+    """
+    num_segs = ceildiv_int(N, seg_n)
+
+    @tilelang.jit(out_idx=[2])
+    def _func():
+        @T.prim_func
+        def main(
+            seg_max: T.Tensor[(M * num_segs,), "float32"],  # noqa: F821
+            seg_sum: T.Tensor[(M * num_segs,), "float32"],  # noqa: F821
+            y: T.Tensor[(M,), dtype],
+        ):
+            with T.Kernel(M, threads=32) as pid_m:
+                tx = T.get_thread_binding()
+                row_max = T.alloc_local((1,), "float32")
+                row_sum = T.alloc_local((1,), "float32")
+
+                if tx == 0:
+                    row_max[0] = -T.infinity("float32")
+                    for s in T.serial(num_segs):
+                        row_max[0] = T.max(row_max[0], seg_max[pid_m * num_segs + s])
+                    row_sum[0] = 0.0
+                    for s in T.serial(num_segs):
+                        row_sum[0] = row_sum[0] + seg_sum[pid_m * num_segs + s] * T.exp(
+                            seg_max[pid_m * num_segs + s] - row_max[0]
+                        )
+                    y[pid_m] = T.cast(row_max[0] + T.log(row_sum[0]), dtype)
+
+        return main
+
+    return _func
 
 
 # Single-tile kernel (N fits in shared memory) -- original fast path
@@ -456,6 +496,24 @@ class LogSumExpKernel(RowTiledAutotuneMixin, Kernel):
         return restore_reduced(y, in_shape, self.reduce_axes, self.keepdim)
 
     def _reduce_rows(self, x: torch.Tensor) -> torch.Tensor:
-        """Reduce the trailing axis of an ``(M, N)`` buffer."""
+        """Reduce the trailing axis of an ``(M, N)`` buffer.
+
+        A handful of long rows goes to the split pair: softmax's per-segment
+        statistics, then a per-row fold.
+        """
+        seg_n = split_seg_n(
+            self.M,
+            self.N,
+            self.N_padded,
+            (self.M + self.config["block_m"] - 1) // self.config["block_m"],
+        )
+        if seg_n:
+            threads = self.config.get("threads", _DEFAULT_TUNE_THREADS)
+            seg_max, seg_sum = _softmax_split_partials_kernel(
+                self.M, self.N, seg_n, self.dtype_str, threads
+            )()(x)
+            return _logsumexp_split_fold_kernel(self.M, self.N, self.dtype_str, seg_n)()(
+                seg_max, seg_sum
+            )
         program = _logsumexp_kernel(self.M, self.N, self.dtype_str, self._tile_n)
         return program(self.config["block_m"], self.config["threads"])(x)

--- a/src/tileops/kernels/reduction/logsumexp.py
+++ b/src/tileops/kernels/reduction/logsumexp.py
@@ -69,9 +69,16 @@ def _logsumexp_split_fold_kernel(M: int, N: int, dtype: str, seg_n: int):
                     for s in T.serial(num_segs):
                         row_max[0] = T.max(row_max[0], seg_max[pid_m * num_segs + s])
                     row_sum[0] = 0.0
+                    # An all--inf segment contributes nothing; folding it
+                    # through exp(-inf - row_max) would turn NaN when row_max
+                    # is -inf too. An all--inf row then reads -inf + log(0),
+                    # which is torch's -inf.
                     for s in T.serial(num_segs):
-                        row_sum[0] = row_sum[0] + seg_sum[pid_m * num_segs + s] * T.exp(
-                            seg_max[pid_m * num_segs + s] - row_max[0]
+                        row_sum[0] = row_sum[0] + T.if_then_else(
+                            seg_max[pid_m * num_segs + s] == -T.infinity("float32"),
+                            T.cast(0.0, "float32"),
+                            seg_sum[pid_m * num_segs + s]
+                            * T.exp(seg_max[pid_m * num_segs + s] - row_max[0]),
                         )
                     y[pid_m] = T.cast(row_max[0] + T.log(row_sum[0]), dtype)
 
@@ -423,6 +430,14 @@ class LogSumExpKernel(RowTiledAutotuneMixin, Kernel):
         and picks the overall best (block_m, threads, tile_n) config.
         """
         from tilelang.autotuner import autotune as tl_autotune
+
+        # The split pair bypasses the tuned kernel; measuring candidates for
+        # a path forward will not take is waste, so the default config
+        # (whose threads the split kernels share) stands.
+        default = self.default_config
+        if split_seg_n(self.M, self.N, self.N_padded, ceildiv_int(self.M, default["block_m"])):
+            self.config = default
+            return
 
         configs = self.autotune_configs
         if not configs:

--- a/src/tileops/kernels/reduction/logsumexp.py
+++ b/src/tileops/kernels/reduction/logsumexp.py
@@ -429,7 +429,7 @@ class LogSumExpKernel(RowTiledAutotuneMixin, Kernel):
         from tilelang.autotuner import autotune as tl_autotune
 
         # The split pair bypasses the tuned kernel; measuring candidates for
-        # a path forward will not take is waste, so the default config
+        # a path forward will not take is wasted work, so the default config
         # (whose threads the split kernels share) stands.
         default = self.default_config
         if split_seg_n(self.M, self.N, default["block_m"], self._split_target):
@@ -515,7 +515,9 @@ class LogSumExpKernel(RowTiledAutotuneMixin, Kernel):
         """
         seg_n = split_seg_n(self.M, self.N, self.config["block_m"], self._split_target)
         if seg_n:
-            threads = self.config.get("threads", _DEFAULT_TUNE_THREADS)
+            # The split pair stands on the default width: split_seg_n's
+            # fragment cap assumes it, and autotune never sweeps this path.
+            threads = _DEFAULT_TUNE_THREADS
             seg_max, seg_sum = softmax_split_partials_kernel(
                 self.M, self.N, seg_n, self.dtype_str, threads
             )()(x)

--- a/src/tileops/kernels/reduction/logsumexp.py
+++ b/src/tileops/kernels/reduction/logsumexp.py
@@ -72,9 +72,10 @@ def _logsumexp_split_fold_kernel(M: int, N: int, dtype: str, seg_n: int):
                 tx = T.get_thread_binding()
                 row_max = T.alloc_local((1,), "float32")
                 row_sum = T.alloc_local((1,), "float32")
+                held = T.alloc_local((1,), "float32")
 
                 if tx == 0:
-                    fold(seg_max, seg_sum, pid_m * num_segs, row_max, row_sum)
+                    fold(seg_max, seg_sum, pid_m * num_segs, row_max, row_sum, held)
                     y[pid_m] = T.cast(row_max[0] + T.log(row_sum[0]), dtype)
 
         return main

--- a/src/tileops/kernels/reduction/logsumexp.py
+++ b/src/tileops/kernels/reduction/logsumexp.py
@@ -428,9 +428,7 @@ class LogSumExpKernel(RowTiledAutotuneMixin, Kernel):
         """
         from tilelang.autotuner import autotune as tl_autotune
 
-        # The split pair bypasses the tuned kernel; measuring candidates for
-        # a path forward will not take is wasted work, so the default config
-        # (whose threads the split kernels share) stands.
+        # The split pair bypasses the tuned kernel, so the default config stands.
         default = self.default_config
         if split_seg_n(self.M, self.N, default["block_m"], self._split_target):
             self.config = default
@@ -515,8 +513,7 @@ class LogSumExpKernel(RowTiledAutotuneMixin, Kernel):
         """
         seg_n = split_seg_n(self.M, self.N, self.config["block_m"], self._split_target)
         if seg_n:
-            # The split pair stands on the default width: split_seg_n's
-            # fragment cap assumes it, and autotune never sweeps this path.
+            # split_seg_n's fragment cap assumes the default width.
             threads = _DEFAULT_TUNE_THREADS
             seg_max, seg_sum = softmax_split_partials_kernel(
                 self.M, self.N, seg_n, self.dtype_str, threads

--- a/src/tileops/kernels/reduction/logsumexp.py
+++ b/src/tileops/kernels/reduction/logsumexp.py
@@ -33,11 +33,18 @@ from tileops.kernels.reduction._primitives import (
     restore_reduced,
     rows_for_axes,
 )
-from tileops.kernels.reduction.softmax import _softmax_split_partials_kernel, split_seg_n
+from tileops.kernels.reduction._split_softmax import (
+    make_split_fold,
+    softmax_split_partials_kernel,
+    split_seg_n,
+    split_target_blocks,
+)
 
 # These two kernels bake tile_n in at build time and default to the wider
 # thread block; AUTOTUNE_THREADS still bounds what the sweep explores.
 _DEFAULT_TUNE_THREADS = 256
+
+_WARP_LANES = 32
 
 __all__ = ["LogSumExpKernel"]
 
@@ -47,9 +54,11 @@ def _logsumexp_split_fold_kernel(M: int, N: int, dtype: str, seg_n: int):
     """Fold per-segment ``(max, sum)`` into one logsumexp per row.
 
     The fold is over a few hundred fp32 pairs, so one warp per row is enough;
-    unlike softmax there is no second pass over the input.
+    unlike softmax there is no second pass over the input. An all--inf row
+    reads ``-inf + log(0)``, which is torch's ``-inf``.
     """
     num_segs = ceildiv_int(N, seg_n)
+    fold = make_split_fold(num_segs)
 
     @tilelang.jit(out_idx=[2])
     def _func():
@@ -59,27 +68,13 @@ def _logsumexp_split_fold_kernel(M: int, N: int, dtype: str, seg_n: int):
             seg_sum: T.Tensor[(M * num_segs,), "float32"],  # noqa: F821
             y: T.Tensor[(M,), dtype],
         ):
-            with T.Kernel(M, threads=32) as pid_m:
+            with T.Kernel(M, threads=_WARP_LANES) as pid_m:
                 tx = T.get_thread_binding()
                 row_max = T.alloc_local((1,), "float32")
                 row_sum = T.alloc_local((1,), "float32")
 
                 if tx == 0:
-                    row_max[0] = -T.infinity("float32")
-                    for s in T.serial(num_segs):
-                        row_max[0] = T.max(row_max[0], seg_max[pid_m * num_segs + s])
-                    row_sum[0] = 0.0
-                    # An all--inf segment contributes nothing; folding it
-                    # through exp(-inf - row_max) would turn NaN when row_max
-                    # is -inf too. An all--inf row then reads -inf + log(0),
-                    # which is torch's -inf.
-                    for s in T.serial(num_segs):
-                        row_sum[0] = row_sum[0] + T.if_then_else(
-                            seg_max[pid_m * num_segs + s] == -T.infinity("float32"),
-                            T.cast(0.0, "float32"),
-                            seg_sum[pid_m * num_segs + s]
-                            * T.exp(seg_max[pid_m * num_segs + s] - row_max[0]),
-                        )
+                    fold(seg_max, seg_sum, pid_m * num_segs, row_max, row_sum)
                     y[pid_m] = T.cast(row_max[0] + T.log(row_sum[0]), dtype)
 
         return main
@@ -332,6 +327,7 @@ class LogSumExpKernel(RowTiledAutotuneMixin, Kernel):
         self.reduce_axes = tuple(reduce_axes)
         self.keepdim = keepdim
         self.N_padded = align_up(N, DEFAULT_ALIGNMENT)
+        self._split_target = split_target_blocks(device_index)
         self._elem_bytes = _elem_bytes(dtype)
         self._smem_budget = device_smem_budget(device_index)
         self._planner = BlockConfigPlanner(
@@ -435,7 +431,7 @@ class LogSumExpKernel(RowTiledAutotuneMixin, Kernel):
         # a path forward will not take is waste, so the default config
         # (whose threads the split kernels share) stands.
         default = self.default_config
-        if split_seg_n(self.M, self.N, self.N_padded, ceildiv_int(self.M, default["block_m"])):
+        if split_seg_n(self.M, self.N, default["block_m"], self._split_target):
             self.config = default
             return
 
@@ -516,15 +512,10 @@ class LogSumExpKernel(RowTiledAutotuneMixin, Kernel):
         A handful of long rows goes to the split pair: softmax's per-segment
         statistics, then a per-row fold.
         """
-        seg_n = split_seg_n(
-            self.M,
-            self.N,
-            self.N_padded,
-            (self.M + self.config["block_m"] - 1) // self.config["block_m"],
-        )
+        seg_n = split_seg_n(self.M, self.N, self.config["block_m"], self._split_target)
         if seg_n:
             threads = self.config.get("threads", _DEFAULT_TUNE_THREADS)
-            seg_max, seg_sum = _softmax_split_partials_kernel(
+            seg_max, seg_sum = softmax_split_partials_kernel(
                 self.M, self.N, seg_n, self.dtype_str, threads
             )()(x)
             return _logsumexp_split_fold_kernel(self.M, self.N, self.dtype_str, seg_n)()(

--- a/src/tileops/kernels/reduction/reduce.py
+++ b/src/tileops/kernels/reduction/reduce.py
@@ -18,6 +18,8 @@ from tileops.kernels.reduction._primitives import (
     align_up,
     ceildiv_int,
     device_smem_budget,
+    edge_axis_split,
+    reduce_down_rows,
     restore_reduced,
     rows_for_axes,
     torch_dtype_nbytes,
@@ -41,17 +43,6 @@ _FRAG_SLOTS = {
 
 
 @dataclass(frozen=True)
-class LeadingAxisReducePolicy:
-    """Launch heuristics for reductions down contiguous leading axes."""
-
-    cols_per_thread: int = 8
-
-    threads: int = 64
-
-    target_blocks: int = 512
-
-
-@dataclass(frozen=True)
 class ProductReducePolicy:
     """Launch heuristics for product reductions."""
 
@@ -62,7 +53,6 @@ class ProductReducePolicy:
     min_rows_for_vectorized: int = 256
 
 
-_LEADING_POLICY = LeadingAxisReducePolicy()
 _PROD_POLICY = ProductReducePolicy()
 
 
@@ -283,209 +273,6 @@ def leading_axis_split(shape: "tuple[int, ...]", axes: "tuple[int, ...]") -> "tu
 def reduces_leading_axes(ndim: int, axes: "tuple[int, ...]") -> bool:
     """Whether *axes* is a non-empty proper prefix of the axes of an *ndim* tensor."""
     return 0 < len(axes) < ndim and tuple(axes) == tuple(range(len(axes)))
-
-
-def edge_axis_split(ndim: int, axes: "tuple[int, ...]") -> "tuple[int, int]":
-    """Split *axes* into ``(leading, trailing)`` counts when they hug both edges.
-
-    Returns ``(0, 0)`` unless *axes* is a non-empty prefix plus a non-empty
-    suffix with at least one kept axis in between — the layout
-    ``ReduceKernel._reduce_edge_axes`` handles without permuting the tensor.
-    """
-    k = 0
-    while k < len(axes) and axes[k] == k:
-        k += 1
-    j = len(axes) - k
-    if k == 0 or j == 0:
-        return (0, 0)
-    if tuple(axes[k:]) != tuple(range(ndim - j, ndim)):
-        return (0, 0)
-    if k + j >= ndim:
-        return (0, 0)
-    return (k, j)
-
-
-def leading_row_splits(reduced: int, kept: int, threads: int) -> int:
-    """How many ways to split the reduced axis so the grid fills the device."""
-    block_b = threads * _LEADING_POLICY.cols_per_thread
-    column_blocks = ceildiv_int(kept, block_b)
-    return max(1, min(reduced, ceildiv_int(_LEADING_POLICY.target_blocks, column_blocks)))
-
-
-def _make_leading_reduce_ops(op_kind: str, divisor: float, out_dtype: str):
-    """Create the per-op macros used by the leading-axis reduction."""
-
-    @T.macro
-    def init(acc):
-        if op_kind == "amax":
-            T.fill(acc, -T.infinity("float32"))
-        elif op_kind == "amin":
-            T.fill(acc, T.infinity("float32"))
-        else:
-            T.fill(acc, 0.0)
-
-    @T.macro
-    def combine(acc, slot, value):
-        if op_kind == "amax":
-            acc[slot] = T.max(acc[slot], value)
-        elif op_kind == "amin":
-            acc[slot] = T.min(acc[slot], value)
-        else:
-            acc[slot] = acc[slot] + value
-
-    @T.macro
-    def finish(out_local, slot, accumulated):
-        if divisor:
-            out_local[slot] = T.cast(accumulated / divisor, out_dtype)
-        else:
-            out_local[slot] = T.cast(accumulated, out_dtype)
-
-    return init, combine, finish
-
-
-@functools.lru_cache(maxsize=32)
-def _leading_reduce_kernel(
-    A: int,
-    B: int,
-    op_kind: str,
-    in_dtype: str,
-    out_dtype: str,
-    threads: int,
-    splits: int,
-    divisor: float,
-):
-    """Build a reduce down the leading axes of an ``(A, B)`` view.
-
-    One accumulator per output column, walked down the rows the block owns. Adjacent
-    threads take adjacent columns, so every row of the walk is one coalesced pass and
-    the tensor is read once in the layout it already has. The alternative -- permuting
-    the reduced axes to the end and making that contiguous -- reads and writes the whole
-    tensor before the reduction has read anything, which is three passes where this is
-    one.
-
-    The grid is ``(column blocks, splits)``: a leading-axis reduction has only as many
-    output columns as the axes it keeps, and one block per column tile would leave an
-    H200 running four of them.
-
-    Args:
-        A: Elements the reduction consumes per output column.
-        B: Output columns.
-        op_kind: One of ``_LEADING_AXIS_KINDS``.
-        in_dtype: TileLang dtype string of the input.
-        out_dtype: TileLang dtype string of the output. A split pass writes fp32
-            partials whatever it read; the pass that finishes writes the declared dtype.
-        threads: Threads per block.
-        splits: Row slices, each its own block row. Above 1 the output is one row of
-            partials per slice, for a second call with ``splits=1`` to finish.
-        divisor: What the accumulator is divided by before the output cast, or 0 for
-            none. Mean's divisor is the row count of the whole reduction, which a
-            second pass over partials can no longer see.
-    """
-    block_b = threads * _LEADING_POLICY.cols_per_thread
-    rows_per_split = ceildiv_int(A, splits)
-    exact = B % block_b == 0
-    init_acc, combine, finish = _make_leading_reduce_ops(op_kind, divisor, out_dtype)
-
-    @tilelang.jit(out_idx=[1])
-    def _func():
-        @T.prim_func
-        def main(
-            x: T.Tensor[(A, B), in_dtype],
-            out: T.Tensor[(splits * B,), out_dtype],
-        ):
-            with T.Kernel(T.ceildiv(B, block_b), splits, threads=threads) as (pid_b, pid_a):
-                acc = T.alloc_fragment((block_b,), "float32")
-                out_local = T.alloc_fragment((block_b,), out_dtype)
-
-                init_acc(acc)
-
-                for step in T.serial(rows_per_split):
-                    row = pid_a * rows_per_split + step
-                    for j in T.Parallel(block_b):
-                        col = pid_b * block_b + j
-                        in_range = row < A if exact else T.And(row < A, col < B)
-                        val = T.if_then_else(
-                            in_range,
-                            T.cast(x[row, col], "float32"),
-                            T.cast(_pad_value_for_op(op_kind), "float32"),
-                        )
-                        combine(acc, j, val)
-
-                for j in T.Parallel(block_b):
-                    finish(out_local, j, acc[j])
-
-                if exact:
-                    T.copy(out_local, out[pid_a * B + pid_b * block_b])
-                else:
-                    for j in T.Parallel(block_b):
-                        # TileLang requires T.If/T.Then as nested context managers.
-                        with T.If(pid_b * block_b + j < B):  # noqa: SIM117
-                            with T.Then():
-                                out[pid_a * B + pid_b * block_b + j] = out_local[j]
-
-        return main
-
-    return _func
-
-
-def _reduce_down_rows(
-    flat: torch.Tensor,
-    op_kind: str,
-    in_dtype: str,
-    out_dtype: str,
-    divisor: float,
-) -> torch.Tensor:
-    """Reduce an ``(A, B)`` buffer down its rows, writing one *out_dtype* row.
-
-    Splitting the reduced axis is what fills the grid, and each slice leaves an
-    fp32 partial row; a second call over those rows finishes the op. The partials
-    are a few thousand values against the millions the first pass reads, so the
-    second call costs about nothing.
-    """
-    reduced, kept = flat.shape
-    # An input smaller than one grid's worth of work cannot amortize the
-    # extra pass a split costs; reduce it in a single call.
-    grid_work = (
-        _LEADING_POLICY.threads * _LEADING_POLICY.cols_per_thread * _LEADING_POLICY.target_blocks
-    )
-    if reduced * kept <= grid_work:
-        splits = 1
-    else:
-        splits = leading_row_splits(reduced, kept, _LEADING_POLICY.threads)
-    if splits == 1:
-        single = _leading_reduce_kernel(
-            reduced,
-            kept,
-            op_kind,
-            in_dtype,
-            out_dtype,
-            _LEADING_POLICY.threads,
-            1,
-            divisor,
-        )
-        return single()(flat)
-    partials = _leading_reduce_kernel(
-        reduced,
-        kept,
-        op_kind,
-        in_dtype,
-        "float32",
-        _LEADING_POLICY.threads,
-        splits,
-        0.0,
-    )()(flat)
-    # Partials are summed even for mean, whose divisor is the whole row count.
-    finish = _leading_reduce_kernel(
-        splits,
-        kept,
-        "sum" if op_kind == "mean" else op_kind,
-        "float32",
-        out_dtype,
-        _LEADING_POLICY.threads,
-        1,
-        divisor,
-    )
-    return finish()(partials.reshape(splits, kept))
 
 
 @functools.lru_cache(maxsize=32)
@@ -966,6 +753,264 @@ def _welford_reduce_kernel_tiled(M, N, op_kind, correction, dtype, tile_n):
     return _func
 
 
+@functools.lru_cache(maxsize=32)
+def _welford_partials_kernel(M, N, dtype):
+    """Per-row Welford partials: fp32 ``(mean, M2)`` for a cross-row merge.
+
+    The ``var_mean`` body without the finish: each row's mean and its exact sum
+    of squared deviations, padding-corrected, kept in fp32 for the merge that
+    combines rows into one statistic.
+    """
+    N_padded = align_up(N, DEFAULT_ALIGNMENT)
+    _needs_pad = N_padded != N
+
+    @tilelang.jit(out_idx=[1, 2])
+    def _func(block_m, threads):
+        @T.prim_func
+        def main(
+            x: T.Tensor[(M, N), dtype],
+            out_mean: T.Tensor[(M,), "float32"],  # noqa: F821
+            out_m2: T.Tensor[(M,), "float32"],  # noqa: F821
+        ):
+            with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
+                shared_buf = T.alloc_shared((block_m, N_padded), dtype)
+                x_f32 = T.alloc_fragment((block_m, N_padded), "float32")
+                row_sum = T.alloc_fragment((block_m,), "float32")
+                mean_val = T.alloc_fragment((block_m,), "float32")
+                sq_diff = T.alloc_fragment((block_m, N_padded), "float32")
+                var_sum = T.alloc_fragment((block_m,), "float32")
+                out_m = T.alloc_fragment((block_m,), "float32")
+                out_v = T.alloc_fragment((block_m,), "float32")
+
+                if _needs_pad:
+                    for i in T.serial(block_m):
+                        for j in T.Parallel(N_padded):
+                            x_f32[i, j] = T.if_then_else(
+                                T.And(pid_m * block_m + i < M, j < N),
+                                T.cast(x[pid_m * block_m + i, j], "float32"),
+                                T.cast(0.0, "float32"),
+                            )
+                else:
+                    T.copy(x[pid_m * block_m, 0], shared_buf)
+
+                    for i in T.serial(block_m):
+                        for j in T.Parallel(N_padded):
+                            x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
+
+                T.reduce_sum(x_f32, row_sum, dim=1)
+                for i in T.Parallel(block_m):
+                    mean_val[i] = row_sum[i] / float(N)
+
+                for i in T.serial(block_m):
+                    for j in T.Parallel(N_padded):
+                        dev = x_f32[i, j] - mean_val[i]
+                        sq_diff[i, j] = dev * dev
+
+                T.reduce_sum(sq_diff, var_sum, dim=1)
+
+                # Padded elements contribute mean^2 each; subtract them exactly.
+                pad_count = N_padded - N
+                for i in T.Parallel(block_m):
+                    out_v[i] = var_sum[i] - float(pad_count) * mean_val[i] * mean_val[i]
+                    out_m[i] = mean_val[i]
+
+                T.copy(out_m, out_mean[pid_m * block_m])
+                T.copy(out_v, out_m2[pid_m * block_m])
+
+        return main
+
+    return _func
+
+
+@functools.lru_cache(maxsize=32)
+def _welford_partials_kernel_tiled(M, N, dtype, tile_n):
+    """Tiled per-row Welford partials for rows a single fragment cannot hold."""
+    N_padded = align_up(N, DEFAULT_ALIGNMENT)
+    num_tiles = (N_padded + tile_n - 1) // tile_n
+    _needs_mask = num_tiles * tile_n > N
+
+    @tilelang.jit(out_idx=[1, 2])
+    def _func(block_m, threads):
+        @T.macro
+        def load_tile(x, dest, pid_m, t):
+            if _needs_mask:
+                with T.If(t < num_tiles - 1):
+                    with T.Then():
+                        for i in T.serial(block_m):
+                            for j in T.Parallel(tile_n):
+                                dest[i, j] = T.cast(
+                                    x[pid_m * block_m + i, t * tile_n + j], "float32"
+                                )
+                    with T.Else():
+                        for i in T.serial(block_m):
+                            for j in T.Parallel(tile_n):
+                                dest[i, j] = T.if_then_else(
+                                    T.And(pid_m * block_m + i < M, t * tile_n + j < N),
+                                    T.cast(x[pid_m * block_m + i, t * tile_n + j], "float32"),
+                                    T.cast(0.0, "float32"),
+                                )
+            else:
+                for i in T.serial(block_m):
+                    for j in T.Parallel(tile_n):
+                        dest[i, j] = T.cast(x[pid_m * block_m + i, t * tile_n + j], "float32")
+
+        @T.prim_func
+        def main(
+            x: T.Tensor[(M, N), dtype],
+            out_mean: T.Tensor[(M,), "float32"],  # noqa: F821
+            out_m2: T.Tensor[(M,), "float32"],  # noqa: F821
+        ):
+            with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
+                tile_f32 = T.alloc_fragment((block_m, tile_n), "float32")
+                tile_sum = T.alloc_fragment((block_m,), "float32")
+                row_sum = T.alloc_fragment((block_m,), "float32")
+                mean_val = T.alloc_fragment((block_m,), "float32")
+                var_sum = T.alloc_fragment((block_m,), "float32")
+                out_m = T.alloc_fragment((block_m,), "float32")
+                out_v = T.alloc_fragment((block_m,), "float32")
+
+                T.fill(row_sum, 0.0)
+                for t in T.Serial(num_tiles):
+                    load_tile(x, tile_f32, pid_m, t)
+                    T.reduce_sum(tile_f32, tile_sum, dim=1)
+                    for i in T.Parallel(block_m):
+                        row_sum[i] = row_sum[i] + tile_sum[i]
+
+                for i in T.Parallel(block_m):
+                    mean_val[i] = row_sum[i] / float(N)
+
+                # Pass 2: dedicated buffers to avoid TileLang aliasing.
+                p2_f32 = T.alloc_fragment((block_m, tile_n), "float32")
+                sq_diff = T.alloc_fragment((block_m, tile_n), "float32")
+                tile_sq = T.alloc_fragment((block_m,), "float32")
+                T.fill(var_sum, 0.0)
+                for t in T.Serial(num_tiles):
+                    load_tile(x, p2_f32, pid_m, t)
+                    for i in T.serial(block_m):
+                        for j in T.Parallel(tile_n):
+                            dev = p2_f32[i, j] - mean_val[i]
+                            sq_diff[i, j] = dev * dev
+                    T.reduce_sum(sq_diff, tile_sq, dim=1)
+                    for i in T.Parallel(block_m):
+                        var_sum[i] = var_sum[i] + tile_sq[i]
+
+                pad_count = num_tiles * tile_n - N
+                for i in T.Parallel(block_m):
+                    out_v[i] = var_sum[i] - float(pad_count) * mean_val[i] * mean_val[i]
+                    out_m[i] = mean_val[i]
+
+                T.copy(out_m, out_mean[pid_m * block_m])
+                T.copy(out_v, out_m2[pid_m * block_m])
+
+        return main
+
+    return _func
+
+
+@functools.lru_cache(maxsize=32)
+def _welford_merge_kernel(A, B, op_kind, correction, count_per, out_dtype, threads):
+    """Merge per-slice Welford partials down the lead axis with Chan's method.
+
+    ``mean_in`` / ``m2_in`` hold ``A`` slices of ``B`` columns, each statistic
+    over ``count_per`` elements. One thread owns a kept column and folds the
+    slices serially; adjacent threads read adjacent columns, so every step of
+    the walk is one coalesced pass over a buffer of ``A * B`` values.
+    """
+    out_idx = [2, 3] if op_kind == "var_mean" else [2]
+    denom = float(A * count_per - correction)
+    nb = float(count_per)
+
+    @tilelang.jit(out_idx=out_idx)
+    def _func():
+        @T.macro
+        def chan_fold(mean_in, m2_in, col, n_acc, mean_acc, m2_acc, delta, n_new):
+            for a in T.serial(A):
+                delta[0] = mean_in[a, col] - mean_acc[0]
+                n_new[0] = n_acc[0] + nb
+                m2_acc[0] = (
+                    m2_acc[0] + m2_in[a, col] + delta[0] * delta[0] * (n_acc[0] * nb / n_new[0])
+                )
+                mean_acc[0] = mean_acc[0] + delta[0] * (nb / n_new[0])
+                n_acc[0] = n_new[0]
+
+        if op_kind == "var_mean":
+
+            @T.prim_func
+            def main(
+                mean_in: T.Tensor[(A, B), "float32"],  # noqa: F821
+                m2_in: T.Tensor[(A, B), "float32"],  # noqa: F821
+                out_var: T.Tensor[(B,), out_dtype],
+                out_mean: T.Tensor[(B,), out_dtype],
+            ):
+                with T.Kernel(T.ceildiv(B, threads), threads=threads) as pid_b:
+                    tx = T.get_thread_binding()
+                    n_acc = T.alloc_local((1,), "float32")
+                    mean_acc = T.alloc_local((1,), "float32")
+                    m2_acc = T.alloc_local((1,), "float32")
+                    delta = T.alloc_local((1,), "float32")
+                    n_new = T.alloc_local((1,), "float32")
+
+                    n_acc[0] = 0.0
+                    mean_acc[0] = 0.0
+                    m2_acc[0] = 0.0
+                    with T.If(pid_b * threads + tx < B):  # noqa: SIM117
+                        with T.Then():
+                            chan_fold(
+                                mean_in,
+                                m2_in,
+                                pid_b * threads + tx,
+                                n_acc,
+                                mean_acc,
+                                m2_acc,
+                                delta,
+                                n_new,
+                            )
+                            out_var[pid_b * threads + tx] = T.cast(m2_acc[0] / denom, out_dtype)
+                            out_mean[pid_b * threads + tx] = T.cast(mean_acc[0], out_dtype)
+
+        else:
+
+            @T.prim_func
+            def main(
+                mean_in: T.Tensor[(A, B), "float32"],  # noqa: F821
+                m2_in: T.Tensor[(A, B), "float32"],  # noqa: F821
+                out: T.Tensor[(B,), out_dtype],
+            ):
+                with T.Kernel(T.ceildiv(B, threads), threads=threads) as pid_b:
+                    tx = T.get_thread_binding()
+                    n_acc = T.alloc_local((1,), "float32")
+                    mean_acc = T.alloc_local((1,), "float32")
+                    m2_acc = T.alloc_local((1,), "float32")
+                    delta = T.alloc_local((1,), "float32")
+                    n_new = T.alloc_local((1,), "float32")
+
+                    n_acc[0] = 0.0
+                    mean_acc[0] = 0.0
+                    m2_acc[0] = 0.0
+                    with T.If(pid_b * threads + tx < B):  # noqa: SIM117
+                        with T.Then():
+                            chan_fold(
+                                mean_in,
+                                m2_in,
+                                pid_b * threads + tx,
+                                n_acc,
+                                mean_acc,
+                                m2_acc,
+                                delta,
+                                n_new,
+                            )
+                            if op_kind == "std":
+                                out[pid_b * threads + tx] = T.cast(
+                                    T.sqrt(m2_acc[0] / denom), out_dtype
+                                )
+                            else:
+                                out[pid_b * threads + tx] = T.cast(m2_acc[0] / denom, out_dtype)
+
+        return main
+
+    return _func
+
+
 # ReduceKernel class
 
 
@@ -1031,8 +1076,9 @@ class ReduceKernel(Kernel):
             range(len(self.reduce_axes))
         )
         # Axes hugging both edges also run in the tensor's own layout; the rank
-        # check again waits for forward.
-        self._edge_axis_kind = op_kind in _LEADING_AXIS_KINDS
+        # check again waits for forward. Welford kinds merge fp32 (mean, M2)
+        # partials instead of fp32 scalars.
+        self._edge_axis_kind = op_kind in _LEADING_AXIS_KINDS or self._is_welford
         self._elem_bytes = torch_dtype_nbytes(dtype)
         self._smem_budget = device_smem_budget(device_index)
         self._planner = BlockConfigPlanner(
@@ -1121,7 +1167,16 @@ class ReduceKernel(Kernel):
         if self._edge_axis_kind:
             k, j = edge_axis_split(x.ndim, self.reduce_axes)
             if k:
-                y = self._reduce_edge_axes(x, k, j)
+                if self._is_welford:
+                    y = self._welford_edge_axes(x, k, j)
+                    if self.op_kind == "var_mean":
+                        var, mean = y
+                        return (
+                            restore_reduced(var, in_shape, self.reduce_axes, self.keepdim),
+                            restore_reduced(mean, in_shape, self.reduce_axes, self.keepdim),
+                        )
+                else:
+                    y = self._reduce_edge_axes(x, k, j)
                 return restore_reduced(y, in_shape, self.reduce_axes, self.keepdim)
         rows = rows_for_axes(x, self.reduce_axes)
         result = self._reduce_rows(rows)
@@ -1177,7 +1232,7 @@ class ReduceKernel(Kernel):
             )
         partials = rows_stage(cfg["block_m"], cfg["threads"])(x.reshape(lead * kept, trail))
         divisor = float(lead * trail) if self.op_kind == "mean" else 0.0
-        y = _reduce_down_rows(
+        y = reduce_down_rows(
             partials.reshape(lead, kept),
             self.op_kind,
             "float32",
@@ -1186,11 +1241,48 @@ class ReduceKernel(Kernel):
         )
         return y.to(x.dtype)
 
+    def _welford_edge_axes(self, x: torch.Tensor, k: int, j: int) -> object:
+        """Variance over edge axes without permuting the tensor.
+
+        The rows pass leaves fp32 ``(mean, M2)`` per ``(lead, kept)`` slice;
+        Chan's merge folds the slices, so the result is the single-pass
+        Welford statistic, not a naive sum of squares.
+        """
+        shape = tuple(x.shape)
+        lead = prod(shape[:k])
+        kept = prod(shape[k : x.ndim - j])
+        trail = prod(shape[x.ndim - j :])
+        planner = BlockConfigPlanner(
+            align_up(trail, DEFAULT_ALIGNMENT),
+            self._elem_bytes,
+            self._smem_budget,
+            num_buffers=2,
+            frag_slots=_FRAG_SLOTS.get(self.op_kind, 1),
+        )
+        cfg = planner.default_config()
+        if planner.needs_tiling:
+            stage = _welford_partials_kernel_tiled(
+                lead * kept, trail, self.dtype_str, cfg["tile_n"]
+            )
+        else:
+            stage = _welford_partials_kernel(lead * kept, trail, self.dtype_str)
+        mean_p, m2_p = stage(cfg["block_m"], cfg["threads"])(x.reshape(lead * kept, trail))
+        merge = _welford_merge_kernel(
+            lead,
+            kept,
+            self.op_kind,
+            self.correction,
+            trail,
+            self.dtype_str,
+            DEFAULT_THREADS,
+        )
+        return merge()(mean_p.reshape(lead, kept), m2_p.reshape(lead, kept))
+
     def _reduce_leading_axes(self, x: torch.Tensor) -> torch.Tensor:
         """Reduce the leading axes of *x* down to one value per kept column."""
         reduced, kept = leading_axis_split(tuple(x.shape), self.reduce_axes)
         divisor = float(reduced) if self.op_kind == "mean" else 0.0
-        return _reduce_down_rows(
+        return reduce_down_rows(
             x.reshape(reduced, kept),
             self.op_kind,
             self.dtype_str,

--- a/src/tileops/kernels/reduction/reduce.py
+++ b/src/tileops/kernels/reduction/reduce.py
@@ -13,11 +13,13 @@ from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.reduction._primitives import (
     DEFAULT_ALIGNMENT,
     DEFAULT_THREADS,
+    FP32_EXACT_INT_LIMIT,
     VECTOR_ACCESS_BYTES,
     BlockConfigPlanner,
     align_up,
     ceildiv_int,
     device_smem_budget,
+    edge_axis_plan,
     edge_axis_split,
     reduce_down_rows,
     restore_reduced,
@@ -375,21 +377,26 @@ def _welford_reduce_kernel(M, N, op_kind, correction, dtype):
     ``0.0`` via masked loads when ``N`` is not aligned.  The padding
     correction (subtracting ``pad_count * mean^2`` from the variance sum)
     is applied analytically, so the result is exact regardless of padding.
+
+    ``op_kind="partials"`` writes each row's fp32 ``(M2, mean)`` undivided,
+    for a cross-row merge; *correction* is unused there.
     """
     N_padded = align_up(N, DEFAULT_ALIGNMENT)
     _needs_pad = N_padded != N
+    _pair = op_kind in ("var_mean", "partials")
+    _out_dtype = "float32" if op_kind == "partials" else dtype
 
-    out_idx = [1, 2] if op_kind == "var_mean" else [1]
+    out_idx = [1, 2] if _pair else [1]
 
     @tilelang.jit(out_idx=out_idx)
     def _func(block_m, threads):
-        if op_kind == "var_mean":
+        if _pair:
 
             @T.prim_func
             def main(
                 x: T.Tensor[(M, N), dtype],
-                out_var: T.Tensor[(M,), dtype],
-                out_mean: T.Tensor[(M,), dtype],
+                out_var: T.Tensor[(M,), _out_dtype],
+                out_mean: T.Tensor[(M,), _out_dtype],
             ):
                 with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
                     shared_buf = T.alloc_shared((block_m, N_padded), dtype)
@@ -398,8 +405,8 @@ def _welford_reduce_kernel(M, N, op_kind, correction, dtype):
                     mean_val = T.alloc_fragment((block_m,), "float32")
                     sq_diff = T.alloc_fragment((block_m, N_padded), "float32")
                     var_sum = T.alloc_fragment((block_m,), "float32")
-                    out_v = T.alloc_fragment((block_m,), dtype)
-                    out_m = T.alloc_fragment((block_m,), dtype)
+                    out_v = T.alloc_fragment((block_m,), _out_dtype)
+                    out_m = T.alloc_fragment((block_m,), _out_dtype)
 
                     if _needs_pad:
                         for i in T.serial(block_m):
@@ -433,9 +440,12 @@ def _welford_reduce_kernel(M, N, op_kind, correction, dtype):
                     pad_count = N_padded - N
                     for i in T.Parallel(block_m):
                         corrected_sum = var_sum[i] - float(pad_count) * mean_val[i] * mean_val[i]
-                        variance = corrected_sum / float(N - correction)
-                        out_v[i] = T.cast(variance, dtype)
-                        out_m[i] = T.cast(mean_val[i], dtype)
+                        if op_kind == "partials":
+                            out_v[i] = corrected_sum
+                            out_m[i] = mean_val[i]
+                        else:
+                            out_v[i] = T.cast(corrected_sum / float(N - correction), _out_dtype)
+                            out_m[i] = T.cast(mean_val[i], _out_dtype)
 
                     T.copy(out_v, out_var[pid_m * block_m])
                     T.copy(out_m, out_mean[pid_m * block_m])
@@ -514,23 +524,27 @@ def _welford_reduce_kernel_tiled(M, N, op_kind, correction, dtype, tile_n):
     Two-pass approach over N tiles:
       Pass 1: accumulate row sum for mean computation.
       Pass 2: accumulate sum of squared deviations from the mean.
+
+    ``op_kind="partials"`` as in ``_welford_reduce_kernel``.
     """
     N_padded = align_up(N, DEFAULT_ALIGNMENT)
     num_tiles = (N_padded + tile_n - 1) // tile_n
     total_cols = num_tiles * tile_n
     _needs_mask = total_cols > N
+    _pair = op_kind in ("var_mean", "partials")
+    _out_dtype = "float32" if op_kind == "partials" else dtype
 
-    out_idx = [1, 2] if op_kind == "var_mean" else [1]
+    out_idx = [1, 2] if _pair else [1]
 
     @tilelang.jit(out_idx=out_idx)
     def _func(block_m, threads):
-        if op_kind == "var_mean":
+        if _pair:
 
             @T.prim_func
             def main(
                 x: T.Tensor[(M, N), dtype],
-                out_var: T.Tensor[(M,), dtype],
-                out_mean: T.Tensor[(M,), dtype],
+                out_var: T.Tensor[(M,), _out_dtype],
+                out_mean: T.Tensor[(M,), _out_dtype],
             ):
                 with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
                     shared_buf = T.alloc_shared((block_m, tile_n), dtype)
@@ -541,8 +555,8 @@ def _welford_reduce_kernel_tiled(M, N, op_kind, correction, dtype, tile_n):
                     sq_diff = T.alloc_fragment((block_m, tile_n), "float32")
                     tile_sq = T.alloc_fragment((block_m,), "float32")
                     var_sum = T.alloc_fragment((block_m,), "float32")
-                    out_v = T.alloc_fragment((block_m,), dtype)
-                    out_m = T.alloc_fragment((block_m,), dtype)
+                    out_v = T.alloc_fragment((block_m,), _out_dtype)
+                    out_m = T.alloc_fragment((block_m,), _out_dtype)
 
                     T.fill(row_sum, 0.0)
 
@@ -629,8 +643,12 @@ def _welford_reduce_kernel_tiled(M, N, op_kind, correction, dtype, tile_n):
                     pad_count = total_cols - N
                     for i in T.Parallel(block_m):
                         corrected = var_sum[i] - float(pad_count) * mean_val[i] * mean_val[i]
-                        out_v[i] = T.cast(corrected / float(N - correction), dtype)
-                        out_m[i] = T.cast(mean_val[i], dtype)
+                        if op_kind == "partials":
+                            out_v[i] = corrected
+                            out_m[i] = mean_val[i]
+                        else:
+                            out_v[i] = T.cast(corrected / float(N - correction), _out_dtype)
+                            out_m[i] = T.cast(mean_val[i], _out_dtype)
 
                     T.copy(out_v, out_var[pid_m * block_m])
                     T.copy(out_m, out_mean[pid_m * block_m])
@@ -754,160 +772,6 @@ def _welford_reduce_kernel_tiled(M, N, op_kind, correction, dtype, tile_n):
 
 
 @functools.lru_cache(maxsize=32)
-def _welford_partials_kernel(M, N, dtype):
-    """Per-row Welford partials: fp32 ``(mean, M2)`` for a cross-row merge.
-
-    The ``var_mean`` body without the finish: each row's mean and its exact sum
-    of squared deviations, padding-corrected, kept in fp32 for the merge that
-    combines rows into one statistic.
-    """
-    N_padded = align_up(N, DEFAULT_ALIGNMENT)
-    _needs_pad = N_padded != N
-
-    @tilelang.jit(out_idx=[1, 2])
-    def _func(block_m, threads):
-        @T.prim_func
-        def main(
-            x: T.Tensor[(M, N), dtype],
-            out_mean: T.Tensor[(M,), "float32"],  # noqa: F821
-            out_m2: T.Tensor[(M,), "float32"],  # noqa: F821
-        ):
-            with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
-                shared_buf = T.alloc_shared((block_m, N_padded), dtype)
-                x_f32 = T.alloc_fragment((block_m, N_padded), "float32")
-                row_sum = T.alloc_fragment((block_m,), "float32")
-                mean_val = T.alloc_fragment((block_m,), "float32")
-                sq_diff = T.alloc_fragment((block_m, N_padded), "float32")
-                var_sum = T.alloc_fragment((block_m,), "float32")
-                out_m = T.alloc_fragment((block_m,), "float32")
-                out_v = T.alloc_fragment((block_m,), "float32")
-
-                if _needs_pad:
-                    for i in T.serial(block_m):
-                        for j in T.Parallel(N_padded):
-                            x_f32[i, j] = T.if_then_else(
-                                T.And(pid_m * block_m + i < M, j < N),
-                                T.cast(x[pid_m * block_m + i, j], "float32"),
-                                T.cast(0.0, "float32"),
-                            )
-                else:
-                    T.copy(x[pid_m * block_m, 0], shared_buf)
-
-                    for i in T.serial(block_m):
-                        for j in T.Parallel(N_padded):
-                            x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
-
-                T.reduce_sum(x_f32, row_sum, dim=1)
-                for i in T.Parallel(block_m):
-                    mean_val[i] = row_sum[i] / float(N)
-
-                for i in T.serial(block_m):
-                    for j in T.Parallel(N_padded):
-                        dev = x_f32[i, j] - mean_val[i]
-                        sq_diff[i, j] = dev * dev
-
-                T.reduce_sum(sq_diff, var_sum, dim=1)
-
-                # Padded elements contribute mean^2 each; subtract them exactly.
-                pad_count = N_padded - N
-                for i in T.Parallel(block_m):
-                    out_v[i] = var_sum[i] - float(pad_count) * mean_val[i] * mean_val[i]
-                    out_m[i] = mean_val[i]
-
-                T.copy(out_m, out_mean[pid_m * block_m])
-                T.copy(out_v, out_m2[pid_m * block_m])
-
-        return main
-
-    return _func
-
-
-@functools.lru_cache(maxsize=32)
-def _welford_partials_kernel_tiled(M, N, dtype, tile_n):
-    """Tiled per-row Welford partials for rows a single fragment cannot hold."""
-    N_padded = align_up(N, DEFAULT_ALIGNMENT)
-    num_tiles = (N_padded + tile_n - 1) // tile_n
-    _needs_mask = num_tiles * tile_n > N
-
-    @tilelang.jit(out_idx=[1, 2])
-    def _func(block_m, threads):
-        @T.macro
-        def load_tile(x, dest, pid_m, t):
-            if _needs_mask:
-                with T.If(t < num_tiles - 1):
-                    with T.Then():
-                        for i in T.serial(block_m):
-                            for j in T.Parallel(tile_n):
-                                dest[i, j] = T.cast(
-                                    x[pid_m * block_m + i, t * tile_n + j], "float32"
-                                )
-                    with T.Else():
-                        for i in T.serial(block_m):
-                            for j in T.Parallel(tile_n):
-                                dest[i, j] = T.if_then_else(
-                                    T.And(pid_m * block_m + i < M, t * tile_n + j < N),
-                                    T.cast(x[pid_m * block_m + i, t * tile_n + j], "float32"),
-                                    T.cast(0.0, "float32"),
-                                )
-            else:
-                for i in T.serial(block_m):
-                    for j in T.Parallel(tile_n):
-                        dest[i, j] = T.cast(x[pid_m * block_m + i, t * tile_n + j], "float32")
-
-        @T.prim_func
-        def main(
-            x: T.Tensor[(M, N), dtype],
-            out_mean: T.Tensor[(M,), "float32"],  # noqa: F821
-            out_m2: T.Tensor[(M,), "float32"],  # noqa: F821
-        ):
-            with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
-                tile_f32 = T.alloc_fragment((block_m, tile_n), "float32")
-                tile_sum = T.alloc_fragment((block_m,), "float32")
-                row_sum = T.alloc_fragment((block_m,), "float32")
-                mean_val = T.alloc_fragment((block_m,), "float32")
-                var_sum = T.alloc_fragment((block_m,), "float32")
-                out_m = T.alloc_fragment((block_m,), "float32")
-                out_v = T.alloc_fragment((block_m,), "float32")
-
-                T.fill(row_sum, 0.0)
-                for t in T.Serial(num_tiles):
-                    load_tile(x, tile_f32, pid_m, t)
-                    T.reduce_sum(tile_f32, tile_sum, dim=1)
-                    for i in T.Parallel(block_m):
-                        row_sum[i] = row_sum[i] + tile_sum[i]
-
-                for i in T.Parallel(block_m):
-                    mean_val[i] = row_sum[i] / float(N)
-
-                # Pass 2: dedicated buffers to avoid TileLang aliasing.
-                p2_f32 = T.alloc_fragment((block_m, tile_n), "float32")
-                sq_diff = T.alloc_fragment((block_m, tile_n), "float32")
-                tile_sq = T.alloc_fragment((block_m,), "float32")
-                T.fill(var_sum, 0.0)
-                for t in T.Serial(num_tiles):
-                    load_tile(x, p2_f32, pid_m, t)
-                    for i in T.serial(block_m):
-                        for j in T.Parallel(tile_n):
-                            dev = p2_f32[i, j] - mean_val[i]
-                            sq_diff[i, j] = dev * dev
-                    T.reduce_sum(sq_diff, tile_sq, dim=1)
-                    for i in T.Parallel(block_m):
-                        var_sum[i] = var_sum[i] + tile_sq[i]
-
-                pad_count = num_tiles * tile_n - N
-                for i in T.Parallel(block_m):
-                    out_v[i] = var_sum[i] - float(pad_count) * mean_val[i] * mean_val[i]
-                    out_m[i] = mean_val[i]
-
-                T.copy(out_m, out_mean[pid_m * block_m])
-                T.copy(out_v, out_m2[pid_m * block_m])
-
-        return main
-
-    return _func
-
-
-@functools.lru_cache(maxsize=32)
 def _welford_merge_kernel(A, B, op_kind, correction, count_per, out_dtype, threads):
     """Merge per-slice Welford partials down the lead axis with Chan's method.
 
@@ -915,96 +779,50 @@ def _welford_merge_kernel(A, B, op_kind, correction, count_per, out_dtype, threa
     over ``count_per`` elements. One thread owns a kept column and folds the
     slices serially; adjacent threads read adjacent columns, so every step of
     the walk is one coalesced pass over a buffer of ``A * B`` values.
+
+    Every kind writes the ``(statistic, mean)`` pair -- ``B`` extra values --
+    so one prim_func serves the three; the caller keeps what its op returns.
     """
-    out_idx = [2, 3] if op_kind == "var_mean" else [2]
     denom = float(A * count_per - correction)
     nb = float(count_per)
 
-    @tilelang.jit(out_idx=out_idx)
+    @tilelang.jit(out_idx=[2, 3])
     def _func():
-        @T.macro
-        def chan_fold(mean_in, m2_in, col, n_acc, mean_acc, m2_acc, delta, n_new):
-            for a in T.serial(A):
-                delta[0] = mean_in[a, col] - mean_acc[0]
-                n_new[0] = n_acc[0] + nb
-                m2_acc[0] = (
-                    m2_acc[0] + m2_in[a, col] + delta[0] * delta[0] * (n_acc[0] * nb / n_new[0])
-                )
-                mean_acc[0] = mean_acc[0] + delta[0] * (nb / n_new[0])
-                n_acc[0] = n_new[0]
+        @T.prim_func
+        def main(
+            mean_in: T.Tensor[(A, B), "float32"],  # noqa: F821
+            m2_in: T.Tensor[(A, B), "float32"],  # noqa: F821
+            out_stat: T.Tensor[(B,), out_dtype],
+            out_mean: T.Tensor[(B,), out_dtype],
+        ):
+            with T.Kernel(T.ceildiv(B, threads), threads=threads) as pid_b:
+                tx = T.get_thread_binding()
+                n_acc = T.alloc_local((1,), "float32")
+                mean_acc = T.alloc_local((1,), "float32")
+                m2_acc = T.alloc_local((1,), "float32")
+                delta = T.alloc_local((1,), "float32")
 
-        if op_kind == "var_mean":
-
-            @T.prim_func
-            def main(
-                mean_in: T.Tensor[(A, B), "float32"],  # noqa: F821
-                m2_in: T.Tensor[(A, B), "float32"],  # noqa: F821
-                out_var: T.Tensor[(B,), out_dtype],
-                out_mean: T.Tensor[(B,), out_dtype],
-            ):
-                with T.Kernel(T.ceildiv(B, threads), threads=threads) as pid_b:
-                    tx = T.get_thread_binding()
-                    n_acc = T.alloc_local((1,), "float32")
-                    mean_acc = T.alloc_local((1,), "float32")
-                    m2_acc = T.alloc_local((1,), "float32")
-                    delta = T.alloc_local((1,), "float32")
-                    n_new = T.alloc_local((1,), "float32")
-
-                    n_acc[0] = 0.0
-                    mean_acc[0] = 0.0
-                    m2_acc[0] = 0.0
-                    with T.If(pid_b * threads + tx < B):  # noqa: SIM117
-                        with T.Then():
-                            chan_fold(
-                                mean_in,
-                                m2_in,
-                                pid_b * threads + tx,
-                                n_acc,
-                                mean_acc,
-                                m2_acc,
-                                delta,
-                                n_new,
+                n_acc[0] = 0.0
+                mean_acc[0] = 0.0
+                m2_acc[0] = 0.0
+                with T.If(pid_b * threads + tx < B):  # noqa: SIM117
+                    with T.Then():
+                        for a in T.serial(A):
+                            delta[0] = mean_in[a, pid_b * threads + tx] - mean_acc[0]
+                            m2_acc[0] = (
+                                m2_acc[0]
+                                + m2_in[a, pid_b * threads + tx]
+                                + delta[0] * delta[0] * (n_acc[0] * nb / (n_acc[0] + nb))
                             )
-                            out_var[pid_b * threads + tx] = T.cast(m2_acc[0] / denom, out_dtype)
-                            out_mean[pid_b * threads + tx] = T.cast(mean_acc[0], out_dtype)
-
-        else:
-
-            @T.prim_func
-            def main(
-                mean_in: T.Tensor[(A, B), "float32"],  # noqa: F821
-                m2_in: T.Tensor[(A, B), "float32"],  # noqa: F821
-                out: T.Tensor[(B,), out_dtype],
-            ):
-                with T.Kernel(T.ceildiv(B, threads), threads=threads) as pid_b:
-                    tx = T.get_thread_binding()
-                    n_acc = T.alloc_local((1,), "float32")
-                    mean_acc = T.alloc_local((1,), "float32")
-                    m2_acc = T.alloc_local((1,), "float32")
-                    delta = T.alloc_local((1,), "float32")
-                    n_new = T.alloc_local((1,), "float32")
-
-                    n_acc[0] = 0.0
-                    mean_acc[0] = 0.0
-                    m2_acc[0] = 0.0
-                    with T.If(pid_b * threads + tx < B):  # noqa: SIM117
-                        with T.Then():
-                            chan_fold(
-                                mean_in,
-                                m2_in,
-                                pid_b * threads + tx,
-                                n_acc,
-                                mean_acc,
-                                m2_acc,
-                                delta,
-                                n_new,
+                            mean_acc[0] = mean_acc[0] + delta[0] * (nb / (n_acc[0] + nb))
+                            n_acc[0] = n_acc[0] + nb
+                        if op_kind == "std":
+                            out_stat[pid_b * threads + tx] = T.cast(
+                                T.sqrt(m2_acc[0] / denom), out_dtype
                             )
-                            if op_kind == "std":
-                                out[pid_b * threads + tx] = T.cast(
-                                    T.sqrt(m2_acc[0] / denom), out_dtype
-                                )
-                            else:
-                                out[pid_b * threads + tx] = T.cast(m2_acc[0] / denom, out_dtype)
+                        else:
+                            out_stat[pid_b * threads + tx] = T.cast(m2_acc[0] / denom, out_dtype)
+                        out_mean[pid_b * threads + tx] = T.cast(mean_acc[0], out_dtype)
 
         return main
 
@@ -1170,7 +988,7 @@ class ReduceKernel(Kernel):
             # range the weights drift, so those sizes keep the permute path.
             if k and self._is_welford:
                 reduced_count = x.numel() // prod(x.shape[k : x.ndim - j])
-                if reduced_count > 2**24:
+                if reduced_count > FP32_EXACT_INT_LIMIT:
                     k = 0
             if k:
                 if self._is_welford:
@@ -1208,17 +1026,10 @@ class ReduceKernel(Kernel):
         like the single-pass kernels. ``mean`` runs the first pass as ``sum``
         and divides in the second by the full reduced count.
         """
-        shape = tuple(x.shape)
-        lead = prod(shape[:k])
-        kept = prod(shape[k : x.ndim - j])
-        trail = prod(shape[x.ndim - j :])
-        inner_kind = "sum" if self.op_kind == "mean" else self.op_kind
-        planner = BlockConfigPlanner(
-            align_up(trail, DEFAULT_ALIGNMENT),
-            self._elem_bytes,
-            self._smem_budget,
+        lead, kept, trail, planner, cfg = edge_axis_plan(
+            tuple(x.shape), k, j, self._elem_bytes, self._smem_budget
         )
-        cfg = planner.default_config()
+        inner_kind = "sum" if self.op_kind == "mean" else self.op_kind
         if planner.needs_tiling:
             rows_stage = _simple_reduce_kernel_tiled(
                 lead * kept,
@@ -1254,25 +1065,22 @@ class ReduceKernel(Kernel):
         Chan's merge folds the slices, so the result is the single-pass
         Welford statistic, not a naive sum of squares.
         """
-        shape = tuple(x.shape)
-        lead = prod(shape[:k])
-        kept = prod(shape[k : x.ndim - j])
-        trail = prod(shape[x.ndim - j :])
-        planner = BlockConfigPlanner(
-            align_up(trail, DEFAULT_ALIGNMENT),
+        lead, kept, trail, planner, cfg = edge_axis_plan(
+            tuple(x.shape),
+            k,
+            j,
             self._elem_bytes,
             self._smem_budget,
             num_buffers=2,
             frag_slots=_FRAG_SLOTS.get(self.op_kind, 1),
         )
-        cfg = planner.default_config()
         if planner.needs_tiling:
-            stage = _welford_partials_kernel_tiled(
-                lead * kept, trail, self.dtype_str, cfg["tile_n"]
+            stage = _welford_reduce_kernel_tiled(
+                lead * kept, trail, "partials", 0, self.dtype_str, cfg["tile_n"]
             )
         else:
-            stage = _welford_partials_kernel(lead * kept, trail, self.dtype_str)
-        mean_p, m2_p = stage(cfg["block_m"], cfg["threads"])(x.reshape(lead * kept, trail))
+            stage = _welford_reduce_kernel(lead * kept, trail, "partials", 0, self.dtype_str)
+        m2_p, mean_p = stage(cfg["block_m"], cfg["threads"])(x.reshape(lead * kept, trail))
         merge = _welford_merge_kernel(
             lead,
             kept,
@@ -1282,7 +1090,8 @@ class ReduceKernel(Kernel):
             self.dtype_str,
             DEFAULT_THREADS,
         )
-        return merge()(mean_p.reshape(lead, kept), m2_p.reshape(lead, kept))
+        stat, mean = merge()(mean_p.reshape(lead, kept), m2_p.reshape(lead, kept))
+        return (stat, mean) if self.op_kind == "var_mean" else stat
 
     def _reduce_leading_axes(self, x: torch.Tensor) -> torch.Tensor:
         """Reduce the leading axes of *x* down to one value per kept column."""

--- a/src/tileops/kernels/reduction/reduce.py
+++ b/src/tileops/kernels/reduction/reduce.py
@@ -1166,6 +1166,12 @@ class ReduceKernel(Kernel):
             return restore_reduced(columns, in_shape, self.reduce_axes, self.keepdim)
         if self._edge_axis_kind:
             k, j = edge_axis_split(x.ndim, self.reduce_axes)
+            # The Welford merge folds counts in fp32; past fp32's integer
+            # range the weights drift, so those sizes keep the permute path.
+            if k and self._is_welford:
+                reduced_count = x.numel() // prod(x.shape[k : x.ndim - j])
+                if reduced_count > 2**24:
+                    k = 0
             if k:
                 if self._is_welford:
                     y = self._welford_edge_axes(x, k, j)

--- a/src/tileops/kernels/reduction/softmax.py
+++ b/src/tileops/kernels/reduction/softmax.py
@@ -34,18 +34,16 @@ from tileops.kernels.reduction._primitives import (
     restore_same_shape,
     rows_for_axes,
 )
+from tileops.kernels.reduction._split_softmax import (
+    make_split_fold,
+    softmax_split_partials_kernel,
+    split_seg_n,
+    split_target_blocks,
+)
 
 # These two kernels bake tile_n in at build time and default to the wider
 # thread block; AUTOTUNE_THREADS still bounds what the sweep explores.
 _DEFAULT_TUNE_THREADS = 256
-
-# The split-row path turns on only when one block per row leaves the device
-# this far under-filled and a row is long enough to amortize its fold pass.
-_SPLIT_TARGET_BLOCKS = 264
-_SPLIT_MIN_COLS = 16384
-# Widest segment a partials block holds in its fragment: 64 fp32 registers
-# per thread at 256 threads, inside the flat region of the register curve.
-_SPLIT_MAX_SEG_COLS = 16384
 
 __all__ = ["SoftmaxKernel"]
 
@@ -449,64 +447,17 @@ def _softmax_kernel(M: int, N: int, op_kind: str, dtype: str, tile_n: int = 0):
 
 
 @functools.lru_cache(maxsize=64)
-def _softmax_split_partials_kernel(M: int, N: int, seg_n: int, dtype: str, threads: int):
-    """Per-segment softmax statistics: fp32 ``(max, sum)`` for a later fold.
-
-    One block owns one ``seg_n``-column segment of one row and writes the
-    segment's max and its sum of ``exp(x - max)``. A handful of long rows
-    cannot fill the device one block per row; ``ceildiv(N, seg_n)`` blocks
-    per row can. With a finite segment max, a masked lane contributes
-    ``exp(-inf) = 0``; a segment whose max is ``-inf`` (all lanes masked
-    ``-inf``) writes an explicit zero sum, since ``exp(-inf - -inf)`` is NaN.
-    """
-    num_segs = ceildiv_int(N, seg_n)
-
-    @tilelang.jit(out_idx=[1, 2])
-    def _func():
-        @T.prim_func
-        def main(
-            x: T.Tensor[(M, N), dtype],
-            seg_max: T.Tensor[(M * num_segs,), "float32"],  # noqa: F821
-            seg_sum: T.Tensor[(M * num_segs,), "float32"],  # noqa: F821
-        ):
-            with T.Kernel(num_segs, M, threads=threads) as (pid_s, pid_m):
-                x_f32 = T.alloc_fragment((1, seg_n), "float32")
-                m_s = T.alloc_fragment((1,), "float32")
-                s_s = T.alloc_fragment((1,), "float32")
-
-                for _, j in T.Parallel(1, seg_n):
-                    x_f32[0, j] = T.if_then_else(
-                        pid_s * seg_n + j < N,
-                        T.cast(x[pid_m, pid_s * seg_n + j], "float32"),
-                        -T.infinity("float32"),
-                    )
-                T.fill(m_s, -T.infinity("float32"))
-                T.reduce_max(x_f32, m_s, dim=1, clear=False)
-                for _, j in T.Parallel(1, seg_n):
-                    x_f32[0, j] = T.exp(x_f32[0, j] - m_s[0])
-                T.reduce_sum(x_f32, s_s, dim=1)
-
-                seg_max[pid_m * num_segs + pid_s] = m_s[0]
-                seg_sum[pid_m * num_segs + pid_s] = T.if_then_else(
-                    m_s[0] == -T.infinity("float32"), T.cast(0.0, "float32"), s_s[0]
-                )
-
-        return main
-
-    return _func
-
-
-@functools.lru_cache(maxsize=64)
 def _softmax_split_finalize_kernel(
     M: int, N: int, op_kind: str, dtype: str, seg_n: int, threads: int
 ):
     """Fold per-segment ``(max, sum)`` and write one normalized segment per block.
 
-    The fold reads ``num_segs`` fp32 pairs from shared memory — a few hundred
-    bytes against the segment re-read — so every thread folds redundantly
-    rather than synchronizing a broadcast.
+    The fold reads ``num_segs`` fp32 pairs — a few hundred bytes against the
+    segment re-read — so every thread folds redundantly rather than
+    synchronizing a broadcast.
     """
     num_segs = ceildiv_int(N, seg_n)
+    fold = make_split_fold(num_segs)
 
     @tilelang.jit(out_idx=[3])
     def _func():
@@ -518,46 +469,22 @@ def _softmax_split_finalize_kernel(
             y: T.Tensor[(M, N), dtype],
         ):
             with T.Kernel(num_segs, M, threads=threads) as (pid_s, pid_m):
-                stats = T.alloc_shared((num_segs, 2), "float32")
                 row_max = T.alloc_local((1,), "float32")
                 row_sum = T.alloc_local((1,), "float32")
 
-                for s, c in T.Parallel(num_segs, 2):
-                    stats[s, c] = T.if_then_else(
-                        c == 0,
-                        seg_max[pid_m * num_segs + s],
-                        seg_sum[pid_m * num_segs + s],
-                    )
-                T.sync_threads()
+                fold(seg_max, seg_sum, pid_m * num_segs, row_max, row_sum)
 
-                row_max[0] = -T.infinity("float32")
-                for s in T.serial(num_segs):
-                    row_max[0] = T.max(row_max[0], stats[s, 0])
-                row_sum[0] = 0.0
-                # An all--inf segment contributes nothing; folding it through
-                # exp(-inf - row_max) would turn NaN when row_max is -inf too.
-                for s in T.serial(num_segs):
-                    row_sum[0] = row_sum[0] + T.if_then_else(
-                        stats[s, 0] == -T.infinity("float32"),
-                        T.cast(0.0, "float32"),
-                        stats[s, 1] * T.exp(stats[s, 0] - row_max[0]),
-                    )
-
-                if op_kind == "softmax":
-                    for _, j in T.Parallel(1, seg_n):
-                        col = pid_s * seg_n + j
-                        with T.If(col < N):  # noqa: SIM117
-                            with T.Then():
+                for _, j in T.Parallel(1, seg_n):
+                    col = pid_s * seg_n + j
+                    with T.If(col < N):  # noqa: SIM117
+                        with T.Then():
+                            if op_kind == "softmax":
                                 y[pid_m, col] = T.cast(
                                     T.exp(T.cast(x[pid_m, col], "float32") - row_max[0])
                                     / row_sum[0],
                                     dtype,
                                 )
-                else:
-                    for _, j in T.Parallel(1, seg_n):
-                        col = pid_s * seg_n + j
-                        with T.If(col < N):  # noqa: SIM117
-                            with T.Then():
+                            else:
                                 y[pid_m, col] = T.cast(
                                     T.cast(x[pid_m, col], "float32")
                                     - row_max[0]
@@ -568,23 +495,6 @@ def _softmax_split_finalize_kernel(
         return main
 
     return _func
-
-
-def split_seg_n(M: int, N: int, N_padded: int, row_blocks: int) -> int:
-    """The split-row segment width, or 0 when one block per row is enough.
-
-    Applies when the row grid leaves the device under-filled and a row is
-    long enough to amortize the fold pass; the segment count targets
-    ``_SPLIT_TARGET_BLOCKS`` blocks and stays aligned.
-    """
-    if N_padded < _SPLIT_MIN_COLS or row_blocks >= _SPLIT_TARGET_BLOCKS:
-        return 0
-    num_segs = max(1, ceildiv_int(_SPLIT_TARGET_BLOCKS, M))
-    seg_n = align_up(ceildiv_int(N, num_segs), DEFAULT_ALIGNMENT)
-    seg_n = min(seg_n, _SPLIT_MAX_SEG_COLS)
-    if ceildiv_int(N, seg_n) < 2:
-        return 0
-    return seg_n
 
 
 def _compute_padded_cols(N: int, tile_n: int) -> int:
@@ -659,6 +569,7 @@ class SoftmaxKernel(RowTiledAutotuneMixin, Kernel):
         self.N_padded = align_up(N, DEFAULT_ALIGNMENT)
         self._elem_bytes = _elem_bytes(dtype)
         self._smem_budget = device_smem_budget(device_index)
+        self._split_target = split_target_blocks(device_index)
         self._planner = BlockConfigPlanner(
             self.N_padded,
             self._elem_bytes,
@@ -781,7 +692,7 @@ class SoftmaxKernel(RowTiledAutotuneMixin, Kernel):
         # for a path forward will not take is waste, so the default config
         # (whose threads the split kernels share) stands.
         default = self.default_config
-        if split_seg_n(self.M, self.N, self.N_padded, ceildiv_int(self.M, default["block_m"])):
+        if split_seg_n(self.M, self.N, default["block_m"], self._split_target):
             self.config = default
             return
 
@@ -866,15 +777,10 @@ class SoftmaxKernel(RowTiledAutotuneMixin, Kernel):
         here. A handful of long rows goes to the split-row pair instead, which
         writes exact columns.
         """
-        seg_n = split_seg_n(
-            self.M,
-            self.N,
-            self.N_padded,
-            (self.M + self.config["block_m"] - 1) // self.config["block_m"],
-        )
+        seg_n = split_seg_n(self.M, self.N, self.config["block_m"], self._split_target)
         if seg_n:
             threads = self.config.get("threads", _DEFAULT_TUNE_THREADS)
-            seg_max, seg_sum = _softmax_split_partials_kernel(
+            seg_max, seg_sum = softmax_split_partials_kernel(
                 self.M, self.N, seg_n, self.dtype_str, threads
             )()(x)
             return _softmax_split_finalize_kernel(

--- a/src/tileops/kernels/reduction/softmax.py
+++ b/src/tileops/kernels/reduction/softmax.py
@@ -452,9 +452,9 @@ def _softmax_split_finalize_kernel(
 ):
     """Fold per-segment ``(max, sum)`` and write one normalized segment per block.
 
-    The fold reads ``num_segs`` fp32 pairs — a few hundred bytes against the
-    segment re-read — so every thread folds redundantly rather than
-    synchronizing a broadcast.
+    The fold reads ``num_segs`` fp32 pairs; staged through shared memory
+    once, every thread then folds redundantly from there rather than each
+    walking global memory.
     """
     num_segs = ceildiv_int(N, seg_n)
     fold = make_split_fold(num_segs)
@@ -469,10 +469,18 @@ def _softmax_split_finalize_kernel(
             y: T.Tensor[(M, N), dtype],
         ):
             with T.Kernel(num_segs, M, threads=threads) as (pid_s, pid_m):
+                stat_max = T.alloc_shared((num_segs,), "float32")
+                stat_sum = T.alloc_shared((num_segs,), "float32")
                 row_max = T.alloc_local((1,), "float32")
                 row_sum = T.alloc_local((1,), "float32")
+                held = T.alloc_local((1,), "float32")
 
-                fold(seg_max, seg_sum, pid_m * num_segs, row_max, row_sum)
+                for s in T.Parallel(num_segs):
+                    stat_max[s] = seg_max[pid_m * num_segs + s]
+                    stat_sum[s] = seg_sum[pid_m * num_segs + s]
+                T.sync_threads()
+
+                fold(stat_max, stat_sum, 0, row_max, row_sum, held)
 
                 for _, j in T.Parallel(1, seg_n):
                     col = pid_s * seg_n + j

--- a/src/tileops/kernels/reduction/softmax.py
+++ b/src/tileops/kernels/reduction/softmax.py
@@ -697,7 +697,7 @@ class SoftmaxKernel(RowTiledAutotuneMixin, Kernel):
         from tilelang.autotuner import autotune as tl_autotune
 
         # The split-row pair bypasses the tuned kernel; measuring candidates
-        # for a path forward will not take is waste, so the default config
+        # for a path forward will not take is wasted work, so the default config
         # (whose threads the split kernels share) stands.
         default = self.default_config
         if split_seg_n(self.M, self.N, default["block_m"], self._split_target):
@@ -787,7 +787,9 @@ class SoftmaxKernel(RowTiledAutotuneMixin, Kernel):
         """
         seg_n = split_seg_n(self.M, self.N, self.config["block_m"], self._split_target)
         if seg_n:
-            threads = self.config.get("threads", _DEFAULT_TUNE_THREADS)
+            # The split pair stands on the default width: split_seg_n's
+            # fragment cap assumes it, and autotune never sweeps this path.
+            threads = _DEFAULT_TUNE_THREADS
             seg_max, seg_sum = softmax_split_partials_kernel(
                 self.M, self.N, seg_n, self.dtype_str, threads
             )()(x)

--- a/src/tileops/kernels/reduction/softmax.py
+++ b/src/tileops/kernels/reduction/softmax.py
@@ -43,6 +43,9 @@ _DEFAULT_TUNE_THREADS = 256
 # this far under-filled and a row is long enough to amortize its fold pass.
 _SPLIT_TARGET_BLOCKS = 264
 _SPLIT_MIN_COLS = 16384
+# Widest segment a partials block holds in its fragment: 64 fp32 registers
+# per thread at 256 threads, inside the flat region of the register curve.
+_SPLIT_MAX_SEG_COLS = 16384
 
 __all__ = ["SoftmaxKernel"]
 
@@ -452,8 +455,9 @@ def _softmax_split_partials_kernel(M: int, N: int, seg_n: int, dtype: str, threa
     One block owns one ``seg_n``-column segment of one row and writes the
     segment's max and its sum of ``exp(x - max)``. A handful of long rows
     cannot fill the device one block per row; ``ceildiv(N, seg_n)`` blocks
-    per row can. A masked lane loads ``-inf`` and contributes ``exp(-inf)``,
-    which is zero.
+    per row can. With a finite segment max, a masked lane contributes
+    ``exp(-inf) = 0``; a segment whose max is ``-inf`` (all lanes masked
+    ``-inf``) writes an explicit zero sum, since ``exp(-inf - -inf)`` is NaN.
     """
     num_segs = ceildiv_int(N, seg_n)
 
@@ -483,7 +487,9 @@ def _softmax_split_partials_kernel(M: int, N: int, seg_n: int, dtype: str, threa
                 T.reduce_sum(x_f32, s_s, dim=1)
 
                 seg_max[pid_m * num_segs + pid_s] = m_s[0]
-                seg_sum[pid_m * num_segs + pid_s] = s_s[0]
+                seg_sum[pid_m * num_segs + pid_s] = T.if_then_else(
+                    m_s[0] == -T.infinity("float32"), T.cast(0.0, "float32"), s_s[0]
+                )
 
         return main
 
@@ -528,8 +534,14 @@ def _softmax_split_finalize_kernel(
                 for s in T.serial(num_segs):
                     row_max[0] = T.max(row_max[0], stats[s, 0])
                 row_sum[0] = 0.0
+                # An all--inf segment contributes nothing; folding it through
+                # exp(-inf - row_max) would turn NaN when row_max is -inf too.
                 for s in T.serial(num_segs):
-                    row_sum[0] = row_sum[0] + stats[s, 1] * T.exp(stats[s, 0] - row_max[0])
+                    row_sum[0] = row_sum[0] + T.if_then_else(
+                        stats[s, 0] == -T.infinity("float32"),
+                        T.cast(0.0, "float32"),
+                        stats[s, 1] * T.exp(stats[s, 0] - row_max[0]),
+                    )
 
                 if op_kind == "softmax":
                     for _, j in T.Parallel(1, seg_n):
@@ -569,6 +581,7 @@ def split_seg_n(M: int, N: int, N_padded: int, row_blocks: int) -> int:
         return 0
     num_segs = max(1, ceildiv_int(_SPLIT_TARGET_BLOCKS, M))
     seg_n = align_up(ceildiv_int(N, num_segs), DEFAULT_ALIGNMENT)
+    seg_n = min(seg_n, _SPLIT_MAX_SEG_COLS)
     if ceildiv_int(N, seg_n) < 2:
         return 0
     return seg_n
@@ -763,6 +776,14 @@ class SoftmaxKernel(RowTiledAutotuneMixin, Kernel):
         and picks the overall best (block_m, threads, tile_n) config.
         """
         from tilelang.autotuner import autotune as tl_autotune
+
+        # The split-row pair bypasses the tuned kernel; measuring candidates
+        # for a path forward will not take is waste, so the default config
+        # (whose threads the split kernels share) stands.
+        default = self.default_config
+        if split_seg_n(self.M, self.N, self.N_padded, ceildiv_int(self.M, default["block_m"])):
+            self.config = default
+            return
 
         configs = self.autotune_configs
         if not configs:

--- a/src/tileops/kernels/reduction/softmax.py
+++ b/src/tileops/kernels/reduction/softmax.py
@@ -696,9 +696,7 @@ class SoftmaxKernel(RowTiledAutotuneMixin, Kernel):
         """
         from tilelang.autotuner import autotune as tl_autotune
 
-        # The split-row pair bypasses the tuned kernel; measuring candidates
-        # for a path forward will not take is wasted work, so the default config
-        # (whose threads the split kernels share) stands.
+        # The split pair bypasses the tuned kernel, so the default config stands.
         default = self.default_config
         if split_seg_n(self.M, self.N, default["block_m"], self._split_target):
             self.config = default
@@ -787,8 +785,7 @@ class SoftmaxKernel(RowTiledAutotuneMixin, Kernel):
         """
         seg_n = split_seg_n(self.M, self.N, self.config["block_m"], self._split_target)
         if seg_n:
-            # The split pair stands on the default width: split_seg_n's
-            # fragment cap assumes it, and autotune never sweeps this path.
+            # split_seg_n's fragment cap assumes the default width.
             threads = _DEFAULT_TUNE_THREADS
             seg_max, seg_sum = softmax_split_partials_kernel(
                 self.M, self.N, seg_n, self.dtype_str, threads

--- a/src/tileops/kernels/reduction/softmax.py
+++ b/src/tileops/kernels/reduction/softmax.py
@@ -29,6 +29,7 @@ from tileops.kernels.reduction._primitives import (
     BlockConfigPlanner,
     RowTiledAutotuneMixin,
     align_up,
+    ceildiv_int,
     device_smem_budget,
     restore_same_shape,
     rows_for_axes,
@@ -37,6 +38,11 @@ from tileops.kernels.reduction._primitives import (
 # These two kernels bake tile_n in at build time and default to the wider
 # thread block; AUTOTUNE_THREADS still bounds what the sweep explores.
 _DEFAULT_TUNE_THREADS = 256
+
+# The split-row path turns on only when one block per row leaves the device
+# this far under-filled and a row is long enough to amortize its fold pass.
+_SPLIT_TARGET_BLOCKS = 264
+_SPLIT_MIN_COLS = 16384
 
 __all__ = ["SoftmaxKernel"]
 
@@ -439,6 +445,135 @@ def _softmax_kernel(M: int, N: int, op_kind: str, dtype: str, tile_n: int = 0):
     return _softmax_kernel_tiled(M, N, op_kind, dtype, tile_n)
 
 
+@functools.lru_cache(maxsize=64)
+def _softmax_split_partials_kernel(M: int, N: int, seg_n: int, dtype: str, threads: int):
+    """Per-segment softmax statistics: fp32 ``(max, sum)`` for a later fold.
+
+    One block owns one ``seg_n``-column segment of one row and writes the
+    segment's max and its sum of ``exp(x - max)``. A handful of long rows
+    cannot fill the device one block per row; ``ceildiv(N, seg_n)`` blocks
+    per row can. A masked lane loads ``-inf`` and contributes ``exp(-inf)``,
+    which is zero.
+    """
+    num_segs = ceildiv_int(N, seg_n)
+
+    @tilelang.jit(out_idx=[1, 2])
+    def _func():
+        @T.prim_func
+        def main(
+            x: T.Tensor[(M, N), dtype],
+            seg_max: T.Tensor[(M * num_segs,), "float32"],  # noqa: F821
+            seg_sum: T.Tensor[(M * num_segs,), "float32"],  # noqa: F821
+        ):
+            with T.Kernel(num_segs, M, threads=threads) as (pid_s, pid_m):
+                x_f32 = T.alloc_fragment((1, seg_n), "float32")
+                m_s = T.alloc_fragment((1,), "float32")
+                s_s = T.alloc_fragment((1,), "float32")
+
+                for _, j in T.Parallel(1, seg_n):
+                    x_f32[0, j] = T.if_then_else(
+                        pid_s * seg_n + j < N,
+                        T.cast(x[pid_m, pid_s * seg_n + j], "float32"),
+                        -T.infinity("float32"),
+                    )
+                T.fill(m_s, -T.infinity("float32"))
+                T.reduce_max(x_f32, m_s, dim=1, clear=False)
+                for _, j in T.Parallel(1, seg_n):
+                    x_f32[0, j] = T.exp(x_f32[0, j] - m_s[0])
+                T.reduce_sum(x_f32, s_s, dim=1)
+
+                seg_max[pid_m * num_segs + pid_s] = m_s[0]
+                seg_sum[pid_m * num_segs + pid_s] = s_s[0]
+
+        return main
+
+    return _func
+
+
+@functools.lru_cache(maxsize=64)
+def _softmax_split_finalize_kernel(
+    M: int, N: int, op_kind: str, dtype: str, seg_n: int, threads: int
+):
+    """Fold per-segment ``(max, sum)`` and write one normalized segment per block.
+
+    The fold reads ``num_segs`` fp32 pairs from shared memory — a few hundred
+    bytes against the segment re-read — so every thread folds redundantly
+    rather than synchronizing a broadcast.
+    """
+    num_segs = ceildiv_int(N, seg_n)
+
+    @tilelang.jit(out_idx=[3])
+    def _func():
+        @T.prim_func
+        def main(
+            x: T.Tensor[(M, N), dtype],
+            seg_max: T.Tensor[(M * num_segs,), "float32"],  # noqa: F821
+            seg_sum: T.Tensor[(M * num_segs,), "float32"],  # noqa: F821
+            y: T.Tensor[(M, N), dtype],
+        ):
+            with T.Kernel(num_segs, M, threads=threads) as (pid_s, pid_m):
+                stats = T.alloc_shared((num_segs, 2), "float32")
+                row_max = T.alloc_local((1,), "float32")
+                row_sum = T.alloc_local((1,), "float32")
+
+                for s, c in T.Parallel(num_segs, 2):
+                    stats[s, c] = T.if_then_else(
+                        c == 0,
+                        seg_max[pid_m * num_segs + s],
+                        seg_sum[pid_m * num_segs + s],
+                    )
+                T.sync_threads()
+
+                row_max[0] = -T.infinity("float32")
+                for s in T.serial(num_segs):
+                    row_max[0] = T.max(row_max[0], stats[s, 0])
+                row_sum[0] = 0.0
+                for s in T.serial(num_segs):
+                    row_sum[0] = row_sum[0] + stats[s, 1] * T.exp(stats[s, 0] - row_max[0])
+
+                if op_kind == "softmax":
+                    for _, j in T.Parallel(1, seg_n):
+                        col = pid_s * seg_n + j
+                        with T.If(col < N):  # noqa: SIM117
+                            with T.Then():
+                                y[pid_m, col] = T.cast(
+                                    T.exp(T.cast(x[pid_m, col], "float32") - row_max[0])
+                                    / row_sum[0],
+                                    dtype,
+                                )
+                else:
+                    for _, j in T.Parallel(1, seg_n):
+                        col = pid_s * seg_n + j
+                        with T.If(col < N):  # noqa: SIM117
+                            with T.Then():
+                                y[pid_m, col] = T.cast(
+                                    T.cast(x[pid_m, col], "float32")
+                                    - row_max[0]
+                                    - T.log(row_sum[0]),
+                                    dtype,
+                                )
+
+        return main
+
+    return _func
+
+
+def split_seg_n(M: int, N: int, N_padded: int, row_blocks: int) -> int:
+    """The split-row segment width, or 0 when one block per row is enough.
+
+    Applies when the row grid leaves the device under-filled and a row is
+    long enough to amortize the fold pass; the segment count targets
+    ``_SPLIT_TARGET_BLOCKS`` blocks and stays aligned.
+    """
+    if N_padded < _SPLIT_MIN_COLS or row_blocks >= _SPLIT_TARGET_BLOCKS:
+        return 0
+    num_segs = max(1, ceildiv_int(_SPLIT_TARGET_BLOCKS, M))
+    seg_n = align_up(ceildiv_int(N, num_segs), DEFAULT_ALIGNMENT)
+    if ceildiv_int(N, seg_n) < 2:
+        return 0
+    return seg_n
+
+
 def _compute_padded_cols(N: int, tile_n: int) -> int:
     """Compute the total column count (may exceed N_padded for tiled path)."""
     N_padded = align_up(N, DEFAULT_ALIGNMENT)
@@ -707,8 +842,23 @@ class SoftmaxKernel(RowTiledAutotuneMixin, Kernel):
         """Normalize the trailing axis of an ``(M, N)`` buffer.
 
         The prim_func writes an alignment-padded row; the surplus columns are trimmed
-        here.
+        here. A handful of long rows goes to the split-row pair instead, which
+        writes exact columns.
         """
+        seg_n = split_seg_n(
+            self.M,
+            self.N,
+            self.N_padded,
+            (self.M + self.config["block_m"] - 1) // self.config["block_m"],
+        )
+        if seg_n:
+            threads = self.config.get("threads", _DEFAULT_TUNE_THREADS)
+            seg_max, seg_sum = _softmax_split_partials_kernel(
+                self.M, self.N, seg_n, self.dtype_str, threads
+            )()(x)
+            return _softmax_split_finalize_kernel(
+                self.M, self.N, self.op_kind, self.dtype_str, seg_n, threads
+            )()(x, seg_max, seg_sum)
         program = _softmax_kernel(self.M, self.N, self.op_kind, self.dtype_str, self._tile_n)
         y = program(self.config["block_m"], self.config["threads"])(x)
         return y[:, : self.N] if y.shape[1] > self.N else y

--- a/src/tileops/kernels/reduction/vector_norm.py
+++ b/src/tileops/kernels/reduction/vector_norm.py
@@ -13,6 +13,7 @@ Output dtype matches input dtype; l1 and l2 compute in fp32.
 """
 
 import functools
+from math import prod
 from typing import Optional
 
 import tilelang
@@ -26,6 +27,8 @@ from tileops.kernels.reduction._primitives import (
     BlockConfigPlanner,
     align_up,
     device_smem_budget,
+    edge_axis_split,
+    reduce_down_rows,
     restore_reduced,
     rows_for_axes,
     tune_by_forward,
@@ -65,7 +68,7 @@ def _finished(accumulated, op_kind: str, dtype: str):
 
 
 @functools.lru_cache(maxsize=32)
-def _vector_norm_kernel(M: int, N: int, op_kind: str, dtype: str):
+def _vector_norm_kernel(M: int, N: int, op_kind: str, dtype: str, partial: bool = False):
     """Build a TileLang l1/l2/inf norm kernel.
 
     Args:
@@ -73,6 +76,8 @@ def _vector_norm_kernel(M: int, N: int, op_kind: str, dtype: str):
         N: Original hidden dimension (last dim, before padding).
         op_kind: One of "l1", "l2", "inf".
         dtype: TileLang dtype string (e.g. "float16", "bfloat16", "float32").
+        partial: Write fp32 partials for an outer pass — no l2 sqrt, no cast
+            to the storage dtype. ``inf`` partials stay NaN-carrying values.
 
     Returns:
         A TileLang JIT-compiled kernel factory accepting (block_m, threads).
@@ -80,18 +85,19 @@ def _vector_norm_kernel(M: int, N: int, op_kind: str, dtype: str):
     N_padded = align_up(N, DEFAULT_ALIGNMENT)
     _needs_pad = N_padded != N
     work_dtype = _WORK_DTYPE[op_kind]
+    out_dtype = "float32" if partial else dtype
 
     @tilelang.jit(out_idx=[1])
     def _func(block_m, threads):
         @T.prim_func
         def main(
             x: T.Tensor[(M, N), dtype],
-            out: T.Tensor[(M,), dtype],
+            out: T.Tensor[(M,), out_dtype],
         ):
             with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
                 work = T.alloc_fragment((block_m, N_padded), work_dtype)
                 acc = T.alloc_fragment((block_m,), work_dtype)
-                out_local = T.alloc_fragment((block_m,), dtype)
+                out_local = T.alloc_fragment((block_m,), out_dtype)
 
                 # Loaded straight into the working fragment, with no staging buffer.
                 for i in T.serial(block_m):
@@ -106,13 +112,14 @@ def _vector_norm_kernel(M: int, N: int, op_kind: str, dtype: str):
                     T.reduce_sum(work, acc, dim=1)
                 elif op_kind == "l2":
                     T.reduce_sum(work, acc, dim=1)
-                    for i in T.Parallel(block_m):
-                        acc[i] = T.sqrt(acc[i])
+                    if not partial:
+                        for i in T.Parallel(block_m):
+                            acc[i] = T.sqrt(acc[i])
                 else:
                     T.reduce_max(work, acc, dim=1)
 
                 for i in T.Parallel(block_m):
-                    out_local[i] = _finished(acc[i], op_kind, dtype)
+                    out_local[i] = _finished(acc[i], op_kind, out_dtype)
 
                 T.copy(out_local, out[pid_m * block_m])
 
@@ -122,28 +129,33 @@ def _vector_norm_kernel(M: int, N: int, op_kind: str, dtype: str):
 
 
 @functools.lru_cache(maxsize=32)
-def _vector_norm_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_n: int):
+def _vector_norm_kernel_tiled(
+    M: int, N: int, op_kind: str, dtype: str, tile_n: int, partial: bool = False
+):
     """Build a tiled TileLang l1/l2/inf norm kernel.
 
     Iterates over the reduction dimension in chunks of ``tile_n`` columns,
     avoiding TileLang's single-fragment column limit at 32768 columns.
+    ``partial`` writes fp32 partials for an outer pass, as in
+    ``_vector_norm_kernel``.
     """
     N_padded = align_up(N, DEFAULT_ALIGNMENT)
     num_tiles = (N_padded + tile_n - 1) // tile_n
     work_dtype = _WORK_DTYPE[op_kind]
+    out_dtype = "float32" if partial else dtype
 
     @tilelang.jit(out_idx=[1])
     def _func(block_m, threads):
         @T.prim_func
         def main(
             x: T.Tensor[(M, N), dtype],
-            out: T.Tensor[(M,), dtype],
+            out: T.Tensor[(M,), out_dtype],
         ):
             with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
                 work = T.alloc_fragment((block_m, tile_n), work_dtype)
                 acc = T.alloc_fragment((block_m,), work_dtype)
                 tile_acc = T.alloc_fragment((block_m,), work_dtype)
-                out_local = T.alloc_fragment((block_m,), dtype)
+                out_local = T.alloc_fragment((block_m,), out_dtype)
 
                 # Zero is every kind's identity; for inf it is +0.0's bit pattern.
                 T.fill(acc, 0)
@@ -168,14 +180,51 @@ def _vector_norm_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_n: 
                         for i in T.Parallel(block_m):
                             acc[i] = acc[i] + tile_acc[i]
 
-                if op_kind == "l2":
+                if op_kind == "l2" and not partial:
                     for i in T.Parallel(block_m):
                         acc[i] = T.sqrt(acc[i])
 
                 for i in T.Parallel(block_m):
-                    out_local[i] = _finished(acc[i], op_kind, dtype)
+                    out_local[i] = _finished(acc[i], op_kind, out_dtype)
 
                 T.copy(out_local, out[pid_m * block_m])
+
+        return main
+
+    return _func
+
+
+@functools.lru_cache(maxsize=32)
+def _inf_merge_kernel(A: int, B: int, out_dtype: str, threads: int):
+    """Merge fp32 abs-max partials down the lead axis over IEEE bit patterns.
+
+    A plain float max drops NaN; comparing the partials' non-negative bit
+    patterns as int32 keeps it, exactly like the rows pass. One thread owns a
+    kept column, so every step of the walk is one coalesced pass.
+    """
+
+    @tilelang.jit(out_idx=[1])
+    def _func():
+        @T.prim_func
+        def main(
+            partials: T.Tensor[(A, B), "float32"],  # noqa: F821
+            out: T.Tensor[(B,), out_dtype],
+        ):
+            with T.Kernel(T.ceildiv(B, threads), threads=threads) as pid_b:
+                tx = T.get_thread_binding()
+                acc = T.alloc_local((1,), "int32")
+
+                acc[0] = 0
+                with T.If(pid_b * threads + tx < B):  # noqa: SIM117
+                    with T.Then():
+                        for a in T.serial(A):
+                            acc[0] = T.max(
+                                acc[0],
+                                T.reinterpret(partials[a, pid_b * threads + tx], "int32"),
+                            )
+                        out[pid_b * threads + tx] = T.cast(
+                            T.reinterpret(acc[0], "float32"), out_dtype
+                        )
 
         return main
 
@@ -296,9 +345,45 @@ class VectorNormKernel(Kernel):
         """
         self._require_cuda(x=x)
         in_shape = tuple(x.shape)
+        k, j = edge_axis_split(x.ndim, self.reduce_axes)
+        if k:
+            y = self._norm_edge_axes(x, k, j)
+            return restore_reduced(y, in_shape, self.reduce_axes, self.keepdim)
         rows = rows_for_axes(x, self.reduce_axes)
         y = self._norm_rows(rows)
         return restore_reduced(y, in_shape, self.reduce_axes, self.keepdim)
+
+    def _norm_edge_axes(self, x: torch.Tensor, k: int, j: int) -> torch.Tensor:
+        """Norm a prefix and a suffix of the axes without permuting the tensor.
+
+        Two passes in the tensor's own layout: the trailing axes reduce as
+        contiguous rows into fp32 partials, then the leading axes fold down the
+        columns of those partials. ``l2`` takes its square root and ``inf`` its
+        NaN-carrying bit-pattern max at the fold.
+        """
+        shape = tuple(x.shape)
+        lead = prod(shape[:k])
+        kept = prod(shape[k : x.ndim - j])
+        trail = prod(shape[x.ndim - j :])
+        dtype_str = self.dtype_to_str(self.dtype)
+        planner = BlockConfigPlanner(
+            align_up(trail, DEFAULT_ALIGNMENT),
+            self._elem_bytes,
+            self._smem_budget,
+        )
+        cfg = planner.default_config()
+        if planner.needs_tiling:
+            stage = _vector_norm_kernel_tiled(
+                lead * kept, trail, self.op_kind, dtype_str, cfg["tile_n"], partial=True
+            )
+        else:
+            stage = _vector_norm_kernel(lead * kept, trail, self.op_kind, dtype_str, partial=True)
+        partials = stage(cfg["block_m"], cfg["threads"])(x.reshape(lead * kept, trail))
+        partials = partials.reshape(lead, kept)
+        if self.op_kind == "inf":
+            return _inf_merge_kernel(lead, kept, dtype_str, DEFAULT_THREADS)()(partials)
+        epilogue = "sqrt" if self.op_kind == "l2" else ""
+        return reduce_down_rows(partials, "sum", "float32", dtype_str, 0.0, epilogue)
 
     def _norm_rows(self, x: torch.Tensor) -> torch.Tensor:
         """Norm the trailing axis of an ``(M, N)`` buffer."""

--- a/src/tileops/kernels/reduction/vector_norm.py
+++ b/src/tileops/kernels/reduction/vector_norm.py
@@ -13,7 +13,6 @@ Output dtype matches input dtype; l1 and l2 compute in fp32.
 """
 
 import functools
-from math import prod
 from typing import Optional
 
 import tilelang
@@ -27,6 +26,7 @@ from tileops.kernels.reduction._primitives import (
     BlockConfigPlanner,
     align_up,
     device_smem_budget,
+    edge_axis_plan,
     edge_axis_split,
     reduce_down_rows,
     restore_reduced,
@@ -361,17 +361,10 @@ class VectorNormKernel(Kernel):
         columns of those partials. ``l2`` takes its square root and ``inf`` its
         NaN-carrying bit-pattern max at the fold.
         """
-        shape = tuple(x.shape)
-        lead = prod(shape[:k])
-        kept = prod(shape[k : x.ndim - j])
-        trail = prod(shape[x.ndim - j :])
-        dtype_str = self.dtype_to_str(self.dtype)
-        planner = BlockConfigPlanner(
-            align_up(trail, DEFAULT_ALIGNMENT),
-            self._elem_bytes,
-            self._smem_budget,
+        lead, kept, trail, planner, cfg = edge_axis_plan(
+            tuple(x.shape), k, j, self._elem_bytes, self._smem_budget
         )
-        cfg = planner.default_config()
+        dtype_str = self.dtype_to_str(self.dtype)
         if planner.needs_tiling:
             stage = _vector_norm_kernel_tiled(
                 lead * kept, trail, self.op_kind, dtype_str, cfg["tile_n"], partial=True

--- a/tests/ops/test_elementwise_binary_broadcast.py
+++ b/tests/ops/test_elementwise_binary_broadcast.py
@@ -116,6 +116,24 @@ def test_binary_op_bidirectional_broadcast(
     torch.testing.assert_close(out, ref, atol=atol, rtol=rtol)
 
 
+@pytest.mark.smoke
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("op_name", ["MaximumFwdOp", "DivFwdOp"])
+def test_channel_broadcast_with_ragged_inner_dim(op_name: str) -> None:
+    """A per-channel operand over a non-tile-multiple inner dim.
+
+    The row-broadcast body splits at trace time into full blocks and one
+    guarded tail block; 300 columns force the tail. ``div`` is ordered, so a
+    swapped operand would not cancel out.
+    """
+    cls = getattr(elementwise_mod, op_name)
+    a = torch.randn(2, 3, 10, 30, dtype=torch.float16, device="cuda")
+    b = torch.rand(3, 1, 1, dtype=torch.float16, device="cuda") + 0.5
+    ref = torch.maximum(a, b) if op_name == "MaximumFwdOp" else a / b
+    out = cls()(a, b)
+    torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+
+
 # ----------------------------------------------------------------------
 # Spec pins for the broadcast-binary roofline helpers (no CUDA build).
 # ----------------------------------------------------------------------

--- a/tests/ops/test_logical_reduce.py
+++ b/tests/ops/test_logical_reduce.py
@@ -718,3 +718,32 @@ def test_logical_reduce_returns_bool(op_name: str) -> None:
     x = torch.randn(_M, _N, dtype=torch.float16, device="cuda")
     out = op(x)
     assert out.dtype == torch.bool
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "op_kind, dtype",
+    [
+        ("any", torch.bool),
+        ("all", torch.bool),
+        ("count_nonzero", torch.float16),
+    ],
+)
+def test_logical_reduce_edge_axes_in_own_layout(op_kind: str, dtype: torch.dtype) -> None:
+    """``dim=[0, 2]`` reduces without a permute: 0/1 (or count) partials, then a fold."""
+    from tileops.ops.reduction.logical_reduce import AllFwdOp, AnyFwdOp, CountNonzeroFwdOp
+
+    op_map = {"any": AnyFwdOp, "all": AllFwdOp, "count_nonzero": CountNonzeroFwdOp}
+    op = op_map[op_kind](dim=[0, 2])
+    if dtype == torch.bool:
+        x = torch.rand(4, 24, 4096, device="cuda") > 0.999
+        if op_kind == "all":
+            x = ~x
+    else:
+        x = torch.randn(4, 24, 4096, dtype=dtype, device="cuda")
+    ref = {
+        "any": lambda: x.any(0).any(-1),
+        "all": lambda: x.all(0).all(-1),
+        "count_nonzero": lambda: torch.count_nonzero(x, (0, 2)),
+    }[op_kind]()
+    assert torch.equal(op(x), ref)

--- a/tests/ops/test_reduce_variance_conformance.py
+++ b/tests/ops/test_reduce_variance_conformance.py
@@ -94,12 +94,28 @@ def test_every_declared_dtype_matches_torch(op_cls, ref_fn, dtype) -> None:
 
 @pytest.mark.smoke
 @pytest.mark.parametrize("op_cls, ref_fn", _OPS)
-def test_a_zero_correction_matches_torch(op_cls, ref_fn) -> None:
-    """The one ``correction`` that differs in kind: the denominator is ``N``, not ``N - c``."""
+@pytest.mark.parametrize(
+    "dim", [pytest.param(-1, id="dim=int"), pytest.param((0, 2), id="dim=tuple")]
+)
+def test_a_zero_correction_matches_torch(op_cls, ref_fn, dim) -> None:
+    """The one ``correction`` that differs in kind: the denominator is ``N``, not ``N - c``.
+
+    ``dim=(0, 2)`` bakes the correction into the edge-axis merge instead of the
+    rows kernel, so both denominators are exercised.
+    """
     torch.manual_seed(0)
     x = torch.randn(*_SHAPE, dtype=torch.float16, device="cuda")
 
-    _check(op_cls, ref_fn, x, dim=-1, keepdim=False, correction=0)
+    _check(op_cls, ref_fn, x, dim=dim, keepdim=False, correction=0)
+
+
+@pytest.mark.smoke
+def test_edge_axis_variance_keeps_a_large_mean_fp16() -> None:
+    """The edge-axis path merges Welford partials; a naive sum of squares would cancel."""
+    torch.manual_seed(0)
+    x = (torch.randn(4, 8, 256, dtype=torch.float16, device="cuda") + 60.0).half()
+
+    _check(VarFwdOp, _ref_var, x, dim=(0, 2), keepdim=False, correction=1)
 
 
 @pytest.mark.smoke

--- a/tests/ops/test_softmax.py
+++ b/tests/ops/test_softmax.py
@@ -706,3 +706,23 @@ def test_logsumexp_few_long_rows_split_across_blocks() -> None:
     torch.testing.assert_close(
         LogSumExpFwdOp(dim=-1)(x), torch.logsumexp(x, dim=-1), atol=1e-5, rtol=1e-5
     )
+
+
+@pytest.mark.smoke
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_split_rows_survive_fully_masked_segments() -> None:
+    """A segment of only ``-inf`` contributes zero to the fold, not NaN.
+
+    Masked inputs make whole segments ``-inf``; the segment-local max is then
+    ``-inf`` and an unguarded ``exp(-inf - -inf)`` would poison rows the
+    single-block path computes fine. An all--inf row stays torch: NaN for
+    softmax, ``-inf`` for logsumexp.
+    """
+    x = torch.randn(4, 102400, dtype=torch.float32, device="cuda")
+    x[:, :4096] = float("-inf")  # first segments fully masked, rest finite
+    torch.testing.assert_close(SoftmaxFwdOp(dim=-1)(x), F.softmax(x, dim=-1))
+    torch.testing.assert_close(LogSumExpFwdOp(dim=-1)(x), torch.logsumexp(x, dim=-1))
+
+    x[0, :] = float("-inf")
+    torch.testing.assert_close(SoftmaxFwdOp(dim=-1)(x), F.softmax(x, dim=-1), equal_nan=True)
+    torch.testing.assert_close(LogSumExpFwdOp(dim=-1)(x), torch.logsumexp(x, dim=-1))

--- a/tests/ops/test_softmax.py
+++ b/tests/ops/test_softmax.py
@@ -679,3 +679,30 @@ def test_log_softmax_eval_roofline_flops_5mn() -> None:
     assert mem_bytes == 2 * M * N * elem_bytes, (
         f"LogSoftmax bytes {mem_bytes} != 2 * M * N * elem_bytes = {2 * M * N * elem_bytes}"
     )
+
+
+@pytest.mark.smoke
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16], ids=["fp32", "fp16"])
+def test_softmax_few_long_rows_split_across_blocks(dtype: torch.dtype) -> None:
+    """A handful of long rows runs as segments plus a fold, not one block per row.
+
+    102400 is not a segment multiple, so the tail segment's masked lanes
+    contribute ``exp(-inf) = 0`` to the fold.
+    """
+    x = torch.randn(4, 102400, dtype=dtype, device="cuda")
+    atol, rtol = (1e-6, 1e-6) if dtype == torch.float32 else (1e-3, 1e-3)
+    torch.testing.assert_close(SoftmaxFwdOp(dim=-1)(x), F.softmax(x, dim=-1), atol=atol, rtol=rtol)
+    torch.testing.assert_close(
+        LogSoftmaxFwdOp(dim=-1)(x), F.log_softmax(x, dim=-1), atol=5e-3, rtol=5e-3
+    )
+
+
+@pytest.mark.smoke
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_logsumexp_few_long_rows_split_across_blocks() -> None:
+    """logsumexp folds the shared segment statistics without re-reading the input."""
+    x = torch.randn(4, 102400, dtype=torch.float32, device="cuda")
+    torch.testing.assert_close(
+        LogSumExpFwdOp(dim=-1)(x), torch.logsumexp(x, dim=-1), atol=1e-5, rtol=1e-5
+    )

--- a/tests/ops/test_vector_norm.py
+++ b/tests/ops/test_vector_norm.py
@@ -606,3 +606,30 @@ def test_vector_norm_tiled_autotune() -> None:
     (kernel,) = op.built_kernels(op._kernel_key).values()
     assert kernel._needs_tiling
     assert kernel.config in kernel.autotune_configs
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("op_kind", ["l1", "l2", "inf"])
+def test_vector_norm_edge_axes_in_own_layout(op_kind: str) -> None:
+    """``dim=[0, 2]`` reduces without a permute: a rows pass, then a fold.
+
+    ``l2`` takes its square root only at the fold; a sqrt applied per partial
+    would compound instead of finishing.
+    """
+    dtype = torch.float16
+    x = torch.randn(4, 24, 4096, dtype=dtype, device="cuda")
+    op = _make_op(op_kind, dim=[0, 2])
+    ords = {"l1": 1, "l2": 2, "inf": torch.inf}
+    ref = torch.linalg.vector_norm(x.float(), ords[op_kind], (0, 2)).to(dtype)
+    atol, rtol = _get_tolerances(dtype)
+    allclose_compare(op(x), ref, atol=atol, rtol=rtol)
+
+
+@pytest.mark.smoke
+def test_inf_norm_edge_axes_carries_nan() -> None:
+    """A NaN survives both passes: the fold compares bit patterns, not floats."""
+    x = torch.randn(4, 24, 4096, dtype=torch.float16, device="cuda")
+    x[3, 7, 4095] = float("nan")
+    y = _make_op("inf", dim=[0, 2])(x)
+    ref = torch.linalg.vector_norm(x, torch.inf, (0, 2))
+    assert torch.equal(y.isnan(), ref.isnan())


### PR DESCRIPTION
## problems

- A `dim=[0, 2]` reduction in vector_norm, logical_reduce, and the Welford kinds permuted the whole tensor to rows before reducing; the own-layout two-pass path covered only sum/mean/amax/amin.
- A binary broadcast computed a divmod offset chain per element, and the gathered accesses it produces never vectorize.
- softmax, log_softmax and logsumexp launch one block per row; an lm-head-shaped input keeps 4 blocks on a 132-SM device.

## changes

- Edge-axis reductions run as two passes in the tensor's own layout: rows fold into fp32 / int8 / (mean, M2) partials, and the lead axis folds them with sum, sum+sqrt, a NaN-carrying bit-pattern max, or Chan's merge. fp32-exactness gates decline counts past `FP32_EXACT_INT_LIMIT` per output.
- A broadcast whose innermost coalesced dim reads at stride 0 or 1 gets a per-row kernel: the offset chain runs once per block, the inner loop indexes affinely and vectorizes, and a ragged extent splits into full blocks plus one guarded tail.
- Under two row blocks per SM, a long row splits into aligned segments: one pass writes fp32 (max, sum) per segment, a fold writes the normalized segment; logsumexp shares the statistics pass and folds without re-reading. An all--inf segment folds as zero, so masked rows match torch.
- maximum/minimum keep their isnan guards: every correct guard variant measures alike (the selects are the cost), and `x != x` is not a guard — TileLang lowers `!=` as an ordered compare.
- Shared machinery lives with its owner: the down-rows engine and `edge_axis_plan` in `_primitives.py`, the split gate, statistics pass and fold in `_split_softmax.py`. The split block target reads the device's SM count; the segment cap, fp32's exact-integer bound, the grid-axis limit and the warp width are named or derived constants.
- Test node delta: +17 on five existing files, one node per new code path.

## measured

H200, image `cu132-torch2.13-tl-afcebed1-dev`, `device_busy` via torch.profiler, torch = eager on the same idle card; "before" ratios from the 2026-08-25 nightly (vs torch-compile).

| row | before (nightly ratio) | TO busy after | vs torch eager |
| --- | --- | --- | --- |
| l1_norm `3d-multidim` fp16 | 0.405 | 2.8 us | 2.43x |
| var `3d-multidim` fp16 | 0.500 | 3.3 us | 3.42x |
| any `3d-multidim` bool | 0.338 | 3.1 us | 4.69x |
| count_nonzero `3d-multidim` fp16 | 0.413 | 4.3 us | 4.04x |
| maximum cnn-feat-broadcast | 0.362 | 29.2 us | 1.36x |
| div cnn-feat-broadcast | 0.920 | 14.1 us | 2.81x |
| softmax lm-head fp32 | 0.283 | 8.0 us (was 54.3) | 3.28x |
| log_softmax lm-head fp32 | 0.309 | 7.9 us | 2.89x |
| logsumexp lm-head fp32 | 0.641 | 6.1 us | 5.18x |

Filled-grid softmax rows keep the single-block path; sum/mean edge rows are unchanged; 678 tests pass across the affected suites.
