### PR TITLE
[Perf][kernels] Stream long logsumexp rows straight to registers

### DIFF
--- a/src/tileops/kernels/attention/gqa_fwd.py
+++ b/src/tileops/kernels/attention/gqa_fwd.py
@@ -5,6 +5,7 @@ import tilelang
 import tilelang.language as T
 import torch
 
+from tileops.kernels.constants import FP8_E4M3_MAX
 from tileops.kernels.kernel_base import Kernel
 
 from ._config import tile_stage_thread_configs
@@ -1053,8 +1054,8 @@ def _gqa_prefill_paged_with_fp8_kv_cache_fwd_kernel(
         )
         rescale = make_rescale(block_m, dim)
         page_size_log2 = page_size.bit_length() - 1
-        fp8_min = -448.0
-        fp8_max = 448.0
+        fp8_min = -FP8_E4M3_MAX
+        fp8_max = FP8_E4M3_MAX
 
         @T.macro
         def quantize_fp8(value, scale_value):

--- a/src/tileops/kernels/attention/gqa_prefill_fwd_ws.py
+++ b/src/tileops/kernels/attention/gqa_prefill_fwd_ws.py
@@ -21,6 +21,8 @@ import tilelang.language as T
 import torch
 from tilelang.layout import make_swizzled_layout
 
+from tileops.kernels.constants import LOG2E
+
 from .call_spec import (
     ATTENTION_DTYPES,
     WS_ARCH,
@@ -76,7 +78,7 @@ def _gqa_prefill_fwd_fa3_kernel(
 ):
     score_scale = (1.0 / D) ** 0.5 if sm_scale is None else sm_scale
     use_softcap = softcap > 0.0
-    scale = 1.44269504 if use_softcap else score_scale * 1.44269504
+    scale = LOG2E if use_softcap else score_scale * LOG2E
     groups = H // Hkv
     co = Skv - Sq
     accum = "float"

--- a/src/tileops/kernels/attention/mha_decode_paged_ws.py
+++ b/src/tileops/kernels/attention/mha_decode_paged_ws.py
@@ -32,6 +32,7 @@ import tilelang.language as T
 import torch
 from tilelang.layout import make_swizzled_layout
 
+from tileops.kernels.constants import LOG2E
 from tileops.kernels.kernel_base import Kernel
 
 from .call_spec import paged_decode_ws_region
@@ -39,7 +40,6 @@ from .call_spec import paged_decode_ws_region
 __all__ = ["MHADecodePagedWsKernel"]
 
 #: log2(e): the softmax runs on exp2, which is one instruction.
-LOG2E = 1.44269504
 
 WARP = 32
 #: Warps in the consumer group. One warp group of each role, 256 threads: two

--- a/src/tileops/kernels/attention/online_softmax.py
+++ b/src/tileops/kernels/attention/online_softmax.py
@@ -9,6 +9,8 @@ The online softmax algorithm computes softmax incrementally over blocks:
 
 import tilelang.language as T
 
+from tileops.kernels.constants import LOG2E
+
 __all__ = [
     "LOG2E",
     "make_apply_softcap",
@@ -21,7 +23,6 @@ __all__ = [
 
 # log2(e) -- used to convert exp(x) into exp2(x * log2(e))
 # which allows the compiler to fuse the multiply into an ffma instruction.
-LOG2E = 1.44269504
 
 
 def make_log2e_scale(dim):

--- a/src/tileops/kernels/constants.py
+++ b/src/tileops/kernels/constants.py
@@ -1,0 +1,17 @@
+"""Hardware and math constants shared across kernel families."""
+
+# Widest vectorized global access the kernels plan for: 128 bits.
+VECTOR_ACCESS_BYTES: int = 16
+
+# log2(e), to fold exp(x) into the single-instruction exp2(x * LOG2E).
+LOG2E: float = 1.4426950408889634
+
+# 1/sqrt(2), for the erf form of GELU: 0.5 * x * (1 + erf(x / sqrt(2))).
+INV_SQRT2: float = 0.7071067811865476
+
+# sqrt(2/pi) and the cubic coefficient of torch's tanh-approximate GELU.
+SQRT_2_OVER_PI: float = 0.7978845608028654
+GELU_TANH_COEFF: float = 0.044715
+
+# Largest finite float8_e4m3fn value; quantizers clamp to +-FP8_E4M3_MAX.
+FP8_E4M3_MAX: float = 448.0

--- a/src/tileops/kernels/elementwise/activations.py
+++ b/src/tileops/kernels/elementwise/activations.py
@@ -5,6 +5,8 @@ import functools
 import tilelang
 import tilelang.language as T
 
+from tileops.kernels.constants import GELU_TANH_COEFF, INV_SQRT2, LOG2E, SQRT_2_OVER_PI
+
 from ._base import (
     _FLOAT_DTYPES,
     FloatUnaryKernel,
@@ -47,7 +49,7 @@ class GeluFwdKernel(FloatUnaryKernel):
 
     @staticmethod
     def op_func(x):
-        inv_sqrt_2 = T.cast(0.7071067811865476, "float32")
+        inv_sqrt_2 = T.cast(INV_SQRT2, "float32")
         half = T.cast(0.5, "float32")
         one = T.cast(1.0, "float32")
         return half * x * (one + T.erf(T.cast(x, "float32") * inv_sqrt_2))
@@ -62,8 +64,8 @@ class GeluTanhFwdKernel(FloatUnaryKernel):
 
     @staticmethod
     def op_func(x):
-        sqrt_2_over_pi = T.cast(0.7978845608028654, "float32")
-        coeff = T.cast(0.044715, "float32")
+        sqrt_2_over_pi = T.cast(SQRT_2_OVER_PI, "float32")
+        coeff = T.cast(GELU_TANH_COEFF, "float32")
         half = T.cast(0.5, "float32")
         one = T.cast(1.0, "float32")
         x_f32 = T.cast(x, "float32")
@@ -475,7 +477,7 @@ class SiluAndMulFwdKernel(FusedGatedKernel):
         # exp2 form (fp32): exp2 lowers to one MUFU.EX2 vs expf's multi-op sequence.
         g = T.Cast("float32", x)
         one = T.cast(1.0, "float32")
-        log2e = T.cast(1.4426950408889634, "float32")
+        log2e = T.cast(LOG2E, "float32")
         return g / (one + T.exp2(-g * log2e))
 
 
@@ -490,7 +492,7 @@ class GeluAndMulFwdKernel(FusedGatedKernel):
 
     @staticmethod
     def activation_func(x):
-        inv_sqrt2 = T.cast(0.7071067811865476, "float32")  # 1/sqrt(2)
+        inv_sqrt2 = T.cast(INV_SQRT2, "float32")  # 1/sqrt(2)
         half = T.cast(0.5, x.dtype)
         one = T.cast(1.0, x.dtype)
         x_f32 = T.Cast("float32", x)
@@ -508,8 +510,8 @@ class GeluTanhAndMulFwdKernel(FusedGatedKernel):
 
     @staticmethod
     def activation_func(x):
-        sqrt_2_over_pi = T.cast(0.7978845608028654, "float32")  # sqrt(2/pi)
-        coeff = T.cast(0.044715, "float32")  # GELU tanh approx coefficient
+        sqrt_2_over_pi = T.cast(SQRT_2_OVER_PI, "float32")  # sqrt(2/pi)
+        coeff = T.cast(GELU_TANH_COEFF, "float32")  # GELU tanh approx coefficient
         half = T.cast(0.5, x.dtype)
         one = T.cast(1.0, x.dtype)
         x_f32 = T.Cast("float32", x)

--- a/src/tileops/kernels/fp8_quant.py
+++ b/src/tileops/kernels/fp8_quant.py
@@ -6,6 +6,7 @@ import tilelang
 import tilelang.language as T
 import torch
 
+from tileops.kernels.constants import FP8_E4M3_MAX
 from tileops.kernels.kernel_base import Kernel
 
 __all__ = ["FP8QuantKernel"]
@@ -17,8 +18,8 @@ def _fp8_quant_kernel(batch, seq_len_kv, kv_group, index_dim, in_dtype: str):
     def _fp8_quant_fwd_func(num_stages, block_m):
         out_dtype = T.float8_e4m3fn
         scale_dtype = T.float32
-        fp8_min = -448.0
-        fp8_max = 448.0
+        fp8_min = -FP8_E4M3_MAX
+        fp8_max = FP8_E4M3_MAX
         fp8_max_inv = 1 / fp8_max
 
         @T.prim_func

--- a/src/tileops/kernels/linear_attention/gated_deltanet/compute_w_u_bwd.py
+++ b/src/tileops/kernels/linear_attention/gated_deltanet/compute_w_u_bwd.py
@@ -15,7 +15,7 @@ import functools
 import tilelang
 import tilelang.language as T
 
-from .fused_prepare_compute_w_u import _LOG2E
+from tileops.kernels.constants import LOG2E
 
 __all__ = ["compute_w_u_bwd_full_tl"]
 
@@ -127,7 +127,7 @@ def compute_w_u_bwd_full_tl(
                 # dGram = dL * beta_i * exp(g_i - g_j).
                 for i, j in T.Parallel(block_C, block_C):
                     matrix_b_s[i, j] = (
-                        matrix_a_s[i, j] * beta_s[i] * T.exp2((g_s[i] - g_s[j]) * _LOG2E)
+                        matrix_a_s[i, j] * beta_s[i] * T.exp2((g_s[i] - g_s[j]) * LOG2E)
                     )
                 T.clear(dk_A_frag)
                 T.gemm(matrix_b_s, k_s, dk_A_frag)
@@ -145,7 +145,7 @@ def compute_w_u_bwd_full_tl(
                 T.gemm(k_s, k_s, matrix_frag, transpose_B=True)
                 for i, j in T.Parallel(block_C, block_C):
                     matrix_b_s[i, j] = (
-                        matrix_a_s[i, j] * T.exp2((g_s[i] - g_s[j]) * _LOG2E) * matrix_frag[i, j]
+                        matrix_a_s[i, j] * T.exp2((g_s[i] - g_s[j]) * LOG2E) * matrix_frag[i, j]
                     )
                     matrix_a_s[i, j] = matrix_b_s[i, j] * beta_s[i]
 

--- a/src/tileops/kernels/linear_attention/gated_deltanet/fused_prepare_compute_w_u.py
+++ b/src/tileops/kernels/linear_attention/gated_deltanet/fused_prepare_compute_w_u.py
@@ -17,9 +17,9 @@ import math
 import tilelang
 import tilelang.language as T
 
-__all__ = ["fused_prepare_compute_w_u_tl"]
+from tileops.kernels.constants import LOG2E
 
-_LOG2E = 1.4426950408889634
+__all__ = ["fused_prepare_compute_w_u_tl"]
 
 
 @functools.lru_cache(maxsize=32)
@@ -104,7 +104,7 @@ def fused_prepare_compute_w_u_tl(
                         i > j,
                         -gram_frag[i, j]
                         * beta_shared[i]
-                        * T.exp2((g_shared[i] - g_shared[j]) * _LOG2E),
+                        * T.exp2((g_shared[i] - g_shared[j]) * LOG2E),
                         T.float32(0.0),
                     )
                 for i, j in T.Parallel(block_C, block_C):

--- a/src/tileops/kernels/linear_attention/gated_deltanet/gated_deltanet_bwd.py
+++ b/src/tileops/kernels/linear_attention/gated_deltanet/gated_deltanet_bwd.py
@@ -17,10 +17,10 @@ import tilelang
 import tilelang.language as T
 import torch
 
+from tileops.kernels.constants import LOG2E
 from tileops.kernels.kernel_base import Kernel
 
 from ..v_tile import resolve_block_v
-from .gated_deltanet_fwd import _LOG2E
 
 __all__ = [
     "GatedDeltaNetBwdKernel",
@@ -123,10 +123,10 @@ def _bwd_parallel_tl(
                 T.clear(ws_frag)
                 T.gemm(w_c, h_c, ws_frag)
                 for i in T.Parallel(block_C):
-                    exp_g[i] = T.exp2(g_c[i] * _LOG2E)
+                    exp_g[i] = T.exp2(g_c[i] * LOG2E)
                 for i, j in T.Parallel(block_C, dim_v):
                     v_new_c[i, j] = u_c[i, j] - ws_frag[i, j] * T.exp2(
-                        (g_c[i] + g_c[block_C - 1]) * _LOG2E
+                        (g_c[i] + g_c[block_C - 1]) * LOG2E
                     )
 
                 # Store v_new for recurrence kernel
@@ -145,7 +145,7 @@ def _bwd_parallel_tl(
                 T.gemm(q_c, k_c, attn_frag, transpose_B=True)
                 for i, j in T.Parallel(block_C, block_C):
                     attn[i, j] = T.if_then_else(
-                        i >= j, attn_frag[i, j] * T.exp2((g_c[i] - g_c[j]) * _LOG2E), T.float32(0.0)
+                        i >= j, attn_frag[i, j] * T.exp2((g_c[i] - g_c[j]) * LOG2E), T.float32(0.0)
                     )
 
                 T.clear(dh_frag)
@@ -185,7 +185,7 @@ def _bwd_parallel_tl(
 
                 for i, j in T.Parallel(block_C, block_C):
                     d_attn[i, j] = T.if_then_else(
-                        i >= j, d_attn[i, j] * T.exp2((g_c[i] - g_c[j]) * _LOG2E), T.float32(0.0)
+                        i >= j, d_attn[i, j] * T.exp2((g_c[i] - g_c[j]) * LOG2E), T.float32(0.0)
                     )
 
                 T.gemm(d_attn, k_c, d_q_c_frag)
@@ -197,7 +197,7 @@ def _bwd_parallel_tl(
 
                 # Step 5: dh from w/v_new, dw, dg from P
                 for i, j in T.Parallel(block_C, dim_k):
-                    P[i, j] = w_c[i, j] * T.exp2((g_c[i] + g_c[block_C - 1]) * _LOG2E)
+                    P[i, j] = w_c[i, j] * T.exp2((g_c[i] + g_c[block_C - 1]) * LOG2E)
                 T.clear(dP_frag)
                 T.gemm(d_v_new_c, h_c, dP_frag, transpose_B=True)
                 for i, j in T.Parallel(block_C, dim_k):
@@ -209,7 +209,7 @@ def _bwd_parallel_tl(
                     dh_frag[i, j] -= dh_sub_frag[i, j]
                 # dw
                 for i, j in T.Parallel(block_C, dim_k):
-                    d_w_c[i, j] = dP[i, j] * T.exp2((g_c[i] + g_c[block_C - 1]) * _LOG2E)
+                    d_w_c[i, j] = dP[i, j] * T.exp2((g_c[i] + g_c[block_C - 1]) * LOG2E)
                 # dg from P*dP
                 for i, j in T.Parallel(block_C, dim_k):
                     P[i, j] = P[i, j] * dP[i, j]
@@ -288,7 +288,7 @@ def _make_dh_correction_from_carry_macro(
         v_offset,
     ):
         for pn, sk in T.Parallel(block_C, dim_k):
-            k_scaled[pn, sk] = k_c[pn, sk] * T.exp2((g_c[block_C - 1] - g_c[pn]) * _LOG2E)
+            k_scaled[pn, sk] = k_c[pn, sk] * T.exp2((g_c[block_C - 1] - g_c[pn]) * LOG2E)
 
         T.clear(du_corr_frag)
         T.gemm(k_scaled, dh_buf, du_corr_frag)
@@ -308,7 +308,7 @@ def _make_dh_correction_from_carry_macro(
         T.gemm(du_corr_c, h_c, dP_frag, transpose_B=True)
         for n, kk in T.Parallel(block_C, dim_k):
             dw_corr_partial[bid, hid, vid, chunk_offset + n, kk] = -dP_frag[n, kk] * T.exp2(
-                (g_c[n] + g_c[block_C - 1]) * _LOG2E
+                (g_c[n] + g_c[block_C - 1]) * LOG2E
             )
 
         T.clear(dP_frag)
@@ -316,7 +316,7 @@ def _make_dh_correction_from_carry_macro(
         T.copy(dP_frag, dP)
         for n, kk in T.Parallel(block_C, dim_k):
             dk_corr_partial[bid, hid, vid, chunk_offset + n, kk] = dP[n, kk] * T.exp2(
-                (g_c[block_C - 1] - g_c[n]) * _LOG2E
+                (g_c[block_C - 1] - g_c[n]) * LOG2E
             )
 
         for n, kk in T.Parallel(block_C, dim_k):
@@ -332,7 +332,7 @@ def _make_dh_correction_from_carry_macro(
         T.reduce_sum(d_g_pos, d_g_last_scalar2, dim=0)
         dg_c[block_C - 1] = (
             dg_c[block_C - 1]
-            + d_g_last_scalar1[0] * T.exp2(g_c[block_C - 1] * _LOG2E)
+            + d_g_last_scalar1[0] * T.exp2(g_c[block_C - 1] * LOG2E)
             + d_g_last_scalar2[0]
         )
 
@@ -458,7 +458,7 @@ def _dh_recurrence_bwd_tl(
                     # dh = dh_local + dh_buf * exp(g_last)
                     for i, j in T.Parallel(dim_k, BV):
                         dh_frag[i, j] = dh_loc[i, j] + dh_buf[i, j] * T.exp2(
-                            g_c[block_C - 1] * _LOG2E
+                            g_c[block_C - 1] * LOG2E
                         )
 
                     correction_from_carry(
@@ -803,7 +803,7 @@ def _dh_segment_summary_tl(
                         dh_loc,
                         disable_tma=True,
                     )
-                    alpha = T.exp2(g_c[block_C - 1] * _LOG2E)
+                    alpha = T.exp2(g_c[block_C - 1] * LOG2E)
                     for i, j in T.Parallel(dim_k, BV):
                         summary_frag[i, j] = dh_loc[i, j] + summary[i, j] * alpha
                     T.copy(summary_frag, summary)
@@ -962,7 +962,7 @@ def _dh_segment_local_carry_tl(
                         dh_loc,
                         disable_tma=True,
                     )
-                    alpha = T.exp2(g_c[block_C - 1] * _LOG2E)
+                    alpha = T.exp2(g_c[block_C - 1] * LOG2E)
                     for i, j in T.Parallel(dim_k, BV):
                         carry_frag[i, j] = dh_loc[i, j] + carry[i, j] * alpha
                     T.copy(carry_frag, carry)

--- a/src/tileops/kernels/linear_attention/gated_deltanet/gated_deltanet_fwd.py
+++ b/src/tileops/kernels/linear_attention/gated_deltanet/gated_deltanet_fwd.py
@@ -18,6 +18,7 @@ import tilelang
 import tilelang.language as T
 import torch
 
+from tileops.kernels.constants import LOG2E
 from tileops.kernels.kernel_base import Kernel
 
 from ..autotune import (
@@ -29,8 +30,6 @@ from ..v_tile import resolve_block_v
 from .fused_prepare_compute_w_u import fused_prepare_compute_w_u_tl
 
 __all__ = ["GatedDeltaNetFwdKernel", "GatedDeltaNetFwdProductionKernel"]
-
-_LOG2E = 1.4426950408889634
 
 
 # Split kernel: h_recurrence  (sequential over chunks, state update only)
@@ -112,7 +111,7 @@ def _h_recurrence_tl(
                     T.gemm(w_c, h_c, ws_frag)
                     for i, j in T.Parallel(block_C, BV):
                         v_new_c[i, j] = u_c[i, j] - ws_frag[i, j] * T.exp2(
-                            (g_c[i] + g_c[block_C - 1]) * _LOG2E
+                            (g_c[i] + g_c[block_C - 1]) * LOG2E
                         )
 
                     # Store v_new tile
@@ -124,9 +123,9 @@ def _h_recurrence_tl(
 
                     # h_tile_next = h_tile * exp(g_last) + k^T @ scaled_v_new_tile
                     for n, j in T.Parallel(block_C, BV):
-                        v_new_c[n, j] = v_new_c[n, j] * T.exp2((g_c[block_C - 1] - g_c[n]) * _LOG2E)
+                        v_new_c[n, j] = v_new_c[n, j] * T.exp2((g_c[block_C - 1] - g_c[n]) * LOG2E)
                     for i, j in T.Parallel(dim_k, BV):
-                        h_next_frag[i, j] = h_c[i, j] * T.exp2(g_c[block_C - 1] * _LOG2E)
+                        h_next_frag[i, j] = h_c[i, j] * T.exp2(g_c[block_C - 1] * LOG2E)
                     T.gemm(
                         k_c,
                         v_new_c,
@@ -207,14 +206,14 @@ def _output_o_tl(
                 T.clear(o_frag)
                 T.gemm(q_c, h_c, o_frag)
                 for i, j in T.Parallel(block_C, dim_v):
-                    o_frag[i, j] = o_frag[i, j] * T.exp2(g_c[i] * _LOG2E)
+                    o_frag[i, j] = o_frag[i, j] * T.exp2(g_c[i] * LOG2E)
 
                 # attn = causal(q @ k^T) * Gamma
                 T.clear(attn_frag)
                 T.gemm(q_c, k_c, attn_frag, transpose_B=True)
                 for i, j in T.Parallel(block_C, block_C):
                     attn[i, j] = T.if_then_else(
-                        i >= j, attn_frag[i, j] * T.exp2((g_c[i] - g_c[j]) * _LOG2E), T.float32(0.0)
+                        i >= j, attn_frag[i, j] * T.exp2((g_c[i] - g_c[j]) * LOG2E), T.float32(0.0)
                     )
 
                 # o += attn @ v_new

--- a/src/tileops/kernels/linear_attention/gated_deltanet/gated_deltanet_prefill.py
+++ b/src/tileops/kernels/linear_attention/gated_deltanet/gated_deltanet_prefill.py
@@ -15,11 +15,11 @@ import tilelang
 import tilelang.language as T
 import torch
 
+from tileops.kernels.constants import LOG2E
 from tileops.kernels.kernel_base import Kernel
 
 from ..v_tile import resolve_block_v
 from .gated_deltanet_fwd import (
-    _LOG2E,
     _chunk_local_cumsum,
     _h_recurrence_tl,
     _output_o_tl,
@@ -306,8 +306,8 @@ def _prefill_prepare_w_u_bhtd_tl(
                 for i_s, i_k in T.Parallel(block_C, dim_k):
                     k_beta_shared[i_s, i_k] = k_shared[i_s, i_k] * beta_shared[i_s]
                 for i in T.Parallel(block_C):
-                    g_pos_shared[i] = T.exp2(g_shared[i] * _LOG2E)
-                    g_neg_shared[i] = T.exp2(-g_shared[i] * _LOG2E)
+                    g_pos_shared[i] = T.exp2(g_shared[i] * LOG2E)
+                    g_neg_shared[i] = T.exp2(-g_shared[i] * LOG2E)
                 T.clear(gram_frag)
                 T.gemm(k_beta_shared, k_shared, gram_frag, transpose_B=True)
 
@@ -541,14 +541,14 @@ def _prefill_blocksolve_A_bthd_tl(
                     g_val = T.cast(g_s[t], accum_dtype) if use_gate else T.float32(0.0)
                     gate0_s[t] = T.exp2(
                         (g_val - (T.cast(g_s[0], accum_dtype) if use_gate else T.float32(0.0)))
-                        * _LOG2E
+                        * LOG2E
                     )
                     gate1_s[t] = T.exp2(
                         (
                             g_val
                             - (T.cast(g_s[block_c], accum_dtype) if use_gate else T.float32(0.0))
                         )
-                        * _LOG2E
+                        * LOG2E
                     )
                     gate2_s[t] = T.exp2(
                         (
@@ -559,7 +559,7 @@ def _prefill_blocksolve_A_bthd_tl(
                                 else T.float32(0.0)
                             )
                         )
-                        * _LOG2E
+                        * LOG2E
                     )
                     gate3_s[t] = T.exp2(
                         (
@@ -570,7 +570,7 @@ def _prefill_blocksolve_A_bthd_tl(
                                 else T.float32(0.0)
                             )
                         )
-                        * _LOG2E
+                        * LOG2E
                     )
                     beta_f_s[t] = beta_s[t]
                 T.sync_threads()
@@ -1065,8 +1065,8 @@ def _prefill_prepare_w_u_bthd_tl(
                 for i, d in T.Parallel(block_C, dim_k):
                     k_beta_shared[i, d] = k_shared[i, d] * beta_shared[i]
                 for i in T.Parallel(block_C):
-                    g_pos_shared[i] = T.exp2(g_shared[i] * _LOG2E)
-                    g_neg_shared[i] = T.exp2(-g_shared[i] * _LOG2E)
+                    g_pos_shared[i] = T.exp2(g_shared[i] * LOG2E)
+                    g_neg_shared[i] = T.exp2(-g_shared[i] * LOG2E)
                 T.clear(gram_frag)
                 T.gemm(k_beta_shared, k_shared, gram_frag, transpose_B=True)
 
@@ -1176,16 +1176,16 @@ def _prefill_h_recurrence_bthd_tl(
                     T.gemm(w_c, h_c, ws_frag)
                     for i, j in T.Parallel(block_C, BV):
                         v_new_c[i, j] = u_c[i, j] - ws_frag[i, j] * T.exp2(
-                            (g_c[i] + g_c[block_C - 1]) * _LOG2E
+                            (g_c[i] + g_c[block_C - 1]) * LOG2E
                         )
 
                     for i, j in T.Parallel(block_C, BV):
                         v_new[bid, base + i, hid, v_offset + j] = v_new_c[i, j]
 
                     for n, j in T.Parallel(block_C, BV):
-                        v_new_c[n, j] = v_new_c[n, j] * T.exp2((g_c[block_C - 1] - g_c[n]) * _LOG2E)
+                        v_new_c[n, j] = v_new_c[n, j] * T.exp2((g_c[block_C - 1] - g_c[n]) * LOG2E)
                     for i, j in T.Parallel(dim_k, BV):
-                        h_next_frag[i, j] = h_c[i, j] * T.exp2(g_c[block_C - 1] * _LOG2E)
+                        h_next_frag[i, j] = h_c[i, j] * T.exp2(g_c[block_C - 1] * LOG2E)
                     T.gemm(
                         k_c,
                         v_new_c,
@@ -1257,14 +1257,14 @@ def _prefill_output_o_bthd_tl(
                 T.clear(o_frag)
                 T.gemm(q_c, h_c, o_frag)
                 for i, j in T.Parallel(block_C, dim_v):
-                    o_frag[i, j] = o_frag[i, j] * T.exp2(g_c[i] * _LOG2E)
+                    o_frag[i, j] = o_frag[i, j] * T.exp2(g_c[i] * LOG2E)
 
                 T.clear(attn_frag)
                 T.gemm(q_c, k_c, attn_frag, transpose_B=True)
                 for i, j in T.Parallel(block_C, block_C):
                     attn[i, j] = T.if_then_else(
                         i >= j,
-                        attn_frag[i, j] * T.exp2((g_c[i] - g_c[j]) * _LOG2E),
+                        attn_frag[i, j] * T.exp2((g_c[i] - g_c[j]) * LOG2E),
                         T.float32(0.0),
                     )
 
@@ -1363,13 +1363,13 @@ def _prefill_group_transition_summary_bthd_tl(
                     T.gemm(w_c, h_c, ws_frag)
                     for i, j in T.Parallel(block_C, BV):
                         v_new_c[i, j] = u_c[i, j] - ws_frag[i, j] * T.exp2(
-                            (g_c[i] + g_c[block_C - 1]) * _LOG2E
+                            (g_c[i] + g_c[block_C - 1]) * LOG2E
                         )
 
                     for n, j in T.Parallel(block_C, BV):
-                        v_new_c[n, j] = v_new_c[n, j] * T.exp2((g_c[block_C - 1] - g_c[n]) * _LOG2E)
+                        v_new_c[n, j] = v_new_c[n, j] * T.exp2((g_c[block_C - 1] - g_c[n]) * LOG2E)
                     for i, j in T.Parallel(dim_k, BV):
-                        h_next_frag[i, j] = h_c[i, j] * T.exp2(g_c[block_C - 1] * _LOG2E)
+                        h_next_frag[i, j] = h_c[i, j] * T.exp2(g_c[block_C - 1] * LOG2E)
                     T.gemm(
                         k_c,
                         v_new_c,
@@ -1528,16 +1528,16 @@ def _prefill_grouped_replay_bthd_tl(
                     T.gemm(w_c, h_c, ws_frag)
                     for i, j in T.Parallel(block_C, BV):
                         v_new_c[i, j] = u_c[i, j] - ws_frag[i, j] * T.exp2(
-                            (g_c[i] + g_c[block_C - 1]) * _LOG2E
+                            (g_c[i] + g_c[block_C - 1]) * LOG2E
                         )
 
                     for i, j in T.Parallel(block_C, BV):
                         v_new[bid, base + i, hid, v_offset + j] = v_new_c[i, j]
 
                     for n, j in T.Parallel(block_C, BV):
-                        v_new_c[n, j] = v_new_c[n, j] * T.exp2((g_c[block_C - 1] - g_c[n]) * _LOG2E)
+                        v_new_c[n, j] = v_new_c[n, j] * T.exp2((g_c[block_C - 1] - g_c[n]) * LOG2E)
                     for i, j in T.Parallel(dim_k, BV):
-                        h_next_frag[i, j] = h_c[i, j] * T.exp2(g_c[block_C - 1] * _LOG2E)
+                        h_next_frag[i, j] = h_c[i, j] * T.exp2(g_c[block_C - 1] * LOG2E)
                     T.gemm(
                         k_c,
                         v_new_c,

--- a/src/tileops/kernels/linear_attention/gated_deltanet/prefill/fused_fwd.py
+++ b/src/tileops/kernels/linear_attention/gated_deltanet/prefill/fused_fwd.py
@@ -9,6 +9,8 @@ import tilelang
 import tilelang.language as T
 import torch
 
+from tileops.kernels.constants import LOG2E
+
 from .utils import prepare_chunk_offsets
 
 MULTI_PROCESSOR_COUNT = torch.cuda.get_device_properties().multi_processor_count
@@ -249,12 +251,12 @@ def _build_fused_chunk_gdr_fwd_kernel(
                     T.barrier_wait(bar_0, i_s % 2)
                     # Precompute g, g_last/g
                     for j_s in T.Parallel(block_S):
-                        g_exp_shared[j_s] = T.exp2(g_shared[i_s % 2, j_s] * 1.442695)
+                        g_exp_shared[j_s] = T.exp2(g_shared[i_s % 2, j_s] * LOG2E)
                     for j_s in T.Parallel(block_S):
                         g_rev_exp_shared[j_s] = T.if_then_else(
                             seq_start_idx + i_s * block_S + j_s < seq_end_idx,
                             T.exp2(
-                                (g_shared[i_s % 2, block_S - 1] - g_shared[i_s % 2, j_s]) * 1.442695
+                                (g_shared[i_s % 2, block_S - 1] - g_shared[i_s % 2, j_s]) * LOG2E
                             ),
                             0.0,
                         )
@@ -326,7 +328,7 @@ def _build_fused_chunk_gdr_fwd_kernel(
                         g_fragment[j_s, j_t] = g_shared[i_s % 2, j_s] - g_shared[i_s % 2, j_t]
                     for j_s, j_t in T.Parallel(block_S, block_S):
                         if j_s >= j_t:
-                            g_fragment[j_s, j_t] = T.exp2(g_fragment[j_s, j_t] * 1.442695)
+                            g_fragment[j_s, j_t] = T.exp2(g_fragment[j_s, j_t] * LOG2E)
                         else:
                             g_fragment[j_s, j_t] = 0
                     # Ag = G * Ar * b

--- a/src/tileops/kernels/linear_attention/gated_deltanet/prefill/prepare_h.py
+++ b/src/tileops/kernels/linear_attention/gated_deltanet/prefill/prepare_h.py
@@ -8,6 +8,8 @@ import tilelang
 import tilelang.language as T
 import torch
 
+from tileops.kernels.constants import LOG2E
+
 from .utils import prepare_chunk_offsets
 
 
@@ -172,7 +174,7 @@ def _build_prepare_h_kernel(
                     # [STAGE = i_s % num_stages] 1
                     T.barrier_wait(bar_1, i_s % 2)
                     # S = g_last * S
-                    g_last_local_S[0] = T.exp2(g_shared[i_s % num_stages, block_S - 1] * 1.442695)
+                    g_last_local_S[0] = T.exp2(g_shared[i_s % num_stages, block_S - 1] * LOG2E)
                     for j_k, j_v in T.Parallel(DK, DV):
                         h_fragment[j_k, j_v] *= g_last_local_S[0]
                     T.barrier_arrive(bar_2)
@@ -260,7 +262,7 @@ def _build_prepare_h_kernel(
                     T.barrier_arrive(data_is_free[i_s % num_stages])
 
                 if calc_mt:
-                    g_last_local_X[0] = T.exp2(g_prod_X[0] * 1.442695)
+                    g_last_local_X[0] = T.exp2(g_prod_X[0] * LOG2E)
                     for j_k, j_v in T.Parallel(DK, DK // 2):
                         m_fragment_R[j_k, j_v] *= g_last_local_X[0]
                     T.copy(m_fragment_R, mt[bb, bh, 0:DK, DK // 2 :])
@@ -288,9 +290,9 @@ def _build_prepare_h_kernel(
                     g_last_local_Y[0] = g_shared[i_s % num_stages, block_S - 1]
                     for j_s in T.Parallel(block_S):
                         g_rev_exp_shared[j_s] = T.exp2(
-                            (g_last_local_Y[0] - g_shared[i_s % num_stages, j_s]) * 1.442695
+                            (g_last_local_Y[0] - g_shared[i_s % num_stages, j_s]) * LOG2E
                         )
-                    g_last_local_Y[0] = T.exp2(g_last_local_Y[0] * 1.442695)
+                    g_last_local_Y[0] = T.exp2(g_last_local_Y[0] * LOG2E)
                     T.barrier_arrive(bar_1)
 
                     # [STAGE = i_s % num_stages] 1
@@ -342,7 +344,7 @@ def _build_prepare_h_kernel(
                     T.barrier_arrive(data_is_free[i_s % num_stages])
 
                 if calc_mt:
-                    g_last_local_Y[0] = T.exp2(g_prod_Y[0] * 1.442695)
+                    g_last_local_Y[0] = T.exp2(g_prod_Y[0] * LOG2E)
                     for j_k, j_v in T.Parallel(DK, DK // 2):
                         m_fragment_L[j_k, j_v] *= g_last_local_Y[0]
                     T.copy(m_fragment_L, mt[bb, bh, 0:DK, : DK // 2])

--- a/src/tileops/kernels/linear_attention/gated_deltanet_recurrence.py
+++ b/src/tileops/kernels/linear_attention/gated_deltanet_recurrence.py
@@ -24,6 +24,7 @@ import tilelang
 import tilelang.language as T
 import torch
 
+from tileops.kernels.constants import LOG2E
 from tileops.kernels.kernel_base import Kernel
 
 __all__ = [
@@ -32,7 +33,6 @@ __all__ = [
     "GatedDeltaNetDecodeRawCudaFlaStyleKernel",
 ]
 
-_LOG2E = 1.4426950408889634
 _DEFAULT_K_TILE = 16
 
 
@@ -108,7 +108,7 @@ def _gated_deltanet_decode_raw_cuda_flastyle_tl(
                         q_shared[kk] = T.cast(q[bid, hid, kk], "float32")
                 T.sync_threads()
 
-                alpha = T.exp2(T.cast(g[bid, hid], "float32") * _LOG2E)
+                alpha = T.exp2(T.cast(g[bid, hid], "float32") * LOG2E)
                 beta_val = T.cast(beta[bid, hid], "float32")
 
                 for ii in T.serial(k_chunk):
@@ -178,7 +178,7 @@ def _gated_deltanet_decode_tl(
 
                 g_val = T.cast(g[bid, hid], accum_dtype)
                 beta_val = T.cast(beta[bid, hid], accum_dtype)
-                alpha = T.exp2(g_val * _LOG2E)
+                alpha = T.exp2(g_val * LOG2E)
                 alpha_beta = alpha * beta_val
 
                 # Full-fp32 matvecs.  TileLang 0.1.9 cannot reliably lower
@@ -554,7 +554,7 @@ def _gated_deltanet_decode_fp32_tl(
 
                 g_val = T.cast(g[bid, hid], accum_dtype)
                 beta_val = T.cast(beta[bid, hid], accum_dtype)
-                alpha = T.exp2(g_val * _LOG2E)
+                alpha = T.exp2(g_val * LOG2E)
                 alpha_beta = alpha * beta_val
 
                 # Zero-init fragment accumulators

--- a/src/tileops/kernels/linear_attention/gla/gla_bwd.py
+++ b/src/tileops/kernels/linear_attention/gla/gla_bwd.py
@@ -19,14 +19,13 @@ import torch
 from tilelang import language as T
 from tilelang.profiler import do_bench
 
+from tileops.kernels.constants import LOG2E
 from tileops.kernels.kernel_base import Kernel
 
 from ..v_tile import GEMM_MIN_N
 from .gla_fwd import _gla_precompute_g_kernel
 
 __all__ = ["GLABwdKernel"]
-
-LOG2_E = 1.44269504
 
 
 # Pass 1: compute dh per chunk (reverse order, sequential)
@@ -135,7 +134,7 @@ def _gla_bwd_dh_kernel(
                     for i_t, i_k in T.Parallel(chunk_size, dim_k):
                         q_gated_s[i_t, i_k] = T.cast(
                             T.cast(q_s[i_t, i_k], accum_dtype)
-                            * T.exp2(g_cumsum_s[i_t, i_k] * LOG2_E),
+                            * T.exp2(g_cumsum_s[i_t, i_k] * LOG2E),
                             dtype,
                         )
 
@@ -154,7 +153,7 @@ def _gla_bwd_dh_kernel(
 
                     # Decay for next (earlier) chunk
                     for i_k, i_v in T.Parallel(dim_k, dim_v_part):
-                        dh_s[i_k, i_v] = dh_s[i_k, i_v] * T.exp2(g_last[i_k] * LOG2_E)
+                        dh_s[i_k, i_v] = dh_s[i_k, i_v] * T.exp2(g_last[i_k] * LOG2E)
 
                 # Write dh0
                 if has_initial_state:
@@ -266,7 +265,7 @@ def _gla_bwd_fused_kernel(
                         A_frag[i_t, i_j] = A_frag[i_t, i_j] + (
                             T.cast(q_s[i_t, i_k], accum_dtype)
                             * T.cast(k_s[i_j, i_k], accum_dtype)
-                            * T.exp2((g_cumsum_s[i_t, i_k] - g_cumsum_s[i_j, i_k]) * LOG2_E)
+                            * T.exp2((g_cumsum_s[i_t, i_k] - g_cumsum_s[i_j, i_k]) * LOG2E)
                         )
                 for i_t, i_j in T.Parallel(BT, BT):
                     A_s[i_t, i_j] = T.cast(
@@ -314,7 +313,7 @@ def _gla_bwd_fused_kernel(
                                             g_cumsum_s[s_i * BC, i_k]
                                             - g_cumsum_s[s_j * BC + i_t, i_k]
                                         )
-                                        * LOG2_E
+                                        * LOG2E
                                     ),
                                     dtype,
                                 )
@@ -323,7 +322,7 @@ def _gla_bwd_fused_kernel(
                     for i_local, i_k in T.Parallel(BC, dim_k):
                         dq_sub[i_local, i_k] = dq_sub[i_local, i_k] * T.exp2(
                             (g_cumsum_s[s_i * BC + i_local, i_k] - g_cumsum_s[s_i * BC, i_k])
-                            * LOG2_E
+                            * LOG2E
                         )
 
                     # Diagonal: fragment-based to avoid bf16 smem codegen bug
@@ -343,7 +342,7 @@ def _gla_bwd_fused_kernel(
                         for i_local, i_k in T.Parallel(BC, dim_k):
                             dq_sub[i_local, i_k] = dq_sub[i_local, i_k] + dA_col[i_local] * k_row[
                                 i_k
-                            ] * T.exp2((g_cumsum_s[s_i * BC + i_local, i_k] - g_j[i_k]) * LOG2_E)
+                            ] * T.exp2((g_cumsum_s[s_i * BC + i_local, i_k] - g_j[i_k]) * LOG2E)
 
                     for i_local, i_k in T.Parallel(BC, dim_k):
                         dq_frag[s_i * BC + i_local, i_k] = dq_sub[i_local, i_k]
@@ -369,7 +368,7 @@ def _gla_bwd_fused_kernel(
                                             g_cumsum_s[s_i * BC + i_t, i_k]
                                             - g_cumsum_s[(s_j + 1) * BC - 1, i_k]
                                         )
-                                        * LOG2_E
+                                        * LOG2E
                                     ),
                                     dtype,
                                 )
@@ -387,7 +386,7 @@ def _gla_bwd_fused_kernel(
                                 g_cumsum_s[(s_j + 1) * BC - 1, i_k]
                                 - g_cumsum_s[s_j * BC + j_local, i_k]
                             )
-                            * LOG2_E
+                            * LOG2E
                         )
 
                     # Diagonal: fragment-based
@@ -407,7 +406,7 @@ def _gla_bwd_fused_kernel(
                         for j_local, i_k in T.Parallel(BC, dim_k):
                             dk_sub[j_local, i_k] = dk_sub[j_local, i_k] + dA_row[j_local] * q_row[
                                 i_k
-                            ] * T.exp2((g_i[i_k] - g_cumsum_s[s_j * BC + j_local, i_k]) * LOG2_E)
+                            ] * T.exp2((g_i[i_k] - g_cumsum_s[s_j * BC + j_local, i_k]) * LOG2E)
 
                     for j_local, i_k in T.Parallel(BC, dim_k):
                         dk_frag[s_j * BC + j_local, i_k] = dk_sub[j_local, i_k]
@@ -431,7 +430,7 @@ def _gla_bwd_fused_kernel(
                 for i_t, i_k in T.Parallel(BT, dim_k):
                     k_gated_s[i_t, i_k] = T.cast(
                         T.cast(k_s[i_t, i_k], accum_dtype)
-                        * T.exp2((g_last[i_k] - g_cumsum_s[i_t, i_k]) * LOG2_E),
+                        * T.exp2((g_last[i_k] - g_cumsum_s[i_t, i_k]) * LOG2E),
                         dtype,
                     )
 
@@ -453,7 +452,7 @@ def _gla_bwd_fused_kernel(
                 # dq = dq_intra + scale * dq_inter * exp(g_cumsum)
                 for i_t, i_k in T.Parallel(BT, dim_k):
                     dq_frag[i_t, i_k] = dq_frag[i_t, i_k] + scale * dq_inter_s[i_t, i_k] * T.exp2(
-                        g_cumsum_s[i_t, i_k] * LOG2_E
+                        g_cumsum_s[i_t, i_k] * LOG2E
                     )
                 for i_t, i_k in T.Parallel(BT, dim_k):
                     dq_out[i_b, chunk_start + i_t, i_h, i_k] = dq_frag[i_t, i_k]
@@ -471,7 +470,7 @@ def _gla_bwd_fused_kernel(
                 # dk = dk_intra + dk_inter * exp(g_last - g_cumsum)
                 for i_t, i_k in T.Parallel(BT, dim_k):
                     dk_frag[i_t, i_k] = dk_frag[i_t, i_k] + dk_inter_s[i_t, i_k] * T.exp2(
-                        (g_last[i_k] - g_cumsum_s[i_t, i_k]) * LOG2_E
+                        (g_last[i_k] - g_cumsum_s[i_t, i_k]) * LOG2E
                     )
                 for i_t, i_k in T.Parallel(BT, dim_k):
                     dk_out[i_b, chunk_start + i_t, i_h, i_k] = dk_frag[i_t, i_k]
@@ -487,7 +486,7 @@ def _gla_bwd_fused_kernel(
                             * T.cast(dh[i_b, i_c, i_h, i_k, i_v2], accum_dtype)
                         )
                 for i_k in T.Parallel(dim_k):
-                    dg_inter[i_k] = dg_inter[i_k] * T.exp2(g_last[i_k] * LOG2_E)
+                    dg_inter[i_k] = dg_inter[i_k] * T.exp2(g_last[i_k] * LOG2E)
 
                 # Correction: k * dk_inter_gated
                 corr_s = T.alloc_shared([BT, dim_k], accum_dtype)
@@ -495,7 +494,7 @@ def _gla_bwd_fused_kernel(
                     corr_s[i_t, i_k] = (
                         T.cast(k_s[i_t, i_k], accum_dtype)
                         * dk_inter_s[i_t, i_k]
-                        * T.exp2((g_last[i_k] - g_cumsum_s[i_t, i_k]) * LOG2_E)
+                        * T.exp2((g_last[i_k] - g_cumsum_s[i_t, i_k]) * LOG2E)
                     )
                 for i_t in T.Serial(BT):
                     for i_k in T.Parallel(dim_k):

--- a/src/tileops/kernels/linear_attention/gla/gla_fwd.py
+++ b/src/tileops/kernels/linear_attention/gla/gla_fwd.py
@@ -6,12 +6,10 @@ import torch
 from tilelang import language as T
 from tilelang.profiler import do_bench
 
+from tileops.kernels.constants import LOG2E
 from tileops.kernels.kernel_base import Kernel
 
 from ..v_tile import GEMM_MIN_N
-
-LOG2_E = 1.44269504
-
 
 # Pre-compute: g_cumsum per chunk (parallel, B*H*NC thread blocks)
 
@@ -198,14 +196,14 @@ def _gla_fwd_h_kernel(
 
                     # Decay h
                     for i_k, i_v in T.Parallel(dim_k_part, dim_v_part):
-                        h_s[i_k, i_v] = h_s[i_k, i_v] * T.exp2(g_last[i_k] * LOG2_E)
+                        h_s[i_k, i_v] = h_s[i_k, i_v] * T.exp2(g_last[i_k] * LOG2E)
 
                     # k_adj in fragment (RS GEMM: A=register, B=shared)
                     k_adj_f = T.alloc_fragment([chunk_size, dim_k_part], dtype)
                     for i_t, i_k in T.Parallel(chunk_size, dim_k_part):
                         k_adj_f[i_t, i_k] = T.cast(
                             T.cast(k_s[i_t, i_k], accum_dtype)
-                            * T.exp2((g_last[i_k] - g_cumsum_s[i_t, i_k]) * LOG2_E),
+                            * T.exp2((g_last[i_k] - g_cumsum_s[i_t, i_k]) * LOG2E),
                             dtype,
                         )
 
@@ -315,7 +313,7 @@ def _gla_fwd_o_kernel(
                 # ---- Gated q (inter-chunk term, exp(g_cumsum) <= 1) ----
                 for i_t, i_k in T.Parallel(chunk_size, dim_k):
                     q_gated_s[i_t, i_k] = T.cast(
-                        T.cast(q_s[i_t, i_k], accum_dtype) * T.exp2(g_cumsum_s[i_t, i_k] * LOG2_E),
+                        T.cast(q_s[i_t, i_k], accum_dtype) * T.exp2(g_cumsum_s[i_t, i_k] * LOG2E),
                         dtype,
                     )
 
@@ -327,7 +325,7 @@ def _gla_fwd_o_kernel(
                         A_frag[i_t, i_j] = A_frag[i_t, i_j] + (
                             T.cast(q_s[i_t, i_k], accum_dtype)
                             * T.cast(k_s[i_j, i_k], accum_dtype)
-                            * T.exp2((g_cumsum_s[i_t, i_k] - g_cumsum_s[i_j, i_k]) * LOG2_E)
+                            * T.exp2((g_cumsum_s[i_t, i_k] - g_cumsum_s[i_j, i_k]) * LOG2E)
                         )
                 for i_t, i_j in T.Parallel(chunk_size, chunk_size):
                     A_s[i_t, i_j] = T.cast(

--- a/src/tileops/kernels/linear_attention/gla_recurrence.py
+++ b/src/tileops/kernels/linear_attention/gla_recurrence.py
@@ -21,11 +21,11 @@ import tilelang
 import tilelang.language as T
 import torch
 
+from tileops.kernels.constants import LOG2E
 from tileops.kernels.kernel_base import Kernel
 
 __all__ = ["GLADecodeFP32Kernel", "GLADecodeKernel"]
 
-_LOG2E = 1.4426950408889634
 _DEFAULT_K_TILE = 16
 
 
@@ -99,7 +99,7 @@ def _gla_decode_tl(
                     T.copy(state[bid, hid, kt * k_tile, 0], h_tile_o)
                     for kk in T.Serial(k_tile):
                         gk_val = gk_shared[kt * k_tile + kk]
-                        alpha_i = T.exp2(gk_val * _LOG2E)
+                        alpha_i = T.exp2(gk_val * LOG2E)
                         q_gated = q_shared[kt * k_tile + kk] * alpha_i
                         for j in T.Parallel(dim_v):
                             sq_frag[j] = sq_frag[j] + q_gated * T.cast(h_tile_o[kk, j], accum_dtype)
@@ -124,7 +124,7 @@ def _gla_decode_tl(
                     T.copy(state[bid, hid, kt * k_tile, 0], h_tile)
                     for kk, j in T.Parallel(k_tile, dim_v):
                         new_state[bid, hid, kt * k_tile + kk, j] = T.cast(
-                            T.exp2(gk_shared[kt * k_tile + kk] * _LOG2E)
+                            T.exp2(gk_shared[kt * k_tile + kk] * LOG2E)
                             * T.cast(h_tile[kk, j], accum_dtype)
                             + k_shared[kt * k_tile + kk] * v_shared[j],
                             dtype,
@@ -374,7 +374,7 @@ def _gla_decode_fp32_tl(
                 # S @ q_gated where q_gated = q * exp(gk)
                 for kk in T.Serial(dim_k):
                     gk_val = gk_shared[kk]
-                    alpha_i = T.exp2(gk_val * _LOG2E)
+                    alpha_i = T.exp2(gk_val * LOG2E)
                     q_gated = q_shared[kk] * alpha_i
                     for j in T.Parallel(dim_v):
                         sq_frag[j] = sq_frag[j] + q_gated * state[bid, hid, kk, j]
@@ -395,7 +395,7 @@ def _gla_decode_fp32_tl(
                     T.copy(state[bid, hid, kt * k_tile, 0], h_tile)
                     for kk, j in T.Parallel(k_tile, dim_v):
                         new_state[bid, hid, kt * k_tile + kk, j] = (
-                            T.exp2(gk_shared[kt * k_tile + kk] * _LOG2E) * h_tile[kk, j]
+                            T.exp2(gk_shared[kt * k_tile + kk] * LOG2E) * h_tile[kk, j]
                             + k_shared[kt * k_tile + kk] * v_shared[j]
                         )
 

--- a/src/tileops/kernels/moe/fused_topk.py
+++ b/src/tileops/kernels/moe/fused_topk.py
@@ -65,11 +65,11 @@ import tilelang.language as T
 import torch
 
 from tileops.kernels.kernel_base import Kernel
+from tileops.utils import WARP_LANES
 
 __all__ = ["FusedTopKKernel"]
 
 _SCORING_FUNCS = ("softmax", "sigmoid")
-_WARP_SIZE = 32
 
 
 @functools.lru_cache(maxsize=64)
@@ -101,7 +101,7 @@ def _fused_topk_kernel(
 
     @tilelang.jit(out_idx=[])
     def _func(TOKENS_PER_BLOCK):
-        WARP_SIZE = _WARP_SIZE
+        WARP_SIZE = WARP_LANES
         # Each lane handles ceil(E / 32) experts stored in local registers.
         ELEMS_PER_THREAD = -(-num_experts // WARP_SIZE)  # ceildiv(E, 32)
         LOG_WARP = int(math.log2(WARP_SIZE))  # = 5 for WARP_SIZE=32

--- a/src/tileops/kernels/moe/moe_grouped_gemm_persistent_3wg_fused_act.py
+++ b/src/tileops/kernels/moe/moe_grouped_gemm_persistent_3wg_fused_act.py
@@ -16,6 +16,7 @@ import tilelang
 import tilelang.language as T
 import torch
 
+from tileops.kernels.constants import INV_SQRT2
 from tileops.kernels.grouped_gemm import rows_per_group_regime
 from tileops.kernels.grouped_tiling import GroupTiling
 from tileops.kernels.kernel_base import Kernel
@@ -58,10 +59,7 @@ def _fused_act_expr(name):
     if name == "gelu_and_mul":
         # exact erf GELU: 0.5*g*(1+erf(g/sqrt(2)))
         return lambda gate, up: (
-            T.float32(0.5)
-            * gate
-            * (T.float32(1.0) + T.erf(gate * T.float32(0.7071067811865476)))
-            * up
+            T.float32(0.5) * gate * (T.float32(1.0) + T.erf(gate * T.float32(INV_SQRT2))) * up
         )
     raise ValueError(f"unsupported activation {name!r}")
 

--- a/src/tileops/kernels/norm/_config.py
+++ b/src/tileops/kernels/norm/_config.py
@@ -17,6 +17,8 @@ measured runtime.
 
 import torch
 
+from tileops.kernels.constants import VECTOR_ACCESS_BYTES
+
 __all__ = ["select_row_config", "select_row_configs"]
 
 # Powers of two only (tl::AllReduce is an XOR butterfly) that also divide
@@ -36,7 +38,7 @@ def _feasible_threads(n_padded: int, dtype: torch.dtype = torch.float16) -> list
     4 for fp32). If no candidate meets that floor (small rows), fall back to any
     thread count that divides the row so the autotune space is never empty.
     """
-    min_elements = 16 // torch.tensor([], dtype=dtype).element_size()
+    min_elements = VECTOR_ACCESS_BYTES // torch.tensor([], dtype=dtype).element_size()
     candidates = [t for t in _CANDIDATE_THREADS if n_padded % t == 0]
     vectorizable = [t for t in candidates if n_padded // t >= min_elements]
     return vectorizable or candidates

--- a/src/tileops/kernels/reduction/_primitives.py
+++ b/src/tileops/kernels/reduction/_primitives.py
@@ -21,7 +21,8 @@ import tilelang
 import tilelang.language as T
 import torch
 
-from tileops.kernels.tiling import align_up
+from tileops.kernels.constants import VECTOR_ACCESS_BYTES
+from tileops.kernels.tiling import ALIGNMENT, align_up
 
 __all__ = [
     "AUTOTUNE_THREADS",
@@ -55,7 +56,7 @@ __all__ = [
 
 # 256-element alignment (512 bytes for fp16/bf16) required by T.copy()
 # shared memory instructions.  Sub-categories may override this default.
-DEFAULT_ALIGNMENT: int = 256
+DEFAULT_ALIGNMENT: int = ALIGNMENT
 
 # Widest single fragment/shared-memory tile the reduction kernels plan; shared memory
 # and the register file are checked separately.
@@ -65,9 +66,6 @@ MAX_SINGLE_TILE_COLS: int = 32768
 # block_m that fits within a single thread block's shared memory allocation.
 SHARED_MEMORY_BUDGET_BYTES: int = 48 * 1024
 
-# Width of the vectorized ``ld/st`` TileLang plans for a tile buffer on the
-# architectures the reduction kernels declare (SM80-SM90): 128 bits.
-VECTOR_ACCESS_BYTES: int = 16
 
 # Thread counts offered by the reduction autotune candidate lists.
 AUTOTUNE_THREADS: tuple[int, ...] = (128, 256, 512)

--- a/src/tileops/kernels/reduction/argreduce.py
+++ b/src/tileops/kernels/reduction/argreduce.py
@@ -21,11 +21,11 @@ from tileops.kernels.reduction._primitives import (
     rows_for_axes,
     torch_dtype_nbytes,
 )
+from tileops.utils import WARP_LANES
 
 __all__ = ["ArgreduceKernel"]
 
 _ARGREDUCE_KINDS = {"argmax", "argmin"}
-_WARP_SIZE = 32
 _NUM_ACCUMULATORS = 4
 
 #: Magnitude bits of a float32 pattern -- everything but the sign; see _ordering_key.
@@ -84,7 +84,7 @@ def _plan_row_split(M: int, N: int) -> int:
 
 def _lanes_per_row(n: int) -> int:
     lanes = 1
-    while lanes < min(n, _WARP_SIZE):
+    while lanes < min(n, WARP_LANES):
         lanes *= 2
     return lanes
 
@@ -207,11 +207,11 @@ def _make_block_reduce(
         warp_indices,
         tx,
     ):
-        lane = tx % _WARP_SIZE
-        warp = tx // _WARP_SIZE
+        lane = tx % WARP_LANES
+        warp = tx // WARP_LANES
 
         ops.merge_accumulators(keys, indices, best_key, best_index)
-        ops.warp_reduce(best_key, best_index, 5, _WARP_SIZE)
+        ops.warp_reduce(best_key, best_index, WARP_LANES.bit_length() - 1, WARP_LANES)
 
         if lane == 0:
             warp_keys[warp] = best_key[0]
@@ -224,7 +224,7 @@ def _make_block_reduce(
             best_index[0] = warp_indices[lane]
 
         if warp == 0:
-            ops.warp_reduce(best_key, best_index, 5, _WARP_SIZE)
+            ops.warp_reduce(best_key, best_index, WARP_LANES.bit_length() - 1, WARP_LANES)
 
     return block_reduce
 
@@ -385,7 +385,7 @@ def _argreduce_cta_kernel(M: int, N: int, op_kind: str, dtype: str):
 
     @tilelang.jit(out_idx=[1])
     def _func(threads: int):
-        num_warps = threads // _WARP_SIZE
+        num_warps = threads // WARP_LANES
         iterations = (N + threads * _NUM_ACCUMULATORS - 1) // (threads * _NUM_ACCUMULATORS)
         held = threads * FRAGMENT_ELEMS_PER_THREAD >= N
         ops = _make_pair_ops(op_kind, N)
@@ -462,7 +462,7 @@ def _argreduce_multicta_partial_kernel(
     def _func(threads: int, ctas_per_row: int):
         chunk_size = (N + ctas_per_row - 1) // ctas_per_row
         num_partials = M * ctas_per_row
-        num_warps = threads // _WARP_SIZE
+        num_warps = threads // WARP_LANES
         iterations = (chunk_size + threads * _NUM_ACCUMULATORS - 1) // (threads * _NUM_ACCUMULATORS)
         ops = _make_pair_ops(op_kind, N)
         key_of = _ordering_key(op_kind)
@@ -530,11 +530,11 @@ def _argreduce_multicta_final_kernel(
     """Build the final reduction over per-row block partials."""
     num_partials = M * ctas_per_row
     rows_per_block = 8
-    threads = rows_per_block * _WARP_SIZE
+    threads = rows_per_block * WARP_LANES
 
     # A lane walks its share of the row's partials, so the split is free to be
     # wider than a warp; reading one partial per lane would drop the rest.
-    partials_per_lane = ceildiv_int(ctas_per_row, _WARP_SIZE)
+    partials_per_lane = ceildiv_int(ctas_per_row, WARP_LANES)
 
     @tilelang.jit(out_idx=[2])
     def _func():
@@ -548,14 +548,14 @@ def _argreduce_multicta_final_kernel(
         ):
             with T.Kernel(T.ceildiv(M, rows_per_block), threads=threads) as pid:
                 tx = T.get_thread_binding()
-                row = pid * rows_per_block + tx // _WARP_SIZE
-                lane = tx % _WARP_SIZE
+                row = pid * rows_per_block + tx // WARP_LANES
+                lane = tx % WARP_LANES
                 best_key = T.alloc_local((1,), "int32")
                 best_index = T.alloc_local((1,), "int32")
                 ops.set_identity(best_key, best_index, 0)
 
                 for step in T.serial(partials_per_lane):
-                    partial = step * _WARP_SIZE + lane
+                    partial = step * WARP_LANES + lane
                     if row < M and partial < ctas_per_row:
                         ops.update(
                             best_key,
@@ -565,7 +565,7 @@ def _argreduce_multicta_final_kernel(
                             partial_indices[row * ctas_per_row + partial],
                         )
 
-                ops.warp_reduce(best_key, best_index, 5, _WARP_SIZE)
+                ops.warp_reduce(best_key, best_index, WARP_LANES.bit_length() - 1, WARP_LANES)
                 if row < M and lane == 0:
                     out[row] = T.cast(best_index[0], "int64")
 

--- a/src/tileops/kernels/reduction/logsumexp.py
+++ b/src/tileops/kernels/reduction/logsumexp.py
@@ -7,6 +7,10 @@ Supports arbitrarily large N dimensions by tiling over N when the full
 N_padded does not fit in shared memory.  Uses the online softmax recurrence
 (track running max and rescaled running sum) across N-tiles.
 
+Long fp16/bf16 rows on a filled grid take a streaming kernel instead: direct
+vectorized loads into registers with per-thread online chains, no
+shared-memory staging (see ``_logsumexp_kernel_stream``).
+
 256-element alignment (512 bytes for fp16/bf16) required by T.copy() shared
 memory instructions.  Boundary handling for non-aligned N is performed
 inside the kernel via masked loads and -inf fills, eliminating host-side
@@ -45,6 +49,31 @@ from tileops.kernels.reduction._split_softmax import (
 _DEFAULT_TUNE_THREADS = 256
 
 _WARP_LANES = 32
+
+# Launch shape of the streaming kernel: one block per row, each thread owning
+# `cols_per_thread` consecutive elements per chunk. Fixed rather than tuned --
+# measured best at [1024, 32768] bf16 on H200 with the L2 flushed per
+# iteration (the benchmark's metric), and the eligibility gate below keeps
+# the kernel on shapes where this pair was measured.
+_STREAM_THREADS = 128
+_STREAM_COLS_PER_THREAD = 8
+
+# Streaming eligibility: enough rows to fill the device with one block per
+# row, and rows long enough that the tiled kernel's staging measurably loses.
+_STREAM_MIN_ROWS = 256
+_STREAM_MIN_COLS = 16384
+
+# Bounds that keep the streaming kernel's exponent arguments NaN-free with no
+# per-element guard. The running max seeds at the floor -- below every finite
+# fp16/bf16 value, but finite -- so an all--inf row keeps a zero sum and
+# floor + log(0) folds to -inf. Exponents subtract the max clamped to the
+# ceiling -- above every finite fp16/bf16 value, but finite -- so a +inf
+# element yields exp2(+inf) = +inf and its row folds to +inf. Both match
+# torch; a NaN element propagates through exp2 either way.
+_STREAM_MAX_FLOOR = -3.4e38
+_STREAM_MAX_CEIL = 3.4e38
+
+_LOG2E = 1.4426950408889634
 
 __all__ = ["LogSumExpKernel"]
 
@@ -248,6 +277,143 @@ def _logsumexp_kernel_tiled(M: int, N: int, dtype: str, tile_n: int):
     return _func
 
 
+# Streaming kernel (one block per row, direct vectorized loads)
+
+
+@functools.lru_cache(maxsize=64)
+def _logsumexp_kernel_stream(M: int, N: int, dtype: str, threads: int, cols_per_thread: int):
+    """Build a streaming logsumexp kernel for long, device-filling rows.
+
+    One block per row. Each thread vector-loads its ``cols_per_thread``
+    consecutive elements per chunk straight into registers (no shared-memory
+    staging -- a reduction has no reuse to stage for), keeps one running max
+    and ``cols_per_thread`` independent fp32 sum chains, and rescales the
+    chains once per chunk with the online-softmax recurrence. Threads merge
+    once at the end: a warp shuffle tree, then one warp folding the per-warp
+    partials. ``exp2((v - clamped_max) * log2e)`` is the fast
+    single-instruction exponential; for finite rows the argument is never
+    positive, and the ceiling clamp turns a +inf element into ``exp2(+inf)``
+    instead of NaN (see ``_STREAM_MAX_CEIL``).
+
+    Requires ``N % (threads * cols_per_thread) == 0`` and an fp16/bf16 input
+    (``_STREAM_MAX_FLOOR`` sits below every finite value of those dtypes).
+    """
+    chunk = threads * cols_per_thread
+    if N % chunk:
+        raise ValueError(f"streaming kernel needs N % {chunk} == 0, got N={N}")
+    num_chunks = N // chunk
+    num_warps = threads // _WARP_LANES
+    elem_bytes = torch.tensor([], dtype=getattr(torch, dtype)).element_size()
+    vec_elems = min(cols_per_thread, 16 // elem_bytes)
+    vec_groups = cols_per_thread // vec_elems
+    warp_stages = _WARP_LANES.bit_length() - 1
+
+    @tilelang.jit(out_idx=[1])
+    def _func():
+        @T.prim_func
+        def main(
+            x: T.Tensor[(M, N), dtype],
+            y: T.Tensor[(M,), dtype],
+        ):
+            with T.Kernel(M, threads=threads) as row:
+                tx = T.get_thread_binding()
+                held = T.alloc_local((cols_per_thread,), dtype)
+                held_f = T.alloc_local((cols_per_thread,), "float32")
+                slots = T.alloc_local((cols_per_thread,), "float32")
+                m_run = T.alloc_local((1,), "float32")
+                m_safe = T.alloc_local((1,), "float32")
+                s_run = T.alloc_local((1,), "float32")
+                m_new = T.alloc_local((1,), "float32")
+                scale = T.alloc_local((1,), "float32")
+                warp_m = T.alloc_shared((num_warps,), "float32")
+                warp_s = T.alloc_shared((num_warps,), "float32")
+
+                m_run[0] = _STREAM_MAX_FLOOR
+                m_safe[0] = _STREAM_MAX_FLOOR
+                for c in T.serial(cols_per_thread):
+                    slots[c] = 0.0
+
+                for t in T.serial(num_chunks):
+                    for g in T.serial(vec_groups):
+                        for c in T.vectorized(vec_elems):
+                            held[g * vec_elems + c] = x[
+                                row, t * chunk + tx * cols_per_thread + g * vec_elems + c
+                            ]
+                    for c in T.serial(cols_per_thread):
+                        held_f[c] = T.cast(held[c], "float32")
+
+                    m_new[0] = m_run[0]
+                    for c in T.serial(cols_per_thread):
+                        m_new[0] = T.max(m_new[0], held_f[c])
+                    # Exponents subtract the ceiling-clamped max, never the true
+                    # one, so (+inf) - (+inf) = NaN cannot form: a +inf element
+                    # contributes exp2(+inf) = +inf, its row folds to
+                    # max + log(inf) = +inf, and finite rows are untouched --
+                    # every finite fp16/bf16 max sits below the ceiling, where
+                    # the clamp is exact. NaN still propagates through exp2.
+                    scale[0] = T.exp2((m_safe[0] - T.min(m_new[0], _STREAM_MAX_CEIL)) * _LOG2E)
+                    m_run[0] = m_new[0]
+                    m_safe[0] = T.min(m_new[0], _STREAM_MAX_CEIL)
+                    for c in T.serial(cols_per_thread):
+                        slots[c] = slots[c] * scale[0] + T.exp2((held_f[c] - m_safe[0]) * _LOG2E)
+
+                s_run[0] = slots[0]
+                for c in T.serial(1, cols_per_thread):
+                    s_run[0] = s_run[0] + slots[c]
+
+                other_m = T.alloc_local((1,), "float32")
+                other_s = T.alloc_local((1,), "float32")
+                for stage in T.serial(warp_stages):
+                    # Bound locals: a bare expression is substituted per mention.
+                    other_m[0] = T.shfl_xor(
+                        m_run[0], T.int32(_WARP_LANES // 2) >> stage, width=_WARP_LANES
+                    )
+                    other_s[0] = T.shfl_xor(
+                        s_run[0], T.int32(_WARP_LANES // 2) >> stage, width=_WARP_LANES
+                    )
+                    m_new[0] = T.max(m_run[0], other_m[0])
+                    m_safe[0] = T.min(m_new[0], _STREAM_MAX_CEIL)
+                    s_run[0] = s_run[0] * T.exp2(
+                        (T.min(m_run[0], _STREAM_MAX_CEIL) - m_safe[0]) * _LOG2E
+                    ) + other_s[0] * T.exp2(
+                        (T.min(other_m[0], _STREAM_MAX_CEIL) - m_safe[0]) * _LOG2E
+                    )
+                    m_run[0] = m_new[0]
+                if tx % _WARP_LANES == 0:
+                    warp_m[tx // _WARP_LANES] = m_run[0]
+                    warp_s[tx // _WARP_LANES] = s_run[0]
+                T.sync_threads()
+                if tx == 0:
+                    for w in T.serial(1, num_warps):
+                        m_new[0] = T.max(warp_m[0], warp_m[w])
+                        m_safe[0] = T.min(m_new[0], _STREAM_MAX_CEIL)
+                        warp_s[0] = warp_s[0] * T.exp2(
+                            (T.min(warp_m[0], _STREAM_MAX_CEIL) - m_safe[0]) * _LOG2E
+                        ) + warp_s[w] * T.exp2(
+                            (T.min(warp_m[w], _STREAM_MAX_CEIL) - m_safe[0]) * _LOG2E
+                        )
+                        warp_m[0] = m_new[0]
+                    y[row] = T.cast(warp_m[0] + T.log(warp_s[0]), dtype)
+
+        return main
+
+    return _func
+
+
+def _stream_eligible(M: int, N: int, dtype: torch.dtype) -> bool:
+    """Whether the streaming kernel serves this row shape.
+
+    Narrow by design: only the fp16/bf16 long-row, device-filling shapes it
+    was measured on. Everything else keeps the tiled/single-tile paths.
+    """
+    return (
+        dtype in (torch.float16, torch.bfloat16)
+        and M >= _STREAM_MIN_ROWS
+        and N >= _STREAM_MIN_COLS
+        and N % (_STREAM_THREADS * _STREAM_COLS_PER_THREAD) == 0
+    )
+
+
 # Dispatch
 
 
@@ -342,20 +508,30 @@ class LogSumExpKernel(RowTiledAutotuneMixin, Kernel):
         #
         # tile_n is baked into the kernel at build time, so pre-compute it from
         # default_config; autotune() rebuilds once per candidate width.
+        self._streaming = _stream_eligible(M, N, dtype)
         self._tile_n = self.default_config["tile_n"]
-        self.kernel = _logsumexp_kernel(
-            self.M,
-            self.N,
-            self.dtype_str,
-            self._tile_n,
-        )
+        if self._streaming:
+            self.kernel = _logsumexp_kernel_stream(
+                self.M,
+                self.N,
+                self.dtype_str,
+                _STREAM_THREADS,
+                _STREAM_COLS_PER_THREAD,
+            )
+        else:
+            self.kernel = _logsumexp_kernel(
+                self.M,
+                self.N,
+                self.dtype_str,
+                self._tile_n,
+            )
 
         self.init_config(config, tune)
 
         # When tune=True, autotune() already set self._tile_n and
         # self.config["tile_n"], and rebuilt the kernel.  Only apply
         # the post-init tile_n fixup for user-provided configs.
-        if not tune:
+        if not tune and not self._streaming:
             # If the caller supplied an explicit tile_n (e.g. from a
             # previous autotuner result), honour it.  Only fall back to
             # the heuristic when tile_n was not provided.
@@ -427,6 +603,12 @@ class LogSumExpKernel(RowTiledAutotuneMixin, Kernel):
         and picks the overall best (block_m, threads, tile_n) config.
         """
         from tilelang.autotuner import autotune as tl_autotune
+
+        # The streaming kernel bakes its launch shape in at build time; there
+        # is nothing for the sweep to vary, so the default config stands.
+        if self._streaming:
+            self.config = self.default_config
+            return
 
         # The split pair bypasses the tuned kernel, so the default config stands.
         default = self.default_config
@@ -508,9 +690,12 @@ class LogSumExpKernel(RowTiledAutotuneMixin, Kernel):
     def _reduce_rows(self, x: torch.Tensor) -> torch.Tensor:
         """Reduce the trailing axis of an ``(M, N)`` buffer.
 
-        A handful of long rows goes to the split pair: softmax's per-segment
-        statistics, then a per-row fold.
+        Long rows on a filled grid stream straight to registers; a handful of
+        long rows goes to the split pair: softmax's per-segment statistics,
+        then a per-row fold.
         """
+        if self._streaming:
+            return self.kernel()(x)
         seg_n = split_seg_n(self.M, self.N, self.config["block_m"], self._split_target)
         if seg_n:
             # split_seg_n's fragment cap assumes the default width.

--- a/src/tileops/kernels/reduction/logsumexp.py
+++ b/src/tileops/kernels/reduction/logsumexp.py
@@ -7,9 +7,8 @@ Supports arbitrarily large N dimensions by tiling over N when the full
 N_padded does not fit in shared memory.  Uses the online softmax recurrence
 (track running max and rescaled running sum) across N-tiles.
 
-Long fp16/bf16 rows on a filled grid take a streaming kernel instead: direct
-vectorized loads into registers with per-thread online chains, no
-shared-memory staging (see ``_logsumexp_kernel_stream``).
+Long fp16/bf16 rows on a filled grid take a streaming kernel instead
+(see ``_logsumexp_kernel_streaming`` and ``StreamingLogSumExpPolicy``).
 
 256-element alignment (512 bytes for fp16/bf16) required by T.copy() shared
 memory instructions.  Boundary handling for non-aligned N is performed
@@ -20,6 +19,7 @@ vectorized T.copy path since their columns are fully in-bounds.
 """
 
 import functools
+from dataclasses import dataclass
 from typing import Optional
 
 import tilelang
@@ -29,6 +29,7 @@ import torch
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.reduction._primitives import (
     DEFAULT_ALIGNMENT,
+    VECTOR_ACCESS_BYTES,
     BlockConfigPlanner,
     RowTiledAutotuneMixin,
     align_up,
@@ -36,6 +37,7 @@ from tileops.kernels.reduction._primitives import (
     device_smem_budget,
     restore_reduced,
     rows_for_axes,
+    torch_dtype_nbytes,
 )
 from tileops.kernels.reduction._split_softmax import (
     make_split_fold,
@@ -50,30 +52,59 @@ _DEFAULT_TUNE_THREADS = 256
 
 _WARP_LANES = 32
 
-# Launch shape of the streaming kernel: one block per row, each thread owning
-# `cols_per_thread` consecutive elements per chunk. Fixed rather than tuned --
-# measured best at [1024, 32768] bf16 on H200 with the L2 flushed per
-# iteration (the benchmark's metric), and the eligibility gate below keeps
-# the kernel on shapes where this pair was measured.
-_STREAM_THREADS = 128
-_STREAM_COLS_PER_THREAD = 8
-
-# Streaming eligibility: enough rows to fill the device with one block per
-# row, and rows long enough that the tiled kernel's staging measurably loses.
-_STREAM_MIN_ROWS = 256
-_STREAM_MIN_COLS = 16384
-
-# Bounds that keep the streaming kernel's exponent arguments NaN-free with no
-# per-element guard. The running max seeds at the floor -- below every finite
-# fp16/bf16 value, but finite -- so an all--inf row keeps a zero sum and
-# floor + log(0) folds to -inf. Exponents subtract the max clamped to the
-# ceiling -- above every finite fp16/bf16 value, but finite -- so a +inf
-# element yields exp2(+inf) = +inf and its row folds to +inf. Both match
-# torch; a NaN element propagates through exp2 either way.
-_STREAM_MAX_FLOOR = -3.4e38
-_STREAM_MAX_CEIL = 3.4e38
-
 _LOG2E = 1.4426950408889634
+
+
+@dataclass(frozen=True)
+class StreamingLogSumExpPolicy:
+    """Launch shape and eligibility gate of the streaming kernel.
+
+    The launch pair is fixed rather than tuned: measured best at
+    [1024, 32768] bf16 on H200 with the L2 flushed per iteration (the
+    benchmark's metric), and ``eligible`` keeps the kernel on shapes
+    where that pair was measured.
+    """
+
+    threads: int = 128
+
+    cols_per_thread: int = 8
+
+    # Enough rows to fill the device with one block per row.
+    min_rows: int = 256
+
+    # Rows long enough that the tiled kernel's staging measurably loses.
+    min_cols: int = 16384
+
+    # Seed of the running max: below every finite fp16/bf16 value, but
+    # finite, so an all--inf row keeps a zero sum and folds to
+    # max_floor + log(0) = -inf, matching torch.
+    max_floor: float = -3.4e38
+
+    @property
+    def max_ceil(self) -> float:
+        """Clamp for exponent arguments: above every finite fp16/bf16 value.
+
+        Subtracting ``min(max, max_ceil)`` instead of the true max keeps
+        (+inf) - (+inf) = NaN out of exp2: a +inf element contributes
+        exp2(+inf) = +inf and its row folds to +inf, matching torch. A NaN
+        element propagates through exp2, and a finite max is never clamped.
+        """
+        return -self.max_floor
+
+    @property
+    def chunk(self) -> int:
+        return self.threads * self.cols_per_thread
+
+    def eligible(self, M: int, N: int, dtype: torch.dtype) -> bool:
+        return (
+            dtype in (torch.float16, torch.bfloat16)
+            and self.min_rows <= M
+            and self.min_cols <= N
+            and N % self.chunk == 0
+        )
+
+
+_STREAM_POLICY = StreamingLogSumExpPolicy()
 
 __all__ = ["LogSumExpKernel"]
 
@@ -280,36 +311,41 @@ def _logsumexp_kernel_tiled(M: int, N: int, dtype: str, tile_n: int):
 # Streaming kernel (one block per row, direct vectorized loads)
 
 
-@functools.lru_cache(maxsize=64)
-def _logsumexp_kernel_stream(M: int, N: int, dtype: str, threads: int, cols_per_thread: int):
-    """Build a streaming logsumexp kernel for long, device-filling rows.
+@functools.lru_cache(maxsize=32)
+def _logsumexp_kernel_streaming(M: int, N: int, dtype: str, threads: int, cols_per_thread: int):
+    """Build a streaming logsumexp kernel for long rows on a filled grid.
 
     One block per row. Each thread vector-loads its ``cols_per_thread``
-    consecutive elements per chunk straight into registers (no shared-memory
-    staging -- a reduction has no reuse to stage for), keeps one running max
-    and ``cols_per_thread`` independent fp32 sum chains, and rescales the
-    chains once per chunk with the online-softmax recurrence. Threads merge
-    once at the end: a warp shuffle tree, then one warp folding the per-warp
-    partials. ``exp2((v - clamped_max) * log2e)`` is the fast
-    single-instruction exponential; for finite rows the argument is never
-    positive, and the ceiling clamp turns a +inf element into ``exp2(+inf)``
-    instead of NaN (see ``_STREAM_MAX_CEIL``).
-
-    Requires ``N % (threads * cols_per_thread) == 0`` and an fp16/bf16 input
-    (``_STREAM_MAX_FLOOR`` sits below every finite value of those dtypes).
+    consecutive elements per chunk straight into registers (a reduction has
+    no reuse to stage through shared memory), keeps one running max and
+    ``cols_per_thread`` independent fp32 sum chains rescaled once per chunk
+    with the online-softmax recurrence, and merges once at the end: a warp
+    shuffle tree, then one warp folding the per-warp partials.
     """
     chunk = threads * cols_per_thread
     if N % chunk:
         raise ValueError(f"streaming kernel needs N % {chunk} == 0, got N={N}")
     num_chunks = N // chunk
     num_warps = threads // _WARP_LANES
-    elem_bytes = torch.tensor([], dtype=getattr(torch, dtype)).element_size()
-    vec_elems = min(cols_per_thread, 16 // elem_bytes)
+    vec_elems = min(cols_per_thread, VECTOR_ACCESS_BYTES // torch_dtype_nbytes(dtype))
     vec_groups = cols_per_thread // vec_elems
     warp_stages = _WARP_LANES.bit_length() - 1
+    floor = _STREAM_POLICY.max_floor
+    ceil = _STREAM_POLICY.max_ceil
 
     @tilelang.jit(out_idx=[1])
     def _func():
+        @T.macro
+        def merge_pair(dst_m, dst_s, src_m, src_s, m_new, m_safe):
+            # Exponents subtract the ceiling-clamped max, never the true one,
+            # so (+inf) - (+inf) = NaN cannot form; see _STREAM_POLICY.max_ceil.
+            m_new[0] = T.max(dst_m[0], src_m)
+            m_safe[0] = T.min(m_new[0], ceil)
+            dst_s[0] = dst_s[0] * T.exp2(
+                (T.min(dst_m[0], ceil) - m_safe[0]) * _LOG2E
+            ) + src_s * T.exp2((T.min(src_m, ceil) - m_safe[0]) * _LOG2E)
+            dst_m[0] = m_new[0]
+
         @T.prim_func
         def main(
             x: T.Tensor[(M, N), dtype],
@@ -325,11 +361,13 @@ def _logsumexp_kernel_stream(M: int, N: int, dtype: str, threads: int, cols_per_
                 s_run = T.alloc_local((1,), "float32")
                 m_new = T.alloc_local((1,), "float32")
                 scale = T.alloc_local((1,), "float32")
+                other_m = T.alloc_local((1,), "float32")
+                other_s = T.alloc_local((1,), "float32")
                 warp_m = T.alloc_shared((num_warps,), "float32")
                 warp_s = T.alloc_shared((num_warps,), "float32")
 
-                m_run[0] = _STREAM_MAX_FLOOR
-                m_safe[0] = _STREAM_MAX_FLOOR
+                m_run[0] = floor
+                m_safe[0] = floor
                 for c in T.serial(cols_per_thread):
                     slots[c] = 0.0
 
@@ -345,15 +383,9 @@ def _logsumexp_kernel_stream(M: int, N: int, dtype: str, threads: int, cols_per_
                     m_new[0] = m_run[0]
                     for c in T.serial(cols_per_thread):
                         m_new[0] = T.max(m_new[0], held_f[c])
-                    # Exponents subtract the ceiling-clamped max, never the true
-                    # one, so (+inf) - (+inf) = NaN cannot form: a +inf element
-                    # contributes exp2(+inf) = +inf, its row folds to
-                    # max + log(inf) = +inf, and finite rows are untouched --
-                    # every finite fp16/bf16 max sits below the ceiling, where
-                    # the clamp is exact. NaN still propagates through exp2.
-                    scale[0] = T.exp2((m_safe[0] - T.min(m_new[0], _STREAM_MAX_CEIL)) * _LOG2E)
+                    scale[0] = T.exp2((m_safe[0] - T.min(m_new[0], ceil)) * _LOG2E)
                     m_run[0] = m_new[0]
-                    m_safe[0] = T.min(m_new[0], _STREAM_MAX_CEIL)
+                    m_safe[0] = T.min(m_new[0], ceil)
                     for c in T.serial(cols_per_thread):
                         slots[c] = slots[c] * scale[0] + T.exp2((held_f[c] - m_safe[0]) * _LOG2E)
 
@@ -361,8 +393,6 @@ def _logsumexp_kernel_stream(M: int, N: int, dtype: str, threads: int, cols_per_
                 for c in T.serial(1, cols_per_thread):
                     s_run[0] = s_run[0] + slots[c]
 
-                other_m = T.alloc_local((1,), "float32")
-                other_s = T.alloc_local((1,), "float32")
                 for stage in T.serial(warp_stages):
                     # Bound locals: a bare expression is substituted per mention.
                     other_m[0] = T.shfl_xor(
@@ -371,47 +401,19 @@ def _logsumexp_kernel_stream(M: int, N: int, dtype: str, threads: int, cols_per_
                     other_s[0] = T.shfl_xor(
                         s_run[0], T.int32(_WARP_LANES // 2) >> stage, width=_WARP_LANES
                     )
-                    m_new[0] = T.max(m_run[0], other_m[0])
-                    m_safe[0] = T.min(m_new[0], _STREAM_MAX_CEIL)
-                    s_run[0] = s_run[0] * T.exp2(
-                        (T.min(m_run[0], _STREAM_MAX_CEIL) - m_safe[0]) * _LOG2E
-                    ) + other_s[0] * T.exp2(
-                        (T.min(other_m[0], _STREAM_MAX_CEIL) - m_safe[0]) * _LOG2E
-                    )
-                    m_run[0] = m_new[0]
+                    merge_pair(m_run, s_run, other_m[0], other_s[0], m_new, m_safe)
                 if tx % _WARP_LANES == 0:
                     warp_m[tx // _WARP_LANES] = m_run[0]
                     warp_s[tx // _WARP_LANES] = s_run[0]
                 T.sync_threads()
                 if tx == 0:
                     for w in T.serial(1, num_warps):
-                        m_new[0] = T.max(warp_m[0], warp_m[w])
-                        m_safe[0] = T.min(m_new[0], _STREAM_MAX_CEIL)
-                        warp_s[0] = warp_s[0] * T.exp2(
-                            (T.min(warp_m[0], _STREAM_MAX_CEIL) - m_safe[0]) * _LOG2E
-                        ) + warp_s[w] * T.exp2(
-                            (T.min(warp_m[w], _STREAM_MAX_CEIL) - m_safe[0]) * _LOG2E
-                        )
-                        warp_m[0] = m_new[0]
+                        merge_pair(warp_m, warp_s, warp_m[w], warp_s[w], m_new, m_safe)
                     y[row] = T.cast(warp_m[0] + T.log(warp_s[0]), dtype)
 
         return main
 
     return _func
-
-
-def _stream_eligible(M: int, N: int, dtype: torch.dtype) -> bool:
-    """Whether the streaming kernel serves this row shape.
-
-    Narrow by design: only the fp16/bf16 long-row, device-filling shapes it
-    was measured on. Everything else keeps the tiled/single-tile paths.
-    """
-    return (
-        dtype in (torch.float16, torch.bfloat16)
-        and M >= _STREAM_MIN_ROWS
-        and N >= _STREAM_MIN_COLS
-        and N % (_STREAM_THREADS * _STREAM_COLS_PER_THREAD) == 0
-    )
 
 
 # Dispatch
@@ -432,11 +434,6 @@ def _compute_padded_cols(N: int, tile_n: int) -> int:
         return N_padded
     num_tiles = (N_padded + tile_n - 1) // tile_n
     return num_tiles * tile_n
-
-
-def _elem_bytes(dtype: torch.dtype) -> int:
-    """Return bytes per element for the given dtype."""
-    return torch.tensor([], dtype=dtype).element_size()
 
 
 class LogSumExpKernel(RowTiledAutotuneMixin, Kernel):
@@ -495,7 +492,7 @@ class LogSumExpKernel(RowTiledAutotuneMixin, Kernel):
         self.keepdim = keepdim
         self.N_padded = align_up(N, DEFAULT_ALIGNMENT)
         self._split_target = split_target_blocks(device_index)
-        self._elem_bytes = _elem_bytes(dtype)
+        self._elem_bytes = torch_dtype_nbytes(dtype)
         self._smem_budget = device_smem_budget(device_index)
         self._planner = BlockConfigPlanner(
             self.N_padded,
@@ -508,15 +505,15 @@ class LogSumExpKernel(RowTiledAutotuneMixin, Kernel):
         #
         # tile_n is baked into the kernel at build time, so pre-compute it from
         # default_config; autotune() rebuilds once per candidate width.
-        self._streaming = _stream_eligible(M, N, dtype)
+        self._streaming = _STREAM_POLICY.eligible(M, N, dtype)
         self._tile_n = self.default_config["tile_n"]
         if self._streaming:
-            self.kernel = _logsumexp_kernel_stream(
+            self.kernel = _logsumexp_kernel_streaming(
                 self.M,
                 self.N,
                 self.dtype_str,
-                _STREAM_THREADS,
-                _STREAM_COLS_PER_THREAD,
+                _STREAM_POLICY.threads,
+                _STREAM_POLICY.cols_per_thread,
             )
         else:
             self.kernel = _logsumexp_kernel(

--- a/src/tileops/kernels/reduction/logsumexp.py
+++ b/src/tileops/kernels/reduction/logsumexp.py
@@ -26,6 +26,7 @@ import tilelang
 import tilelang.language as T
 import torch
 
+from tileops.kernels.constants import LOG2E
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.reduction._primitives import (
     DEFAULT_ALIGNMENT,
@@ -45,14 +46,11 @@ from tileops.kernels.reduction._split_softmax import (
     split_seg_n,
     split_target_blocks,
 )
+from tileops.utils import WARP_LANES
 
 # These two kernels bake tile_n in at build time and default to the wider
 # thread block; AUTOTUNE_THREADS still bounds what the sweep explores.
 _DEFAULT_TUNE_THREADS = 256
-
-_WARP_LANES = 32
-
-_LOG2E = 1.4426950408889634
 
 
 @dataclass(frozen=True)
@@ -128,7 +126,7 @@ def _logsumexp_split_fold_kernel(M: int, N: int, dtype: str, seg_n: int):
             seg_sum: T.Tensor[(M * num_segs,), "float32"],  # noqa: F821
             y: T.Tensor[(M,), dtype],
         ):
-            with T.Kernel(M, threads=_WARP_LANES) as pid_m:
+            with T.Kernel(M, threads=WARP_LANES) as pid_m:
                 tx = T.get_thread_binding()
                 row_max = T.alloc_local((1,), "float32")
                 row_sum = T.alloc_local((1,), "float32")
@@ -326,10 +324,10 @@ def _logsumexp_kernel_streaming(M: int, N: int, dtype: str, threads: int, cols_p
     if N % chunk:
         raise ValueError(f"streaming kernel needs N % {chunk} == 0, got N={N}")
     num_chunks = N // chunk
-    num_warps = threads // _WARP_LANES
+    num_warps = threads // WARP_LANES
     vec_elems = min(cols_per_thread, VECTOR_ACCESS_BYTES // torch_dtype_nbytes(dtype))
     vec_groups = cols_per_thread // vec_elems
-    warp_stages = _WARP_LANES.bit_length() - 1
+    warp_stages = WARP_LANES.bit_length() - 1
     floor = _STREAM_POLICY.max_floor
     ceil = _STREAM_POLICY.max_ceil
 
@@ -342,8 +340,8 @@ def _logsumexp_kernel_streaming(M: int, N: int, dtype: str, threads: int, cols_p
             m_new[0] = T.max(dst_m[0], src_m)
             m_safe[0] = T.min(m_new[0], ceil)
             dst_s[0] = dst_s[0] * T.exp2(
-                (T.min(dst_m[0], ceil) - m_safe[0]) * _LOG2E
-            ) + src_s * T.exp2((T.min(src_m, ceil) - m_safe[0]) * _LOG2E)
+                (T.min(dst_m[0], ceil) - m_safe[0]) * LOG2E
+            ) + src_s * T.exp2((T.min(src_m, ceil) - m_safe[0]) * LOG2E)
             dst_m[0] = m_new[0]
 
         @T.prim_func
@@ -383,11 +381,11 @@ def _logsumexp_kernel_streaming(M: int, N: int, dtype: str, threads: int, cols_p
                     m_new[0] = m_run[0]
                     for c in T.serial(cols_per_thread):
                         m_new[0] = T.max(m_new[0], held_f[c])
-                    scale[0] = T.exp2((m_safe[0] - T.min(m_new[0], ceil)) * _LOG2E)
+                    scale[0] = T.exp2((m_safe[0] - T.min(m_new[0], ceil)) * LOG2E)
                     m_run[0] = m_new[0]
                     m_safe[0] = T.min(m_new[0], ceil)
                     for c in T.serial(cols_per_thread):
-                        slots[c] = slots[c] * scale[0] + T.exp2((held_f[c] - m_safe[0]) * _LOG2E)
+                        slots[c] = slots[c] * scale[0] + T.exp2((held_f[c] - m_safe[0]) * LOG2E)
 
                 s_run[0] = slots[0]
                 for c in T.serial(1, cols_per_thread):
@@ -396,15 +394,15 @@ def _logsumexp_kernel_streaming(M: int, N: int, dtype: str, threads: int, cols_p
                 for stage in T.serial(warp_stages):
                     # Bound locals: a bare expression is substituted per mention.
                     other_m[0] = T.shfl_xor(
-                        m_run[0], T.int32(_WARP_LANES // 2) >> stage, width=_WARP_LANES
+                        m_run[0], T.int32(WARP_LANES // 2) >> stage, width=WARP_LANES
                     )
                     other_s[0] = T.shfl_xor(
-                        s_run[0], T.int32(_WARP_LANES // 2) >> stage, width=_WARP_LANES
+                        s_run[0], T.int32(WARP_LANES // 2) >> stage, width=WARP_LANES
                     )
                     merge_pair(m_run, s_run, other_m[0], other_s[0], m_new, m_safe)
-                if tx % _WARP_LANES == 0:
-                    warp_m[tx // _WARP_LANES] = m_run[0]
-                    warp_s[tx // _WARP_LANES] = s_run[0]
+                if tx % WARP_LANES == 0:
+                    warp_m[tx // WARP_LANES] = m_run[0]
+                    warp_s[tx // WARP_LANES] = s_run[0]
                 T.sync_threads()
                 if tx == 0:
                     for w in T.serial(1, num_warps):

--- a/src/tileops/kernels/reduction/reduce.py
+++ b/src/tileops/kernels/reduction/reduce.py
@@ -27,15 +27,15 @@ from tileops.kernels.reduction._primitives import (
     torch_dtype_nbytes,
     tune_by_forward,
 )
+from tileops.utils import WARP_LANES
 
 __all__ = ["ReduceKernel"]
 
 _WELFORD_KINDS = {"std", "var", "var_mean"}
 
-_WARP_LANES = 32
 
 # Stride-halving shuffle steps that reduce one warp.
-_WARP_STAGES = 5
+_WARP_STAGES = WARP_LANES.bit_length() - 1
 
 _FRAG_SLOTS = {
     "std": 2,
@@ -294,7 +294,7 @@ def _prod_reduce_kernel(M: int, N: int, dtype: str, threads: int):
     full_tiles = N // chunk if vectorized else 0
     tiles = ceildiv_int(N, chunk)
     exact = tiles * chunk == N
-    num_warps = threads // _WARP_LANES
+    num_warps = threads // WARP_LANES
     # One vector access is at most 16 bytes; wider per-thread spans split into
     # several back-to-back vector loads.
     vec_elems = min(_PROD_POLICY.cols_per_thread, VECTOR_ACCESS_BYTES // torch_dtype_nbytes(dtype))
@@ -354,10 +354,10 @@ def _prod_reduce_kernel(M: int, N: int, dtype: str, threads: int):
 
                 for stage in T.serial(_WARP_STAGES):
                     running[0] = running[0] * T.shfl_xor(
-                        running[0], T.int32(_WARP_LANES // 2) >> stage, width=_WARP_LANES
+                        running[0], T.int32(WARP_LANES // 2) >> stage, width=WARP_LANES
                     )
-                if tx % _WARP_LANES == 0:
-                    warp_prod[tx // _WARP_LANES] = running[0]
+                if tx % WARP_LANES == 0:
+                    warp_prod[tx // WARP_LANES] = running[0]
                 T.sync_threads()
                 if tx == 0:
                     for w in T.serial(1, num_warps):

--- a/src/tileops/ops/fp8_lightning_indexer.py
+++ b/src/tileops/ops/fp8_lightning_indexer.py
@@ -2,6 +2,7 @@ from typing import Dict, Optional, Tuple
 
 import torch
 
+from tileops.kernels.constants import FP8_E4M3_MAX
 from tileops.kernels.fp8_lightning_indexer import FP8LightningIndexerKernel
 from tileops.kernels.kernel_base import Kernel
 
@@ -213,7 +214,7 @@ class FP8LightningIndexerFwdOp(Op):
         self, x: torch.Tensor, dims: Tuple[int], use_ue8m0: bool
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         x_absmax = x.to(torch.float32).abs().amax(dim=-1, keepdim=True).clamp(1e-4)
-        sf = x_absmax / 448.0
+        sf = x_absmax / FP8_E4M3_MAX
         if use_ue8m0:
             assert sf.view(-1).amax().item() > 0
             sf = torch.pow(2.0, torch.ceil(torch.log2(x_absmax)))

--- a/src/tileops/utils/__init__.py
+++ b/src/tileops/utils/__init__.py
@@ -1,4 +1,5 @@
 from .utils import (
+    WARP_LANES,
     forget_device_properties,
     get_sm_count,
     get_sm_version,
@@ -7,6 +8,7 @@ from .utils import (
 )
 
 __all__ = [
+    "WARP_LANES",
     "forget_device_properties",
     "get_sm_count",
     "get_sm_version",

--- a/src/tileops/utils/utils.py
+++ b/src/tileops/utils/utils.py
@@ -2,6 +2,11 @@ import functools
 
 import torch
 
+# Lanes in a CUDA warp. Identical on every supported architecture (SM80-SM90)
+# and baked into TIR at build time (loop bounds, shuffle widths), so it is a
+# constant rather than a per-device query like the properties below.
+WARP_LANES: int = 32
+
 str2dtype = {
     "float16": torch.float16,
     "bfloat16": torch.bfloat16,
@@ -27,11 +32,6 @@ def _sm_version(index: int) -> int:
     return major * 10 + minor
 
 
-@functools.lru_cache(maxsize=16)
-def _sm_count(index: int) -> int:
-    return torch.cuda.get_device_properties(index).multi_processor_count
-
-
 def is_h200(index: "int | None" = None) -> bool:
     """Whether the device is an H200; defaults to the current device."""
     if not torch.cuda.is_available():
@@ -47,14 +47,15 @@ def get_sm_version(index: "int | None" = None) -> int:
 def get_sm_count(index: "int | None" = None) -> int:
     """Multiprocessors on the device; defaults to current.
 
-    Persistent kernels size their grid by this, so it is read once per kernel
-    construction rather than kept as a constant per kernel.
+    Uncached: torch already caches device properties in C++, and the only
+    callers read this once per kernel construction.
     """
-    return _sm_count(torch.cuda.current_device() if index is None else index)
+    device = torch.cuda.current_device() if index is None else index
+    return torch.cuda.get_device_properties(device).multi_processor_count
 
 
 def forget_device_properties() -> None:
-    """Drop the cached architecture, multiprocessor count and name of every device.
+    """Drop the cached architecture and name of every device.
 
     A device's properties do not change, so the cache is normally never
     invalidated. What does change is whether the query itself can be answered —
@@ -63,4 +64,3 @@ def forget_device_properties() -> None:
     """
     _device_name.cache_clear()
     _sm_version.cache_clear()
-    _sm_count.cache_clear()

--- a/tests/ops/test_softmax.py
+++ b/tests/ops/test_softmax.py
@@ -297,6 +297,9 @@ class LogSumExpFixture(FixtureBase):
                 pytest.param((33, 33000), -1, torch.float16, False, marks=pytest.mark.full),
                 # dim=-1, non-aligned M + large-N tiled path
                 pytest.param((33, 32768), -1, torch.float16, False, marks=pytest.mark.full),
+                # dim=-1, long rows on a filled grid (streaming kernel)
+                pytest.param((256, 16384), -1, torch.float16, False, marks=pytest.mark.full),
+                pytest.param((256, 16384), -1, torch.bfloat16, False, marks=pytest.mark.full),
                 # dim=0
                 pytest.param((256, 32), 0, torch.float32, False, marks=pytest.mark.full),
                 pytest.param((256, 32), 0, torch.float16, False, marks=pytest.mark.full),
@@ -361,6 +364,35 @@ def test_logsumexp_keepdim(shape: tuple, dim: int, dtype: torch.dtype) -> None:
     atol, rtol = _get_tolerances(dtype)
     assert torch.allclose(y, y_ref, atol=atol, rtol=rtol), (
         f"keepdim logsumexp failed, max err: {(y - y_ref).abs().max()}"
+    )
+
+
+@pytest.mark.smoke
+def test_logsumexp_streaming_special_values() -> None:
+    """Streaming-kernel special rows: -inf folds, +inf stays +inf, NaN propagates.
+
+    The streaming kernel seeds its running max with a finite floor instead of
+    -inf and guards the exp2 call sites for +inf; these rows pin the
+    semantics those choices must preserve.
+    """
+    x = torch.randn(256, 16384, dtype=torch.bfloat16, device="cuda")
+    x[0] = float("-inf")
+    x[1] = float("-inf")
+    x[1, 7] = 2.0
+    x[2, ::2] = float("-inf")
+    x[3, 100] = float("nan")
+    x[4, 200] = float("inf")
+    op = LogSumExpFwdOp(dim=-1)
+
+    y = op(x).float()
+    y_ref = torch.logsumexp(x.float(), dim=-1)
+    assert y[0].item() == float("-inf")
+    assert torch.isnan(y[3])
+    assert y[4].item() == float("inf")
+    atol, rtol = _get_tolerances(torch.bfloat16)
+    finite = torch.isfinite(y_ref)
+    assert torch.allclose(y[finite], y_ref[finite], atol=atol, rtol=rtol), (
+        f"special-value logsumexp failed, max err: {(y[finite] - y_ref[finite]).abs().max()}"
     )
 
 

--- a/tests/ops/test_softmax.py
+++ b/tests/ops/test_softmax.py
@@ -369,12 +369,7 @@ def test_logsumexp_keepdim(shape: tuple, dim: int, dtype: torch.dtype) -> None:
 
 @pytest.mark.smoke
 def test_logsumexp_streaming_special_values() -> None:
-    """Streaming-kernel special rows: -inf folds, +inf stays +inf, NaN propagates.
-
-    The streaming kernel seeds its running max with a finite floor instead of
-    -inf and guards the exp2 call sites for +inf; these rows pin the
-    semantics those choices must preserve.
-    """
+    """Streaming logsumexp preserves -inf, +inf, and NaN row semantics."""
     x = torch.randn(256, 16384, dtype=torch.bfloat16, device="cuda")
     x[0] = float("-inf")
     x[1] = float("-inf")


### PR DESCRIPTION

## problems

- The nightly `attn-weights-32k-bfloat16` logsumexp row regressed 32.6 us -> 37.2 us: raising `MAX_SINGLE_TILE_COLS` to 32768 replaced the tuner's tile_n=16384 candidates with a whole-row tile that measures slower.
- The tiled kernel tops out near 30 us on that row over its whole config space, 55% of the 16.5 us roofline: it stages every tile through shared memory, but a reduction has no reuse to stage for.

## changes

- Long fp16/bf16 rows on a filled grid take a new streaming kernel: one block per row, each thread vector-loads its consecutive elements straight into registers, keeps independent fp32 sum chains with one online-softmax rescale per chunk, and merges once at the end (warp shuffle tree, then one warp over the per-warp partials).
- The exponential is `exp2((v - max) * log2e)`: single SFU instruction, argument never positive, so it cannot overflow.
- Special values cost no per-element guard: the running max seeds at a finite floor below every fp16/bf16 value (an all--inf row folds to `floor + log(0) = -inf`), and exponents subtract the max clamped to a finite ceiling above every fp16/bf16 value (a +inf element yields `exp2(+inf) = +inf` and its row folds to +inf, where the tiled kernel returns NaN and torch returns +inf). NaN propagates through exp2. Finite rows never see either clamp.
- Tests pin all four semantics on the streaming shape: all -inf, mixed -inf, NaN, +inf.
- Eligibility is narrow: fp16/bf16, `M >= 256`, `N >= 16384`, `N % 1024 == 0`; everything else keeps the existing single-tile/tiled paths untouched. Autotune returns the default config for streaming shapes -- the launch shape is baked in.
- Tests: streaming-path rows (256x16384, fp16/bf16) and the special-values case above. Test node delta: +3 on tests/ops/test_softmax.py (135 -> 138).
- `StreamingLogSumExpPolicy` (frozen dataclass, following `ProductReducePolicy`) owns the launch pair, eligibility gate and finite sentinels; a `merge_pair` T.macro folds the warp-shuffle and per-warp merges once; `VECTOR_ACCESS_BYTES` / `torch_dtype_nbytes` replace local byte math.
- Shared constants get one home: `WARP_LANES` in `tileops.utils` beside the device properties; `LOG2E`, `VECTOR_ACCESS_BYTES`, `INV_SQRT2`, `SQRT_2_OVER_PI`, `GELU_TANH_COEFF`, `FP8_E4M3_MAX` in `kernels/constants.py`. 22 files drop their private copies (all literal variants fold to the same fp32 value); `get_sm_count` drops a redundant lru_cache.

## measured

H200, image `cu132-torch2.13-tl-afcebed1-dev`, idle device. Regression row `[32, 32, 32768]` bf16 dim=-1, `device_busy` from the repo benchmark (L2 flushed per iteration):

| kernel | device busy |
| --- | --- |
| tiled, nightly 2026-08-26 (tuner pick after the candidate change, CI device) | 37.2 us |
| tiled, nightly 2026-08-23 (tuner pick before, CI device) | 32.6 us |
| tiled, main, idle device | 33.4 us |
| torch-compile baseline, this run | 36.8 us |
| streaming (this PR), this run | 25.5 us |
| same read machinery with max instead of exp (cold read ceiling) | 22.8 us |
| torch.sum / torch.amax on the same row, cold | 26.9 / 32.6 us |
| DRAM roofline: 67.1 MB read at 4800 GB/s x 0.848 STREAM | 16.5 us |

The 2.5 us above the kernel's own read ceiling is SFU exp throughput -- one `exp2` per element is algorithmically minimal, and every measured alternative loses (fp16-packed exp2 +1 us, FMA-polynomial exp2 +8.5 us, SFU+FMA hybrid +3.8 us, warm-L2 numbers). The read machinery itself already beats torch's native reduce kernels on this row.

All logsumexp bench rows, `tileops_device_busy`, main and this PR on the same idle device:

| row | this PR (rebased on the split-row PR) |
| --- | --- |
| attn-weights-32k-bfloat16 | 25.5 us (main: 33.4 us, same device) |
| attn-weights-4k-float16 / bfloat16 | 6.6 / 6.6 us |
| lm-head-logits-float16 / bfloat16 | 7.4 / 7.4 us |
| 3d-multidim-reduce-float16 | 12.4 us |

Every row except the 32k one dispatches exactly as on main (lm-head takes the split pair the split-row PR added; 4k, 3d-multidim, ragged N and fp32 all fail the streaming gate). When both the streaming gate and the split gate admit a shape, streaming wins: its one-block-per-row grid is what the M >= 256 gate guarantees.

342 tests pass across tests/ops/{test_softmax, test_reduce_multidim, test_reduce_dim_none, test_reduction_compile}.py (smoke + full, dev runner image).
