### PR TITLE
[Perf][Reduction] Let measurement pick the split, and read edge-axis logsumexp in place

### DIFF
--- a/src/tileops/kernels/reduction/_primitives.py
+++ b/src/tileops/kernels/reduction/_primitives.py
@@ -95,7 +95,7 @@ def torch_dtype_nbytes(dtype: torch.dtype | str) -> int:
 _BUSY_TIMING_SPIN_CYCLES = 50_000_000
 
 
-def device_busy_of(call, device=None, warmup: int = 5, rep: int = 20) -> float:
+def device_busy_of(call, device: "torch.device", warmup: int = 5, rep: int = 20) -> float:
     """Mean device time of *call* in milliseconds with host gaps excluded.
 
     Judges paths that launch different kernel counts by their GPU work alone;
@@ -106,7 +106,7 @@ def device_busy_of(call, device=None, warmup: int = 5, rep: int = 20) -> float:
     owns the process's CUPTI subscription, and a second subscriber would break
     its kernel attribution for the rest of the process.
     """
-    with torch.cuda.device(device if device is not None else torch.cuda.current_device()):
+    with torch.cuda.device(device):
         for _ in range(warmup):
             call()
         torch.cuda.synchronize()

--- a/src/tileops/kernels/reduction/_primitives.py
+++ b/src/tileops/kernels/reduction/_primitives.py
@@ -38,6 +38,7 @@ __all__ = [
     "align_up",
     "ceildiv_int",
     "compute_tile_n",
+    "device_busy_of",
     "device_smem_budget",
     "edge_axis_plan",
     "edge_axis_split",
@@ -87,6 +88,37 @@ def torch_dtype_nbytes(dtype: torch.dtype | str) -> int:
     if isinstance(dtype, str):
         dtype = getattr(torch, dtype)
     return torch.empty(0, dtype=dtype).element_size()
+
+
+# Spin cycles queued before a device_busy_of measurement: tens of milliseconds
+# on any supported clock, ample to enqueue every timed call first.
+_BUSY_TIMING_SPIN_CYCLES = 50_000_000
+
+
+def device_busy_of(call, device=None, warmup: int = 5, rep: int = 20) -> float:
+    """Mean device time of *call* in milliseconds with host gaps excluded.
+
+    Judges paths that launch different kernel counts by their GPU work alone;
+    wall latency would charge a multi-launch path the host gaps between its
+    launches. A spin kernel holds the device while every timed call is
+    enqueued, so the queue then drains back to back and the event pair brackets
+    execution only. Deliberately not a profiler: the benchmark's own collector
+    owns the process's CUPTI subscription, and a second subscriber would break
+    its kernel attribution for the rest of the process.
+    """
+    with torch.cuda.device(device if device is not None else torch.cuda.current_device()):
+        for _ in range(warmup):
+            call()
+        torch.cuda.synchronize()
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        torch.cuda._sleep(_BUSY_TIMING_SPIN_CYCLES)
+        start.record()
+        for _ in range(rep):
+            call()
+        end.record()
+        torch.cuda.synchronize()
+        return start.elapsed_time(end) / rep
 
 
 def reduce_column_alignment(elem_bytes: int, threads: int) -> int:

--- a/src/tileops/kernels/reduction/_primitives.py
+++ b/src/tileops/kernels/reduction/_primitives.py
@@ -38,7 +38,6 @@ __all__ = [
     "align_up",
     "ceildiv_int",
     "compute_tile_n",
-    "device_busy_of",
     "device_smem_budget",
     "edge_axis_plan",
     "edge_axis_split",
@@ -88,37 +87,6 @@ def torch_dtype_nbytes(dtype: torch.dtype | str) -> int:
     if isinstance(dtype, str):
         dtype = getattr(torch, dtype)
     return torch.empty(0, dtype=dtype).element_size()
-
-
-# Spin cycles queued before a device_busy_of measurement: tens of milliseconds
-# on any supported clock, ample to enqueue every timed call first.
-_BUSY_TIMING_SPIN_CYCLES = 50_000_000
-
-
-def device_busy_of(call, device: "torch.device", warmup: int = 5, rep: int = 20) -> float:
-    """Mean device time of *call* in milliseconds with host gaps excluded.
-
-    Judges paths that launch different kernel counts by their GPU work alone;
-    wall latency would charge a multi-launch path the host gaps between its
-    launches. A spin kernel holds the device while every timed call is
-    enqueued, so the queue then drains back to back and the event pair brackets
-    execution only. Deliberately not a profiler: the benchmark's own collector
-    owns the process's CUPTI subscription, and a second subscriber would break
-    its kernel attribution for the rest of the process.
-    """
-    with torch.cuda.device(device):
-        for _ in range(warmup):
-            call()
-        torch.cuda.synchronize()
-        start = torch.cuda.Event(enable_timing=True)
-        end = torch.cuda.Event(enable_timing=True)
-        torch.cuda._sleep(_BUSY_TIMING_SPIN_CYCLES)
-        start.record()
-        for _ in range(rep):
-            call()
-        end.record()
-        torch.cuda.synchronize()
-        return start.elapsed_time(end) / rep
 
 
 def reduce_column_alignment(elem_bytes: int, threads: int) -> int:

--- a/src/tileops/kernels/reduction/_split_softmax.py
+++ b/src/tileops/kernels/reduction/_split_softmax.py
@@ -7,6 +7,7 @@ op's output stays in that op's module.
 """
 
 import functools
+from math import prod
 
 import tilelang
 import tilelang.language as T
@@ -21,6 +22,8 @@ from tileops.kernels.reduction._primitives import (
 )
 
 __all__ = [
+    "edge_split_partials_kernel",
+    "edge_split_view",
     "make_split_fold",
     "softmax_split_partials_kernel",
     "split_seg_n",
@@ -148,3 +151,64 @@ def make_split_fold(num_segs: int):
             )
 
     return fold
+
+
+def edge_split_view(
+    shape: "tuple[int, ...]", k: int, j: int, threads: int
+) -> "tuple[int, int, int] | None":
+    """The ``(outer, kept, inner)`` view an edge-axis split reads, or None.
+
+    An edge-axis reduction (a leading prefix of *k* axes plus a trailing
+    suffix of *j* axes) leaves each kept row as ``outer`` contiguous runs of
+    ``inner`` elements in the tensor's own layout, so the partials pass can
+    read it without the permute ``rows_for_axes`` would pay. Eligible when a
+    ``(1, inner)`` fragment builds (``threads`` divides ``inner``) and stays
+    in registers.
+    """
+    outer = prod(shape[:k])
+    inner = prod(shape[len(shape) - j :])
+    kept = prod(shape[k : len(shape) - j])
+    if inner % threads or inner > _SPLIT_MAX_SEG_COLS:
+        return None
+    return (outer, kept, inner)
+
+
+@functools.lru_cache(maxsize=32)
+def edge_split_partials_kernel(outer: int, kept: int, inner: int, dtype: str, threads: int):
+    """Per-run softmax statistics over an ``(outer, kept, inner)`` view.
+
+    One block owns one row's run ``x[s, m, :]`` and writes its fp32
+    ``(max, sum)`` pair at ``m * outer + s`` -- row-major by kept row, the
+    order ``make_split_fold`` reads. Semantics match
+    ``softmax_split_partials_kernel``: an all--inf run writes a zero sum.
+    """
+
+    @tilelang.jit(out_idx=[1, 2])
+    def _func():
+        @T.prim_func
+        def main(
+            x: T.Tensor[(outer, kept, inner), dtype],
+            seg_max: T.Tensor[(kept * outer,), "float32"],  # noqa: F821
+            seg_sum: T.Tensor[(kept * outer,), "float32"],  # noqa: F821
+        ):
+            with T.Kernel(outer, kept, threads=threads) as (pid_s, pid_m):
+                x_f32 = T.alloc_fragment((1, inner), "float32")
+                m_s = T.alloc_fragment((1,), "float32")
+                s_s = T.alloc_fragment((1,), "float32")
+
+                for _, i in T.Parallel(1, inner):
+                    x_f32[0, i] = T.cast(x[pid_s, pid_m, i], "float32")
+                T.fill(m_s, -T.infinity("float32"))
+                T.reduce_max(x_f32, m_s, dim=1, clear=False)
+                for _, i in T.Parallel(1, inner):
+                    x_f32[0, i] = T.exp(x_f32[0, i] - m_s[0])
+                T.reduce_sum(x_f32, s_s, dim=1)
+
+                seg_max[pid_m * outer + pid_s] = m_s[0]
+                seg_sum[pid_m * outer + pid_s] = T.if_then_else(
+                    m_s[0] == -T.infinity("float32"), T.cast(0.0, "float32"), s_s[0]
+                )
+
+        return main
+
+    return _func

--- a/src/tileops/kernels/reduction/logsumexp.py
+++ b/src/tileops/kernels/reduction/logsumexp.py
@@ -35,12 +35,16 @@ from tileops.kernels.reduction._primitives import (
     RowTiledAutotuneMixin,
     align_up,
     ceildiv_int,
+    device_busy_of,
     device_smem_budget,
+    edge_axis_split,
     restore_reduced,
     rows_for_axes,
     torch_dtype_nbytes,
 )
 from tileops.kernels.reduction._split_softmax import (
+    edge_split_partials_kernel,
+    edge_split_view,
     make_split_fold,
     softmax_split_partials_kernel,
     split_seg_n,
@@ -554,6 +558,13 @@ class LogSumExpKernel(RowTiledAutotuneMixin, Kernel):
                 )
             self.config["tile_n"] = self._tile_n
 
+        # A config from before the split choice was recorded falls back to
+        # the gate; a round-tripped tuned config keeps its recorded choice.
+        self.config.setdefault(
+            "split",
+            bool(split_seg_n(self.M, self.N, self.config["block_m"], self._split_target)),
+        )
+
     @property
     def default_config(self) -> dict:
         """Select default block_m based on shared memory budget.
@@ -589,7 +600,12 @@ class LogSumExpKernel(RowTiledAutotuneMixin, Kernel):
                     best_bm = bm
                     best_tile_n = tn
 
-        return {"block_m": best_bm, "threads": _DEFAULT_TUNE_THREADS, "tile_n": best_tile_n}
+        return {
+            "block_m": best_bm,
+            "threads": _DEFAULT_TUNE_THREADS,
+            "tile_n": best_tile_n,
+            "split": bool(split_seg_n(self.M, self.N, best_bm, self._split_target)),
+        }
 
     def autotune(self, warmup: int = 10, rep: int = 10) -> None:
         """Autotune across tile_n candidates by rebuilding the kernel per regime.
@@ -605,14 +621,12 @@ class LogSumExpKernel(RowTiledAutotuneMixin, Kernel):
             self.config = self.default_config
             return
 
-        # The split pair bypasses the tuned kernel, so the default config stands.
         default = self.default_config
-        if split_seg_n(self.M, self.N, default["block_m"], self._split_target):
-            self.config = default
-            return
+        split_eligible = bool(split_seg_n(self.M, self.N, default["block_m"], self._split_target))
 
         configs = self.autotune_configs
         if not configs:
+            self.config = default
             return
 
         # Group configs by tile_n
@@ -663,6 +677,23 @@ class LogSumExpKernel(RowTiledAutotuneMixin, Kernel):
                     self._tile_n,
                 )
 
+        # The split pair has nothing for the sweep to vary, so it is timed
+        # against the sweep's winner on device kernel time: paths launching
+        # different kernel counts are judged by GPU work, not host-launch gaps.
+        if split_eligible and best_config is not None:
+            device = torch.device(
+                "cuda",
+                self.device_index if self.device_index is not None else torch.cuda.current_device(),
+            )
+            probe = torch.randn(self.M, self.N, dtype=self.dtype, device=device)
+            swept_config = dict(self.config, split=False)
+            self.config = swept_config
+            swept_ms = device_busy_of(lambda: self._reduce_rows(probe), device)
+            self.config = default
+            split_ms = device_busy_of(lambda: self._reduce_rows(probe), device)
+            if split_ms > swept_ms:
+                self.config = swept_config
+
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Reduce *reduce_axes* of *x*.
 
@@ -679,8 +710,34 @@ class LogSumExpKernel(RowTiledAutotuneMixin, Kernel):
         """
         self._require_cuda(x=x)
         in_shape = tuple(x.shape)
-        y = self._reduce_rows(rows_for_axes(x, self.reduce_axes))
+        k, j = edge_axis_split(x.ndim, self.reduce_axes)
+        view = edge_split_view(in_shape, k, j, _DEFAULT_TUNE_THREADS) if k else None
+        if view is not None:
+            y = self._reduce_edge_axes(x, view)
+        else:
+            y = self._reduce_rows(rows_for_axes(x, self.reduce_axes))
         return restore_reduced(y, in_shape, self.reduce_axes, self.keepdim)
+
+    def _reduce_edge_axes(self, x: torch.Tensor, view: "tuple[int, int, int]") -> torch.Tensor:
+        """Reduce edge axes in the tensor's own layout.
+
+        Each kept row is ``outer`` contiguous runs of ``inner`` elements, so
+        the split pair reads them directly -- per-run ``(max, sum)`` partials,
+        then the per-row fold -- skipping the permute ``rows_for_axes`` pays.
+
+        A layout dispatch decided from the shape alone, like the vector-norm
+        edge path: the alternative pays the permute and then the same
+        reduction, so there is no trade for the tuner to referee.
+        ``config["split"]`` governs only the long-row split in
+        ``_reduce_rows``.
+        """
+        outer, kept, inner = view
+        seg_max, seg_sum = edge_split_partials_kernel(
+            outer, kept, inner, self.dtype_str, _DEFAULT_TUNE_THREADS
+        )()(x.reshape(view))
+        return _logsumexp_split_fold_kernel(kept, outer * inner, self.dtype_str, inner)()(
+            seg_max, seg_sum
+        )
 
     def _reduce_rows(self, x: torch.Tensor) -> torch.Tensor:
         """Reduce the trailing axis of an ``(M, N)`` buffer.
@@ -691,7 +748,11 @@ class LogSumExpKernel(RowTiledAutotuneMixin, Kernel):
         """
         if self._streaming:
             return self.kernel()(x)
-        seg_n = split_seg_n(self.M, self.N, self.config["block_m"], self._split_target)
+        seg_n = (
+            split_seg_n(self.M, self.N, self.config["block_m"], self._split_target)
+            if self.config["split"]
+            else 0
+        )
         if seg_n:
             # split_seg_n's fragment cap assumes the default width.
             threads = _DEFAULT_TUNE_THREADS

--- a/src/tileops/kernels/reduction/logsumexp.py
+++ b/src/tileops/kernels/reduction/logsumexp.py
@@ -35,7 +35,6 @@ from tileops.kernels.reduction._primitives import (
     RowTiledAutotuneMixin,
     align_up,
     ceildiv_int,
-    device_busy_of,
     device_smem_budget,
     edge_axis_split,
     restore_reduced,
@@ -50,7 +49,7 @@ from tileops.kernels.reduction._split_softmax import (
     split_seg_n,
     split_target_blocks,
 )
-from tileops.utils import WARP_LANES
+from tileops.utils import WARP_LANES, device_busy_of
 
 # These two kernels bake tile_n in at build time and default to the wider
 # thread block; AUTOTUNE_THREADS still bounds what the sweep explores.

--- a/src/tileops/kernels/reduction/softmax.py
+++ b/src/tileops/kernels/reduction/softmax.py
@@ -30,6 +30,7 @@ from tileops.kernels.reduction._primitives import (
     RowTiledAutotuneMixin,
     align_up,
     ceildiv_int,
+    device_busy_of,
     device_smem_budget,
     restore_same_shape,
     rows_for_axes,
@@ -633,6 +634,13 @@ class SoftmaxKernel(RowTiledAutotuneMixin, Kernel):
                 )
             self.config["tile_n"] = self._tile_n
 
+        # A config from before the split choice was recorded falls back to
+        # the gate; a round-tripped tuned config keeps its recorded choice.
+        self.config.setdefault(
+            "split",
+            bool(split_seg_n(self.M, self.N, self.config["block_m"], self._split_target)),
+        )
+
     # Tiled softmax/log_softmax allocates 2 shared buffers (one per pass)
     # due to TileLang allocator aliasing -- see _softmax_kernel_tiled docstring.
     _NUM_SHARED_BUFFERS = 2
@@ -686,7 +694,12 @@ class SoftmaxKernel(RowTiledAutotuneMixin, Kernel):
                     best_bm = bm
                     best_tile_n = tn
 
-        return {"block_m": best_bm, "threads": _DEFAULT_TUNE_THREADS, "tile_n": best_tile_n}
+        return {
+            "block_m": best_bm,
+            "threads": _DEFAULT_TUNE_THREADS,
+            "tile_n": best_tile_n,
+            "split": bool(split_seg_n(self.M, self.N, best_bm, self._split_target)),
+        }
 
     def autotune(self, warmup: int = 10, rep: int = 10) -> None:
         """Autotune across tile_n candidates by rebuilding the kernel per regime.
@@ -696,14 +709,12 @@ class SoftmaxKernel(RowTiledAutotuneMixin, Kernel):
         """
         from tilelang.autotuner import autotune as tl_autotune
 
-        # The split pair bypasses the tuned kernel, so the default config stands.
         default = self.default_config
-        if split_seg_n(self.M, self.N, default["block_m"], self._split_target):
-            self.config = default
-            return
+        split_eligible = bool(split_seg_n(self.M, self.N, default["block_m"], self._split_target))
 
         configs = self.autotune_configs
         if not configs:
+            self.config = default
             return
 
         # Group configs by tile_n
@@ -756,6 +767,23 @@ class SoftmaxKernel(RowTiledAutotuneMixin, Kernel):
                     self._tile_n,
                 )
 
+        # The split pair has nothing for the sweep to vary, so it is timed
+        # against the sweep's winner on device kernel time: paths launching
+        # different kernel counts are judged by GPU work, not host-launch gaps.
+        if split_eligible and best_config is not None:
+            device = torch.device(
+                "cuda",
+                self.device_index if self.device_index is not None else torch.cuda.current_device(),
+            )
+            probe = torch.randn(self.M, self.N, dtype=self.dtype, device=device)
+            swept_config = dict(self.config, split=False)
+            self.config = swept_config
+            swept_ms = device_busy_of(lambda: self._normalize_rows(probe), device)
+            self.config = default
+            split_ms = device_busy_of(lambda: self._normalize_rows(probe), device)
+            if split_ms > swept_ms:
+                self.config = swept_config
+
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Normalize *x* over *norm_axis*.
 
@@ -783,7 +811,11 @@ class SoftmaxKernel(RowTiledAutotuneMixin, Kernel):
         here. A handful of long rows goes to the split-row pair instead, which
         writes exact columns.
         """
-        seg_n = split_seg_n(self.M, self.N, self.config["block_m"], self._split_target)
+        seg_n = (
+            split_seg_n(self.M, self.N, self.config["block_m"], self._split_target)
+            if self.config["split"]
+            else 0
+        )
         if seg_n:
             # split_seg_n's fragment cap assumes the default width.
             threads = _DEFAULT_TUNE_THREADS

--- a/src/tileops/kernels/reduction/softmax.py
+++ b/src/tileops/kernels/reduction/softmax.py
@@ -30,7 +30,6 @@ from tileops.kernels.reduction._primitives import (
     RowTiledAutotuneMixin,
     align_up,
     ceildiv_int,
-    device_busy_of,
     device_smem_budget,
     restore_same_shape,
     rows_for_axes,
@@ -41,6 +40,7 @@ from tileops.kernels.reduction._split_softmax import (
     split_seg_n,
     split_target_blocks,
 )
+from tileops.utils import device_busy_of
 
 # These two kernels bake tile_n in at build time and default to the wider
 # thread block; AUTOTUNE_THREADS still bounds what the sweep explores.

--- a/src/tileops/utils/__init__.py
+++ b/src/tileops/utils/__init__.py
@@ -1,5 +1,6 @@
 from .utils import (
     WARP_LANES,
+    device_busy_of,
     forget_device_properties,
     get_sm_count,
     get_sm_version,
@@ -9,6 +10,7 @@ from .utils import (
 
 __all__ = [
     "WARP_LANES",
+    "device_busy_of",
     "forget_device_properties",
     "get_sm_count",
     "get_sm_version",

--- a/src/tileops/utils/utils.py
+++ b/src/tileops/utils/utils.py
@@ -64,3 +64,34 @@ def forget_device_properties() -> None:
     """
     _device_name.cache_clear()
     _sm_version.cache_clear()
+
+
+# Spin cycles queued before a device_busy_of measurement: tens of milliseconds
+# on any supported clock, ample to enqueue every timed call first.
+_BUSY_TIMING_SPIN_CYCLES = 50_000_000
+
+
+def device_busy_of(call, device: "torch.device", warmup: int = 5, rep: int = 20) -> float:
+    """Mean device time of *call* in milliseconds with host gaps excluded.
+
+    Judges paths that launch different kernel counts by their GPU work alone;
+    wall latency would charge a multi-launch path the host gaps between its
+    launches. A spin kernel holds the device while every timed call is
+    enqueued, so the queue then drains back to back and the event pair brackets
+    execution only. Deliberately not a profiler: the benchmark's own collector
+    owns the process's CUPTI subscription, and a second subscriber would break
+    its kernel attribution for the rest of the process.
+    """
+    with torch.cuda.device(device):
+        for _ in range(warmup):
+            call()
+        torch.cuda.synchronize()
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        torch.cuda._sleep(_BUSY_TIMING_SPIN_CYCLES)
+        start.record()
+        for _ in range(rep):
+            call()
+        end.record()
+        torch.cuda.synchronize()
+        return start.elapsed_time(end) / rep

--- a/tests/ops/test_reduce_multidim.py
+++ b/tests/ops/test_reduce_multidim.py
@@ -264,6 +264,22 @@ def test_logsumexp_multidim(
     assert torch.allclose(y, ref, **tol), f"max err: {(y - ref).abs().max()}"
 
 
+@pytest.mark.smoke
+def test_logsumexp_edge_axes_special_values() -> None:
+    """Own-layout edge-axis logsumexp preserves -inf and NaN row semantics."""
+    from tileops.ops.reduction.softmax import LogSumExpFwdOp
+
+    x = torch.randn(4, 32, 256, dtype=torch.float16, device="cuda")
+    x[:, 0, :] = float("-inf")
+    x[2, 1, 7] = float("nan")
+    y = LogSumExpFwdOp(dim=[0, 2])(x).float()
+    ref = torch.logsumexp(x.float(), dim=[0, 2])
+    assert y[0].item() == float("-inf")
+    assert torch.isnan(y[1])
+    finite = torch.isfinite(ref)
+    assert torch.allclose(y[finite], ref[finite], **_tol(torch.float16))
+
+
 # Logical reduce ops: all, any, count_nonzero
 
 


### PR DESCRIPTION
## problems

- The nightly flagged `test_logsumexp_bench[3d-multidim-reduce-float16]` +10.7% (device busy 12.6 -> 14.0 us): the split gate captures every under-filled grid, but at (128, 16384) the autotuned single-tile kernel (4.7 us) beats the split pair (5.8 us), and split-eligible shapes skipped the sweep entirely, so measurement never got a say.
- 65% of that row's device time (8.2 of 12.6 us) is the permute `rows_for_axes` pays before any reduction runs: an edge-axis reduction leaves each kept row as `outer` contiguous runs, which nothing read in place.

## changes

- Split-eligible shapes now run the autotune sweep, then the split pair is timed against the sweep's winner on device kernel time and the loser is dropped. The choice is recorded in `config["split"]` so a tuned config round-trips; a config from before the key existed falls back to the gate.
- `device_busy_of` (new, `_primitives.py`) measures with CUDA events behind a spin kernel -- every timed call enqueues while the device spins, so the queue drains back to back and the events bracket GPU execution only. Not a profiler: the benchmark collector owns the process's CUPTI subscription, and a second subscriber breaks its kernel attribution.
- Edge-axis logsumexp reads the tensor's own layout: a new `edge_split_partials_kernel` computes per-run `(max, sum)` over the `(outer, kept, inner)` view (one block per run, pairs written row-major by kept row), and the existing fold reuses unchanged. Applies when `threads` divides `inner` and the run fits the fragment cap; other shapes keep the permute path.
- Softmax/log_softmax get the same measured split pick; the edge path is logsumexp-only, since softmax writes a full tensor back in the original layout.
- Tests: one smoke node pinning -inf/NaN semantics on the edge path (the existing `(2,4,8,256) dim=[0,3]` node covers routing). Test node delta: +1 on tests/ops/test_reduce_multidim.py (83 -> 84).

## measured

H200, image `cu132-torch2.13-tl-afcebed1-dev`, idle device, `device_busy` from the repo benchmark (L2 flushed per iteration). `tune=True` throughout.

| row | main | this PR |
| --- | --- | --- |
| logsumexp 3d-multidim-reduce-float16 | 12.4 us | 5.8 us |
| logsumexp lm-head fp16 / bf16 | 7.5 / 7.4 us | 7.4 / 6.7 us |
| logsumexp attn-4k fp16 / bf16 | 6.7 / 6.6 us | 6.5 / 6.6 us |
| logsumexp attn-32k bf16 | 25.7 us | 25.6 us |
| softmax lm-head fp16 / bf16 / fp32 | 9.2 / 9.1 / 9.4 us | 9.1 / 9.2 / 9.5 us |
| log_softmax lm-head fp16 / bf16 / fp32 | 9.1 / 9.1 / 9.3 us | 9.2 / 9.2 / 9.4 us |

Isolated kernels at (128, 16384) fp16: split pair 5.8 us, tuned single-tile 4.7 us, streaming 7.2 us -- the referee picks the single-tile; at (4, 102400) the split pair wins (7.3 vs 12+) and stays.

20/20 softmax-family bench rows pass; 226 tests pass across tests/ops/{test_softmax, test_reduce_multidim}.py (smoke + full); edge-path special values (-inf rows, NaN, keepdim, outer == 1, non-divisible inner fallback) verified against torch.
