### PR TITLE
[Perf][Roofline] Calibrate the HBM ceiling as an envelope over access mixes

### DIFF
--- a/benchmarks/hardware/README.md
+++ b/benchmarks/hardware/README.md
@@ -20,11 +20,11 @@ Each script ends with the `*.calibration` lines to copy into `<gpu>.yaml`; for a
 
 ## Method
 
-| Benchmark         | Calibrates                         | Kernel                                                   | Selection                                    |
-| ----------------- | ---------------------------------- | -------------------------------------------------------- | -------------------------------------------- |
-| `hbm_bandwidth`   | `hbm`                              | STREAM Triad `a = b + s*c`, `float4`                     | best block size (128/256/512), 200 iters × 5 |
-| `fma_throughput`  | `cuda_core.fp32`                   | register-only FMA chains on the CUDA cores               | best ILP (1..16), median of 5 runs each      |
-| `gemm_throughput` | `tensor_core.{fp16,bf16,tf32,fp8}` | cuBLAS GEMM (`torch.matmul`; `torch._scaled_mm` for fp8) | best n (4096/8192/16384), median of 5 × ~4 s |
+| Benchmark         | Calibrates                         | Kernel                                                   | Selection                                          |
+| ----------------- | ---------------------------------- | -------------------------------------------------------- | -------------------------------------------------- |
+| `hbm_bandwidth`   | `hbm`                              | envelope over copy / Triad / read / write, `float4`      | best mix × block size (128/256/512), 200 iters × 5 |
+| `fma_throughput`  | `cuda_core.fp32`                   | register-only FMA chains on the CUDA cores               | best ILP (1..16), median of 5 runs each            |
+| `gemm_throughput` | `tensor_core.{fp16,bf16,tf32,fp8}` | cuBLAS GEMM (`torch.matmul`; `torch._scaled_mm` for fp8) | best n (4096/8192/16384), median of 5 × ~4 s       |
 
 - `fma_throughput` withholds the calibration when the SM clock moved more than one boost bin (`--allow-unlocked-clocks` overrides). After editing the kernel, confirm `cuobjdump -sass` shows only the instruction under test and that runtime scales linearly with `--iters`.
 - `gemm_throughput` is power-cap limited — the cap, not the lock, sets the clock. It warms up to a steady clock, then records `calibration` (sustained; what `effective` is computed from) and `calibration_burst` (first ~200 ms of load after 5 s idle, before the cap engages). A tf32 rate at or below the non-tensor fp32 ceiling aborts the run: TF32 never engaged.

--- a/benchmarks/hardware/memory/hbm_bandwidth.py
+++ b/benchmarks/hardware/memory/hbm_bandwidth.py
@@ -133,8 +133,10 @@ def main():
         print(f"\nEnvelope ({envelope_mix}):  {measured_peak:.2f} GB/s")
         print(f"Theoretical:      {theo_peak_gbs:.1f} GB/s")
         print(f"Calibration:      {calibration:.4f}")
+        mixes = ", ".join(f"{m}: {peaks[m] / theo_peak_gbs:.4f}" for m in _MIXES)
         print(f"\nUpdate src/tileops/perf/profiles/{args.profile}.yaml:")
         print(f"  hbm.calibration: {calibration:.4f}")
+        print(f"  hbm.calibration_mixes: {{{mixes}}}")
         print(f"{'=' * 60}")
 
 

--- a/benchmarks/hardware/memory/hbm_bandwidth.py
+++ b/benchmarks/hardware/memory/hbm_bandwidth.py
@@ -3,8 +3,13 @@
 Compiles and runs the CUDA microbenchmark, parses output, and prints
 the calibration factor for src/tileops/perf/profiles/.
 
-Calibration is derived from the STREAM Triad kernel (a = b + s*c, 2 reads +
-1 write).  Triad is the industry standard for roofline bandwidth calibration:
+Calibration is the **envelope** across the measured access mixes (copy 1R:1W,
+STREAM Triad 2R:1W, pure read, pure write): the highest sustained rate any mix
+reaches.  A ceiling is a rate no kernel exceeds; calibrating on one mix alone
+(Triad) put read-heavy kernels — decode reading a KV cache, multi-input
+elementwise — above 100% SOL on the nightly pages, which must be reserved for
+formula errors.  Triad remains the reference mix the roofline literature
+calibrates against; each mix's own rate is printed for the profile comment:
 
     McCalpin, J.D., 1995. "Memory Bandwidth and Machine Balance in Current
     High Performance Computers." IEEE TCCA Newsletter.
@@ -55,26 +60,28 @@ def _run(binary_path, size_mb, theo_peak_gbs):
     return result.stdout.strip().splitlines()
 
 
-def _parse_triad_peak(lines):
-    """Extract the best Triad bandwidth (GB/s) from CSV output.
+_MIXES = ("copy", "triad", "read", "write")
 
-    Only considers lines starting with 'triad,' — STREAM Triad (2 reads +
-    1 write) is the standard calibration kernel for roofline analysis.
-    Its 2:1 read:write ratio is closer to real compute kernels than pure
-    copy (1:1), which suffers worst-case HBM bus turnaround overhead.
+
+def _parse_peaks(lines):
+    """Best bandwidth (GB/s) per access mix from the CSV output.
+
+    The benchmark sweeps block sizes per mix; the mix's rate is the best
+    row. The calibration is the maximum over the mixes — the envelope a
+    kernel of any read:write ratio can reach.
     """
-    best_gbs = 0.0
+    peaks = dict.fromkeys(_MIXES, 0.0)
     for line in lines:
-        if not line.startswith("triad,"):
+        op = line.split(",", 1)[0]
+        if op not in peaks:
             continue
         parts = line.split(",")
         if len(parts) >= 6:
             try:
-                gbs = float(parts[5])  # best_gbs column
-                best_gbs = max(best_gbs, gbs)
+                peaks[op] = max(peaks[op], float(parts[5]))  # best_gbs column
             except ValueError:
                 continue
-    return best_gbs
+    return peaks
 
 
 def main():
@@ -105,14 +112,27 @@ def main():
     for line in lines:
         print(line)
 
-    # Extract calibration from STREAM Triad results
-    measured_peak = _parse_triad_peak(lines)
+    # Calibration = the envelope over the measured access mixes. A mix the
+    # output no longer carries would silently shrink the envelope, so refuse.
+    peaks = _parse_peaks(lines)
+    missing = [mix for mix, gbs in peaks.items() if gbs <= 0]
+    if missing:
+        print(
+            f"no measurement for mixes {missing}; the envelope needs all of {list(_MIXES)}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    envelope_mix = max(peaks, key=peaks.get)
+    measured_peak = peaks[envelope_mix]
     if measured_peak > 0 and theo_peak_gbs > 0:
-        calibration = measured_peak / theo_peak_gbs
         print(f"\n{'=' * 60}")
-        print(f"Measured peak (triad vec4): {measured_peak:.2f} GB/s")
-        print(f"Theoretical:               {theo_peak_gbs:.1f} GB/s")
-        print(f"Calibration:               {calibration:.4f}")
+        for mix in _MIXES:
+            frac = peaks[mix] / theo_peak_gbs
+            print(f"{mix:>6}: {peaks[mix]:8.2f} GB/s  ({frac:.4f} of theoretical)")
+        calibration = measured_peak / theo_peak_gbs
+        print(f"\nEnvelope ({envelope_mix}):  {measured_peak:.2f} GB/s")
+        print(f"Theoretical:      {theo_peak_gbs:.1f} GB/s")
+        print(f"Calibration:      {calibration:.4f}")
         print(f"\nUpdate src/tileops/perf/profiles/{args.profile}.yaml:")
         print(f"  hbm.calibration: {calibration:.4f}")
         print(f"{'=' * 60}")

--- a/benchmarks/hardware/memory/hbm_bandwidth.py
+++ b/benchmarks/hardware/memory/hbm_bandwidth.py
@@ -3,13 +3,10 @@
 Compiles and runs the CUDA microbenchmark, parses output, and prints
 the calibration factor for src/tileops/perf/profiles/.
 
-Calibration is the **envelope** across the measured access mixes (copy 1R:1W,
-STREAM Triad 2R:1W, pure read, pure write): the highest sustained rate any mix
-reaches.  A ceiling is a rate no kernel exceeds; calibrating on one mix alone
-(Triad) put read-heavy kernels — decode reading a KV cache, multi-input
-elementwise — above 100% SOL on the nightly pages, which must be reserved for
-formula errors.  Triad remains the reference mix the roofline literature
-calibrates against; each mix's own rate is printed for the profile comment:
+Calibration is the envelope across the measured access mixes (copy 1R:1W,
+STREAM Triad 2R:1W, pure read, pure write): a ceiling is a rate no kernel
+exceeds, and one mix's rate is not that — read-heavier kernels beat it.
+Each mix's rate is emitted for the profile's ``calibration_mixes``.
 
     McCalpin, J.D., 1995. "Memory Bandwidth and Machine Balance in Current
     High Performance Computers." IEEE TCCA Newsletter.
@@ -112,8 +109,7 @@ def main():
     for line in lines:
         print(line)
 
-    # Calibration = the envelope over the measured access mixes. A mix the
-    # output no longer carries would silently shrink the envelope, so refuse.
+    # A mix the output no longer carries would silently shrink the envelope.
     peaks = _parse_peaks(lines)
     missing = [mix for mix, gbs in peaks.items() if gbs <= 0]
     if missing:

--- a/benchmarks/hardware/memory/hbm_saturation.cu
+++ b/benchmarks/hardware/memory/hbm_saturation.cu
@@ -1,7 +1,9 @@
 // HBM Saturation Benchmark
 // Measures peak HBM bandwidth with vectorized CUDA kernels.
-// Uses STREAM Triad [1] as the primary calibration pattern for roofline
-// analysis [2], with Copy/Read/Write as reference measurements.
+// The calibration is the envelope over the measured access mixes
+// (Copy/Triad/Read/Write): the highest sustained rate any mix reaches,
+// so no legitimate kernel exceeds the effective ceiling [2]. STREAM
+// Triad [1] remains the reference mix the roofline literature quotes.
 //
 // Triad (a[i] = b[i] + s*c[i]) has a 2:1 read:write ratio — closer to real
 // compute kernels than pure Copy (1:1), which suffers worst-case HBM bus
@@ -198,7 +200,7 @@ int main(int argc, char* argv[]) {
     //    Note: 1:1 read:write creates worst-case bus turnaround pressure.
     //    Real kernels are typically read-heavy and achieve higher bandwidth.
     // ============================================================
-    printf("# Copy (read+write, 1:1 ratio) — reference\n");
+    printf("# Copy (read+write, 1:1 ratio)\n");
     for (int bi = 0; bi < 3; bi++) {
         int bs = bss[bi];
         int nblocks = sm_count * (2048 / bs);
@@ -211,10 +213,9 @@ int main(int argc, char* argv[]) {
     // ============================================================
     // 2. STREAM Triad: a[i] = b[i] + s*c[i] (2 reads + 1 write)
     //    Bytes reported = 3 * nbytes (read b + read c + write a)
-    //    2:1 read:write ratio — closer to real compute kernels than copy.
-    //    Used as the primary calibration measurement.
+    //    2:1 read:write ratio — the literature's reference mix.
     // ============================================================
-    printf("# Triad (2 reads + 1 write) — primary calibration\n");
+    printf("# Triad (2 reads + 1 write)\n");
     for (int bi = 0; bi < 3; bi++) {
         int bs = bss[bi];
         int nblocks = sm_count * (2048 / bs);
@@ -229,9 +230,9 @@ int main(int argc, char* argv[]) {
     }
 
     // ============================================================
-    // 3. Read-only (for reference, not used for calibration)
+    // 3. Read-only — the highest-rate mix, usually the envelope
     // ============================================================
-    printf("# Read-only — reference\n");
+    printf("# Read-only\n");
     for (int bi = 0; bi < 3; bi++) {
         int bs = bss[bi];
         int nblocks = sm_count * (2048 / bs);
@@ -242,9 +243,9 @@ int main(int argc, char* argv[]) {
     }
 
     // ============================================================
-    // 4. Write-only (for reference, not used for calibration)
+    // 4. Write-only
     // ============================================================
-    printf("# Write-only — reference\n");
+    printf("# Write-only\n");
     for (int bi = 0; bi < 3; bi++) {
         int bs = bss[bi];
         int nblocks = sm_count * (2048 / bs);

--- a/docs/design/roofline.md
+++ b/docs/design/roofline.md
@@ -307,7 +307,7 @@ A completeness test keeps the classification total: every implemented op is audi
 
 ### 5.1 GPU Profile
 
-Hardware parameters use theoretical values with calibration factors from one-time microbenchmark measurements. A bandwidth calibration is the **envelope** over the measured access mixes (copy, Triad, pure read, pure write): a ceiling some legitimate mix can exceed is not a ceiling, and readings above 100% must stay reserved for formula errors. YAML files store only `theoretical` and `calibration`; `effective = theoretical × calibration` is computed by `load_profile()`:
+Hardware parameters use theoretical values with calibration factors from one-time microbenchmark measurements. A bandwidth calibration is the **envelope** over the measured access mixes (copy, Triad, pure read, pure write): a ceiling some legitimate mix can exceed is not a ceiling, and readings above 100% must stay reserved for formula errors; each mix's own measured fraction is kept as data (`calibration_mixes`), so a future per-mix ceiling reads it instead of re-measuring. YAML files store only measured values; `effective = theoretical × calibration` is computed by `load_profile()`:
 
 ```yaml
 # src/tileops/perf/profiles/<gpu>.yaml

--- a/docs/design/roofline.md
+++ b/docs/design/roofline.md
@@ -152,10 +152,10 @@ Does not interpret formula strings at all. M5 reads pre-computed numbers from th
 
 Verdict lines are rendering thresholds, not CI gates:
 
-| Verdict    | Condition                               | Meaning                                                                                            |
-| ---------- | --------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| At ceiling | memory-bound ≥ 90%, compute-bound ≥ 80% | Done; the compute line is looser because tensor-core sustained calibration is noisier.             |
-| Anomaly    | > 105%                                  | Above the achievable ceiling: the formula or the calibration is wrong. Excluded from "at ceiling". |
+| Verdict    | Condition | Meaning                                                                                                                                                                                                           |
+| ---------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| At ceiling | ≥ 80%     | Done. The HBM ceiling is an envelope over access mixes, and a kernel's own mix caps below it (a perfect 2R:1W kernel reaches ~90% of it, a perfect 1R:1W ~87%); the line sits below every mix's personal ceiling. |
+| Anomaly    | > 105%    | Above the achievable ceiling: the formula or the calibration is wrong. Excluded from "at ceiling".                                                                                                                |
 
 Physics check: every row's implied rates (`bytes / time`, `flops / time`) are compared against the *theoretical* ceilings of its roofs. A breach is physically impossible, so it is reported as a formula error that fails the run's health — a formula edit that inflates work is caught on the next nightly. This check is the standing guard on formula overestimation; equality-level validation belongs to the structural oracle (§4.6), hardware-counter validation to the bytes audit (§4.5).
 
@@ -307,13 +307,13 @@ A completeness test keeps the classification total: every implemented op is audi
 
 ### 5.1 GPU Profile
 
-Hardware parameters use theoretical values with calibration factors from one-time microbenchmark measurements. YAML files store only `theoretical` and `calibration`; `effective = theoretical × calibration` is computed by `load_profile()`:
+Hardware parameters use theoretical values with calibration factors from one-time microbenchmark measurements. A bandwidth calibration is the **envelope** over the measured access mixes (copy, Triad, pure read, pure write): a ceiling some legitimate mix can exceed is not a ceiling, and readings above 100% must stay reserved for formula errors. YAML files store only `theoretical` and `calibration`; `effective = theoretical × calibration` is computed by `load_profile()`:
 
 ```yaml
 # src/tileops/perf/profiles/<gpu>.yaml
 hbm:
   theoretical: 4800e9       # bytes/s, from spec sheet
-  calibration: 0.848        # from microbench (STREAM Triad)
+  calibration: 0.938        # microbench envelope over access mixes
 tensor_core:
   fp16:
     theoretical: 989.5e12   # FLOPS, from spec sheet

--- a/scripts/nightly_report.py
+++ b/scripts/nightly_report.py
@@ -58,7 +58,13 @@ HISTORY_RETENTION_DAYS = 14
 # Algorithmic speed-of-light (SOL) verdict lines. Efficiency is
 # sol_time / measured_time against the *calibrated* (effective) ceilings;
 # see docs/design/roofline.md §1.2 and §4.3.
-SOL_GREEN_MEMORY = 0.90  # memory-bound row at its achievable ceiling
+#
+# The HBM ceiling is the envelope over access mixes (pure read is the highest),
+# while a kernel's own mix caps lower — a perfect 2R:1W kernel reaches ~90% of
+# the envelope, a perfect 1R:1W ~87%. The green line sits below every mix's
+# personal ceiling; tightening it above ~0.87 would bar copy-shaped kernels
+# from ever reading as done.
+SOL_GREEN_MEMORY = 0.80
 SOL_GREEN_COMPUTE = 0.80  # tensor-core sustained calibration is noisier
 SOL_ANOMALY = 1.05  # above the effective ceiling: formula or profile is wrong
 # Below both floors the roofline has no traction: launch overhead and wave

--- a/scripts/nightly_report.py
+++ b/scripts/nightly_report.py
@@ -59,11 +59,9 @@ HISTORY_RETENTION_DAYS = 14
 # sol_time / measured_time against the *calibrated* (effective) ceilings;
 # see docs/design/roofline.md §1.2 and §4.3.
 #
-# The HBM ceiling is the envelope over access mixes (pure read is the highest),
-# while a kernel's own mix caps lower — a perfect 2R:1W kernel reaches ~90% of
-# the envelope, a perfect 1R:1W ~87%. The green line sits below every mix's
-# personal ceiling; tightening it above ~0.87 would bar copy-shaped kernels
-# from ever reading as done.
+# The HBM ceiling is the envelope over access mixes, and a kernel's own mix
+# caps lower (a perfect 2R:1W kernel reaches ~90% of it, a perfect 1R:1W ~87%);
+# the green line must sit below every mix's personal ceiling.
 SOL_GREEN_MEMORY = 0.80
 SOL_GREEN_COMPUTE = 0.80  # tensor-core sustained calibration is noisier
 SOL_ANOMALY = 1.05  # above the effective ceiling: formula or profile is wrong

--- a/src/tileops/perf/profiles/h200.yaml
+++ b/src/tileops/perf/profiles/h200.yaml
@@ -9,12 +9,9 @@
 gpu: NVIDIA H200
 compute_capability: 9.0
 
-# calibration is the envelope over the measured access mixes — the highest
-# sustained rate any read:write ratio reaches — so no legitimate kernel can
-# exceed the effective ceiling. calibration_mixes keeps each mix's own measured
-# fraction as data (a future per-mix ceiling reads it instead of re-measuring).
-# From benchmarks/hardware/memory/hbm_bandwidth.py on one board: 2048 MB working
-# set, 5 runs x 200 reps, memory clock at its 3201 MHz max.
+# From benchmarks/hardware/memory/hbm_bandwidth.py: 2048 MB working set,
+# 5 runs x 200 reps, memory clock at its 3201 MHz max. Envelope semantics:
+# docs/design/roofline.md §5.1.
 hbm:
   theoretical: 4800e9        # bytes/s, spec sheet
   calibration: 0.9380        # = max(calibration_mixes)

--- a/src/tileops/perf/profiles/h200.yaml
+++ b/src/tileops/perf/profiles/h200.yaml
@@ -2,7 +2,8 @@
 # Source: NVIDIA H200 datasheet (dense, no sparsity)
 # Calibration: benchmarks/hardware/ microbenchmarks
 #
-# Only store measured values here (theoretical, calibration, calibration_burst).
+# Only store measured values here (theoretical, calibration,
+# calibration_burst, calibration_mixes).
 # effective = theoretical × calibration is computed by load_profile().
 
 gpu: NVIDIA H200
@@ -10,12 +11,14 @@ compute_capability: 9.0
 
 # calibration is the envelope over the measured access mixes — the highest
 # sustained rate any read:write ratio reaches — so no legitimate kernel can
-# exceed the effective ceiling. From benchmarks/hardware/memory/hbm_bandwidth.py
-# on one board (2048 MB working set, 5 runs x 200 reps, memory clock at its
-# 3201 MHz max): copy 0.8183, triad 0.8427, read 0.9380 (envelope), write 0.8926.
+# exceed the effective ceiling. calibration_mixes keeps each mix's own measured
+# fraction as data (a future per-mix ceiling reads it instead of re-measuring).
+# From benchmarks/hardware/memory/hbm_bandwidth.py on one board: 2048 MB working
+# set, 5 runs x 200 reps, memory clock at its 3201 MHz max.
 hbm:
   theoretical: 4800e9        # bytes/s, spec sheet
-  calibration: 0.9380
+  calibration: 0.9380        # = max(calibration_mixes)
+  calibration_mixes: {copy: 0.8183, triad: 0.8427, read: 0.9380, write: 0.8926}
 
 cuda_core:
   fp32:

--- a/src/tileops/perf/profiles/h200.yaml
+++ b/src/tileops/perf/profiles/h200.yaml
@@ -8,9 +8,14 @@
 gpu: NVIDIA H200
 compute_capability: 9.0
 
+# calibration is the envelope over the measured access mixes — the highest
+# sustained rate any read:write ratio reaches — so no legitimate kernel can
+# exceed the effective ceiling. From benchmarks/hardware/memory/hbm_bandwidth.py
+# on one board (2048 MB working set, 5 runs x 200 reps, memory clock at its
+# 3201 MHz max): copy 0.8183, triad 0.8427, read 0.9380 (envelope), write 0.8926.
 hbm:
   theoretical: 4800e9        # bytes/s, spec sheet
-  calibration: 0.848         # STREAM Triad, from benchmarks/hardware/memory/hbm_bandwidth.py
+  calibration: 0.9380
 
 cuda_core:
   fp32:

--- a/src/tileops/perf/profiles/h20_3e.yaml
+++ b/src/tileops/perf/profiles/h20_3e.yaml
@@ -23,6 +23,9 @@ compute_capability: 9.0
 
 hbm:
   theoretical: 4800e9        # bytes/s, HBM3e 141GB stack (same silicon as H200)
+  # Triad-only measurement; envelope semantics (max over access mixes, see
+  # benchmarks/hardware/memory/hbm_bandwidth.py) not yet re-measured on this
+  # part, so read-heavy kernels may read above 100% SOL until it is.
   calibration: 0.8083
 
 tensor_core:

--- a/src/tileops/perf/profiles/h20_3e.yaml
+++ b/src/tileops/perf/profiles/h20_3e.yaml
@@ -23,9 +23,8 @@ compute_capability: 9.0
 
 hbm:
   theoretical: 4800e9        # bytes/s, HBM3e 141GB stack (same silicon as H200)
-  # Triad-only measurement; envelope semantics (max over access mixes, see
-  # benchmarks/hardware/memory/hbm_bandwidth.py) not yet re-measured on this
-  # part, so read-heavy kernels may read above 100% SOL until it is.
+  # Triad-only; until re-measured as an envelope (hbm_bandwidth.py),
+  # read-heavy kernels on this part may read above 100% SOL.
   calibration: 0.8083
 
 tensor_core:


### PR DESCRIPTION
## Problems

- The SOL denominator used a single-mix calibration: STREAM Triad (2R:1W, 0.848 of theoretical). A ceiling is a rate no legitimate kernel exceeds, and read-heavier kernels — decode reading a KV cache, multi-input elementwise — sustain more aggregate bytes/s than Triad, so 33 nightly rows read 105–109% and were flagged `⚠` for a formula error they do not have. Readings above 100% must stay reserved for formula errors.
- The CUDA microbenchmark already measures all four mixes; only the wrapper's calibration extraction was Triad-only.

## Changes

- `benchmarks/hardware/memory/hbm_bandwidth.py`: the calibration is the envelope — max over copy / triad / read / write — with per-mix rates printed for the profile comment. The wrapper refuses to emit a calibration when any mix is missing, so an output-format drift cannot silently shrink the envelope. CUDA source comments synced; kernels unchanged.
- `h200.yaml`: `hbm.calibration` 0.848 → 0.9380, with each mix kept as data in `hbm.calibration_mixes` (copy 0.8183 / triad 0.8427 / read 0.9380 / write 0.8926; one H200, 2048 MB working set, 5 runs × 200 reps, memory clock at its 3201 MHz maximum), so a future per-mix ceiling reads it instead of re-measuring.
- `SOL_GREEN_MEMORY` 0.90 → 0.80: under the envelope each mix's own ceiling sits below 100% (perfect 2R:1W ≈ 90%, 1R:1W ≈ 87%), so a 90% line would bar Triad-shaped kernels from ever reading as done; 0.80 sits below every mix's personal ceiling.
- `h20_3e.yaml` keeps its Triad-only value with a note that read-heavy kernels there may read above 100% until re-measured.
- Docs synced: roofline.md §4.3 verdict table and §5.1 envelope definition; benchmarks/hardware/README.md method row.

| Recomputed on tonight's nightly (1038 rows) | old (Triad, 90% line) | new (envelope, 80% line) |
| --- | --- | --- |
| `⚠` anomalies | 38 | 0 |
| rows > 100% | 38 (max 108.7%) | 0 (max 99.9%) |
| at-ceiling (green) | ≈ old ≥90% set | 193 (same population: old ≥90% ⇔ new ≥81.3%) |

Reviewed by codex (two issues — fail-closed envelope parsing, stale CUDA comments — both fixed): NO-BLOCKERS. The site's reading page quotes the thresholds from this module at render time, so it follows without a change.
