### PR TITLE
[Perf][Nightly] Report algorithmic SOL efficiency against declared compute roofs

### DIFF
--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -95,6 +95,14 @@ class BenchmarkBase(Generic[W], ABC):
         """Bytes moved by one call, or ``None`` to leave bandwidth out of the row."""
         raise NotImplementedError
 
+    def compute_roof(self) -> Optional[str]:
+        """GPU-profile key pricing the FLOPs, or ``None`` to leave it out of the row.
+
+        ``ManifestBenchmark`` reads it off ``op.compute_roof()``; a benchmark
+        without an Op instance has no roof to declare.
+        """
+        return None
+
     def profile(self, functor: Any, *inputs: Any) -> dict:
         """Profile a callable and return its structured result."""
         with torch.no_grad():
@@ -204,6 +212,9 @@ class BenchmarkBase(Generic[W], ABC):
         if memory is not None:
             result["bytes"] = memory
             result["bandwidth_tbs"] = memory / busy * 1e-9
+        roof = self.compute_roof()
+        if roof is not None:
+            result["compute_roof"] = roof
         return result
 
 
@@ -355,3 +366,6 @@ class ManifestBenchmark(BenchmarkBase[Any]):
 
     def calculate_memory(self) -> Optional[float]:
         return self._get_roofline()[1]
+
+    def compute_roof(self) -> Optional[str]:
+        return self._op.compute_roof()

--- a/docs/design/ops-design.md
+++ b/docs/design/ops-design.md
@@ -252,6 +252,8 @@ class ExampleCumsumFwdOp(Op):
 
 **Reference.** [Slot S19](../../.claude/skills/scaffold-op/slot-rules.md#slot-s19).
 
+**Compute roof.** `Op.compute_roof()` names the GPU-profile unit that prices the FLOPs `eval_roofline()` counts; the base default `"cuda_core.fp32"` covers CUDA-core fp32 arithmetic. An op whose FLOPs are matmul contractions overrides it — normally `return tensor_core_roof(self.dtype)`, branching on instance state (a backend switch) where the contraction dtype differs from the input dtype. Contract and rationale: [`roofline.md §1.4`](roofline.md#14-compute-roof).
+
 ### Step 7: Package registration
 
 **Input.** The class name (Step 2) and the op's source filename.

--- a/docs/design/roofline.md
+++ b/docs/design/roofline.md
@@ -22,17 +22,21 @@ Inputs:
 - `bytes_moved`, `total_flops` — manifest `roofline` (§2).
 - `hbm_bandwidth` — GPU profile (§5.1), `hbm` section, effective value.
 - `peak_flops` — GPU profile section named by `op.compute_roof()` (§1.4), effective value.
-- `actual_time` — benchmark output (§5.2): device-busy time plus any device copies the reading excluded (`uncounted_copy_ms`).
+- `actual_time` — benchmark output (§5.2): device-busy time plus any device copies excluded from it (`uncounted_copy_ms`).
 
 Bound type is whichever term dominates `sol_time` (memory-bound if `memory_time > compute_time`, else compute-bound). It depends on shape, not on the op; the roofline tool computes it per-workload and the manifest does not declare it.
 
-The metric is **algorithmic** SOL efficiency, and every reading carries three scope statements:
+The metric is **algorithmic** SOL efficiency. Three statements delimit what a reading means:
 
 1. `bytes_moved` is the algorithm's minimum traffic (each input read once, each output written once), not measured DRAM traffic.
 1. `total_flops` follows the §1.3 counting convention, not per-instruction hardware cost; the metric does not certify an SFU-bound kernel as at its limit.
 1. The compute roof is the unit an optimal implementation would use (§1.4), not the unit the current kernel runs on.
 
-A reading the model cannot judge is left blank rather than guessed: a row timed without CUPTI, a row whose `bytes` formula yields zero, or a device with no GPU profile. A row whose `sol_time` and measured time are both below the latency floor is labeled latency-bound — launch overhead dominates and the model has no traction there; regression detection still covers it. A row implying a rate above a *theoretical* ceiling is reported as a formula error, never as a fast kernel.
+Rows the model cannot price honestly are handled three ways:
+
+- **Blank, never guessed** — timed without CUPTI, `bytes` formula yields zero, or no GPU profile matches the device.
+- **Labeled latency-bound** — `sol_time` and measured time both below the latency floor: launch overhead dominates and the model has no traction; regression detection still covers the row.
+- **Reported as a formula error, never as a fast kernel** — the row implies a rate above a *theoretical* ceiling.
 
 ### 1.3 Convention
 
@@ -49,16 +53,16 @@ Composite ops sum their primitives — `sigmoid = neg + exp + add + recip = 4` F
 
 `Op.compute_roof()` returns the GPU-profile key (§5.1) of the unit that prices the op's FLOPs — `"cuda_core.fp32"`, `"tensor_core.bf16"`, `"tensor_core.fp8"`, ….
 
-- The key states which unit an **optimal** implementation of the op would use. It is declared by the op author in code, never inferred from the running kernel or from an input dtype alone: inferring from the implementation would measure a kernel on the wrong unit against the wrong ceiling and hide exactly the gap the metric exists to expose, and an input dtype does not determine the contraction dtype (an fp8-backend attention takes fp16/bf16 tensors).
-- The `Op` base defaults to `"cuda_core.fp32"`, which covers every op whose arithmetic runs on CUDA cores in fp32 (elementwise, reductions, norms, scans). An op whose FLOPs are matmul contractions overrides it, normally with `tensor_core_roof(self.dtype)`; an op whose unit depends on instance state (a backend switch, a quantized path) branches on that state in its override.
+- The key states the unit an **optimal** implementation would use, declared by the op author in code. It is never inferred from the running kernel — that would price a kernel on the wrong unit against the wrong ceiling and hide exactly the gap the metric exists to expose. Nor from the input dtype alone — an fp8-backend attention takes fp16/bf16 tensors.
+- The `Op` base defaults to `"cuda_core.fp32"`, which covers every op whose arithmetic runs on CUDA cores in fp32 (elementwise, reductions, norms, scans). An op whose FLOPs are matmul contractions overrides it, normally with `tensor_core_roof(self.dtype)`; one whose unit depends on instance state (a backend switch, a quantized path) branches on that state.
 - The declaration is valid whenever `eval_roofline()` is — after the op's dtype is bound.
-- A wrong or missing override is caught by the nightly physics check (§4.3): a tensor-core kernel priced against the CUDA-core ceiling implies a FLOP rate above that ceiling's theoretical value, which is reported as a formula error on the next run.
+- A wrong or missing override is caught by the nightly physics check (§4.3): a tensor-core kernel priced against the CUDA-core ceiling implies a FLOP rate above that ceiling's theoretical value, reported as a formula error on the next run.
 
 ## 2. Field Specification
 
 ### 2.1 Output Contract
 
-Per workload, the `roofline` field yields `(flops: int, bytes: int)`. Consumers read these integers via `op.eval_roofline()` on an instantiated Op (§4.4).
+Per workload, the `roofline` field yields `(flops: int, bytes: int)`. Consumers read these integers via `op.eval_roofline()` on an instantiated Op (§4.4). The compute roof is not part of the manifest field; the op declares it in code (§1.4).
 
 ### 2.2 Formula Modes
 
@@ -98,8 +102,10 @@ roofline:
 
 - **Schema validator / CI** — structural checks only (schema, mode exclusivity, `func` importability). Does **not** execute formulas or hold a helper whitelist. Spec: §4.1.
 - **Benchmark layer** — instantiates an Op per workload and reads `(flops, bytes)` from `op.eval_roofline()`. Hardcoded formulas in benchmark files are a CI failure. Spec: §4.2.
-- **Roofline tool (M5)** — reads `(flops, bytes)` from benchmark output (which was produced by `op.eval_roofline()`), combines with GPU profile (§5.1) to compute SOL efficiency and bound type. Spec: §4.3.
+- **Roofline tool (M5)** — reads per-workload `(flops, bytes)`, the roof key, and timing from benchmark output, prices them against the GPU profile (§5.1), and emits SOL efficiency and verdicts. Spec: §4.3.
 - **Op codegen** — generates each op's `eval_roofline()` method; is the authoritative gate for name and form correctness. Spec: §4.4.
+
+Two auditors check the field's values rather than consume them: the structural oracle (§4.6) and the NCU bytes audit (§4.5).
 
 Tests and workloads are not consumers: they may supply shapes and dtypes but must not define or reinterpret roofline formulas.
 
@@ -116,8 +122,6 @@ Every roofline entry MUST satisfy:
 - Field types: `flops`/`bytes`/`func` are non-empty strings; `vars` is a mapping of str → non-empty str.
 - `func` dotted path resolves at import time.
 
-The validator enforces these rules.
-
 Out of the validator's scope:
 
 - Name whitelist — a formula's names are checked by codegen (§4.4), which owns the binding table. Validator does not mirror it.
@@ -133,7 +137,7 @@ Contract:
 - Instantiate the Op for each workload and call `op.eval_roofline()` to obtain `(flops, bytes)`. No manifest-level helper exists — roofline evaluation lives only inside each Op's generated method.
 - `ManifestBenchmark` and `workloads_to_params(..., include_extra=True)` are the canonical consumers; non-reserved workload keys forward as op-call params passed to the Op's `__init__`.
 - A benchmark file that computes FLOPs or bytes locally is a CI failure.
-- Benchmark output must record the `(flops, bytes)` returned by `op.eval_roofline()` and the roof key returned by `op.compute_roof()` (§1.4), so downstream consumers (M5) can read the numbers without re-instantiating ops.
+- Benchmark output must record the `(flops, bytes)` from `op.eval_roofline()` and the roof key from `op.compute_roof()` (§1.4), so M5 reads the numbers without re-instantiating ops.
 
 ### 4.3 Roofline Tool (M5)
 
@@ -142,13 +146,18 @@ Inputs:
 - Benchmark output produced by M4, carrying per-workload timing, the `(flops, bytes)` from `op.eval_roofline()`, and the roof key from `op.compute_roof()`.
 - GPU profile (§5.1), selected by matching the profile's `gpu` field against the measured device name; no match leaves every SOL reading blank.
 
-Outputs: SOL efficiency, bound type, latency-bound labels, and anomaly reports, per workload.
+Per-workload outputs: SOL efficiency, bound type, latency-bound labels, anomaly reports.
 
 Does not interpret formula strings at all. M5 reads pre-computed numbers from the benchmark output; it never instantiates Ops or runs roofline expressions.
 
-Verdict lines (rendering thresholds, not CI gates): a memory-bound row is at its ceiling from 90% efficiency, a compute-bound row from 80% (the tensor-core sustained calibration is noisier). A row above 105% is an anomaly — excluded from green verdicts, since a reading above the achievable ceiling means the formula or the calibration is wrong.
+Verdict lines are rendering thresholds, not CI gates:
 
-Physics check: every row's implied rates (`bytes / time`, `flops / time`) are compared against the *theoretical* ceilings of its roofs. A breach is physically impossible and is reported as a formula error that fails the run's health, so a formula edit that inflates work is caught on the next nightly. This is the standing guard on formula overestimation; equality-level formula validation belongs to tests, and hardware-counter validation to the bytes audit script (§4.5).
+| Verdict    | Condition                               | Meaning                                                                                            |
+| ---------- | --------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| At ceiling | memory-bound ≥ 90%, compute-bound ≥ 80% | Done; the compute line is looser because tensor-core sustained calibration is noisier.             |
+| Anomaly    | > 105%                                  | Above the achievable ceiling: the formula or the calibration is wrong. Excluded from "at ceiling". |
+
+Physics check: every row's implied rates (`bytes / time`, `flops / time`) are compared against the *theoretical* ceilings of its roofs. A breach is physically impossible, so it is reported as a formula error that fails the run's health — a formula edit that inflates work is caught on the next nightly. This check is the standing guard on formula overestimation; equality-level validation belongs to the structural oracle (§4.6), hardware-counter validation to the bytes audit (§4.5).
 
 ### 4.4 Op Codegen
 
@@ -176,7 +185,7 @@ def eval_roofline(self) -> tuple[int, int]:
 For each manifest entry, codegen reads one of:
 
 - **Inline** — `vars` (optional), `flops`, `bytes`. All are Python expression source strings. Codegen emits the method body per §4.4.3.
-- **Func** — `func` (dotted module path resolving to a human-authored callable). Codegen emits `return <func>(self)` as the method body. This presumes the **recommended** signature `func(op) -> tuple[int, int]` (returning `(flops, bytes)`), aligned with the agent-generated `eval_roofline(self)` shape. The recommendation is a reference for authors, not a gate — codegen does not introspect or validate the callable. If the author wants a different signature, they take responsibility for making the callable work with the emitted call (e.g., by writing a thin wrapper at the dotted path).
+- **Func** — `func` (dotted module path resolving to a human-authored callable). Codegen emits `return <func>(self)` as the method body. This presumes the **recommended** signature `func(op) -> tuple[int, int]` (returning `(flops, bytes)`), aligned with the agent-generated `eval_roofline(self)` shape. The recommendation is not a gate: codegen does not introspect the callable, and an author choosing another signature owns making it work with the emitted call (e.g. a thin wrapper at the dotted path).
 
 #### 4.4.3 Expression Layers
 
@@ -184,8 +193,6 @@ Inline mode has two layers. Codegen emits them as two sequential blocks in the m
 
 - **vars layer** — shape-derived resolution. Allowed operations: tensor shape access, slicing, `product()`, `range()`, small comprehensions.
 - **arithmetic layer** — `flops` and `bytes` over resolved variables + `elem_bytes` + approved helpers only. Forbidden: tensor access, shape slicing, comprehensions, attributes, arbitrary calls.
-
-Codegen actions emit two sequential blocks:
 
 **Block 1 — vars resolution.**
 
@@ -266,7 +273,7 @@ Roofline expressions live in exactly one place at runtime: the plain Python body
 
 Rules:
 
-- No `tileops.manifest.eval_roofline()` / `resolve_roofline_vars()` helper that evaluates roofline expressions exists in the target design. Any consumer wanting `(flops, bytes)` either calls `op.eval_roofline()` on an Op instance or reads pre-computed values from benchmark output.
+- No `tileops.manifest.eval_roofline()` / `resolve_roofline_vars()` helper that evaluates roofline expressions exists. Any consumer wanting `(flops, bytes)` either calls `op.eval_roofline()` on an Op instance or reads pre-computed values from benchmark output.
 - Generated `eval_roofline()` must not parse, AST-analyze, or safe-eval its own formula strings. Codegen does the name/form check at generation time (§4.4.3 / §4.4.4) and then copies validated expressions into plain Python.
 - If a formula is too complex for inline arithmetic (conditionals, shape traversal, data-dependent logic), switch the entry to `func` mode (§2.2). Do not extend inline formulas into a mini-language.
 
@@ -279,13 +286,22 @@ Method, per audited op:
 1. Pick workloads covering the formula's branch signatures (dtype combos, optional-input presence, backend labels), from the manifest's real workloads — never scaled-up shapes, which can cross kernel-selection thresholds and audit an implementation the benchmark does not run.
 1. Run `forward()` once (input-inferred ops bind their roofline variables there), then read `op.eval_roofline()`.
 1. Measure a second `forward()` under Nsight Compute with cache control on, summing `dram__bytes_read.sum + dram__bytes_write.sum` over the call's kernels.
-1. Verdicts: `measured < formula × (1 − ε)` **FAIL** (only a formula overestimate produces it — sector granularity, write-allocate, ECC, and replay cache-flushing all push `measured` up); `measured > formula × 1.5` **WARN** (multi-pass implementation or replay inflation; informational); a missing metric or an empty kernel range is **ERROR**, never a verdict.
+
+| Verdict | Condition                            | Reading                                                                                                                             |
+| ------- | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| FAIL    | `measured < formula × (1 − ε)`       | Only a formula overestimate produces it: sector granularity, write-allocate, ECC, and replay cache-flushing all push `measured` up. |
+| WARN    | `measured > formula × 1.5`           | Multi-pass implementation or replay inflation; informational.                                                                       |
+| ERROR   | missing metric or empty kernel range | A broken audit, never a verdict.                                                                                                    |
 
 Runs on demand (profiling permissions, replay cost) — after a manifest `roofline` edit, and as the mandatory check for ops exempt from the structural oracle (data-dependent traffic the oracle cannot count).
 
 ### 4.6 Structural Oracle (tests)
 
-A CI test recomputes each audited `bytes` value from an independent path — the sizes of the tensors the workload actually binds (each distinct input storage once, each output once) — and requires equality with `eval_roofline()`. The formula and the oracle share only the minimum-traffic definition; a coefficient slip, a missed output, a wrong `elem_bytes`, or a broadcast counted at the wrong shape breaks the equality. Ops whose traffic depends on tensor *content* (gather-style indexing) are exempt by explicit list and covered by §4.5 instead. Coverage is golden workloads per op, not randomized sweeps.
+A CI test recomputes each audited `bytes` value from an independent path — the sizes of the tensors the workload actually binds (each distinct input storage once, each output once) — and requires equality with `eval_roofline()`. The formula and the oracle share only the minimum-traffic definition, so a coefficient slip, a missed output, a wrong `elem_bytes`, or a broadcast counted at the wrong shape breaks the equality.
+
+Ops whose traffic depends on tensor *content* (gather-style indexing) are exempt by explicit list and covered by §4.5 instead. Coverage is golden workloads per op, not randomized sweeps.
+
+A completeness test keeps the classification total: every implemented op is audited, exempt with a reason, or on an explicit pending list to burn down. An op added to the manifest fails the test until it is classified.
 
 ## 5. Reference
 

--- a/docs/design/roofline.md
+++ b/docs/design/roofline.md
@@ -20,10 +20,19 @@ efficiency   = sol_time / actual_time
 Inputs:
 
 - `bytes_moved`, `total_flops` — manifest `roofline` (§2).
-- `hbm_bandwidth`, `peak_flops` — GPU profile (§5.1).
-- `actual_time` — benchmark output (§5.2).
+- `hbm_bandwidth` — GPU profile (§5.1), `hbm` section, effective value.
+- `peak_flops` — GPU profile section named by `op.compute_roof()` (§1.4), effective value.
+- `actual_time` — benchmark output (§5.2): device-busy time plus any device copies the reading excluded (`uncounted_copy_ms`).
 
 Bound type is whichever term dominates `sol_time` (memory-bound if `memory_time > compute_time`, else compute-bound). It depends on shape, not on the op; the roofline tool computes it per-workload and the manifest does not declare it.
+
+The metric is **algorithmic** SOL efficiency, and every reading carries three scope statements:
+
+1. `bytes_moved` is the algorithm's minimum traffic (each input read once, each output written once), not measured DRAM traffic.
+1. `total_flops` follows the §1.3 counting convention, not per-instruction hardware cost; the metric does not certify an SFU-bound kernel as at its limit.
+1. The compute roof is the unit an optimal implementation would use (§1.4), not the unit the current kernel runs on.
+
+A reading the model cannot judge is left blank rather than guessed: a row timed without CUPTI, a row whose `bytes` formula yields zero, or a device with no GPU profile. A row whose `sol_time` and measured time are both below the latency floor is labeled latency-bound — launch overhead dominates and the model has no traction there; regression detection still covers it. A row implying a rate above a *theoretical* ceiling is reported as a formula error, never as a fast kernel.
 
 ### 1.3 Convention
 
@@ -35,6 +44,15 @@ Per-element FLOP rule for elementwise ops:
 - Predicate-only outputs (`eq`, `gt`, etc.) count as 1 FLOP per element.
 
 Composite ops sum their primitives — `sigmoid = neg + exp + add + recip = 4` FLOPs/elem; `silu = sigmoid + mul = 5` FLOPs/elem.
+
+### 1.4 Compute Roof
+
+`Op.compute_roof()` returns the GPU-profile key (§5.1) of the unit that prices the op's FLOPs — `"cuda_core.fp32"`, `"tensor_core.bf16"`, `"tensor_core.fp8"`, ….
+
+- The key states which unit an **optimal** implementation of the op would use. It is declared by the op author in code, never inferred from the running kernel or from an input dtype alone: inferring from the implementation would measure a kernel on the wrong unit against the wrong ceiling and hide exactly the gap the metric exists to expose, and an input dtype does not determine the contraction dtype (an fp8-backend attention takes fp16/bf16 tensors).
+- The `Op` base defaults to `"cuda_core.fp32"`, which covers every op whose arithmetic runs on CUDA cores in fp32 (elementwise, reductions, norms, scans). An op whose FLOPs are matmul contractions overrides it, normally with `tensor_core_roof(self.dtype)`; an op whose unit depends on instance state (a backend switch, a quantized path) branches on that state in its override.
+- The declaration is valid whenever `eval_roofline()` is — after the op's dtype is bound.
+- A wrong or missing override is caught by the nightly physics check (§4.3): a tensor-core kernel priced against the CUDA-core ceiling implies a FLOP rate above that ceiling's theoretical value, which is reported as a formula error on the next run.
 
 ## 2. Field Specification
 
@@ -115,18 +133,22 @@ Contract:
 - Instantiate the Op for each workload and call `op.eval_roofline()` to obtain `(flops, bytes)`. No manifest-level helper exists — roofline evaluation lives only inside each Op's generated method.
 - `ManifestBenchmark` and `workloads_to_params(..., include_extra=True)` are the canonical consumers; non-reserved workload keys forward as op-call params passed to the Op's `__init__`.
 - A benchmark file that computes FLOPs or bytes locally is a CI failure.
-- Benchmark output must record the `(flops, bytes)` returned by `op.eval_roofline()` so downstream consumers (M5) can read the numbers without re-instantiating ops.
+- Benchmark output must record the `(flops, bytes)` returned by `op.eval_roofline()` and the roof key returned by `op.compute_roof()` (§1.4), so downstream consumers (M5) can read the numbers without re-instantiating ops.
 
 ### 4.3 Roofline Tool (M5)
 
 Inputs:
 
-- Benchmark output (JSON/CSV) produced by M4, carrying per-workload latency and the `(flops, bytes)` that benchmark obtained from `op.eval_roofline()`.
-- GPU profile (§5.1).
+- Benchmark output produced by M4, carrying per-workload timing, the `(flops, bytes)` from `op.eval_roofline()`, and the roof key from `op.compute_roof()`.
+- GPU profile (§5.1), selected by matching the profile's `gpu` field against the measured device name; no match leaves every SOL reading blank.
 
-Outputs: SOL efficiency, bound type, per-workload reports.
+Outputs: SOL efficiency, bound type, latency-bound labels, and anomaly reports, per workload.
 
 Does not interpret formula strings at all. M5 reads pre-computed numbers from the benchmark output; it never instantiates Ops or runs roofline expressions.
+
+Verdict lines (rendering thresholds, not CI gates): a memory-bound row is at its ceiling from 90% efficiency, a compute-bound row from 80% (the tensor-core sustained calibration is noisier). A row above 105% is an anomaly — excluded from green verdicts, since a reading above the achievable ceiling means the formula or the calibration is wrong.
+
+Physics check: every row's implied rates (`bytes / time`, `flops / time`) are compared against the *theoretical* ceilings of its roofs. A breach is physically impossible and is reported as a formula error that fails the run's health, so a formula edit that inflates work is caught on the next nightly. This is the standing guard on formula overestimation; equality-level formula validation belongs to tests, and hardware-counter validation to the bytes audit script (§4.5).
 
 ### 4.4 Op Codegen
 
@@ -247,6 +269,23 @@ Rules:
 - No `tileops.manifest.eval_roofline()` / `resolve_roofline_vars()` helper that evaluates roofline expressions exists in the target design. Any consumer wanting `(flops, bytes)` either calls `op.eval_roofline()` on an Op instance or reads pre-computed values from benchmark output.
 - Generated `eval_roofline()` must not parse, AST-analyze, or safe-eval its own formula strings. Codegen does the name/form check at generation time (§4.4.3 / §4.4.4) and then copies validated expressions into plain Python.
 - If a formula is too complex for inline arithmetic (conditionals, shape traversal, data-dependent logic), switch the entry to `func` mode (§2.2). Do not extend inline formulas into a mini-language.
+
+### 4.5 Bytes Audit (NCU)
+
+`scripts/validate_roofline_bytes.py` compares each op's `bytes` formula against hardware counters. It exists because the metric's objectivity rests on `bytes` being the true minimum traffic, and an overestimating formula inflates every efficiency reading in a way neither review nor the physics check is guaranteed to catch.
+
+Method, per audited op:
+
+1. Pick workloads covering the formula's branch signatures (dtype combos, optional-input presence, backend labels), from the manifest's real workloads — never scaled-up shapes, which can cross kernel-selection thresholds and audit an implementation the benchmark does not run.
+1. Run `forward()` once (input-inferred ops bind their roofline variables there), then read `op.eval_roofline()`.
+1. Measure a second `forward()` under Nsight Compute with cache control on, summing `dram__bytes_read.sum + dram__bytes_write.sum` over the call's kernels.
+1. Verdicts: `measured < formula × (1 − ε)` **FAIL** (only a formula overestimate produces it — sector granularity, write-allocate, ECC, and replay cache-flushing all push `measured` up); `measured > formula × 1.5` **WARN** (multi-pass implementation or replay inflation; informational); a missing metric or an empty kernel range is **ERROR**, never a verdict.
+
+Runs on demand (profiling permissions, replay cost) — after a manifest `roofline` edit, and as the mandatory check for ops exempt from the structural oracle (data-dependent traffic the oracle cannot count).
+
+### 4.6 Structural Oracle (tests)
+
+A CI test recomputes each audited `bytes` value from an independent path — the sizes of the tensors the workload actually binds (each distinct input storage once, each output once) — and requires equality with `eval_roofline()`. The formula and the oracle share only the minimum-traffic definition; a coefficient slip, a missed output, a wrong `elem_bytes`, or a broadcast counted at the wrong shape breaks the equality. Ops whose traffic depends on tensor *content* (gather-style indexing) are exempt by explicit list and covered by §4.5 instead. Coverage is golden workloads per op, not randomized sweeps.
 
 ## 5. Reference
 

--- a/scripts/nightly_report.py
+++ b/scripts/nightly_report.py
@@ -39,6 +39,8 @@ _PERF_KEYS = (
     "tileops_flops",
     "tileops_bytes",
     "tileops_bandwidth_tbs",
+    "tileops_compute_roof",
+    "tileops_uncounted_copy_ms",
     "tileops_variant",
     "tileops_timing",
     "tileops_device_busy_p10_ms",
@@ -52,6 +54,18 @@ _PERF_KEYS = (
 )
 BASELINE_RATIO_ALERT = 0.80  # tileops slower than baseline by >25%
 HISTORY_RETENTION_DAYS = 14
+
+# Algorithmic speed-of-light (SOL) verdict lines. Efficiency is
+# sol_time / measured_time against the *calibrated* (effective) ceilings;
+# see docs/design/roofline.md §1.2 and §4.3.
+SOL_GREEN_MEMORY = 0.90  # memory-bound row at its achievable ceiling
+SOL_GREEN_COMPUTE = 0.80  # tensor-core sustained calibration is noisier
+SOL_ANOMALY = 1.05  # above the effective ceiling: formula or profile is wrong
+# Below both floors the roofline has no traction: launch overhead and wave
+# quantization dominate, so the row is labeled instead of judged. Regression
+# detection still covers it.
+LATENCY_BOUND_SOL_MS = 0.003
+LATENCY_BOUND_MEASURED_MS = 0.020
 
 # ── Emoji constants ───────────────────────────────────────────────────────
 _PASS = "\u2705"  # ✅
@@ -581,12 +595,20 @@ def build_history_entry(bench_ops: dict, coverage: list[dict] | None = None) -> 
                     "tflops",
                     "flops",
                     "bytes",
+                    "compute_roof",
                     "device_busy_p10_ms",
                     "device_busy_p90_ms",
                 ):
                     value = cfg.get(f"tileops_{name}")
                     if value is not None:
                         entry["tileops"][name] = value
+                sol = cfg.get("sol")
+                if sol is not None:
+                    entry["tileops"]["sol"] = {
+                        "efficiency": round(sol["efficiency"], 4),
+                        "bound": sol["bound"],
+                        "latency_bound": sol["latency_bound"],
+                    }
             bl_lat = cfg.get("baseline_latency_ms")
             bl_busy = cfg.get(f"baseline_{_CONCLUSION_KEY}")
             if bl_lat is not None or bl_busy is not None:
@@ -687,6 +709,117 @@ def _get_gpu_name() -> str:
 
 
 # ---------------------------------------------------------------------------
+# Speed-of-Light (M5)
+# ---------------------------------------------------------------------------
+
+
+def _load_gpu_profile(gpu_name: str) -> dict | None:
+    """Profile matching the measured device, or None when none claims it."""
+    try:
+        from tileops.perf.profile import find_profile
+    except ImportError:
+        return None
+    try:
+        return find_profile(gpu_name)
+    except Exception:
+        return None
+
+
+def _compute_sol(cfg: dict, profile: dict) -> dict | None:
+    """Algorithmic SOL efficiency for one benchmark row, or None.
+
+    Returns None when the row lacks any input the model needs: (flops,
+    bytes) from ``op.eval_roofline()``, a declared compute roof, a CUPTI
+    reading, and a calibrated profile section for both ceilings. A missing
+    input leaves the SOL column blank rather than guessing.
+    """
+    from tileops.perf.profile import resolve_roof
+
+    flops = cfg.get("tileops_flops")
+    nbytes = cfg.get("tileops_bytes")
+    busy = cfg.get("tileops_device_busy_ms")
+    roof_key = cfg.get("tileops_compute_roof")
+    if not all(isinstance(v, (int, float)) for v in (flops, nbytes, busy)):
+        return None
+    if nbytes <= 0 or busy <= 0 or not isinstance(roof_key, str):
+        return None
+    if cfg.get("tileops_timing") != "cupti":
+        return None
+    hbm = profile.get("hbm")
+    roof = resolve_roof(profile, roof_key)
+    if not isinstance(hbm, dict) or "effective" not in hbm or roof is None:
+        return None
+    # Copies the reading excluded are device work the op's algorithm issued;
+    # the roofline denominator has to carry them or efficiency inflates.
+    denom_ms = busy + (cfg.get("tileops_uncounted_copy_ms") or 0.0)
+    mem_ms = nbytes / hbm["effective"] * 1e3
+    comp_ms = flops / roof["effective"] * 1e3
+    sol_ms = max(mem_ms, comp_ms)
+    return {
+        "efficiency": sol_ms / denom_ms,
+        "bound": "memory" if mem_ms >= comp_ms else "compute",
+        "latency_bound": (sol_ms < LATENCY_BOUND_SOL_MS and denom_ms < LATENCY_BOUND_MEASURED_MS),
+        "roof": roof_key,
+        # Physically impossible rates: the formula (or roof) is wrong, not fast.
+        "impossible": [
+            signal
+            for signal, rate, ceiling in (
+                ("bytes/s over HBM theoretical", nbytes / denom_ms * 1e3, hbm["theoretical"]),
+                ("FLOP/s over roof theoretical", flops / denom_ms * 1e3, roof["theoretical"]),
+            )
+            if rate > ceiling
+        ],
+    }
+
+
+def annotate_sol(bench_ops: dict, profile: dict | None) -> list[dict]:
+    """Attach a ``sol`` reading to every config row; return the anomalies.
+
+    FAIL anomalies are physically impossible rates (a broken formula or
+    roof); WARN anomalies exceed the calibrated ceiling by more than
+    ``SOL_ANOMALY`` allows. Both exclude the row from green verdicts.
+    """
+    anomalies = []
+    if profile is None:
+        return anomalies
+    for op, data in bench_ops.items():
+        for cfg in data["configs"]:
+            sol = _compute_sol(cfg, profile)
+            if sol is None:
+                continue
+            cfg["sol"] = sol
+            for signal in sol["impossible"]:
+                anomalies.append(
+                    {"level": "FAIL", "op": op, "config": cfg["name"], "signal": signal}
+                )
+            if not sol["impossible"] and sol["efficiency"] > SOL_ANOMALY:
+                anomalies.append(
+                    {
+                        "level": "WARN",
+                        "op": op,
+                        "config": cfg["name"],
+                        "signal": f"{sol['efficiency']:.0%} of the calibrated ceiling",
+                    }
+                )
+    return anomalies
+
+
+def _sol_cell(sol: dict | None) -> str:
+    """Render one row's SOL reading for the benchmark table."""
+    if sol is None:
+        return "-"
+    eff = sol["efficiency"]
+    bound = "M" if sol["bound"] == "memory" else "C"
+    if sol["impossible"] or eff > SOL_ANOMALY:
+        return f"{_WARN} {eff:.0%} {bound}"
+    if sol["latency_bound"]:
+        return "<sub>lat-bound</sub>"
+    green = SOL_GREEN_MEMORY if sol["bound"] == "memory" else SOL_GREEN_COMPUTE
+    mark = f"{_PASS} " if eff >= green else ""
+    return f"{mark}{eff:.0%} {bound}"
+
+
+# ---------------------------------------------------------------------------
 # Report generation
 # ---------------------------------------------------------------------------
 
@@ -713,12 +846,15 @@ def generate_report(
     coverage_prev: dict | None = None,
     bench_skips: int = 0,
     previous_run_shifts: list[dict] | None = None,
+    sol_anomalies: list[dict] | None = None,
+    have_gpu_profile: bool = False,
 ) -> str:
     """Generate markdown report."""
     lines = []
     commit = _get_git_commit()
     gpu = _get_gpu_name()
     now = datetime.now().strftime("%Y-%m-%d %H:%M")
+    sol_fails = [a for a in (sol_anomalies or []) if a["level"] == "FAIL"]
 
     # ── Header ────────────────────────────────────────────────────────────
     n_test_ops = len(test_ops) if test_ops else 0
@@ -727,7 +863,11 @@ def generate_report(
     total_tests = sum(d["passed"] + d["failed"] + d["skipped"] for d in (test_ops or {}).values())
     total_passed = sum(d["passed"] for d in (test_ops or {}).values())
 
-    health = _PASS if (n_failures == 0 and not regressions and not bench_failures) else _FAIL
+    health = (
+        _PASS
+        if (n_failures == 0 and not regressions and not bench_failures and not sol_fails)
+        else _FAIL
+    )
     lines.append(f"# {health} TileOPs Nightly Report")
     lines.append("")
     lines.append(f"> **{now}** &ensp;|&ensp; `{commit}` &ensp;|&ensp; {gpu}")
@@ -752,6 +892,15 @@ def generate_report(
     lines.append(f"| **Benchmark Failures** | {bench_fail_icon} |")
     lines.append(f"| **Regressions** (vs 14-day median) | {reg_icon} |")
     lines.append(f"| **Baseline Alerts** (< {BASELINE_RATIO_ALERT:.0%}) | {alert_icon} |")
+    if have_gpu_profile:
+        sol_icon = (
+            f"{_FAIL} {len(sol_fails)} impossible"
+            if sol_fails
+            else f"{_WARN} {len(sol_anomalies)}"
+            if sol_anomalies
+            else f"{_PASS} None"
+        )
+        lines.append(f"| **Roofline anomalies** | {sol_icon} |")
     if improvements:
         lines.append(f"| **Improvements** (vs 14-day best) | {_PARTY} {len(improvements)} |")
     if previous_run_shifts:
@@ -890,6 +1039,23 @@ def generate_report(
             )
         lines.append("")
 
+    # ── Roofline anomalies ────────────────────────────────────────────────
+    if sol_anomalies:
+        lines.append(f"## {_WARN} Roofline Model Anomalies")
+        lines.append("")
+        lines.append(
+            "> A FAIL row implies a rate above the hardware's theoretical"
+            " ceiling: its (flops, bytes) formula or declared roof is wrong,"
+            " and its SOL reading cannot be trusted. A WARN row exceeds the"
+            " calibrated ceiling; recheck the formula or the calibration."
+        )
+        lines.append("")
+        lines.append("| Level | Op | Config | Signal |")
+        lines.append("|:------|:---|:-------|:-------|")
+        for a in sorted(sol_anomalies, key=lambda x: (x["level"] != "FAIL", x["op"])):
+            lines.append(f"| {a['level']} | **{a['op']}** | {a['config']} | {a['signal']} |")
+        lines.append("")
+
     # ── Baseline Alerts ───────────────────────────────────────────────────
     if baseline_alerts:
         lines.append(f"## {_RED} Baseline Performance Alerts")
@@ -943,8 +1109,23 @@ def generate_report(
             f" {n_bench_ops} ops)</strong></summary>"
         )
         lines.append("")
-        lines.append("| | Op | Config | Device busy (ms) | TFLOPS | BW (TB/s) | Via | Ratio |")
-        lines.append("|:-|:---|:-------|------------:|-------:|----------:|:----|------:|")
+        if have_gpu_profile:
+            lines.append(
+                "> SOL = algorithmic speed-of-light efficiency:"
+                " `max(bytes/BW, flops/roof) / device-busy` against the"
+                " calibrated ceilings. `bytes` is the algorithm's minimum"
+                " traffic (not measured DRAM bytes); `flops` follows the"
+                " TileOPs counting convention; the roof is the unit an"
+                " optimal implementation would use, not the running kernel's."
+                f" M/C = memory/compute-bound; {_PASS} at"
+                f" ≥{SOL_GREEN_MEMORY:.0%} (M) / ≥{SOL_GREEN_COMPUTE:.0%} (C);"
+                " lat-bound rows are too small for the model to judge."
+            )
+            lines.append("")
+        lines.append(
+            "| | Op | Config | Device busy (ms) | TFLOPS | BW (TB/s) | SOL | Via | Ratio |"
+        )
+        lines.append("|:-|:---|:-------|------------:|-------:|----------:|----:|:----|------:|")
         for op in sorted(bench_ops):
             for cfg in bench_ops[op]["configs"]:
                 lat = _conclusion_ms(cfg)
@@ -954,6 +1135,7 @@ def generate_report(
                 lat_str = f"{lat:.4f}" if lat is not None else "-"
                 tflops_str = f"{tflops:.2f}" if tflops is not None else "-"
                 bw_str = f"{bw:.2f}" if bw is not None else "-"
+                sol_str = _sol_cell(cfg.get("sol"))
 
                 # Collect all baselines for this config into rows
                 bl_rows = []
@@ -970,7 +1152,7 @@ def generate_report(
                     bl_str = f"strategy: {variant}" if variant else "-"
                     lines.append(
                         f"|  | {op} | {cfg['name']} "
-                        f"| {lat_str} | {tflops_str} | {bw_str} "
+                        f"| {lat_str} | {tflops_str} | {bw_str} | {sol_str} "
                         f"| {bl_str} | - |"
                     )
                 else:
@@ -984,7 +1166,7 @@ def generate_report(
                     emoji = _ratio_emoji(min(rows)) if rows else ""
                     lines.append(
                         f"| {emoji} | {op} | {cfg['name']} "
-                        f"| {lat_str} | {tflops_str} | {bw_str} "
+                        f"| {lat_str} | {tflops_str} | {bw_str} | {sol_str} "
                         f"| {via_str} | - |"
                     )
         lines.append("")
@@ -1148,6 +1330,9 @@ def main():
     # Prune first: the carried-over artifact can hold entries older than the
     # window when a run gap exceeds the retention period, and the verdicts below
     # are labelled with the 14-day window.
+    gpu_profile = _load_gpu_profile(_get_gpu_name())
+    sol_anomalies = annotate_sol(bench_ops, gpu_profile) if bench_ops else []
+
     history_runs = prune_history(load_history(args.history))
     regressions = detect_regressions(bench_ops, history_runs) if bench_ops else []
     improvements = detect_improvements(bench_ops, history_runs) if bench_ops else []
@@ -1172,6 +1357,8 @@ def main():
         coverage_prev,
         bench_skips,
         previous_run_shifts,
+        sol_anomalies,
+        have_gpu_profile=gpu_profile is not None,
     )
     Path(args.output).write_text(report)
     print(f"Report written to {args.output}")

--- a/scripts/validate_roofline_bytes.py
+++ b/scripts/validate_roofline_bytes.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Audit manifest ``bytes`` formulas against NCU DRAM counters.
+
+Spec: docs/design/roofline.md §4.5. For each audited op, one ``forward()``
+runs under Nsight Compute with cache control on; the sum of
+``dram__bytes_read.sum + dram__bytes_write.sum`` over the call's kernels is
+compared against ``op.eval_roofline()``:
+
+- measured < formula × (1 − EPS)  → FAIL  (formula overestimates; SOL inflates)
+- measured > formula × OVER       → WARN  (multi-pass / replay inflation)
+- missing metric or empty range   → ERROR (never a verdict)
+
+Coverage: ops reachable through the manifest single-tensor-input contract run
+generically; multi-input ops run through ``INPUT_BUILDERS``; everything else
+is reported SKIPPED with the reason — silent gaps would read as audited.
+
+Usage:
+    python scripts/validate_roofline_bytes.py [--op OpName] [--out DIR]
+    python scripts/validate_roofline_bytes.py --child OpName --row JSON --dtype bf16
+"""
+
+import argparse
+import csv
+import importlib
+import io
+import json
+import subprocess
+import sys
+from math import prod
+from pathlib import Path
+
+EPS = 0.05  # counter noise allowance below the formula
+OVER = 1.5  # informational ceiling above the formula
+NVTX_RANGE = "tileops_roofline"
+METRICS = "dram__bytes_read.sum,dram__bytes_write.sum"
+# Workloads at least this large keep fixed sector/TLB overheads inside EPS.
+SMALL_WORKLOAD_BYTES = 32 * 2**20
+
+
+def _op_class(op_name: str, entry: dict):
+    mod_path = entry["source"]["op"].removesuffix(".py").replace("/", ".")
+    return getattr(importlib.import_module(mod_path), op_name)
+
+
+def _single_input_case(op_name: str, entry: dict, row: dict, dtype):
+    """(op, inputs) via the manifest single-tensor-input contract, or None."""
+    import torch
+
+    from tileops.manifest import single_input_workload_contract
+
+    contract = single_input_workload_contract(entry.get("signature") or {})
+    if contract is None:
+        return None
+    shape_key, _ = contract
+    if shape_key not in row:
+        return None
+    reserved = {"label", "dtypes", "bench_skip_reason", shape_key}
+    params = {k: v for k, v in row.items() if k not in reserved and not k.startswith("__")}
+    op = _op_class(op_name, entry)(**params)
+    # Positive, away from zero: valid for every unary domain (log, rsqrt, ...);
+    # the counters read traffic, not values.
+    x = torch.rand(tuple(row[shape_key]), dtype=dtype, device="cuda") + 0.5
+    return op, (x,)
+
+
+def _gemm_case(op_name: str, entry: dict, row: dict, dtype):
+    import torch
+
+    op = _op_class(op_name, entry)()
+    a = torch.randn(row["m"], row["k"], dtype=dtype, device="cuda")
+    b = torch.randn(row["k"], row["n"], dtype=dtype, device="cuda")
+    return op, (a, b)
+
+
+def _bmm_case(op_name: str, entry: dict, row: dict, dtype):
+    import torch
+
+    op = _op_class(op_name, entry)()
+    a = torch.randn(row["batch"], row["m"], row["k"], dtype=dtype, device="cuda")
+    b = torch.randn(row["batch"], row["k"], row["n"], dtype=dtype, device="cuda")
+    return op, (a, b)
+
+
+# Multi-input ops the audit can build. Extend per family; an op absent here
+# and outside the single-input contract is SKIPPED, visibly.
+INPUT_BUILDERS = {
+    "GemmFwdOp": _gemm_case,
+    "BmmFwdOp": _bmm_case,
+}
+
+
+def _build_case(op_name: str, entry: dict, row: dict, dtype):
+    builder = INPUT_BUILDERS.get(op_name)
+    if builder is not None:
+        return builder(op_name, entry, row, dtype)
+    return _single_input_case(op_name, entry, row, dtype)
+
+
+def _branch_signature(row: dict) -> tuple:
+    """Rows sharing this key exercise the same formula branches."""
+    return (
+        tuple(sorted(row.get("dtypes", []))),
+        row.get("backend"),
+        tuple(sorted(k for k, v in row.items() if v is None)),
+        tuple(sorted(k for k in row if isinstance(row[k], bool))),
+    )
+
+
+def _pick_workloads(entry: dict, cap: int = 6) -> list[tuple[dict, str]]:
+    """One row per branch signature, largest first, at most *cap*."""
+    picked: dict[tuple, tuple[dict, str]] = {}
+    for row in entry.get("workloads") or []:
+        if row.get("bench_skip_reason"):
+            continue
+        for dtype_str in row.get("dtypes", []):
+            key = (*_branch_signature(row), dtype_str)
+            size = 1
+            for v in row.values():
+                if isinstance(v, list) and v and all(isinstance(x, int) for x in v):
+                    size *= prod(v)
+                elif isinstance(v, int) and not isinstance(v, bool) and v > 1:
+                    size *= v  # scalar dims (m/n/k/batch) rank GEMM-style rows
+            held = picked.get(key)
+            if held is None or size > held[0].get("__size", -1):
+                picked[key] = ({**row, "__size": size}, dtype_str)
+    ranked = sorted(picked.values(), key=lambda p: -p[0]["__size"])
+    return [({k: v for k, v in r.items() if k != "__size"}, d) for r, d in ranked[:cap]]
+
+
+def run_child(op_name: str, row_json: str, dtype_str: str) -> None:
+    """Run one op's forward inside an NVTX range; print the formula values."""
+    import torch
+
+    from tileops.manifest import load_manifest
+
+    entry = load_manifest()[op_name]
+    dtype = getattr(torch, dtype_str)
+    case = _build_case(op_name, entry, json.loads(row_json), dtype)
+    if case is None:
+        print(json.dumps({"error": "no input builder"}))
+        sys.exit(3)
+    op, inputs = case
+    with torch.no_grad():
+        op(*inputs)  # bind input-inferred roofline vars; build kernels
+        torch.cuda.synchronize()
+        flops, nbytes = op.eval_roofline()
+        torch.cuda.nvtx.range_push(NVTX_RANGE)
+        op(*inputs)
+        torch.cuda.nvtx.range_pop()
+        torch.cuda.synchronize()
+    print(json.dumps({"formula_flops": int(flops), "formula_bytes": int(nbytes)}))
+
+
+def _parse_ncu_csv(path: Path) -> tuple[float | None, int]:
+    """(summed dram bytes over profiled kernels, kernel count); None on gaps."""
+    text = path.read_text(errors="replace")
+    lines = [ln for ln in text.splitlines() if ln.startswith('"')]
+    if not lines:
+        return None, 0
+    rows = list(csv.DictReader(io.StringIO("\n".join(lines))))
+    per_kernel: dict[tuple, dict[str, float]] = {}
+    for r in rows:
+        name = r.get("Metric Name", "")
+        if name not in ("dram__bytes_read.sum", "dram__bytes_write.sum"):
+            continue
+        kid = (r.get("ID"), r.get("Kernel Name"))
+        raw = (r.get("Metric Value") or "").replace(",", "")
+        try:
+            per_kernel.setdefault(kid, {})[name] = float(raw)
+        except ValueError:
+            return None, len(per_kernel)  # n/a: never read as zero
+    if not per_kernel:
+        return None, 0
+    for metrics in per_kernel.values():
+        if len(metrics) != 2:
+            return None, len(per_kernel)
+    total = sum(sum(m.values()) for m in per_kernel.values())
+    return total, len(per_kernel)
+
+
+def audit_one(op_name: str, entry: dict, out_dir: Path) -> list[dict]:
+    results = []
+    cases = _pick_workloads(entry)
+    if not cases:
+        return [{"op": op_name, "verdict": "SKIPPED", "reason": "no workloads"}]
+    for row, dtype_str in cases:
+        label = row.get("label", "workload")
+        csv_path = out_dir / f"{op_name}.{label}.{dtype_str}.csv"
+        cmd = [
+            "ncu",
+            "--nvtx",
+            f"--nvtx-include={NVTX_RANGE}/",
+            "--metrics", METRICS,
+            "--cache-control", "all",
+            "--target-processes", "all",
+            "--csv",
+            "--log-file", str(csv_path),
+            sys.executable, __file__,
+            "--child", op_name,
+            "--row", json.dumps(row),
+            "--dtype", dtype_str,
+        ]  # fmt: skip
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=1800)
+        base = {"op": op_name, "workload": label, "dtype": dtype_str}
+        if proc.returncode == 3:
+            results.append({**base, "verdict": "SKIPPED", "reason": "no input builder"})
+            continue
+        if proc.returncode != 0:
+            reason = (proc.stderr or proc.stdout).strip().splitlines()[-1:] or ["?"]
+            results.append({**base, "verdict": "ERROR", "reason": reason[0][:200]})
+            continue
+        try:
+            formula = json.loads(proc.stdout.strip().splitlines()[-1])["formula_bytes"]
+        except (ValueError, KeyError, IndexError):
+            results.append({**base, "verdict": "ERROR", "reason": "child emitted no formula"})
+            continue
+        measured, n_kernels = _parse_ncu_csv(csv_path)
+        if measured is None:
+            results.append(
+                {**base, "verdict": "ERROR", "reason": f"metric missing (kernels={n_kernels})"}
+            )
+            continue
+        ratio = measured / formula if formula else float("inf")
+        if measured < formula * (1 - EPS):
+            verdict = "FAIL"
+        elif measured > formula * OVER:
+            verdict = "WARN"
+        else:
+            verdict = "PASS"
+        note = "small workload" if formula < SMALL_WORKLOAD_BYTES else ""
+        results.append(
+            {
+                **base,
+                "verdict": verdict,
+                "formula_bytes": int(formula),
+                "measured_bytes": int(measured),
+                "ratio": round(ratio, 4),
+                "kernels": n_kernels,
+                "note": note,
+            }
+        )
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--op", help="Audit a single op (default: every implemented op)")
+    parser.add_argument("--out", default="roofline_bytes_audit", help="Output directory")
+    parser.add_argument("--child", metavar="OP", help=argparse.SUPPRESS)
+    parser.add_argument("--row", help=argparse.SUPPRESS)
+    parser.add_argument("--dtype", help=argparse.SUPPRESS)
+    args = parser.parse_args()
+
+    if args.child:
+        run_child(args.child, args.row, args.dtype)
+        return
+
+    from tileops.manifest import load_manifest
+
+    manifest = load_manifest()
+    targets = (
+        {args.op: manifest[args.op]}
+        if args.op
+        else {k: v for k, v in manifest.items() if v.get("status") == "implemented"}
+    )
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    all_results = []
+    for op_name, entry in sorted(targets.items()):
+        rows = audit_one(op_name, entry, out_dir)
+        all_results.extend(rows)
+        for r in rows:
+            print(
+                f"{r['verdict']:7} {r['op']:40} {r.get('workload', '-'):28} "
+                f"{r.get('dtype', '-'):9} ratio={r.get('ratio', '-')} {r.get('reason', '')}"
+            )
+
+    (out_dir / "results.json").write_text(json.dumps(all_results, indent=2))
+    counts: dict[str, int] = {}
+    for r in all_results:
+        counts[r["verdict"]] = counts.get(r["verdict"], 0) + 1
+    print(f"\nSummary: {counts} → {out_dir}/results.json")
+    # An ERROR is a broken audit, not a passed one; only SKIPPED stays green.
+    sys.exit(1 if counts.get("FAIL") or counts.get("ERROR") else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tileops/ops/attention/deepseek_dsa.py
+++ b/src/tileops/ops/attention/deepseek_dsa.py
@@ -5,7 +5,7 @@ import torch
 from tileops.kernels.attention import SparseMlaKernel
 from tileops.kernels.kernel_base import Kernel
 
-from ..op_base import Op
+from ..op_base import Op, tensor_core_roof
 
 __all__ = ["DeepSeekSparseAttentionDecodeWithKVCacheFwdOp"]
 
@@ -148,3 +148,7 @@ class DeepSeekSparseAttentionDecodeWithKVCacheFwdOp(Op):
         self._validate_dtypes(q, kv, indices)
         self.dtype = q.dtype
         return self._get_kernel((q, kv, indices), q.dtype)(q, kv, indices)
+
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)

--- a/src/tileops/ops/attention/deepseek_dsa.py
+++ b/src/tileops/ops/attention/deepseek_dsa.py
@@ -4,8 +4,9 @@ import torch
 
 from tileops.kernels.attention import SparseMlaKernel
 from tileops.kernels.kernel_base import Kernel
+from tileops.perf.profile import tensor_core_roof
 
-from ..op_base import Op, tensor_core_roof
+from ..op_base import Op
 
 __all__ = ["DeepSeekSparseAttentionDecodeWithKVCacheFwdOp"]
 

--- a/src/tileops/ops/attention/deepseek_mla.py
+++ b/src/tileops/ops/attention/deepseek_mla.py
@@ -4,8 +4,9 @@ import torch
 
 from tileops.kernels.attention import MLADecodeWsKernel
 from tileops.kernels.kernel_base import Kernel
+from tileops.perf.profile import tensor_core_roof
 
-from ..op_base import Op, tensor_core_roof
+from ..op_base import Op
 
 __all__ = ["MultiHeadLatentAttentionDecodeWithKVCacheFwdOp"]
 

--- a/src/tileops/ops/attention/deepseek_mla.py
+++ b/src/tileops/ops/attention/deepseek_mla.py
@@ -5,7 +5,7 @@ import torch
 from tileops.kernels.attention import MLADecodeWsKernel
 from tileops.kernels.kernel_base import Kernel
 
-from ..op_base import Op
+from ..op_base import Op, tensor_core_roof
 
 __all__ = ["MultiHeadLatentAttentionDecodeWithKVCacheFwdOp"]
 
@@ -89,3 +89,7 @@ class MultiHeadLatentAttentionDecodeWithKVCacheFwdOp(Op):
         self._validate_dtypes(q, q_pe, k, k_pe)
         self.dtype = q.dtype
         return self._get_kernel((q, q_pe, k, k_pe), q.dtype)(q, q_pe, k, k_pe)
+
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)

--- a/src/tileops/ops/attention/gqa.py
+++ b/src/tileops/ops/attention/gqa.py
@@ -25,7 +25,7 @@ from tileops.kernels.attention import (
 )
 from tileops.kernels.kernel_base import Kernel
 
-from ..op_base import Op, UnmanifestedOp
+from ..op_base import Op, UnmanifestedOp, tensor_core_roof
 from ..rope import base_freqs
 from .selection import (
     DECODE_KEYS,
@@ -512,6 +512,10 @@ class GroupedQueryAttentionFwdOp(Op):
         )
         return output.view(q.shape)
 
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)
+
 
 class GroupedQueryAttentionPrefillFwdOp(Op):
     """Canonical packed GQA prefill. Layout: THD.
@@ -832,6 +836,17 @@ class GroupedQueryAttentionPrefillFwdOp(Op):
             kwargs.pop("cu_seqlens_kv")
         )
         return gqa_prefill_varlen_fwd_roofline(**kwargs)
+
+    def compute_roof(self) -> str:
+        """Priced on tensor cores; an fp8 contraction prices at fp8.
+
+        ``backend="auto"`` dispatches to the fp8 kernel when the call passes
+        fp8 tensors, so the recorded call dtype outranks the constructed one.
+        """
+        if self.backend == "fp8":
+            return "tensor_core.fp8"
+        recorded = (getattr(self, "_roofline_kwargs", None) or {}).get("dtype")
+        return tensor_core_roof(recorded if recorded is not None else self.dtype)
 
 
 class GroupedQueryAttentionPrefillVarlenFwdOp(UnmanifestedOp):
@@ -1478,6 +1493,10 @@ class GroupedQueryAttentionPrefillPagedWithKVCacheFwdOp(Op):
             "compute per-sample from cu_seqlens and cache_seqlens at call time."
         )
 
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)
+
 
 class GroupedQueryAttentionBwdOp(Op):
     """Layout: BSHD"""
@@ -1598,6 +1617,10 @@ class GroupedQueryAttentionBwdOp(Op):
         dk, dv = dk.to(q.dtype), dv.to(q.dtype)
         return dq, dk, dv
 
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)
+
 
 class GroupedQueryAttentionDecodeWithKVCacheFwdOp(Op):
     """Layout: BSHD"""
@@ -1710,6 +1733,10 @@ class GroupedQueryAttentionDecodeWithKVCacheFwdOp(Op):
         self._validate_dtypes(q, k, v)
         self.dtype = q.dtype
         return self._get_kernel((q, k, v), q.dtype)(q, k, v, real_seqlen_kv)
+
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)
 
 
 class GroupedQueryAttentionDecodePagedWithKVCacheFwdOp(Op):
@@ -1831,6 +1858,10 @@ class GroupedQueryAttentionDecodePagedWithKVCacheFwdOp(Op):
         return self._get_kernel((q, k, v, real_seqlen_kv, block_table), q.dtype)(
             q, k, v, real_seqlen_kv, block_table
         )
+
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)
 
 
 class GroupedQueryAttentionSlidingWindowFwdOp(Op):
@@ -2007,6 +2038,10 @@ class GroupedQueryAttentionSlidingWindowFwdOp(Op):
             * self.dim
             * self.dtype.itemsize
         )
+
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)
 
 
 class GroupedQueryAttentionSlidingWindowVarlenFwdOp(Op):
@@ -2214,3 +2249,7 @@ class GroupedQueryAttentionSlidingWindowVarlenFwdOp(Op):
             "total_memory is not defined for varlen ops; "
             "compute per-sample from cu_seqlens at call time."
         )
+
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)

--- a/src/tileops/ops/attention/gqa.py
+++ b/src/tileops/ops/attention/gqa.py
@@ -24,8 +24,9 @@ from tileops.kernels.attention import (
     GQASlidingWindowVarlenFwdWgmmaPipelinedKernel,
 )
 from tileops.kernels.kernel_base import Kernel
+from tileops.perf.profile import tensor_core_roof
 
-from ..op_base import Op, UnmanifestedOp, tensor_core_roof
+from ..op_base import Op, UnmanifestedOp
 from ..rope import base_freqs
 from .selection import (
     DECODE_KEYS,
@@ -132,38 +133,38 @@ def _build_packed_prefill_kernel(
 
 
 class GroupedQueryAttentionDenseFwdOp(Op):
-    r"""Shape-agnostic dense BSHD GQA for prefill and contiguous decode.
+    r"""Shape-agnostic dense BSHD grouped-query attention for prefill and contiguous decode.
 
-    Let ``g = H / H_kv`` and ``r(h) = floor(h / g)`` map query head ``h`` to
-    its KV head. Rectangular attention uses bottom-right alignment:
-
-    $$
-    p_i = i + S_{kv} - S_q.
-    $$
-
-    Causal attention admits key position ``j`` when ``j <= p_i``. A finite
-    window additionally requires ``p_i - left <= j <= p_i + right``. Fused
-    RoPE rotates Q at ``p_i`` and K at ``j``; therefore causal and fused-RoPE
-    calls require ``S_q <= S_kv``.
-
-    For FP8 inputs, each query head uses the scale of its KV group:
+    Let $g = H / H_{kv}$ and $r(h) = \lfloor h / g \rfloor$ map query head
+    $h$ to its KV head. Rectangular attention aligns the two sequences at
+    the bottom right, placing query row $i$ at key position
 
     $$
-    \hat q_{bih} = q_{bih} \mathrm{qscale}_{b,r(h)},\quad
-    \hat k_{bjr} = k_{bjr} \mathrm{kscale}_{b,r},\quad
-    \hat v_{bjr} = v_{bjr} \mathrm{vscale}_{b,r}.
+    p_i = i + S_{kv} - S_q .
     $$
 
-    With ``alpha = sm_scale`` (default ``1 / sqrt(D)``), scores are
-    ``z = alpha * dot(q_hat, k_hat)``. When ``softcap > 0`` the score becomes
-    ``softcap * tanh(z / softcap)`` before masking and softmax. Dot products,
-    softmax, and the weighted V reduction accumulate in FP32; the result is
-    cast to ``dtype``.
+    Causal attention admits key position $j$ when $j \le p_i$; a finite
+    window additionally requires
+    $p_i - \mathrm{left} \le j \le p_i + \mathrm{right}$. Fused RoPE rotates
+    Q at $p_i$ and K at $j$. Causal and fused-RoPE calls therefore require
+    $S_q \le S_{kv}$.
 
-    The Op validates this public contract and uses the standard
-    :meth:`Op.get_or_build_kernel` specialization cache. A later BUILTIN PR
-    will supply the shape/dtype key, select one concrete kernel on a miss, and
-    store that kernel directly; there is no second callable-owned cache.
+    FP8 inputs are dequantized with per-KV-head scales; each query head uses
+    the scale of its KV group:
+
+    $$
+    \begin{aligned}
+    \hat q_{b,i,h} &= q_{b,i,h} \cdot \mathrm{qscale}_{b,\,r(h)} \\
+    \hat k_{b,j,r} &= k_{b,j,r} \cdot \mathrm{kscale}_{b,\,r} \\
+    \hat v_{b,j,r} &= v_{b,j,r} \cdot \mathrm{vscale}_{b,\,r}
+    \end{aligned}
+    $$
+
+    With $\alpha$ = ``sm_scale`` (default $1 / \sqrt{D}$), the raw score is
+    $z = \alpha \, \hat q \cdot \hat k$; with ``softcap`` $c > 0$ it becomes
+    $c \tanh(z / c)$ before masking and softmax. Dot products, softmax, and
+    the weighted V reduction accumulate in FP32; the result is cast to the
+    configured output dtype.
     """
 
     def __init__(
@@ -180,7 +181,34 @@ class GroupedQueryAttentionDenseFwdOp(Op):
         *,
         target: Target = None,
     ) -> None:
-        """Configure the public Dense BSHD GQA interface."""
+        r"""Build the op. Tensor shapes arrive with each ``forward`` call.
+
+        Args:
+            is_causal: Apply the causal mask, bottom-right aligned.
+            sm_scale: Score scale $\alpha$. ``None`` resolves to
+                $1 / \sqrt{D}$ from the call's head dimension.
+            softcap: Positive cap $c$ applying $c \tanh(z / c)$ to raw
+                scores. ``None`` or ``0`` disables capping.
+            window_size_left: Keys admitted left of $p_i$; ``-1`` means
+                unlimited.
+            window_size_right: Keys admitted right of $p_i$; ``-1`` means
+                unlimited.
+            dtype: Output dtype. Required (``float16`` or ``bfloat16``) for
+                FP8 inputs; ``None`` outputs the input dtype.
+            pos_encoding_mode: ``"none"``, or ``"rope"`` to fuse the rotary
+                embedding into attention.
+            rotary_dim: Rotated width of each head; even, at most $D$,
+                default the full head dimension. Valid only with
+                ``pos_encoding_mode="rope"``.
+            rope_layout: ``"neox"`` (rotate split halves) or
+                ``"interleaved"`` (rotate adjacent pairs).
+            target: Backend target to serve this op, or ``None`` to decide
+                from the input device.
+
+        Raises:
+            ValueError: A parameter is out of range, or the combination is
+                inconsistent (e.g. ``rotary_dim`` without RoPE).
+        """
         if pos_encoding_mode not in ("none", "rope"):
             raise ValueError(f"pos_encoding_mode must be 'none' or 'rope', got {pos_encoding_mode}")
         if rotary_dim is not None and pos_encoding_mode != "rope":
@@ -378,7 +406,34 @@ class GroupedQueryAttentionDenseFwdOp(Op):
         rope_cos: Optional[torch.Tensor] = None,
         rope_sin: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        """Validate, normalize, resolve one concrete implementation, and run it."""
+        r"""Run dense GQA attention on one batch of BSHD tensors.
+
+        Args:
+            q: Queries, $[B \times S_q \times H \times D]$; ``float16``,
+                ``bfloat16``, or ``float8_e4m3fn``.
+            k: Keys, $[B \times S_{kv} \times H_{kv} \times D]$, same dtype
+                as ``q``.
+            v: Values, $[B \times S_{kv} \times H_{kv} \times D]$, same
+                dtype as ``q``.
+            q_scale: FP8 dequantization scales for ``q``,
+                $[B \times H_{kv}]$, ``float32``. The three scales are
+                required together for FP8 input and invalid otherwise.
+            k_scale: Scales for ``k``, $[B \times H_{kv}]$, ``float32``.
+            v_scale: Scales for ``v``, $[B \times H_{kv}]$, ``float32``.
+            rope_cos: RoPE cosine table, $[P \times d_r / 2]$ with
+                $P \ge S_{kv}$ and $d_r$ = ``rotary_dim``, in the output
+                dtype. The two tables are required together with
+                ``pos_encoding_mode="rope"`` and invalid otherwise.
+            rope_sin: RoPE sine table, same shape and dtype as ``rope_cos``.
+
+        Returns:
+            Attention output, $[B \times S_q \times H \times D]$, in the
+            configured output dtype.
+
+        Raises:
+            ValueError: Shapes, dtypes, devices, or optional-input
+                combinations violate the contract above.
+        """
         self._validate_forward_inputs(q, k, v, q_scale, k_scale, v_scale, rope_cos, rope_sin)
         inputs = self._canonicalize_inputs(q, k, v, q_scale, k_scale, v_scale, rope_cos, rope_sin)
         kernel = self._get_kernel(inputs)

--- a/src/tileops/ops/attention/mha.py
+++ b/src/tileops/ops/attention/mha.py
@@ -14,9 +14,10 @@ from tileops.kernels.attention import (
     MHADecodePagedWsKernel,
 )
 from tileops.kernels.kernel_base import Kernel
+from tileops.perf.profile import tensor_core_roof
 
 from ..compile_boundary import get_instance
-from ..op_base import Op, tensor_core_roof
+from ..op_base import Op
 from .gqa import GroupedQueryAttentionBwdOp, GroupedQueryAttentionFwdOp
 from .selection import MHA_PAGED_DECODE_KEYS, AttentionCall
 

--- a/src/tileops/ops/attention/mha.py
+++ b/src/tileops/ops/attention/mha.py
@@ -16,7 +16,7 @@ from tileops.kernels.attention import (
 from tileops.kernels.kernel_base import Kernel
 
 from ..compile_boundary import get_instance
-from ..op_base import Op
+from ..op_base import Op, tensor_core_roof
 from .gqa import GroupedQueryAttentionBwdOp, GroupedQueryAttentionFwdOp
 from .selection import MHA_PAGED_DECODE_KEYS, AttentionCall
 
@@ -103,6 +103,10 @@ class MultiHeadAttentionFwdOp(Op):
     def _eager_forward(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
         self.dtype = q.dtype
         return self._gqa_op(q, k, v)
+
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)
 
 
 class MultiHeadAttentionBwdOp(Op):
@@ -215,7 +219,12 @@ class MultiHeadAttentionBwdOp(Op):
         Returns:
             ``dq``, ``dk``, ``dv``, as the manifest declares. Shape rules: ``dq.shape == (B, S, H, D)``; ``dk.shape == (B, S, H, D)``; ``dv.shape == (B, S, H, D)``.
         """
+        self.dtype = q.dtype
         return self._gqa_op(q, k, v, o, do, lse)
+
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)
 
 
 class MultiHeadAttentionDecodeWithKVCacheFwdOp(Op):
@@ -297,6 +306,10 @@ class MultiHeadAttentionDecodeWithKVCacheFwdOp(Op):
             )
         self.dtype = q.dtype
         return self._get_kernel((q, k, v), q.dtype)(q, k, v, real_seqlen_kv)
+
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)
 
 
 class MultiHeadAttentionDecodePagedWithKVCacheFwdOp(Op):
@@ -416,6 +429,10 @@ class MultiHeadAttentionDecodePagedWithKVCacheFwdOp(Op):
         return self._get_kernel((q, k, v, real_seqlen_kv, block_table), q.dtype)(
             q, k, v, real_seqlen_kv, block_table
         )
+
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)
 
 
 # torch.compile dispatch boundary (see src/tileops/ops/compile_boundary.py)

--- a/src/tileops/ops/convolution.py
+++ b/src/tileops/ops/convolution.py
@@ -15,9 +15,10 @@ from tileops.kernels.convolution import (
     GroupConv3dKernel,
 )
 from tileops.kernels.kernel_base import Kernel
+from tileops.perf.profile import tensor_core_roof
 
 from .compile_boundary import get_instance
-from .op_base import Op, tensor_core_roof
+from .op_base import Op
 
 __all__ = [
     "Conv1dFwdOp",

--- a/src/tileops/ops/convolution.py
+++ b/src/tileops/ops/convolution.py
@@ -17,7 +17,7 @@ from tileops.kernels.convolution import (
 from tileops.kernels.kernel_base import Kernel
 
 from .compile_boundary import get_instance
-from .op_base import Op
+from .op_base import Op, tensor_core_roof
 
 __all__ = [
     "Conv1dFwdOp",
@@ -555,6 +555,10 @@ class Conv1dFwdOp(Op):
         ) * elem_bytes
         return int(flops), int(bytes_)
 
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)
+
 
 def _pair(value: int | Tuple[int, int]) -> Tuple[int, int]:
     return _conv_tuple(value, 2, "value", "Conv2d")  # type: ignore[return-value]
@@ -978,6 +982,10 @@ class Conv2dFwdOp(Op):
         ) * elem_bytes
         return int(flops), int(bytes_)
 
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)
+
 
 def _triple(value: int | Tuple[int, int, int]) -> Tuple[int, int, int]:
     return _conv_tuple(value, 3, "value", "Conv3d")  # type: ignore[return-value]
@@ -1378,6 +1386,10 @@ class Conv3dFwdOp(Op):
             + (c_out if has_bias else 0)
         ) * elem_bytes
         return int(flops), int(bytes_)
+
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)
 
 
 # The compile boundary, one operator per op. Module-level because registration happens once

--- a/src/tileops/ops/fp8_lightning_indexer.py
+++ b/src/tileops/ops/fp8_lightning_indexer.py
@@ -220,3 +220,7 @@ class FP8LightningIndexerFwdOp(Op):
             sf = torch.pow(2.0, torch.ceil(torch.log2(x_absmax)))
         x_scaled = (x * (1.0 / sf)).to(torch.float8_e4m3fn)
         return x_scaled, sf.squeeze(-1)
+
+    def compute_roof(self) -> str:
+        """Index scores contract at fp8 regardless of the input form."""
+        return "tensor_core.fp8"

--- a/src/tileops/ops/gemm/bmm.py
+++ b/src/tileops/ops/gemm/bmm.py
@@ -11,8 +11,9 @@ import torch
 
 from tileops.kernels.gemm.bmm import BmmFp8Kernel, BmmKernel
 from tileops.kernels.kernel_base import Kernel
+from tileops.perf.profile import tensor_core_roof
 
-from ..op_base import Op, tensor_core_roof
+from ..op_base import Op
 
 __all__ = ["BmmFp8KNFwdOp", "BmmFp8NKFwdOp", "BmmFwdOp"]
 

--- a/src/tileops/ops/gemm/bmm.py
+++ b/src/tileops/ops/gemm/bmm.py
@@ -12,7 +12,7 @@ import torch
 from tileops.kernels.gemm.bmm import BmmFp8Kernel, BmmKernel
 from tileops.kernels.kernel_base import Kernel
 
-from ..op_base import Op
+from ..op_base import Op, tensor_core_roof
 
 __all__ = ["BmmFp8KNFwdOp", "BmmFp8NKFwdOp", "BmmFwdOp"]
 
@@ -164,6 +164,10 @@ class BmmFwdOp(Op):
             self._active_sig = sig
 
         return self._active_kernel(a, b)
+
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)
 
 
 class BmmFp8KNFwdOp(Op):
@@ -406,6 +410,10 @@ class BmmFp8KNFwdOp(Op):
         scale_a = scale_a.reshape(1)
         scale_b = scale_b.reshape(1)
         return self._active(a, b, scale_a, scale_b)
+
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)
 
 
 class BmmFp8NKFwdOp(BmmFp8KNFwdOp):

--- a/src/tileops/ops/gemm/gemm.py
+++ b/src/tileops/ops/gemm/gemm.py
@@ -13,7 +13,7 @@ from tileops.kernels.gemm.w4a16 import GROUP_SIZE, GemmW4A16Kernel
 from tileops.kernels.gemm.w4a16_decode import GemmW4A16DecodeKernel
 from tileops.kernels.kernel_base import Kernel
 
-from ..op_base import Op
+from ..op_base import Op, tensor_core_roof
 
 __all__ = ["GemmFp8FwdOp", "GemmFwdOp", "GemmW4A16FwdOp"]
 
@@ -183,6 +183,10 @@ class GemmFwdOp(Op):
         if mode == "rhs_col":
             return kernel(b.reshape(-1), a).reshape(m, 1)
         return kernel(a, b)
+
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)
 
 
 class GemmFp8FwdOp(Op):
@@ -409,6 +413,10 @@ class GemmFp8FwdOp(Op):
 
         return self._active(a, b, scale_a, scale_b, bias)
 
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)
+
 
 class GemmW4A16FwdOp(Op):
     """Dense W4A16 NT GEMM with group-wise affine weight dequantization.
@@ -609,3 +617,7 @@ class GemmW4A16FwdOp(Op):
             self._active_sig = sig
 
         return self._active(activation, packed_weight, weight_scale, weight_zero)
+
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)

--- a/src/tileops/ops/gemm/gemm.py
+++ b/src/tileops/ops/gemm/gemm.py
@@ -12,8 +12,9 @@ from tileops.kernels.gemm.dense import (
 from tileops.kernels.gemm.w4a16 import GROUP_SIZE, GemmW4A16Kernel
 from tileops.kernels.gemm.w4a16_decode import GemmW4A16DecodeKernel
 from tileops.kernels.kernel_base import Kernel
+from tileops.perf.profile import tensor_core_roof
 
-from ..op_base import Op, tensor_core_roof
+from ..op_base import Op
 
 __all__ = ["GemmFp8FwdOp", "GemmFwdOp", "GemmW4A16FwdOp"]
 

--- a/src/tileops/ops/gemm/grouped_gemm.py
+++ b/src/tileops/ops/gemm/grouped_gemm.py
@@ -8,9 +8,10 @@ from tileops.kernels.grouped_gemm import (
     GroupedGemmPersistent3WGKernel,
 )
 from tileops.kernels.kernel_base import Kernel
+from tileops.perf.profile import tensor_core_roof
 from tileops.utils import get_sm_version
 
-from ..op_base import Op, tensor_core_roof
+from ..op_base import Op
 
 __all__ = ["GroupedGemmFwdOp"]
 

--- a/src/tileops/ops/gemm/grouped_gemm.py
+++ b/src/tileops/ops/gemm/grouped_gemm.py
@@ -10,7 +10,7 @@ from tileops.kernels.grouped_gemm import (
 from tileops.kernels.kernel_base import Kernel
 from tileops.utils import get_sm_version
 
-from ..op_base import Op
+from ..op_base import Op, tensor_core_roof
 
 __all__ = ["GroupedGemmFwdOp"]
 
@@ -240,3 +240,7 @@ class GroupedGemmFwdOp(Op):
             # and has no use for the padded ones.
             return self.kernel(a, b, batch_sizes, batch_offsets)
         return self.kernel(a, b, batch_sizes, batch_offsets, batch_padded_offsets)
+
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)

--- a/src/tileops/ops/linear_attention/deltanet.py
+++ b/src/tileops/ops/linear_attention/deltanet.py
@@ -7,9 +7,10 @@ from tileops.kernels.linear_attention.deltanet import (
     DeltaNetBwdKernel,
     DeltaNetFwdKernel,
 )
+from tileops.perf.profile import tensor_core_roof
 
 from .._validation import check_tensor_shape
-from ..op_base import Op, UnmanifestedOp, tensor_core_roof
+from ..op_base import Op, UnmanifestedOp
 
 __all__ = ["DeltaNetBwdOp", "DeltaNetFwdOp", "DeltaNetOp"]
 

--- a/src/tileops/ops/linear_attention/deltanet.py
+++ b/src/tileops/ops/linear_attention/deltanet.py
@@ -9,7 +9,7 @@ from tileops.kernels.linear_attention.deltanet import (
 )
 
 from .._validation import check_tensor_shape
-from ..op_base import Op, UnmanifestedOp
+from ..op_base import Op, UnmanifestedOp, tensor_core_roof
 
 __all__ = ["DeltaNetBwdOp", "DeltaNetFwdOp", "DeltaNetOp"]
 
@@ -166,6 +166,10 @@ class DeltaNetFwdOp(Op):
         self._bind_from_inputs(q, k, v, beta)
         o, S, Aw, Au, w, u = self.kernel(q, k, v, beta)
         return o, S, Aw, Au, w, u
+
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)
 
 
 class DeltaNetBwdOp(Op):
@@ -328,6 +332,10 @@ class DeltaNetBwdOp(Op):
         self._bind_from_inputs((do, q, k, v, beta, S, Aw, Au, w, u))
         dq, dk, dv, dbeta = self.kernel(do, q, k, v, beta, S, Aw, Au, w, u)
         return dq, dk, dv, dbeta
+
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)
 
 
 class _DeltaNetFunction(torch.autograd.Function):

--- a/src/tileops/ops/linear_attention/gated_deltanet.py
+++ b/src/tileops/ops/linear_attention/gated_deltanet.py
@@ -18,7 +18,7 @@ from tileops.kernels.linear_attention.gated_deltanet_recurrence import (
 )
 
 from .._validation import check_tensor_shape
-from ..op_base import Op, UnmanifestedOp
+from ..op_base import Op, UnmanifestedOp, tensor_core_roof
 
 __all__ = [
     "GatedDeltaNetBHTDFwdOp",
@@ -283,6 +283,10 @@ class GatedDeltaNetBHTDFwdOp(Op):
         o, S, Aw, Au = self.kernel(q, k, v, g, beta)
         return o, S, Aw, Au
 
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)
+
 
 class GatedDeltaNetBTHDFwdOp(Op):
     """Gated DeltaNet forward over token-major (BTHD) inputs.
@@ -439,6 +443,10 @@ class GatedDeltaNetBTHDFwdOp(Op):
         )
         o, S, Aw, Au = self.kernel(q, k, v, g, beta)
         return o, S, Aw, Au
+
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)
 
 
 class GatedDeltaNetPrefillBTHDFwdOp(Op):
@@ -692,6 +700,10 @@ class GatedDeltaNetPrefillBTHDFwdOp(Op):
             self._active_sig = sig
         return self.kernel(q, k, v, g, beta)
 
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)
+
 
 class GatedDeltaNetPrefillBHTDFwdOp(GatedDeltaNetPrefillBTHDFwdOp):
     """Gated DeltaNet inference prefill over head-major (BHTD) inputs.
@@ -830,6 +842,10 @@ class GatedDeltaNetBwdOp(Op):
         )
         dq, dk, dv, dg, dbeta = self.kernel(do, q, k, v, g, beta, S)
         return dq, dk, dv, dg, dbeta
+
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)
 
 
 class _GatedDeltaNetFunction(torch.autograd.Function):

--- a/src/tileops/ops/linear_attention/gated_deltanet.py
+++ b/src/tileops/ops/linear_attention/gated_deltanet.py
@@ -16,9 +16,10 @@ from tileops.kernels.linear_attention.gated_deltanet_recurrence import (
     GatedDeltaNetDecodeKernel,
     GatedDeltaNetDecodeRawCudaFlaStyleKernel,
 )
+from tileops.perf.profile import tensor_core_roof
 
 from .._validation import check_tensor_shape
-from ..op_base import Op, UnmanifestedOp, tensor_core_roof
+from ..op_base import Op, UnmanifestedOp
 
 __all__ = [
     "GatedDeltaNetBHTDFwdOp",

--- a/src/tileops/ops/linear_attention/gla.py
+++ b/src/tileops/ops/linear_attention/gla.py
@@ -4,9 +4,10 @@ import torch
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.linear_attention.gla import GLABwdKernel, GLAFwdKernel
+from tileops.perf.profile import tensor_core_roof
 
 from .._validation import check_tensor_shape
-from ..op_base import Op, tensor_core_roof
+from ..op_base import Op
 
 __all__ = ["GLABwdOp", "GLAFwdOp"]
 

--- a/src/tileops/ops/linear_attention/gla.py
+++ b/src/tileops/ops/linear_attention/gla.py
@@ -6,7 +6,7 @@ from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.linear_attention.gla import GLABwdKernel, GLAFwdKernel
 
 from .._validation import check_tensor_shape
-from ..op_base import Op
+from ..op_base import Op, tensor_core_roof
 
 __all__ = ["GLABwdOp", "GLAFwdOp"]
 
@@ -172,6 +172,10 @@ class GLAFwdOp(Op):
         )
         return self.kernel(q, k, v, g, initial_state)
 
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)
+
 
 class GLABwdOp(Op):
     """GLA (Gated Linear Attention) backward operator.
@@ -319,3 +323,7 @@ class GLABwdOp(Op):
             (q, k, v, g, h, do, dht), batch, seq_len, heads, dim_k, dim_v, dtype, q.device.index
         )
         return self.kernel(q, k, v, g, h, do, dht, has_initial_state)
+
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)

--- a/src/tileops/ops/mamba/cb_producer.py
+++ b/src/tileops/ops/mamba/cb_producer.py
@@ -8,9 +8,10 @@ import torch
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.mamba.cb_producer import CBProducerKernel
+from tileops.perf.profile import tensor_core_roof
 
 from .._validation import check_tensor_shape
-from ..op_base import Op, tensor_core_roof
+from ..op_base import Op
 
 __all__ = ["CBProducerFwdOp"]
 

--- a/src/tileops/ops/mamba/cb_producer.py
+++ b/src/tileops/ops/mamba/cb_producer.py
@@ -10,7 +10,7 @@ from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.mamba.cb_producer import CBProducerKernel
 
 from .._validation import check_tensor_shape
-from ..op_base import Op
+from ..op_base import Op, tensor_core_roof
 
 __all__ = ["CBProducerFwdOp"]
 
@@ -106,3 +106,7 @@ class CBProducerFwdOp(Op):
         C_mat = C_mat.contiguous()
         B_mat = B_mat.contiguous()
         return self._get_kernel((C_mat, B_mat), C_mat.dtype)(C_mat, B_mat)
+
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)

--- a/src/tileops/ops/mamba/mamba2_fwd.py
+++ b/src/tileops/ops/mamba/mamba2_fwd.py
@@ -31,7 +31,7 @@ import torch
 
 from tileops.kernels.kernel_base import Kernel
 
-from ..op_base import Op
+from ..op_base import Op, tensor_core_roof
 from .cb_producer import CBProducerFwdOp
 from .da_cumsum import DaCumsumFwdOp
 from .ssd_chunk_scan import SSDChunkScanFwdOp
@@ -293,3 +293,7 @@ class Mamba2FwdOp(Op):
         # y: (B, S, H, P)  float32
 
         return y, final_states_flat.reshape(batch, n_heads, d_head, d_state)
+
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)

--- a/src/tileops/ops/mamba/mamba2_fwd.py
+++ b/src/tileops/ops/mamba/mamba2_fwd.py
@@ -30,8 +30,9 @@ from typing import Dict, Optional, Tuple
 import torch
 
 from tileops.kernels.kernel_base import Kernel
+from tileops.perf.profile import tensor_core_roof
 
-from ..op_base import Op, tensor_core_roof
+from ..op_base import Op
 from .cb_producer import CBProducerFwdOp
 from .da_cumsum import DaCumsumFwdOp
 from .ssd_chunk_scan import SSDChunkScanFwdOp

--- a/src/tileops/ops/mamba/ssd_chunk_scan.py
+++ b/src/tileops/ops/mamba/ssd_chunk_scan.py
@@ -4,8 +4,9 @@ import torch
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.mamba import SSDChunkScanFwdKernel
+from tileops.perf.profile import tensor_core_roof
 
-from ..op_base import Op, tensor_core_roof
+from ..op_base import Op
 
 __all__ = ["SSDChunkScanFwdOp"]
 

--- a/src/tileops/ops/mamba/ssd_chunk_scan.py
+++ b/src/tileops/ops/mamba/ssd_chunk_scan.py
@@ -5,7 +5,7 @@ import torch
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.mamba import SSDChunkScanFwdKernel
 
-from ..op_base import Op
+from ..op_base import Op, tensor_core_roof
 
 __all__ = ["SSDChunkScanFwdOp"]
 
@@ -180,3 +180,7 @@ class SSDChunkScanFwdOp(Op):
         dt = dt.contiguous()
 
         return self.kernel(x, cb, dA_cumsum, C, prev_states, dt)
+
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)

--- a/src/tileops/ops/mamba/ssd_chunk_state.py
+++ b/src/tileops/ops/mamba/ssd_chunk_state.py
@@ -4,8 +4,9 @@ import torch
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.mamba import SSDChunkStateFwdKernel
+from tileops.perf.profile import tensor_core_roof
 
-from ..op_base import Op, tensor_core_roof
+from ..op_base import Op
 
 __all__ = ["SSDChunkStateFwdOp"]
 

--- a/src/tileops/ops/mamba/ssd_chunk_state.py
+++ b/src/tileops/ops/mamba/ssd_chunk_state.py
@@ -5,7 +5,7 @@ import torch
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.mamba import SSDChunkStateFwdKernel
 
-from ..op_base import Op
+from ..op_base import Op, tensor_core_roof
 
 __all__ = ["SSDChunkStateFwdOp"]
 
@@ -196,3 +196,7 @@ class SSDChunkStateFwdOp(Op):
             seq_idx = seq_idx.contiguous()
 
         return self.kernel(x, Bmat, dt, dA_cumsum, seq_idx)
+
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)

--- a/src/tileops/ops/moe/fused_moe.py
+++ b/src/tileops/ops/moe/fused_moe.py
@@ -22,7 +22,7 @@ from tileops.ops.moe.abc import (
 from tileops.ops.moe.fused_topk import FusedTopKOp
 from tileops.ops.moe.prepare_finalize.no_dp_ep import MoEPrepareAndFinalizeNoDPEP
 from tileops.ops.moe.routed_expert import FusedMoEExpertsNopadPersistent3WGFwdOp
-from tileops.ops.op_base import Op
+from tileops.ops.op_base import Op, tensor_core_roof
 
 __all__ = ["FusedMoe", "FusedMoeFwdOp"]
 
@@ -186,6 +186,8 @@ class FusedMoe(Op):
         self.correction_bias_shape = (
             None if correction_bias is None else tuple(correction_bias.shape)
         )
+        # The roofline prices hidden states and weights at the call's dtype.
+        self.dtype = hidden_states.dtype
 
         r = self._prepare.prepare(
             hidden_states,
@@ -234,6 +236,10 @@ class FusedMoe(Op):
             self._experts.make_weighted_reduce(),
         )
         return output
+
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)
 
 
 class FusedMoeFwdOp(FusedMoe):

--- a/src/tileops/ops/moe/fused_moe.py
+++ b/src/tileops/ops/moe/fused_moe.py
@@ -22,7 +22,8 @@ from tileops.ops.moe.abc import (
 from tileops.ops.moe.fused_topk import FusedTopKOp
 from tileops.ops.moe.prepare_finalize.no_dp_ep import MoEPrepareAndFinalizeNoDPEP
 from tileops.ops.moe.routed_expert import FusedMoEExpertsNopadPersistent3WGFwdOp
-from tileops.ops.op_base import Op, tensor_core_roof
+from tileops.ops.op_base import Op
+from tileops.perf.profile import tensor_core_roof
 
 __all__ = ["FusedMoe", "FusedMoeFwdOp"]
 

--- a/src/tileops/ops/moe/routed_expert/fused_routed_expert.py
+++ b/src/tileops/ops/moe/routed_expert/fused_routed_expert.py
@@ -13,7 +13,7 @@ from torch import Tensor
 
 from tileops.kernels.kernel_base import Kernel
 
-from ...op_base import Op
+from ...op_base import Op, tensor_core_roof
 from ..abc import (
     FusedMoEExpertsModular,
     WeightedReduce,
@@ -256,3 +256,7 @@ class FusedMoEExpertsNopadPersistent3WGFwdOp(FusedMoEExpertsModular):
         # Unpermute reduces into ``output`` directly and folds
         # ``routed_scaling_factor`` into its prim_func — no separate copy/scale.
         self._unpermute(mm2, fwd_idx, topk_weights, out=output)
+
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)

--- a/src/tileops/ops/moe/routed_expert/fused_routed_expert.py
+++ b/src/tileops/ops/moe/routed_expert/fused_routed_expert.py
@@ -12,8 +12,9 @@ import torch
 from torch import Tensor
 
 from tileops.kernels.kernel_base import Kernel
+from tileops.perf.profile import tensor_core_roof
 
-from ...op_base import Op, tensor_core_roof
+from ...op_base import Op
 from ..abc import (
     FusedMoEExpertsModular,
     WeightedReduce,

--- a/src/tileops/ops/moe/routed_expert/gate_up.py
+++ b/src/tileops/ops/moe/routed_expert/gate_up.py
@@ -11,9 +11,10 @@ from tileops.kernels.moe import (
     MoeGroupedGemmPersistent3WGFusedActKernel,
     MoeGroupedGemmSeparateActKernel,
 )
+from tileops.perf.profile import tensor_core_roof
 
 from ...compile_boundary import get_instance
-from ...op_base import Op, tensor_core_roof
+from ...op_base import Op
 from ._common import GroupedOperandEagerForward
 
 __all__ = ["MoeGateUpFwdOp"]

--- a/src/tileops/ops/moe/routed_expert/gate_up.py
+++ b/src/tileops/ops/moe/routed_expert/gate_up.py
@@ -13,7 +13,7 @@ from tileops.kernels.moe import (
 )
 
 from ...compile_boundary import get_instance
-from ...op_base import Op
+from ...op_base import Op, tensor_core_roof
 from ._common import GroupedOperandEagerForward
 
 __all__ = ["MoeGateUpFwdOp"]
@@ -144,6 +144,10 @@ class MoeGateUpFwdOp(GroupedOperandEagerForward, Op):
             [numel, ffn] activated output.
         """
         return _moe_gate_up_fwd(a, b, true_sizes, true_offsets, self._instance_key)
+
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)
 
 
 @torch.library.custom_op("tileops::moe_gate_up_fwd", mutates_args=())

--- a/src/tileops/ops/moe/routed_expert/moe_grouped_gemm_nopad.py
+++ b/src/tileops/ops/moe/routed_expert/moe_grouped_gemm_nopad.py
@@ -9,7 +9,7 @@ from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.moe.moe_grouped_gemm_nopad import MoeGroupedGemmNopadKernel
 
 from ...compile_boundary import get_instance
-from ...op_base import Op
+from ...op_base import Op, tensor_core_roof
 from ._common import GroupedOperandEagerForward
 
 __all__ = ["MoeGroupedGemmNopadFwdOp"]
@@ -124,6 +124,10 @@ class MoeGroupedGemmNopadFwdOp(GroupedOperandEagerForward, Op):
             C: [numel, N] GEMM output.
         """
         return _moe_grouped_gemm_nopad_fwd(a, b, true_sizes, true_offsets, self._instance_key)
+
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)
 
 
 @torch.library.custom_op("tileops::moe_grouped_gemm_nopad_fwd", mutates_args=())

--- a/src/tileops/ops/moe/routed_expert/moe_grouped_gemm_nopad.py
+++ b/src/tileops/ops/moe/routed_expert/moe_grouped_gemm_nopad.py
@@ -7,9 +7,10 @@ import torch
 from tileops.kernels.grouped_gemm import GroupedGemmCall, GroupedGemmPersistent3WGKernel
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.moe.moe_grouped_gemm_nopad import MoeGroupedGemmNopadKernel
+from tileops.perf.profile import tensor_core_roof
 
 from ...compile_boundary import get_instance
-from ...op_base import Op, tensor_core_roof
+from ...op_base import Op
 from ._common import GroupedOperandEagerForward
 
 __all__ = ["MoeGroupedGemmNopadFwdOp"]

--- a/src/tileops/ops/op_base.py
+++ b/src/tileops/ops/op_base.py
@@ -35,42 +35,6 @@ _EMPTY_STATIC_DIMS_WARNED: set = set()
 
 _Entry = TypeVar("_Entry")
 
-# GPU-profile dtype keys (src/tileops/perf/profiles/) for the tensor-core
-# section, by the dtype the contraction consumes. fp32 maps to tf32 because
-# that is the unit an fp32 contraction runs on when tensor cores serve it.
-_TENSOR_CORE_DTYPE_KEYS: dict[str, str] = {
-    "float16": "fp16",
-    "bfloat16": "bf16",
-    "float32": "tf32",
-    "float8_e4m3fn": "fp8",
-    "float8_e5m2": "fp8",
-}
-
-
-def tensor_core_roof(dtype: Union[torch.dtype, str, None]) -> str:
-    """Tensor-core roof key for a contraction computing at *dtype*.
-
-    Args:
-        dtype: The dtype the matmul consumes — a ``torch.dtype`` or its
-            string name. Ops that retain the dtype as either form pass
-            ``self.dtype`` directly.
-
-    Returns:
-        A GPU-profile key such as ``"tensor_core.bf16"``.
-
-    Raises:
-        ValueError: If *dtype* has no tensor-core section in the profile
-            schema (including ``None`` — the op has not bound a dtype yet).
-    """
-    name = str(dtype).removeprefix("torch.") if dtype is not None else None
-    key = _TENSOR_CORE_DTYPE_KEYS.get(name) if name is not None else None
-    if key is None:
-        raise ValueError(
-            f"no tensor-core roof for dtype {dtype!r}; known dtypes: "
-            f"{sorted(_TENSOR_CORE_DTYPE_KEYS)}"
-        )
-    return f"tensor_core.{key}"
-
 
 class _Unresolved:
     """The type of :data:`_UNRESOLVED`, so a traceback says what it is."""

--- a/src/tileops/ops/op_base.py
+++ b/src/tileops/ops/op_base.py
@@ -35,6 +35,42 @@ _EMPTY_STATIC_DIMS_WARNED: set = set()
 
 _Entry = TypeVar("_Entry")
 
+# GPU-profile dtype keys (src/tileops/perf/profiles/) for the tensor-core
+# section, by the dtype the contraction consumes. fp32 maps to tf32 because
+# that is the unit an fp32 contraction runs on when tensor cores serve it.
+_TENSOR_CORE_DTYPE_KEYS: dict[str, str] = {
+    "float16": "fp16",
+    "bfloat16": "bf16",
+    "float32": "tf32",
+    "float8_e4m3fn": "fp8",
+    "float8_e5m2": "fp8",
+}
+
+
+def tensor_core_roof(dtype: Union[torch.dtype, str, None]) -> str:
+    """Tensor-core roof key for a contraction computing at *dtype*.
+
+    Args:
+        dtype: The dtype the matmul consumes — a ``torch.dtype`` or its
+            string name. Ops that retain the dtype as either form pass
+            ``self.dtype`` directly.
+
+    Returns:
+        A GPU-profile key such as ``"tensor_core.bf16"``.
+
+    Raises:
+        ValueError: If *dtype* has no tensor-core section in the profile
+            schema (including ``None`` — the op has not bound a dtype yet).
+    """
+    name = str(dtype).removeprefix("torch.") if dtype is not None else None
+    key = _TENSOR_CORE_DTYPE_KEYS.get(name) if name is not None else None
+    if key is None:
+        raise ValueError(
+            f"no tensor-core roof for dtype {dtype!r}; known dtypes: "
+            f"{sorted(_TENSOR_CORE_DTYPE_KEYS)}"
+        )
+    return f"tensor_core.{key}"
+
 
 class _Unresolved:
     """The type of :data:`_UNRESOLVED`, so a traceback says what it is."""
@@ -194,6 +230,23 @@ class Op(ABC):
             "intentionally does not provide a generic evaluator — see "
             "docs/design/roofline.md §4.4.6 (Evaluator Surface Boundary)"
         )
+
+    def compute_roof(self) -> str:
+        """GPU-profile key of the compute unit that prices this op's FLOPs.
+
+        ``eval_roofline()`` counts the work; ``compute_roof()`` names the
+        peak that bounds it (docs/design/roofline.md §1.2). The key is a
+        statement about the *optimal* implementation, declared by the op
+        author — never inferred from the running kernel, so a kernel on the
+        wrong unit is still measured against the right ceiling.
+
+        The base default covers ops whose arithmetic runs on CUDA cores in
+        fp32 (elementwise, reductions, norms, scans). An op whose FLOPs are
+        matmul contractions overrides this with ``tensor_core_roof(self.dtype)``
+        (or a backend-specific key). Valid whenever ``eval_roofline()`` is —
+        after the dtype is bound.
+        """
+        return "cuda_core.fp32"
 
     def _install_kernel_map(self, candidate_map: Optional[dict[str, Kernel]] = None) -> None:
         """Install the resolved kernel map onto ``self.kernel_map``.

--- a/src/tileops/ops/sequence_modeling/mhc.py
+++ b/src/tileops/ops/sequence_modeling/mhc.py
@@ -5,8 +5,9 @@ import torch
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.mhc import MHCPostKernel, MHCPreKernel
+from tileops.perf.profile import tensor_core_roof
 
-from ..op_base import Op, tensor_core_roof
+from ..op_base import Op
 
 __all__ = ["MHCPostFwdOp", "MHCPreFwdOp"]
 

--- a/src/tileops/ops/sequence_modeling/mhc.py
+++ b/src/tileops/ops/sequence_modeling/mhc.py
@@ -6,7 +6,7 @@ import torch
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.mhc import MHCPostKernel, MHCPreKernel
 
-from ..op_base import Op
+from ..op_base import Op, tensor_core_roof
 
 __all__ = ["MHCPostFwdOp", "MHCPreFwdOp"]
 
@@ -120,6 +120,10 @@ class MHCPreFwdOp(Op):
         return self.kernel(
             phi, x, b, alpha_pre, alpha_post, alpha_res, sinkhorn_repeat, sinkhorn_eps
         )
+
+    def compute_roof(self) -> str:
+        """FLOPs are matmul contractions; priced on tensor cores."""
+        return tensor_core_roof(self.dtype)
 
 
 class MHCPostFwdOp(Op):

--- a/src/tileops/perf/__init__.py
+++ b/src/tileops/perf/__init__.py
@@ -1,5 +1,5 @@
 """Performance evaluation — roofline analysis and GPU hardware profiles."""
 
-from .profile import get_profile_path, load_profile
+from .profile import find_profile, get_profile_path, load_profile, resolve_roof
 
-__all__ = ["get_profile_path", "load_profile"]
+__all__ = ["find_profile", "get_profile_path", "load_profile", "resolve_roof"]

--- a/src/tileops/perf/__init__.py
+++ b/src/tileops/perf/__init__.py
@@ -1,5 +1,17 @@
 """Performance evaluation — roofline analysis and GPU hardware profiles."""
 
-from .profile import find_profile, get_profile_path, load_profile, resolve_roof
+from .profile import (
+    find_profile,
+    get_profile_path,
+    load_profile,
+    resolve_roof,
+    tensor_core_roof,
+)
 
-__all__ = ["find_profile", "get_profile_path", "load_profile", "resolve_roof"]
+__all__ = [
+    "find_profile",
+    "get_profile_path",
+    "load_profile",
+    "resolve_roof",
+    "tensor_core_roof",
+]

--- a/src/tileops/perf/profile.py
+++ b/src/tileops/perf/profile.py
@@ -69,6 +69,42 @@ def _inject_effective(profile):
             section["effective"] = section["theoretical"] * section["calibration"]
 
 
+# Tensor-core dtype keys, by the dtype the contraction consumes. fp32 maps to
+# tf32 because that is the unit an fp32 contraction runs on when tensor cores
+# serve it. Encode side of the roof-key format; ``resolve_roof`` is the decode.
+_TENSOR_CORE_DTYPE_KEYS = {
+    "float16": "fp16",
+    "bfloat16": "bf16",
+    "float32": "tf32",
+    "float8_e4m3fn": "fp8",
+    "float8_e5m2": "fp8",
+}
+
+
+def tensor_core_roof(dtype) -> str:
+    """Tensor-core roof key for a contraction computing at *dtype*.
+
+    Args:
+        dtype: The dtype the matmul consumes — a ``torch.dtype`` or its
+            string name. Ops pass ``self.dtype`` directly.
+
+    Returns:
+        A GPU-profile key such as ``"tensor_core.bf16"``.
+
+    Raises:
+        ValueError: If *dtype* has no tensor-core section in the profile
+            schema (including ``None`` — the op has not bound a dtype yet).
+    """
+    name = str(dtype).removeprefix("torch.") if dtype is not None else None
+    key = _TENSOR_CORE_DTYPE_KEYS.get(name) if name is not None else None
+    if key is None:
+        raise ValueError(
+            f"no tensor-core roof for dtype {dtype!r}; known dtypes: "
+            f"{sorted(_TENSOR_CORE_DTYPE_KEYS)}"
+        )
+    return f"tensor_core.{key}"
+
+
 def find_profile(device_name: str) -> dict | None:
     """Load the profile whose ``gpu`` field names *device_name*, or ``None``.
 

--- a/src/tileops/perf/profile.py
+++ b/src/tileops/perf/profile.py
@@ -69,6 +69,43 @@ def _inject_effective(profile):
             section["effective"] = section["theoretical"] * section["calibration"]
 
 
+def find_profile(device_name: str) -> dict | None:
+    """Load the profile whose ``gpu`` field names *device_name*, or ``None``.
+
+    Args:
+        device_name: The device name as CUDA reports it
+            (``torch.cuda.get_device_name()``), e.g. ``"NVIDIA H200"``.
+
+    Returns:
+        The loaded profile dict, or ``None`` when no profile claims the
+        device — the caller leaves speed-of-light readings blank rather
+        than guessing a ceiling.
+    """
+    for path in _PROFILES_DIR.glob("*.yaml"):
+        profile = load_profile(path.stem)
+        if profile.get("gpu") == device_name:
+            return profile
+    return None
+
+
+def resolve_roof(profile: dict, key: str) -> dict | None:
+    """Resolve a roof key like ``"tensor_core.bf16"`` to its profile section.
+
+    Args:
+        profile: A dict from :func:`load_profile`.
+        key: ``"<unit>.<dtype>"`` as declared by ``Op.compute_roof()``.
+
+    Returns:
+        The section dict (with ``theoretical`` / ``effective``), or ``None``
+        when the profile has no calibrated entry for the key.
+    """
+    unit, _, dt = key.partition(".")
+    section = (profile.get(unit) or {}).get(dt)
+    if isinstance(section, dict) and "effective" in section and "theoretical" in section:
+        return section
+    return None
+
+
 def load_profile(gpu_name: str) -> dict:
     """Load a GPU profile as a dict.
 

--- a/tests/test_compute_roof.py
+++ b/tests/test_compute_roof.py
@@ -1,0 +1,69 @@
+"""Contract tests for ``Op.compute_roof`` (docs/design/roofline.md §1.4)."""
+
+import pytest
+import torch
+
+from tileops.ops.op_base import tensor_core_roof
+
+pytestmark = pytest.mark.smoke
+
+
+class TestTensorCoreRoof:
+    def test_maps_torch_dtypes_to_profile_keys(self):
+        assert tensor_core_roof(torch.float16) == "tensor_core.fp16"
+        assert tensor_core_roof(torch.bfloat16) == "tensor_core.bf16"
+        assert tensor_core_roof(torch.float32) == "tensor_core.tf32"
+        assert tensor_core_roof(torch.float8_e4m3fn) == "tensor_core.fp8"
+        assert tensor_core_roof(torch.float8_e5m2) == "tensor_core.fp8"
+
+    def test_accepts_string_dtype_names(self):
+        assert tensor_core_roof("bfloat16") == "tensor_core.bf16"
+
+    def test_unbound_or_unknown_dtype_raises(self):
+        with pytest.raises(ValueError, match="no tensor-core roof"):
+            tensor_core_roof(None)
+        with pytest.raises(ValueError, match="no tensor-core roof"):
+            tensor_core_roof(torch.int32)
+
+
+class TestComputeRoofContract:
+    # __new__ bypasses kernel construction so the smoke stays CUDA-free;
+    # only the state each override reads is bound.
+
+    def test_base_default_is_cuda_core_fp32(self):
+        from tileops.ops.elementwise.arithmetic import AddFwdOp
+
+        op = AddFwdOp.__new__(AddFwdOp)
+        assert op.compute_roof() == "cuda_core.fp32"
+
+    def test_matmul_op_prices_on_the_bound_dtype(self):
+        from tileops.ops.gemm.gemm import GemmFwdOp
+
+        op = GemmFwdOp.__new__(GemmFwdOp)
+        op.dtype = torch.bfloat16
+        assert op.compute_roof() == "tensor_core.bf16"
+
+    def test_fp8_gemm_follows_its_fp8_input_dtype(self):
+        from tileops.ops.gemm.gemm import GemmFp8FwdOp
+
+        op = GemmFp8FwdOp.__new__(GemmFp8FwdOp)
+        op.dtype = torch.float8_e4m3fn
+        assert op.compute_roof() == "tensor_core.fp8"
+
+    def test_gqa_prefill_fp8_backend_overrides_the_io_dtype(self):
+        from tileops.ops.attention.gqa import GroupedQueryAttentionPrefillFwdOp
+
+        op = GroupedQueryAttentionPrefillFwdOp.__new__(GroupedQueryAttentionPrefillFwdOp)
+        op.dtype = torch.float16
+        op.backend = "fp8"
+        assert op.compute_roof() == "tensor_core.fp8"
+        op.backend = "dense"
+        assert op.compute_roof() == "tensor_core.fp16"
+
+    def test_before_the_dtype_binds_the_declaration_raises(self):
+        from tileops.ops.gemm.gemm import GemmFwdOp
+
+        op = GemmFwdOp.__new__(GemmFwdOp)
+        op.dtype = None
+        with pytest.raises(ValueError, match="no tensor-core roof"):
+            op.compute_roof()

--- a/tests/test_compute_roof.py
+++ b/tests/test_compute_roof.py
@@ -3,7 +3,7 @@
 import pytest
 import torch
 
-from tileops.ops.op_base import tensor_core_roof
+from tileops.perf.profile import tensor_core_roof
 
 pytestmark = pytest.mark.smoke
 
@@ -15,9 +15,6 @@ class TestTensorCoreRoof:
         assert tensor_core_roof(torch.float32) == "tensor_core.tf32"
         assert tensor_core_roof(torch.float8_e4m3fn) == "tensor_core.fp8"
         assert tensor_core_roof(torch.float8_e5m2) == "tensor_core.fp8"
-
-    def test_accepts_string_dtype_names(self):
-        assert tensor_core_roof("bfloat16") == "tensor_core.bf16"
 
     def test_unbound_or_unknown_dtype_raises(self):
         with pytest.raises(ValueError, match="no tensor-core roof"):
@@ -43,14 +40,7 @@ class TestComputeRoofContract:
         op.dtype = torch.bfloat16
         assert op.compute_roof() == "tensor_core.bf16"
 
-    def test_fp8_gemm_follows_its_fp8_input_dtype(self):
-        from tileops.ops.gemm.gemm import GemmFp8FwdOp
-
-        op = GemmFp8FwdOp.__new__(GemmFp8FwdOp)
-        op.dtype = torch.float8_e4m3fn
-        assert op.compute_roof() == "tensor_core.fp8"
-
-    def test_gqa_prefill_fp8_backend_overrides_the_io_dtype(self):
+    def test_gqa_prefill_prices_the_call_that_ran(self):
         from tileops.ops.attention.gqa import GroupedQueryAttentionPrefillFwdOp
 
         op = GroupedQueryAttentionPrefillFwdOp.__new__(GroupedQueryAttentionPrefillFwdOp)
@@ -59,11 +49,8 @@ class TestComputeRoofContract:
         assert op.compute_roof() == "tensor_core.fp8"
         op.backend = "dense"
         assert op.compute_roof() == "tensor_core.fp16"
-
-    def test_before_the_dtype_binds_the_declaration_raises(self):
-        from tileops.ops.gemm.gemm import GemmFwdOp
-
-        op = GemmFwdOp.__new__(GemmFwdOp)
-        op.dtype = None
-        with pytest.raises(ValueError, match="no tensor-core roof"):
-            op.compute_roof()
+        # backend="auto" dispatches by the tensors the call passed, so the
+        # recorded call dtype outranks the constructed one.
+        op.backend = "auto"
+        op._roofline_kwargs = {"dtype": torch.float8_e4m3fn}
+        assert op.compute_roof() == "tensor_core.fp8"

--- a/tests/test_nightly_report.py
+++ b/tests/test_nightly_report.py
@@ -152,3 +152,100 @@ def test_history_entry_records_the_percentiles(report):
     tileops = entry["ops"][_OP][_CONFIG]["tileops"]
     assert tileops["device_busy_p10_ms"] == 0.0099
     assert tileops["device_busy_p90_ms"] == 0.0101
+
+
+# ---------------------------------------------------------------------------
+# Speed-of-Light (M5)
+# ---------------------------------------------------------------------------
+
+# A fixed synthetic profile keeps the expected efficiencies exact; the real
+# h200.yaml numbers are calibration data, not arithmetic under test.
+_PROFILE = {
+    "gpu": "TestGPU",
+    "hbm": {"theoretical": 5e12, "effective": 4e12},
+    "cuda_core": {"fp32": {"theoretical": 6e13, "effective": 5e13}},
+    "tensor_core": {"bf16": {"theoretical": 1e15, "effective": 7e14}},
+}
+
+
+def _sol_row(**overrides):
+    row = {
+        "name": _CONFIG,
+        "tileops_flops": 2e9,
+        "tileops_bytes": 4e9,  # 1 ms at effective HBM
+        "tileops_device_busy_ms": 1.0,
+        "tileops_compute_roof": "cuda_core.fp32",
+        "tileops_timing": "cupti",
+    }
+    row.update(overrides)
+    return row
+
+
+def test_sol_efficiency_is_one_at_the_effective_ceiling(report):
+    sol = report._compute_sol(_sol_row(), _PROFILE)
+    assert sol["bound"] == "memory"
+    assert sol["efficiency"] == pytest.approx(1.0)
+    assert not sol["impossible"] and not sol["latency_bound"]
+
+
+def test_sol_compute_bound_uses_the_declared_roof(report):
+    # 7e11 FLOPs on the bf16 tensor-core roof: sol_time = 1 ms; measured 2 ms.
+    sol = report._compute_sol(
+        _sol_row(
+            tileops_flops=7e11,
+            tileops_bytes=1e6,
+            tileops_device_busy_ms=2.0,
+            tileops_compute_roof="tensor_core.bf16",
+        ),
+        _PROFILE,
+    )
+    assert sol["bound"] == "compute"
+    assert sol["efficiency"] == pytest.approx(0.5)
+
+
+def test_sol_rate_above_theoretical_is_impossible_not_fast(report):
+    sol = report._compute_sol(_sol_row(tileops_device_busy_ms=0.5), _PROFILE)
+    assert sol["impossible"] == ["bytes/s over HBM theoretical"]
+
+
+def test_sol_uncounted_copies_enter_the_denominator(report):
+    sol = report._compute_sol(_sol_row(tileops_uncounted_copy_ms=1.0), _PROFILE)
+    assert sol["efficiency"] == pytest.approx(0.5)
+
+
+def test_sol_skips_rows_the_model_cannot_judge(report):
+    assert report._compute_sol(_sol_row(tileops_timing="cuda-events"), _PROFILE) is None
+    no_timing = _sol_row()
+    del no_timing["tileops_timing"]
+    assert report._compute_sol(no_timing, _PROFILE) is None
+    assert report._compute_sol(_sol_row(tileops_bytes=0), _PROFILE) is None
+    assert report._compute_sol(_sol_row(tileops_compute_roof="tensor_core.fp8"), _PROFILE) is None
+
+
+def test_sol_latency_bound_needs_both_floors(report):
+    tiny = _sol_row(tileops_flops=1e3, tileops_bytes=1e3, tileops_device_busy_ms=0.004)
+    assert report._compute_sol(tiny, _PROFILE)["latency_bound"]
+    # A tiny lower bound with a large measured time is a slow kernel, not noise.
+    slow = _sol_row(tileops_flops=1e3, tileops_bytes=1e3, tileops_device_busy_ms=0.5)
+    assert not report._compute_sol(slow, _PROFILE)["latency_bound"]
+
+
+def test_annotate_sol_reports_anomalies_and_tags_rows(report):
+    bench_ops = {
+        _OP: {
+            "module": "m",
+            "configs": [_sol_row(), _sol_row(name="impossible", tileops_device_busy_ms=0.5)],
+        }
+    }
+    anomalies = report.annotate_sol(bench_ops, _PROFILE)
+    assert [a["level"] for a in anomalies] == ["FAIL"]
+    assert bench_ops[_OP]["configs"][0]["sol"]["efficiency"] == pytest.approx(1.0)
+
+
+def test_history_entry_records_the_sol_reading(report):
+    bench_ops = {_OP: {"module": "m", "configs": [_sol_row()]}}
+    report.annotate_sol(bench_ops, _PROFILE)
+    entry = report.build_history_entry(bench_ops)
+    tileops = entry["ops"][_OP][_CONFIG]["tileops"]
+    assert tileops["compute_roof"] == "cuda_core.fp32"
+    assert tileops["sol"] == {"efficiency": 1.0, "bound": "memory", "latency_bound": False}

--- a/tests/test_roofline_oracle.py
+++ b/tests/test_roofline_oracle.py
@@ -118,3 +118,286 @@ class TestBytesOracle:
             ((m, n), torch.float16),
         )
         assert op.eval_roofline()[1] == oracle
+
+    def test_w4a16_counts_packed_weights_and_group_metadata(self):
+        from tileops.ops.gemm.gemm import GemmW4A16FwdOp
+
+        m, n, k, group_size = 4096, 8192, 8192, 128
+        op = GemmW4A16FwdOp.__new__(GemmW4A16FwdOp)
+        op.m, op.n, op.k = m, n, k
+        op.dtype = torch.float16
+        op.group_size = group_size
+        groups = k // group_size
+        oracle = (
+            _nbytes(((m, k), torch.float16), ((m, n), torch.float16))
+            + n * k // 2  # int4 weights: two per byte
+            + n * groups * 4  # per-group scales, float32
+            + n * groups * 1  # per-group zero points, int8
+        )
+        assert op.eval_roofline()[1] == oracle
+
+    def test_fused_moe_counts_the_bias_the_call_passed(self):
+        from tileops.ops.moe.fused_moe import FusedMoeFwdOp
+
+        tokens, experts, top_k, hidden, ffn = 4096, 64, 8, 4096, 1408
+        for has_bias in (True, False):
+            op = FusedMoeFwdOp.__new__(FusedMoeFwdOp)
+            op.num_tokens, op.num_experts, op.top_k = tokens, experts, top_k
+            op.hidden_size, op.ffn_size = hidden, ffn
+            op.dtype = torch.bfloat16
+            op.correction_bias_shape = (experts,) if has_bias else None
+            oracle = _nbytes(
+                ((tokens, hidden), torch.bfloat16),  # hidden states in
+                ((experts, 2 * ffn, hidden), torch.bfloat16),  # w_gate_up
+                ((experts, hidden, ffn), torch.bfloat16),  # w_down
+                ((tokens, experts), torch.float32),  # gating logits
+                ((tokens, hidden), torch.bfloat16),  # output
+                *((((experts,), torch.float32),) if has_bias else ()),
+            )
+            assert op.eval_roofline()[1] == oracle, f"has_bias={has_bias}"
+
+    def test_gqa_varlen_prefill_counts_packed_qkv_and_cu_seqlens(self):
+        from tileops.ops.attention.gqa import GroupedQueryAttentionPrefillFwdOp
+
+        heads, heads_kv, dim = 32, 8, 128
+        q_lens, kv_lens = [512, 1024], [2048, 4096]
+        total_q, total_kv = sum(q_lens), sum(kv_lens)
+        cu = lambda lens: torch.tensor([0, *torch.tensor(lens).cumsum(0).tolist()])  # noqa: E731
+        op = GroupedQueryAttentionPrefillFwdOp.__new__(GroupedQueryAttentionPrefillFwdOp)
+        op._roofline_kwargs = {
+            "q_shape": (total_q, heads, dim),
+            "k_shape": (total_kv, heads_kv, dim),
+            "batch": 2,
+            "max_seqlen_q": max(q_lens),
+            "max_seqlen_kv": max(kv_lens),
+            "cu_seqlens_q": cu(q_lens),
+            "cu_seqlens_kv": cu(kv_lens),
+            "is_causal": True,
+            "dtype": torch.float16,
+        }
+        oracle = _nbytes(
+            ((total_q, heads, dim), torch.float16),  # q
+            ((total_kv, heads_kv, dim), torch.float16),  # k
+            ((total_kv, heads_kv, dim), torch.float16),  # v
+            ((total_q, heads, dim), torch.float16),  # o
+            ((2, 3), torch.int32),  # cu_seqlens_q + cu_seqlens_kv, [batch+1] each
+        )
+        assert op.eval_roofline()[1] == oracle
+
+
+# Classification registry: every implemented op appears in exactly one of
+# AUDITED (has a bytes-oracle case above), EXEMPT (traffic depends on tensor
+# content; audited by the NCU script instead, roofline.md §4.5), or PENDING.
+# Adding an op to the manifest forces a choice here.
+AUDITED = frozenset(
+    {
+        "AddFwdOp",
+        "ArgmaxFwdOp",
+        "Conv2dFwdOp",
+        "FusedMoeFwdOp",
+        "GemmFp8FwdOp",
+        "GemmW4A16FwdOp",
+        "GroupedQueryAttentionPrefillFwdOp",
+        "RMSNormFwdOp",
+        "VarMeanFwdOp",
+    }
+)
+
+# op name -> why the shape-level oracle cannot count its traffic
+EXEMPT: dict[str, str] = {}
+
+# FIXME(staged-rollout): most implemented ops lack a bytes-oracle case.
+#
+# Broken invariant: every implemented op is AUDITED or EXEMPT.
+# Why: the oracle landed with the SOL metric; cases are added family by
+#   family, highest formula complexity first.
+# Cleanup: PENDING is empty; delete it and this marker.
+PENDING = frozenset(
+    {
+        "AbsFwdOp",
+        "AdaLayerNormFwdOp",
+        "AdaLayerNormZeroFwdOp",
+        "AdaptiveAvgPool2dFwdOp",
+        "AdaptiveMaxPool2dFwdOp",
+        "AdaptiveMaxPool2dIndicesFwdOp",
+        "AlibiFwdOp",
+        "AllFwdOp",
+        "AmaxFwdOp",
+        "AminFwdOp",
+        "AnyFwdOp",
+        "ArgminFwdOp",
+        "AvgPool1dFwdOp",
+        "AvgPool2dFwdOp",
+        "AvgPool3dFwdOp",
+        "BatchNormBwdOp",
+        "BatchNormFwdOp",
+        "BitwiseAndFwdOp",
+        "BitwiseNotFwdOp",
+        "BitwiseOrFwdOp",
+        "BitwiseXorFwdOp",
+        "BmmFp8KNFwdOp",
+        "BmmFp8NKFwdOp",
+        "BmmFwdOp",
+        "CBProducerFwdOp",
+        "CeilFwdOp",
+        "ClampFwdOp",
+        "ClampScalarFwdOp",
+        "Conv1dFwdOp",
+        "Conv3dFwdOp",
+        "CosFwdOp",
+        "CountNonzeroFwdOp",
+        "CumprodFwdOp",
+        "CumsumFwdOp",
+        "DaCumsumFwdOp",
+        "DeepSeekSparseAttentionDecodeWithKVCacheFwdOp",
+        "DeltaNetBwdOp",
+        "DeltaNetDecodeFwdOp",
+        "DeltaNetFwdOp",
+        "DivFwdOp",
+        "DropoutFwdOp",
+        "EluFwdOp",
+        "EngramDecodeFwdOp",
+        "EngramGateConvBwdOp",
+        "EngramGateConvFwdOp",
+        "EqFwdOp",
+        "ErfFwdOp",
+        "ExpFwdOp",
+        "Expm1FwdOp",
+        "FFTC2CFwdOp",
+        "FP8LightningIndexerFwdOp",
+        "FP8QuantFwdOp",
+        "FloorDivideFwdOp",
+        "FloorFwdOp",
+        "FusedAddLayerNormFwdOp",
+        "FusedAddRMSNormFwdOp",
+        "FusedMoEExpertsNopadPersistent3WGFwdOp",
+        "GLABwdOp",
+        "GLADecodeFwdOp",
+        "GLAFwdOp",
+        "GatedDeltaNetBHTDFwdOp",
+        "GatedDeltaNetBTHDFwdOp",
+        "GatedDeltaNetBwdOp",
+        "GatedDeltaNetDecodeFwdOp",
+        "GatedDeltaNetPrefillBHTDFwdOp",
+        "GatedDeltaNetPrefillBTHDFwdOp",
+        "GeFwdOp",
+        "GeluAndMulFwdOp",
+        "GeluFwdOp",
+        "GeluTanhAndMulFwdOp",
+        "GemmFwdOp",
+        "GroupNormFwdOp",
+        "GroupedGemmFwdOp",
+        "GroupedQueryAttentionBwdOp",
+        "GroupedQueryAttentionDecodePagedWithKVCacheFwdOp",
+        "GroupedQueryAttentionDecodeWithKVCacheFwdOp",
+        "GroupedQueryAttentionFwdOp",
+        "GroupedQueryAttentionPrefillPagedWithKVCacheFwdOp",
+        "GroupedQueryAttentionSlidingWindowFwdOp",
+        "GroupedQueryAttentionSlidingWindowVarlenFwdOp",
+        "GtFwdOp",
+        "HardsigmoidFwdOp",
+        "HardswishFwdOp",
+        "HardtanhFwdOp",
+        "InfNormFwdOp",
+        "InstanceNormFwdOp",
+        "IsfiniteFwdOp",
+        "IsinfFwdOp",
+        "IsnanFwdOp",
+        "L1NormFwdOp",
+        "L2NormFwdOp",
+        "LayerNormFwdOp",
+        "LeFwdOp",
+        "LeakyReluFwdOp",
+        "LerpFwdOp",
+        "LerpTensorFwdOp",
+        "Log1pFwdOp",
+        "LogFwdOp",
+        "LogSoftmaxFwdOp",
+        "LogSumExpFwdOp",
+        "LogicalAndFwdOp",
+        "LogicalNotFwdOp",
+        "LogicalOrFwdOp",
+        "LtFwdOp",
+        "MHCPostFwdOp",
+        "MHCPreFwdOp",
+        "Mamba2FwdOp",
+        "MaskedFillFwdOp",
+        "MaskedFillScalarFwdOp",
+        "MaxPool1dFwdOp",
+        "MaxPool1dIndicesFwdOp",
+        "MaxPool2dFwdOp",
+        "MaxPool2dIndicesFwdOp",
+        "MaxPool3dFwdOp",
+        "MaxPool3dIndicesFwdOp",
+        "MaximumFwdOp",
+        "MeanFwdOp",
+        "MinimumFwdOp",
+        "MishFwdOp",
+        "MoeGateUpFwdOp",
+        "MoeGroupedGemmNopadFwdOp",
+        "MoePermuteAlignFwdOp",
+        "MoePermuteNopadFwdOp",
+        "MoeUnpermuteFwdOp",
+        "MulFwdOp",
+        "MultiHeadAttentionBwdOp",
+        "MultiHeadAttentionDecodePagedWithKVCacheFwdOp",
+        "MultiHeadAttentionDecodeWithKVCacheFwdOp",
+        "MultiHeadAttentionFwdOp",
+        "MultiHeadLatentAttentionDecodeWithKVCacheFwdOp",
+        "NanToNumFwdOp",
+        "NeFwdOp",
+        "NegFwdOp",
+        "PowFwdOp",
+        "PreluFwdOp",
+        "ProdFwdOp",
+        "ReciprocalFwdOp",
+        "ReluFwdOp",
+        "RemainderFwdOp",
+        "RopeLlama31FwdOp",
+        "RopeLongRopeFwdOp",
+        "RopeNeoxFwdOp",
+        "RopeNeoxPositionIdsFwdOp",
+        "RopeNonNeoxFwdOp",
+        "RopeYarnFwdOp",
+        "RoundFwdOp",
+        "RsqrtFwdOp",
+        "SSDChunkScanFwdOp",
+        "SSDChunkStateFwdOp",
+        "SSDDecodeFwdOp",
+        "SSDStatePassingFwdOp",
+        "SeluFwdOp",
+        "SigmoidFwdOp",
+        "SignFwdOp",
+        "SiluAndMulFwdOp",
+        "SiluFwdOp",
+        "SinFwdOp",
+        "SinusoidalFwdOp",
+        "SoftmaxFwdOp",
+        "SoftplusFwdOp",
+        "SqrtFwdOp",
+        "StdFwdOp",
+        "SubFwdOp",
+        "SumFwdOp",
+        "TanhFwdOp",
+        "TopkSelectorFwdOp",
+        "TruncFwdOp",
+        "VarFwdOp",
+        "WhereFwdOp",
+    }
+)
+
+
+def test_every_implemented_op_is_classified():
+    """A new op cannot ship a bytes formula nothing accounts for."""
+    from tileops.manifest import load_manifest
+
+    implemented = {name for name, e in load_manifest().items() if e.get("status") == "implemented"}
+    classified = AUDITED | set(EXEMPT) | PENDING
+    assert implemented - classified == set(), (
+        f"unclassified implemented ops: {sorted(implemented - classified)}; "
+        "add an oracle case (AUDITED), an EXEMPT reason, or a PENDING entry"
+    )
+    assert classified - implemented == set(), (
+        f"stale registry entries: {sorted(classified - implemented)}"
+    )
+    assert not (AUDITED & PENDING) and not (AUDITED & set(EXEMPT))

--- a/tests/test_roofline_oracle.py
+++ b/tests/test_roofline_oracle.py
@@ -1,0 +1,120 @@
+"""Structural oracle for roofline ``bytes`` (docs/design/roofline.md §4.6).
+
+Each case recomputes the minimum traffic from the tensors the workload binds
+— every distinct input storage read once, every output written once — and
+requires equality with ``eval_roofline()``. The oracle enumerates tensors
+from the signature, so a formula that drops a term, double-counts a tensor,
+or prices a broadcast operand at the output's shape breaks the equality.
+"""
+
+from math import prod
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.smoke
+
+
+def _nbytes(*tensors: tuple[tuple[int, ...], torch.dtype]) -> int:
+    return sum(prod(shape) * dtype.itemsize for shape, dtype in tensors)
+
+
+class TestBytesOracle:
+    # __new__ + attribute binding keeps the oracle CUDA-free; each case binds
+    # exactly the state the op's eval_roofline reads after a forward().
+
+    def test_conv2d_counts_input_weight_output_and_bias(self):
+        from tileops.ops.convolution import Conv2dFwdOp
+
+        n, c_in, h, w = 8, 64, 56, 56
+        c_out, c_in_g, kh, kw = 128, 64, 3, 3
+        out_h = out_w = 54  # stride 1, no padding
+        for has_bias in (True, False):
+            op = Conv2dFwdOp.__new__(Conv2dFwdOp)
+            op._last_roofline_spec = (
+                n, c_in, h, w, c_out, c_in_g, kh, kw, out_h, out_w,
+                torch.float16, has_bias,
+            )  # fmt: skip
+            oracle = _nbytes(
+                ((n, c_in, h, w), torch.float16),
+                ((c_out, c_in_g, kh, kw), torch.float16),
+                ((n, c_out, out_h, out_w), torch.float16),
+                *((((c_out,), torch.float16),) if has_bias else ()),
+            )
+            assert op.eval_roofline()[1] == oracle, f"has_bias={has_bias}"
+
+    def test_gemm_fp8_counts_fp8_inputs_fp32_scales_and_out_dtype(self):
+        from tileops.ops.gemm.gemm import GemmFp8FwdOp
+
+        m, n, k = 4096, 4096, 8192
+        for has_bias in (True, False):
+            op = GemmFp8FwdOp.__new__(GemmFp8FwdOp)
+            op.m, op.n, op.k = m, n, k
+            op.dtype = torch.float8_e4m3fn
+            op.out_dtype = torch.bfloat16
+            op.scale_a_shape = (m, 1)
+            op.scale_b_shape = (1, n)
+            op.has_bias = has_bias
+            oracle = _nbytes(
+                ((m, k), torch.float8_e4m3fn),
+                ((k, n), torch.float8_e4m3fn),
+                ((m, n), torch.bfloat16),
+                ((m, 1), torch.float32),
+                ((1, n), torch.float32),
+                *((((n,), torch.bfloat16),) if has_bias else ()),
+            )
+            assert op.eval_roofline()[1] == oracle, f"has_bias={has_bias}"
+
+    def test_add_broadcast_counts_the_operand_at_its_own_shape(self):
+        from tileops.ops.elementwise.arithmetic import AddFwdOp
+
+        a_shape, b_shape, out_shape = (4, 4096, 4096), (1, 1, 4096), (4, 4096, 4096)
+        op = AddFwdOp.__new__(AddFwdOp)
+        op.input_shape = a_shape
+        op.other_shape = b_shape  # out_shape derives via _infer_output_shapes
+        op.dtype = torch.bfloat16
+        oracle = _nbytes(
+            (a_shape, torch.bfloat16),
+            (b_shape, torch.bfloat16),
+            (out_shape, torch.bfloat16),
+        )
+        assert op.eval_roofline()[1] == oracle
+
+    def test_var_mean_counts_both_outputs(self):
+        from tileops.ops.reduction.reduce import VarMeanFwdOp
+
+        m, n = 8192, 4096
+        op = VarMeanFwdOp.__new__(VarMeanFwdOp)
+        op._last_roofline_mn = (m, n)
+        op.dtype = torch.float32
+        oracle = _nbytes(
+            ((m, n), torch.float32),
+            ((m,), torch.float32),  # var
+            ((m,), torch.float32),  # mean
+        )
+        assert op.eval_roofline()[1] == oracle
+
+    def test_argmax_counts_int64_indices(self):
+        from tileops.ops.reduction.argreduce import ArgmaxFwdOp
+
+        m, n = 8192, 4096
+        op = ArgmaxFwdOp.__new__(ArgmaxFwdOp)
+        op._last_roofline_mn = (m, n)
+        op.dtype = torch.float16
+        oracle = _nbytes(((m, n), torch.float16), ((m,), torch.int64))
+        assert op.eval_roofline()[1] == oracle
+
+    def test_rms_norm_counts_x_weight_and_output(self):
+        from tileops.ops.norm.rms_norm import RMSNormFwdOp
+
+        m, n = 16384, 8192
+        op = RMSNormFwdOp.__new__(RMSNormFwdOp)
+        op._last_m = m
+        op.N = n
+        op.dtype = torch.float16
+        oracle = _nbytes(
+            ((m, n), torch.float16),
+            ((n,), torch.float16),
+            ((m, n), torch.float16),
+        )
+        assert op.eval_roofline()[1] == oracle


### PR DESCRIPTION
## Problems

- The nightly benchmark reports latency, throughput, and baseline ratios, but no absolute scale: a reader cannot tell whether a kernel has reached the achievable hardware ceiling or still leaves performance on the table.
- The inputs already exist — manifest roofline formulas, calibrated GPU profiles (`src/tileops/perf/profiles/`), CUPTI device-busy timing — but nothing combines them (the roofline.md §4.3 M5 tool was unimplemented).
- Nothing guards the roofline formulas themselves: a `bytes` formula that overestimates traffic inflates every efficiency reading, and neither review nor tests catch it.
- `FusedMoe` never bound `self.dtype`; its bytes formula fell through `_dtype_itemsize(None)` to a 2-byte guess, only coincidentally right for fp16/bf16.

## Changes

- `Op.compute_roof()` names the GPU-profile unit that prices the FLOPs `eval_roofline()` counts. Base default `cuda_core.fp32`; matmul-class ops declare `tensor_core_roof(self.dtype)`; the fp8-backend GQA prefill prices at fp8 whatever the io dtype, preferring the recorded call dtype under `backend="auto"`. Spec: roofline.md §1.4. Decode-recurrence ops (SSD/DeltaNet/GLA/GatedDeltaNet decode) keep the CUDA-core default: their formulas count per-element recurrence work a single-step matvec cannot feed to tensor cores.
- `tensor_core_roof` and its dtype table live in `tileops.perf.profile` beside `resolve_roof`: encode and decode of the roof-key format share one owner.
- The benchmark layer records the roof per row; `scripts/nightly_report.py` computes algorithmic SOL efficiency `max(bytes/BW, flops/roof) / device-busy` against the calibrated ceilings, renders a SOL column with memory/compute-bound and latency-bound labels, and writes the reading into perf history.
- Physics check: a row implying a rate above a *theoretical* ceiling is reported as a formula error and fails the run's health — the standing guard against formula overestimation; `efficiency > 105%` warns. Rows the model cannot judge (non-CUPTI timing, `bytes == 0`, no GPU profile) stay blank.
- `tests/test_roofline_oracle.py`: bytes formulas checked against tensor-size recomputation on golden workloads (conv bias branches, fp8-GEMM mixed dtypes and scales, W4A16 packed weights and group metadata, FusedMoe correction-bias branches, GQA varlen prefill via real cu_seqlens, broadcast operands, multi-output reductions, int64 index outputs). A completeness registry classifies every implemented op as AUDITED / EXEMPT / PENDING, so a new op cannot ship a bytes formula nothing accounts for; the 169-op PENDING list is the burn-down (#1989). Spec: roofline.md §4.6.
- `scripts/validate_roofline_bytes.py`: on-demand NCU audit summing `dram__bytes_read/write.sum` over one forward against `eval_roofline()` bytes (FAIL only on formula overestimation; exits non-zero on FAIL or ERROR). Spec: roofline.md §4.5. First full run and its CI job: #1990.
- `tileops.perf.profile` gains `find_profile` (match by device name) and `resolve_roof` (key → calibrated section).
- `FusedMoe.forward()` binds `self.dtype`, making its existing bytes formula exact for any dtype.
- Docs: roofline.md §1.2/§1.4/§4.2/§4.3/§4.5/§4.6 plus a reading pass; ops-design.md Step 6 notes the `compute_roof` contract; the dense GQA op's user-facing docstrings gain LaTeX math and full Args/Returns.

Test node delta: `tests/test_nightly_report.py` 15 → 23 (+8, one per M5 verdict branch). New files: `tests/test_compute_roof.py` (5), `tests/test_roofline_oracle.py` (10, incl. the completeness test).

Verified on H200: the report renders `✅ 92% M` for fp16 exp at 3.74 TB/s against the STREAM-calibrated 4.07 TB/s ceiling, matching by hand; a constructed impossible row renders `⚠️ 200% M` and flips the run health. Follow-ups: #1988 (flops oracle), #1989 (PENDING burn-down + NCU builders), #1990 (first full NCU audit + workflow_dispatch job). The rendering side of tile-ai/TileOPs.github.io consumes the new `sol` history fields after this lands.