### PR TITLE
[Perf][Reduction] Derive the row-scan staging pad from the chunk

### DIFF
--- a/src/tileops/kernels/constants.py
+++ b/src/tileops/kernels/constants.py
@@ -3,6 +3,9 @@
 # Widest vectorized global access the kernels plan for: 128 bits.
 VECTOR_ACCESS_BYTES: int = 16
 
+# Address range the shared-memory banks cover before repeating: 32 banks of 4 bytes.
+SHARED_BANK_SPAN_BYTES: int = 128
+
 # log2(e), to fold exp(x) into the single-instruction exp2(x * LOG2E).
 LOG2E: float = 1.4426950408889634
 

--- a/src/tileops/kernels/reduction/_primitives.py
+++ b/src/tileops/kernels/reduction/_primitives.py
@@ -21,7 +21,7 @@ import tilelang
 import tilelang.language as T
 import torch
 
-from tileops.kernels.constants import VECTOR_ACCESS_BYTES
+from tileops.kernels.constants import SHARED_BANK_SPAN_BYTES, VECTOR_ACCESS_BYTES
 from tileops.kernels.tiling import ALIGNMENT, align_up
 
 __all__ = [
@@ -31,6 +31,7 @@ __all__ = [
     "FP32_EXACT_INT_LIMIT",
     "FRAGMENT_ELEMS_PER_THREAD",
     "MAX_SINGLE_TILE_COLS",
+    "SHARED_BANK_SPAN_BYTES",
     "SHARED_MEMORY_BUDGET_BYTES",
     "VECTOR_ACCESS_BYTES",
     "BlockConfigPlanner",

--- a/src/tileops/kernels/reduction/cumulative.py
+++ b/src/tileops/kernels/reduction/cumulative.py
@@ -2,6 +2,7 @@
 
 import functools
 import itertools
+import math
 import warnings
 from dataclasses import dataclass
 from typing import Optional
@@ -13,7 +14,9 @@ import torch
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.reduction._primitives import (
     DEFAULT_ALIGNMENT,
+    SHARED_BANK_SPAN_BYTES,
     SHARED_MEMORY_BUDGET_BYTES,
+    VECTOR_ACCESS_BYTES,
     align_up,
     device_smem_budget,
     restore_same_shape,
@@ -34,8 +37,15 @@ class CumulativeScanPolicy:
     # Breaks shared-memory bank conflicts for fp16/bf16 row staging.
     smem_pad: int = 8
 
+    # Elements per thread the split aims for.
     row_scan_chunk: int = 64
-    row_scan_pad_bytes: int = 16
+    # Block width past which the split lengthens the chunk instead of adding warps.
+    row_scan_wide_threads: int = 256
+    # Longest chunk a thread takes. It lives in fp32 registers, so 256 would spill.
+    row_scan_max_chunk: int = 128
+    # Pads row_scan_pad chooses between, in vector accesses. A whole vector access is
+    # what keeps a chunk 16-byte aligned, which the shared access needs to stay 128-bit.
+    row_scan_pad_vectors: tuple = (1, 2)
     row_scan_min_threads: int = 64
     row_scan_max_threads: int = 1024
 
@@ -43,14 +53,50 @@ class CumulativeScanPolicy:
 _SCAN_POLICY = CumulativeScanPolicy()
 
 
-def row_scan_threads(N_padded: int) -> int:
-    """Threads the whole-row kernel gives a row of *N_padded*."""
+def row_scan_pad(chunk: int, elem_bytes: int) -> int:
+    """Return the padding, in elements, each staged chunk gets.
+
+    Neighbouring lanes read one chunk each, so they sit ``(chunk + pad) * elem_bytes``
+    apart, and the conflict ways grow with what that stride shares with
+    ``SHARED_BANK_SPAN_BYTES``. This returns the candidate pad that shares least, which
+    depends on *chunk*: a fixed pad leaves some chunks striding the whole span.
+    """
+    candidates = [k * VECTOR_ACCESS_BYTES // elem_bytes for k in _SCAN_POLICY.row_scan_pad_vectors]
+    return min(
+        candidates,
+        key=lambda pad: (math.gcd((chunk + pad) * elem_bytes, SHARED_BANK_SPAN_BYTES), pad),
+    )
+
+
+def row_scan_chunk_ok(chunk: int, elem_bytes: int, threads: int) -> bool:
+    """Whether a block of *threads* may give each thread a chunk of *chunk* elements.
+
+    Up to ``row_scan_chunk`` always. A block already ``row_scan_wide_threads`` wide may
+    go as far as ``row_scan_max_chunk``, but only with a chunk of whole vector accesses,
+    which is what keeps the chunk 16-byte aligned.
+    """
+    if chunk <= _SCAN_POLICY.row_scan_chunk:
+        return True
+    return (
+        threads >= _SCAN_POLICY.row_scan_wide_threads
+        and chunk <= _SCAN_POLICY.row_scan_max_chunk
+        and (chunk * elem_bytes) % VECTOR_ACCESS_BYTES == 0
+    )
+
+
+def row_scan_threads(N_padded: int, elem_bytes: int) -> int:
+    """Threads the whole-row kernel gives a row of *N_padded*.
+
+    The narrowest block that divides the row and whose chunk :func:`row_scan_chunk_ok`
+    accepts, or the widest divisor tried when no block qualifies -- which
+    :func:`row_scan_fits` then declines.
+    """
     threads = _SCAN_POLICY.row_scan_min_threads
     widest = threads
     while threads <= _SCAN_POLICY.row_scan_max_threads:
         if N_padded % threads == 0:
             widest = threads
-            if N_padded // threads <= _SCAN_POLICY.row_scan_chunk:
+            if row_scan_chunk_ok(N_padded // threads, elem_bytes, threads):
                 return threads
         threads *= 2
     return widest
@@ -58,12 +104,12 @@ def row_scan_threads(N_padded: int) -> int:
 
 def row_scan_fits(N_padded: int, elem_bytes: int, smem_budget: int) -> bool:
     """Whether a row of *N_padded* can be scanned by one thread block."""
-    threads = row_scan_threads(N_padded)
+    threads = row_scan_threads(N_padded, elem_bytes)
     if N_padded % threads:
         return False
     chunk = N_padded // threads
-    staged = threads * (chunk + _SCAN_POLICY.row_scan_pad_bytes // elem_bytes) * elem_bytes
-    return staged <= smem_budget and chunk <= _SCAN_POLICY.row_scan_chunk
+    staged = threads * (chunk + row_scan_pad(chunk, elem_bytes)) * elem_bytes
+    return staged <= smem_budget and row_scan_chunk_ok(chunk, elem_bytes, threads)
 
 
 @functools.lru_cache(maxsize=32)
@@ -93,7 +139,7 @@ def _row_scan_kernel(M: int, N: int, op_kind: str, dtype: str, threads: int):
         threads: Threads per row, from :func:`row_scan_threads`.
     """
     chunk_len = N // threads
-    pad = _SCAN_POLICY.row_scan_pad_bytes // torch_dtype_nbytes(dtype)
+    pad = row_scan_pad(chunk_len, torch_dtype_nbytes(dtype))
     # Stride-doubling steps to scan `threads` totals.
     n_steps = threads.bit_length() - 1
     identity = 0.0 if op_kind == "sum" else 1.0
@@ -393,7 +439,9 @@ class CumulativeKernel(Kernel):
             self.N_padded, self._elem_bytes, device_smem_budget(device_index)
         )
         can_parallel = M < 128 and N > 8192 and op_kind == "sum"
-        self._row_scan_threads = row_scan_threads(self.N_padded) if can_row_scan else 0
+        self._row_scan_threads = (
+            row_scan_threads(self.N_padded, self._elem_bytes) if can_row_scan else 0
+        )
 
         if can_row_scan:
             self.strategy = "row_scan"

--- a/src/tileops/ops/reduction/cumulative.py
+++ b/src/tileops/ops/reduction/cumulative.py
@@ -137,8 +137,9 @@ class CumsumFwdOp(CumulativeOp):
     Output has the same shape and dtype as ``x``. Alignment padding is
     handled inside the kernel via masked loads.
 
-    Shapes with ``M < 128 and N > 8192`` take a three-pass parallel scan for
-    SM utilization; every other shape takes the sequential scan.
+    A row one thread block can stage in shared memory takes the whole-row scan.
+    Of what is left, shapes with ``M < 128 and N > 8192`` take a three-pass
+    parallel scan for SM utilization; every other shape takes the tiled scan.
 
     Args:
         dim: Reduction axis (default -1). Negative values are normalized

--- a/tests/ops/test_cumulative.py
+++ b/tests/ops/test_cumulative.py
@@ -301,13 +301,16 @@ def test_cumprod_dim_axis1(batch: int, hidden: int, seq: int, dtype: torch.dtype
         (64, 32768, torch.bfloat16, "row_scan"),
         (64, 8200, torch.float32, "parallel_scan"),  # a padded width the row scan declines
         (64, 8200, torch.bfloat16, "parallel_scan"),  # same, at the other element width
+        # 65 elements per thread is not a whole number of vector accesses
+        (64, 16640, torch.bfloat16, "parallel_scan"),
     ],
 )
 def test_cumsum_backend_dispatch(M: int, N: int, dtype: torch.dtype, backend: str) -> None:
     """Each shape takes the expected backend and matches torch.cumsum.
 
-    The row scan takes every width it can stage exactly, which is where it measures
-    fastest; the parallel scan is left the widths the alignment would pad.
+    The row scan takes every width it can stage exactly at a chunk whose bytes are a
+    whole number of vector accesses, which is where it measures fastest; the parallel
+    scan is left the widths the alignment would pad and the chunks it would misalign.
     """
     from tileops.ops.reduction.cumulative import CumsumFwdOp
 


### PR DESCRIPTION
## problems

- The whole-row scan pads every chunk by a fixed 16 bytes. A warp's 32 lanes each read one chunk, so the stride between neighbouring lanes is `(chunk + pad) * elem_bytes`, and what that stride shares with the 128 bytes the 32 banks span decides the conflict ways. A fixed pad cannot hold that quantity down: for `chunk = 56` in bf16 the stride is exactly 128 bytes, the whole span, which is the worst case: `cuobjdump` shows the scan loop reading the chunk 64 bits at a time, so the 32 lanes land on the two banks the first lane uses. Row widths that land there include 3584, 7168, 14336, 28672 in bf16 and 1792, 3840, 7680, 15360, 30720 in fp32 — the hidden and FFN widths of Qwen2-7B, Llama-3-70B and Llama-3-8B. `(2048, 3584)` bf16 cumsum reads at 1.38 TB/s where the same kernel with the right pad reads 3.09.
- The split between block width and chunk length was never re-measured against the pad. `row_scan_threads` widens the block until a thread's chunk is 64 elements, which spends 512 or 1024 threads on one row for `N >= 32768`. Measured, the best block is `min(N / 64, 256)` threads: past 256 threads widening costs more than the longer chunk it saves.
- A row the split cannot cut that way is declined outright and falls to the tiled scan, which reads at 0.12 TB/s.

## changes

- `row_scan_pad` derives the pad from the chunk: of the pads that are a whole number of vector accesses — so a chunk's first element stays 16-byte aligned and the scan reads it 128 bits at a time — it takes the one whose stride shares least with the 128 bytes the banks span. Over every row width that is a multiple of `ALIGNMENT` up to 400k and both element widths, 35 configurations drop from 8-, 4- or 2-way to conflict-free and none gets worse.
- `row_scan_chunk_ok` is the single predicate for an allowed chunk: up to 64 elements always; up to 128 once the block is at 256 threads, and only when the chunk's bytes are a whole number of vector accesses. `row_scan_threads` and `row_scan_fits` both use it. 128 is the ceiling because a thread keeps its chunk in fp32 registers and 256 of them exceed one thread's register budget.
- `row_scan_threads` takes `elem_bytes`, which both predicates need. `SHARED_BANK_SPAN_BYTES` joins the other hardware constants in `kernels/constants.py`.
- The stale dispatch sentence on `CumsumFwdOp` now names the whole-row scan, which has taken those shapes since it was added.
- One test case pins the misaligned-chunk rejection. `scripts/test_node_delta.py`: `tests/ops/test_cumulative.py` 50 -> 51, +1.

## measurements

H200, dev runner image, CUPTI device latency, L2 flushed before every iteration, TB/s over read plus write.

Widths where the fixed pad put the stride on the whole bank span:

Same split before and after, so the pad is the only difference:

| op | shape | dtype | threads x chunk | before (pad 8) | after (pad 16) |
| --- | --- | --- | --- | --- | --- |
| CumsumFwdOp | (2048, 3584) | bf16 | 64 x 56 | 1.376 (8-way) | 3.089 (conflict-free) |
| CumsumFwdOp | (2048, 7168) | bf16 | 128 x 56 | 1.585 (8-way) | 3.306 |
| CumprodFwdOp | (2048, 7168) | bf16 | 128 x 56 | 1.579 (8-way) | 3.306 |
| CumsumFwdOp | (1024, 14336) | bf16 | 256 x 56 | 1.513 (8-way) | 3.048 |
| CumsumFwdOp | (2048, 2560) | bf16 | 64 x 40 | 2.530 (2-way) | 2.862 |

A 56-element chunk in fp32 is a different stride and was already conflict-free at the fixed pad; `row_scan_pad` picks the same pad there and `(2048, 7168)` fp32 holds at 3.768 -> 3.776 TB/s.

Widths where the split changes too, so the two effects are not separable:

| op | shape | dtype | before | after |
| --- | --- | --- | --- | --- |
| CumsumFwdOp | (512, 28672) | bf16 | 1.316 (512 x 56, pad 8, 8-way) | 2.374 (256 x 112, pad 8) |
| CumsumFwdOp | (64, 32768) | bf16 | 1.337 (512 x 64, pad 8) | 1.358 (256 x 128, pad 8) |
| CumsumFwdOp | (256, 73728) | bf16 | 0.119 (tiled scan) | 1.800 (row scan, 1024 x 72, pad 16) |

At a forced 512 x 56 split, `(512, 28672)` isolates the pad at 1.316 against 2.332.

Manifest workloads that keep their split and their pad, unchanged within noise:

| op | shape | dtype | before | after |
| --- | --- | --- | --- | --- |
| CumsumFwdOp | (2048, 4096) | fp16 | 3.438 | 3.438 |
| CumsumFwdOp | (2048, 4096) | bf16 | 3.449 | 3.449 |
| CumprodFwdOp | (2048, 4096) | fp16 | 3.461 | 3.449 |
| CumprodFwdOp | (2048, 4096) | bf16 | 3.438 | 3.449 |

Pad sweep behind `row_scan_pad`, bf16 unless noted, pad in elements (the shipped pad is 8 for a 2-byte dtype, 4 for fp32):

| shape | threads x chunk | pad 4 | 8 | 12 | 16 | 24 |
| --- | --- | --- | --- | --- | --- | --- |
| (2048, 4096) | 64 x 64 | 3.42 | **3.42** | 3.42 | 2.67 | - |
| (2048, 3584) | 64 x 56 | - | 1.38 | 2.81 | **3.07** | 2.59 |
| (2048, 7168) | 128 x 56 | - | 1.58 | 3.14 | **3.29** | 3.02 |
| (512, 28672) | 512 x 56 | - | 1.32 | - | **2.33** | - |
| (256, 73728) | 1024 x 72 | 1.74 | 1.69 | 1.72 | **1.80** | 1.42 |
| (2048, 7168) fp32 | 128 x 56 | **3.79** | 2.23 | 3.79 | - | - |

The pad sweep forces the split, so its rows are comparable across pads at a fixed
`threads x chunk`; the two tables above use the split the code selects.

Thread sweep behind the 256-thread cap, bf16:

| N | M | t=64 | 128 | 256 | 512 | 1024 |
| --- | --- | --- | --- | --- | --- | --- |
| 4096 | 2048 | **3.42** | 3.15 | 2.90 | 2.19 | - |
| 8192 | 2048 | 3.51 | **3.55** | 3.48 | 3.08 | 1.92 |
| 16384 | 512 | 2.76 | 2.70 | **2.82** | 2.29 | - |
| 32768 | 64 | 0.57 | 1.27 | **1.38** | 1.35 | 1.19 |
| 65536 | 256 | 0.81 | 1.06 | 2.48 | **2.44** | 2.31 |

At 65536 the fastest block is 256 threads with a 256-element chunk (2.48), which the register ceiling rejects; 512 threads with a 128-element chunk is what ships.

`tests/ops/test_cumulative.py`: 50 passed on origin/main, 51 passed here.
