### PR TITLE
[Perf][Conv3d] Add NDHWC implicit-GEMM fast path for Conv3dFwd

### DIFF
--- a/src/tileops/kernels/convolution/__init__.py
+++ b/src/tileops/kernels/convolution/__init__.py
@@ -7,7 +7,7 @@ from .conv2d import (
     Conv2dSymmetricKernel,
     GroupConv2dKernel,
 )
-from .conv3d import Conv3dKernel, GroupConv3dKernel
+from .conv3d import Conv3dKernel, Conv3dNdhwcKernel, GroupConv3dKernel
 
 __all__ = [
     "Conv1dKernel",
@@ -16,6 +16,7 @@ __all__ = [
     "Conv2dKernel",
     "Conv2dSymmetricKernel",
     "Conv3dKernel",
+    "Conv3dNdhwcKernel",
     "GroupConv1dKernel",
     "GroupConv2dKernel",
     "GroupConv3dKernel",

--- a/src/tileops/kernels/convolution/conv3d.py
+++ b/src/tileops/kernels/convolution/conv3d.py
@@ -350,16 +350,34 @@ def _conv3d_ndhwc_kernel(
     has_bias: bool,
     dtype: str = "float16",
 ):
-    """3D conv on NDHWC: transpose, implicit GEMM, transpose back.
+    """Build the NDHWC-staged dense Conv3d forward kernel.
 
-    Mirrors :func:`tileops.kernels.convolution.conv2d._conv2d_symmetric_kernel`.
+    The public op accepts NCDHW input and OIDHW weight, and returns NCDHW output.
+    This kernel stages those tensors as NDHWC and ODHW(I) before the contraction,
+    then transposes the result back. The computed cross-correlation is::
+
+        out[n, oc, od, oh, ow] =
+            bias[oc] +
+            sum_{ci,kd,kh,kw} x[n, ci, id, ih, iw]
+                              * weight[oc, ci, kd, kh, kw]
+
+        id = od * stride_d + kd * dilation_d - pad_d
+        ih = oh * stride_h + kh * dilation_h - pad_h
+        iw = ow * stride_w + kw * dilation_w - pad_w
+
+    Terms with ``id``, ``ih``, or ``iw`` outside the input bounds contribute
+    zero. Output dimensions are computed per axis as::
+
+        out_axis = floor((in_axis + 2 * pad_axis
+                          - dilation_axis * (kernel_axis - 1) - 1)
+                         / stride_axis) + 1
+
     TileLang's ``T.im2col`` is 2D-only, so the im2col gather is written out as an
-    element-wise ``T.Parallel`` loop over the NDHWC input: the K dim decomposes as
-    ``((kd, kh, kw), c)`` with c contiguous, which lets the parallel-loop
-    vectorizer emit wide global loads — the thing the NCDHW gather cannot do.
-    Kernel/stride/pad/dilation are per-axis trace-time constants; they cost
-    nothing extra here, so unlike the 2D kernel this path is not restricted to
-    symmetric values.
+    element-wise ``T.Parallel`` loop over the NDHWC input. The K dimension is
+    decomposed as ``((kd, kh, kw), c)`` with ``c`` contiguous, which lets the
+    parallel-loop vectorizer emit wide global loads. Kernel, stride, padding,
+    and dilation are per-axis trace-time constants, so this path supports
+    non-symmetric 3D parameters.
     """
     accum_dtype = "float"
     out_d = (d + 2 * pad_d - dilation_d * (kernel_d - 1) - 1) // stride_d + 1
@@ -847,12 +865,28 @@ class GroupConv3dKernel(Kernel):
 
 
 class Conv3dNdhwcKernel(Kernel):
-    """3D conv via NDHWC transpose + implicit GEMM.
+    """Dense Conv3d forward through an NDHWC-staged implicit GEMM.
 
-    Selected by the op layer when ``groups == 1`` and ``c_in % 32 == 0``; pays
-    three layout transposes (input, weight, output) so the im2col gather reads
-    contiguous channel runs, the same trade cuDNN makes for NCDHW inputs.
-    Kernel/stride/pad/dilation may differ per axis.
+    Inputs use the public NCDHW/OIDHW layout and the result is NCDHW. Internally
+    the kernel materializes:
+
+    - ``x_ndhwc`` with shape ``(n, d, h, w, c_in)``
+    - ``weight_kdrsc`` with shape ``(c_out, kernel_d, kernel_h, kernel_w, c_in)``
+    - ``out_ndhwc`` with shape ``(n, out_d, out_h, out_w, c_out)``
+
+    The staged contraction computes the same cross-correlation as
+    ``torch.nn.functional.conv3d`` for ``groups == 1``::
+
+        out[n, oc, od, oh, ow] =
+            bias[oc] +
+            sum_{ci,kd,kh,kw} x[n, ci, id, ih, iw]
+                              * weight[oc, ci, kd, kh, kw]
+
+    where ``id = od * stride_d + kd * dilation_d - pad_d`` and likewise for
+    ``ih`` and ``iw``. Out-of-bounds input coordinates are zero-padded. The op
+    layer selects this variant only for large enough 16-bit dense calls where
+    channel-contiguous NDHWC gathers are expected to amortize the three layout
+    transforms.
     """
 
     supported_archs: list[int] = [80, 86, 89, 90]

--- a/src/tileops/kernels/convolution/conv3d.py
+++ b/src/tileops/kernels/convolution/conv3d.py
@@ -14,6 +14,7 @@ from ._common import _launch, conv_autotune_configs
 
 __all__ = [
     "Conv3dKernel",
+    "Conv3dNdhwcKernel",
     "GroupConv3dKernel",
 ]
 
@@ -326,6 +327,272 @@ def _conv3d_group_kernel(
     return _conv3d_group_func
 
 
+@functools.lru_cache(maxsize=64)
+def _conv3d_ndhwc_kernel(
+    n: int,
+    c_in: int,
+    d: int,
+    h: int,
+    w: int,
+    c_out: int,
+    kernel_d: int,
+    kernel_h: int,
+    kernel_w: int,
+    stride_d: int,
+    stride_h: int,
+    stride_w: int,
+    pad_d: int,
+    pad_h: int,
+    pad_w: int,
+    dilation_d: int,
+    dilation_h: int,
+    dilation_w: int,
+    has_bias: bool,
+    dtype: str = "float16",
+):
+    """3D conv on NDHWC: transpose, implicit GEMM, transpose back.
+
+    Mirrors :func:`tileops.kernels.convolution.conv2d._conv2d_symmetric_kernel`.
+    TileLang's ``T.im2col`` is 2D-only, so the im2col gather is written out as an
+    element-wise ``T.Parallel`` loop over the NDHWC input: the K dim decomposes as
+    ``((kd, kh, kw), c)`` with c contiguous, which lets the parallel-loop
+    vectorizer emit wide global loads — the thing the NCDHW gather cannot do.
+    Kernel/stride/pad/dilation are per-axis trace-time constants; they cost
+    nothing extra here, so unlike the 2D kernel this path is not restricted to
+    symmetric values.
+    """
+    accum_dtype = "float"
+    out_d = (d + 2 * pad_d - dilation_d * (kernel_d - 1) - 1) // stride_d + 1
+    out_h = (h + 2 * pad_h - dilation_h * (kernel_h - 1) - 1) // stride_h + 1
+    out_w = (w + 2 * pad_w - dilation_w * (kernel_w - 1) - 1) // stride_w + 1
+    out_dhw = out_d * out_h * out_w
+    k_total = c_in * kernel_d * kernel_h * kernel_w
+
+    @tilelang.jit(
+        out_idx=[5],
+        compile_flags=["-O3", "-DENABLE_BF16"],
+        pass_configs={"tl.enable_async_copy": False},
+    )
+    def _conv3d_ndhwc_func(
+        block_m: int,
+        block_n: int,
+        block_k: int,
+        num_stages: int,
+        threads: int,
+        enable_rasterization: bool,
+    ):
+        @T.macro
+        def transpose_spatial_channel(
+            src: T.Tensor,
+            dst: T.Tensor,
+            batch_size: int,
+            spatial_size: int,
+            channel_size: int,
+            hw_size: int,
+            width: int,
+            spatial_block: int,
+            channel_block: int,
+            channel_lanes: int,
+            channel_fastest: bool,
+            is_nchw_to_nhwc: bool,
+        ):
+            assert spatial_block * channel_lanes == 256, (
+                "spatial_block * channel_lanes must equal 256"
+            )
+            assert channel_block % channel_lanes == 0, "channel_lanes must divide channel_block"
+            if not channel_fastest:
+                assert channel_block * spatial_block == 256, (
+                    "channel_block * spatial_block must equal 256 when channel_fastest=False"
+                )
+
+            with T.Kernel(
+                T.ceildiv(spatial_size, spatial_block),
+                T.ceildiv(channel_size, channel_block),
+                batch_size,
+                threads=256,
+            ) as (bx, by, bz):
+                if channel_fastest:
+                    values_per_thread = channel_block // channel_lanes
+                    for spatial_inner, channel_lane in T.Parallel(spatial_block, channel_lanes):
+                        spatial = bx * spatial_block + spatial_inner
+                        d_idx = spatial // hw_size
+                        rem = spatial - d_idx * hw_size
+                        h_idx = rem // width
+                        w_idx = rem - h_idx * width
+                        channel_base = by * channel_block
+                        for channel_offset in T.serial(values_per_thread):
+                            c = channel_base + channel_offset * channel_lanes + channel_lane
+                            if (spatial < spatial_size) & (c < channel_size):
+                                if is_nchw_to_nhwc:
+                                    dst[bz, d_idx, h_idx, w_idx, c] = src[
+                                        bz, c, d_idx, h_idx, w_idx
+                                    ]
+                                else:
+                                    dst[bz, c, d_idx, h_idx, w_idx] = src[
+                                        bz, d_idx, h_idx, w_idx, c
+                                    ]
+                else:
+                    for channel_inner, spatial_inner in T.Parallel(channel_block, spatial_block):
+                        spatial = bx * spatial_block + spatial_inner
+                        d_idx = spatial // hw_size
+                        rem = spatial - d_idx * hw_size
+                        h_idx = rem // width
+                        w_idx = rem - h_idx * width
+                        c = by * channel_block + channel_inner
+                        if (spatial < spatial_size) & (c < channel_size):
+                            if is_nchw_to_nhwc:
+                                dst[bz, d_idx, h_idx, w_idx, c] = src[bz, c, d_idx, h_idx, w_idx]
+                            else:
+                                dst[bz, c, d_idx, h_idx, w_idx] = src[bz, d_idx, h_idx, w_idx, c]
+
+        @T.macro
+        def conv_ndhwc_implicit_gemm(x_ndhwc, weight_kdrsc, out_ndhwc, bias):
+            with T.Kernel(
+                T.ceildiv(c_out, block_n),
+                T.ceildiv(n * out_dhw, block_m),
+                threads=threads,
+            ) as (bx, by):
+                data_shared = T.alloc_shared((block_m, block_k), dtype)
+                weight_shared = T.alloc_shared((block_n, block_k), dtype)
+                out_local = T.alloc_fragment((block_m, block_n), accum_dtype)
+                out_shared = T.alloc_shared((block_m, block_n), dtype)
+
+                weight_flat = T.Tensor((c_out, k_total), dtype, weight_kdrsc.data)
+                out_flat = T.Tensor((n * out_dhw, c_out), dtype, out_ndhwc.data)
+
+                T.use_swizzle(10, enable=enable_rasterization)
+                T.clear(out_local)
+
+                for k_iter in T.Pipelined(T.ceildiv(k_total, block_k), num_stages=num_stages):
+                    for i, j in T.Parallel(block_m, block_k):
+                        m = by * block_m + i
+                        k = k_iter * block_k + j
+                        c = k % c_in
+                        tap = k // c_in
+                        kw = tap % kernel_w
+                        kh = (tap // kernel_w) % kernel_h
+                        kd = tap // (kernel_h * kernel_w)
+                        spatial = m % out_dhw
+                        od = spatial // (out_h * out_w)
+                        oh = (spatial // out_w) % out_h
+                        ow = spatial % out_w
+                        id_ = od * stride_d + kd * dilation_d - pad_d
+                        ih = oh * stride_h + kh * dilation_h - pad_h
+                        iw = ow * stride_w + kw * dilation_w - pad_w
+                        in_bound = (
+                            (m < n * out_dhw)
+                            & (id_ >= 0)
+                            & (ih >= 0)
+                            & (iw >= 0)
+                            & (id_ < d)
+                            & (ih < h)
+                            & (iw < w)
+                        )
+                        data_shared[i, j] = T.if_then_else(
+                            in_bound,
+                            x_ndhwc[m // out_dhw, id_, ih, iw, c],
+                            T.cast(0.0, dtype),
+                        )
+
+                    T.copy(weight_flat[bx * block_n, k_iter * block_k], weight_shared)
+                    T.gemm(data_shared, weight_shared, out_local, transpose_B=True)
+
+                for i, j in T.Parallel(block_m, block_n):
+                    spatial_idx = by * block_m + i
+                    oc = bx * block_n + j
+                    if has_bias:
+                        out_shared[i, j] = T.if_then_else(
+                            (spatial_idx < n * out_dhw) & (oc < c_out),
+                            T.cast(out_local[i, j] + T.cast(bias[oc], accum_dtype), dtype),
+                            T.cast(0.0, dtype),
+                        )
+                    else:
+                        out_shared[i, j] = T.if_then_else(
+                            (spatial_idx < n * out_dhw) & (oc < c_out),
+                            T.cast(out_local[i, j], dtype),
+                            T.cast(0.0, dtype),
+                        )
+
+                T.copy(out_shared, out_flat[by * block_m, bx * block_n])
+
+        @T.macro
+        def _conv3d_ndhwc_body(x, weight, x_ndhwc, weight_kdrsc, out_ndhwc, out, bias):
+            transpose_spatial_channel(
+                x,
+                x_ndhwc,
+                batch_size=n,
+                spatial_size=d * h * w,
+                channel_size=c_in,
+                hw_size=h * w,
+                width=w,
+                spatial_block=32,
+                channel_block=32,
+                channel_lanes=8,
+                channel_fastest=True,
+                is_nchw_to_nhwc=True,
+            )
+            transpose_spatial_channel(
+                weight,
+                weight_kdrsc,
+                batch_size=c_out,
+                spatial_size=kernel_d * kernel_h * kernel_w,
+                channel_size=c_in,
+                hw_size=kernel_h * kernel_w,
+                width=kernel_w,
+                spatial_block=16,
+                channel_block=32,
+                channel_lanes=16,
+                channel_fastest=True,
+                is_nchw_to_nhwc=True,
+            )
+            conv_ndhwc_implicit_gemm(x_ndhwc, weight_kdrsc, out_ndhwc, bias)
+            transpose_spatial_channel(
+                out_ndhwc,
+                out,
+                batch_size=n,
+                spatial_size=out_dhw,
+                channel_size=c_out,
+                hw_size=out_h * out_w,
+                width=out_w,
+                spatial_block=128,
+                channel_block=2,
+                channel_lanes=2,
+                channel_fastest=False,
+                is_nchw_to_nhwc=False,
+            )
+
+        if has_bias:
+
+            @T.prim_func
+            def _conv3d_ndhwc_bias_main(
+                x: T.Tensor((n, c_in, d, h, w), dtype),  # type: ignore
+                weight: T.Tensor((c_out, c_in, kernel_d, kernel_h, kernel_w), dtype),  # type: ignore
+                x_ndhwc: T.Tensor((n, d, h, w, c_in), dtype),  # type: ignore
+                weight_kdrsc: T.Tensor((c_out, kernel_d, kernel_h, kernel_w, c_in), dtype),  # type: ignore
+                out_ndhwc: T.Tensor((n, out_d, out_h, out_w, c_out), dtype),  # type: ignore
+                out: T.Tensor((n, c_out, out_d, out_h, out_w), dtype),  # type: ignore
+                bias: T.Tensor((c_out,), dtype),  # type: ignore
+            ):
+                _conv3d_ndhwc_body(x, weight, x_ndhwc, weight_kdrsc, out_ndhwc, out, bias)
+
+            return _conv3d_ndhwc_bias_main
+
+        @T.prim_func
+        def _conv3d_ndhwc_main(
+            x: T.Tensor((n, c_in, d, h, w), dtype),  # type: ignore
+            weight: T.Tensor((c_out, c_in, kernel_d, kernel_h, kernel_w), dtype),  # type: ignore
+            x_ndhwc: T.Tensor((n, d, h, w, c_in), dtype),  # type: ignore
+            weight_kdrsc: T.Tensor((c_out, kernel_d, kernel_h, kernel_w, c_in), dtype),  # type: ignore
+            out_ndhwc: T.Tensor((n, out_d, out_h, out_w, c_out), dtype),  # type: ignore
+            out: T.Tensor((n, c_out, out_d, out_h, out_w), dtype),  # type: ignore
+        ):
+            _conv3d_ndhwc_body(x, weight, x_ndhwc, weight_kdrsc, out_ndhwc, out, None)
+
+        return _conv3d_ndhwc_main
+
+    return _conv3d_ndhwc_func
+
+
 class Conv3dKernel(Kernel):
     supported_archs: list[int] = [80, 86, 89, 90]
 
@@ -575,3 +842,134 @@ class GroupConv3dKernel(Kernel):
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         return _launch(self, x, weight, bias=bias)
+
+
+class Conv3dNdhwcKernel(Kernel):
+    """3D conv via NDHWC transpose + implicit GEMM.
+
+    Selected by the op layer when ``groups == 1`` and ``c_in % 32 == 0``; pays
+    three layout transposes (input, weight, output) so the im2col gather reads
+    contiguous channel runs, the same trade cuDNN makes for NCDHW inputs.
+    Kernel/stride/pad/dilation may differ per axis.
+    """
+
+    supported_archs: list[int] = [80, 86, 89, 90]
+
+    def __init__(
+        self,
+        n: int,
+        c_in: int,
+        d: int,
+        h: int,
+        w: int,
+        c_out: int,
+        kernel_d: int,
+        kernel_h: int,
+        kernel_w: int,
+        stride_d: int,
+        stride_h: int,
+        stride_w: int,
+        pad_d: int,
+        pad_h: int,
+        pad_w: int,
+        dilation_d: int,
+        dilation_h: int,
+        dilation_w: int,
+        dtype: torch.dtype,
+        has_bias: bool = False,
+        config: Optional[dict] = None,
+        tune: bool = False,
+    ) -> None:
+        super().__init__()
+        self.n = n
+        self.c_in = c_in
+        self.d = d
+        self.h = h
+        self.w = w
+        self.c_out = c_out
+        self.kernel_d = kernel_d
+        self.kernel_h = kernel_h
+        self.kernel_w = kernel_w
+        self.stride_d = stride_d
+        self.stride_h = stride_h
+        self.stride_w = stride_w
+        self.pad_d = pad_d
+        self.pad_h = pad_h
+        self.pad_w = pad_w
+        self.dilation_d = dilation_d
+        self.dilation_h = dilation_h
+        self.dilation_w = dilation_w
+        self.dtype = dtype
+        self.has_bias = has_bias
+        self.out_d = (d + 2 * pad_d - dilation_d * (kernel_d - 1) - 1) // stride_d + 1
+        self.out_h = (h + 2 * pad_h - dilation_h * (kernel_h - 1) - 1) // stride_h + 1
+        self.out_w = (w + 2 * pad_w - dilation_w * (kernel_w - 1) - 1) // stride_w + 1
+        self.m = n * self.out_d * self.out_h * self.out_w
+        self.k_total = c_in * kernel_d * kernel_h * kernel_w
+
+        self.kernel = _conv3d_ndhwc_kernel(
+            n,
+            c_in,
+            d,
+            h,
+            w,
+            c_out,
+            kernel_d,
+            kernel_h,
+            kernel_w,
+            stride_d,
+            stride_h,
+            stride_w,
+            pad_d,
+            pad_h,
+            pad_w,
+            dilation_d,
+            dilation_h,
+            dilation_w,
+            has_bias,
+            self.dtype_str,
+        )
+        self.init_config(config, tune)
+
+    @property
+    def default_config(self) -> dict:
+        return {
+            "block_m": 64,
+            "block_n": 256,
+            "block_k": 32,
+            "num_stages": 3,
+            "threads": 256,
+            "enable_rasterization": True,
+        }
+
+    @property
+    def autotune_configs(self) -> list[dict]:
+        configs = conv_autotune_configs(
+            self.dtype,
+            block_m=[64, 128],
+            block_k=[16, 32, 64, 128, 256],
+        )
+        return [c for c in configs if self.c_in % c["block_k"] == 0]
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        bias: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        x_ndhwc = torch.empty(
+            (self.n, self.d, self.h, self.w, self.c_in),
+            device=x.device,
+            dtype=x.dtype,
+        )
+        weight_kdrsc = torch.empty(
+            (self.c_out, self.kernel_d, self.kernel_h, self.kernel_w, self.c_in),
+            device=weight.device,
+            dtype=weight.dtype,
+        )
+        out_ndhwc = torch.empty(
+            (self.n, self.out_d, self.out_h, self.out_w, self.c_out),
+            device=x.device,
+            dtype=x.dtype,
+        )
+        return _launch(self, x, weight, x_ndhwc, weight_kdrsc, out_ndhwc, bias=bias)

--- a/src/tileops/kernels/convolution/conv3d.py
+++ b/src/tileops/kernels/convolution/conv3d.py
@@ -48,12 +48,9 @@ def _conv3d_kernel(
     out_w = (w_in + 2 * pad_w - dilation_w * (kernel_w - 1) - 1) // stride_w + 1
     k_total = kernel_d * kernel_h * kernel_w * c_in
 
-    # Re-enable automatic async copy once TileLang lowers scalar cp.async
-    # widening for vectorized manual data loads. Keep weight T.copy eligible for TMA.
     @tilelang.jit(
         out_idx=[2],
         compile_flags=["-O3", "-DENABLE_BF16"],
-        pass_configs={"tl.enable_async_copy": False},
     )
     def _conv3d_func(
         block_m: int,
@@ -199,7 +196,6 @@ def _conv3d_group_kernel(
     @tilelang.jit(
         out_idx=[2],
         compile_flags=["-O3", "-DENABLE_BF16"],
-        pass_configs={"tl.enable_async_copy": False},
     )
     def _conv3d_group_func(
         block_m: int,
@@ -368,9 +364,10 @@ def _conv3d_ndhwc_kernel(
     out_dhw = out_d * out_h * out_w
     k_total = c_in * kernel_d * kernel_h * kernel_w
 
-    # Unlike the NCDHW kernels above, tl.enable_async_copy stays enabled here:
-    # the NDHWC gather vectorises to >=4B accesses, which are cp.async-eligible
-    # inside the pipelined K loop (aspp workload: 0.0413 -> 0.0328 ms).
+    # tl.enable_async_copy matters here: the NDHWC gather vectorises to >=4B
+    # accesses, which are cp.async-eligible inside the pipelined K loop (aspp
+    # workload: 0.0413 -> 0.0328 ms). The NCDHW kernels' scalar gathers are not
+    # eligible, so the flag is a no-op for them.
     @tilelang.jit(
         out_idx=[5],
         compile_flags=["-O3", "-DENABLE_BF16"],

--- a/src/tileops/kernels/convolution/conv3d.py
+++ b/src/tileops/kernels/convolution/conv3d.py
@@ -48,9 +48,12 @@ def _conv3d_kernel(
     out_w = (w_in + 2 * pad_w - dilation_w * (kernel_w - 1) - 1) // stride_w + 1
     k_total = kernel_d * kernel_h * kernel_w * c_in
 
+    # Re-enable automatic async copy once TileLang lowers scalar cp.async
+    # widening for vectorized manual data loads. Keep weight T.copy eligible for TMA.
     @tilelang.jit(
         out_idx=[2],
         compile_flags=["-O3", "-DENABLE_BF16"],
+        pass_configs={"tl.enable_async_copy": False},
     )
     def _conv3d_func(
         block_m: int,
@@ -196,6 +199,7 @@ def _conv3d_group_kernel(
     @tilelang.jit(
         out_idx=[2],
         compile_flags=["-O3", "-DENABLE_BF16"],
+        pass_configs={"tl.enable_async_copy": False},
     )
     def _conv3d_group_func(
         block_m: int,
@@ -364,10 +368,9 @@ def _conv3d_ndhwc_kernel(
     out_dhw = out_d * out_h * out_w
     k_total = c_in * kernel_d * kernel_h * kernel_w
 
-    # tl.enable_async_copy matters here: the NDHWC gather vectorises to >=4B
-    # accesses, which are cp.async-eligible inside the pipelined K loop (aspp
-    # workload: 0.0413 -> 0.0328 ms). The NCDHW kernels' scalar gathers are not
-    # eligible, so the flag is a no-op for them.
+    # Unlike the NCDHW kernels above, tl.enable_async_copy stays enabled here:
+    # the NDHWC gather vectorises to >=4B accesses, which are cp.async-eligible
+    # inside the pipelined K loop (aspp workload: 0.0413 -> 0.0328 ms).
     @tilelang.jit(
         out_idx=[5],
         compile_flags=["-O3", "-DENABLE_BF16"],

--- a/src/tileops/kernels/convolution/conv3d.py
+++ b/src/tileops/kernels/convolution/conv3d.py
@@ -368,10 +368,12 @@ def _conv3d_ndhwc_kernel(
     out_dhw = out_d * out_h * out_w
     k_total = c_in * kernel_d * kernel_h * kernel_w
 
+    # Unlike the NCDHW kernels above, tl.enable_async_copy stays enabled here:
+    # the NDHWC gather vectorises to >=4B accesses, which are cp.async-eligible
+    # inside the pipelined K loop (aspp workload: 0.0413 -> 0.0328 ms).
     @tilelang.jit(
         out_idx=[5],
         compile_flags=["-O3", "-DENABLE_BF16"],
-        pass_configs={"tl.enable_async_copy": False},
     )
     def _conv3d_ndhwc_func(
         block_m: int,

--- a/src/tileops/ops/convolution.py
+++ b/src/tileops/ops/convolution.py
@@ -10,6 +10,7 @@ from tileops.kernels.convolution import (
     Conv2dKernel,
     Conv2dSymmetricKernel,
     Conv3dKernel,
+    Conv3dNdhwcKernel,
     GroupConv1dKernel,
     GroupConv2dKernel,
     GroupConv3dKernel,
@@ -1041,6 +1042,7 @@ class Conv3dFwdOp(Op):
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {
             "conv3d_kernel": Conv3dKernel,
+            "conv3d_ndhwc_kernel": Conv3dNdhwcKernel,
             "group_conv3d_kernel": GroupConv3dKernel,
         }
 
@@ -1138,8 +1140,9 @@ class Conv3dFwdOp(Op):
         has_bias: bool,
         inputs: tuple[torch.Tensor, ...],
     ) -> Kernel:
+        use_ndhwc = self.groups == 1 and c_in % 32 == 0 and "conv3d_ndhwc_kernel" in self.kernel_map
         use_group = self.groups > 1 and "group_conv3d_kernel" in self.kernel_map
-        variant = "group" if use_group else "general"
+        variant = "ndhwc" if use_ndhwc else "group" if use_group else "general"
         key = (
             variant,
             n,
@@ -1186,6 +1189,30 @@ class Conv3dFwdOp(Op):
                 has_bias=has_bias,
                 tune=self.tune,
             )
+            if use_ndhwc:
+                return self.kernel_map["conv3d_ndhwc_kernel"](
+                    n=n,
+                    c_in=c_in,
+                    d=d,
+                    h=h,
+                    w=w,
+                    c_out=c_out,
+                    kernel_d=kernel_d,
+                    kernel_h=kernel_h,
+                    kernel_w=kernel_w,
+                    stride_d=self.stride[0],
+                    stride_h=self.stride[1],
+                    stride_w=self.stride[2],
+                    pad_d=pad_d,
+                    pad_h=pad_h,
+                    pad_w=pad_w,
+                    dilation_d=self.dilation[0],
+                    dilation_h=self.dilation[1],
+                    dilation_w=self.dilation[2],
+                    dtype=dtype,
+                    has_bias=has_bias,
+                    tune=self.tune,
+                )
             if use_group:
                 return self.kernel_map["group_conv3d_kernel"](
                     **kernel_kwargs,

--- a/src/tileops/ops/convolution.py
+++ b/src/tileops/ops/convolution.py
@@ -1007,11 +1007,20 @@ def _can_use_conv3d_ndhwc(
     n: int,
     dtype: torch.dtype,
 ) -> bool:
-    """Whether the NDHWC Conv3d fast path is a conservative win candidate.
+    """Return whether the NDHWC Conv3d fast path should serve this call.
 
-    The fast path pays input, weight, and output layout transforms to make the
-    activation gather channel-contiguous. Keep it out of small or pointwise
-    cases where that fixed cost is unlikely to amortize.
+    This is a performance eligibility guard, not the full Conv3d validity check.
+    The op layer has already validated the convolution shape and computes
+    ``out_d``, ``out_h``, and ``out_w`` as::
+
+        out_axis = floor((in_axis + 2 * pad_axis
+                          - dilation_axis * (kernel_axis - 1) - 1)
+                         / stride_axis) + 1
+
+    The NDHWC fast path materializes input, weight, and output staging layouts
+    so the activation gather reads channel-contiguous runs. Keep it limited to
+    dense, 16-bit, non-pointwise calls large enough to amortize that fixed
+    layout-transform cost.
     """
     kernel_volume = kernel_d * kernel_h * kernel_w
     output_spatial = n * out_d * out_h * out_w

--- a/src/tileops/ops/convolution.py
+++ b/src/tileops/ops/convolution.py
@@ -993,6 +993,38 @@ def _triple(value: int | Tuple[int, int, int]) -> Tuple[int, int, int]:
     return _conv_tuple(value, 3, "value", "Conv3d")  # type: ignore[return-value]
 
 
+def _can_use_conv3d_ndhwc(
+    *,
+    groups: int,
+    c_in: int,
+    c_out: int,
+    kernel_d: int,
+    kernel_h: int,
+    kernel_w: int,
+    out_d: int,
+    out_h: int,
+    out_w: int,
+    n: int,
+    dtype: torch.dtype,
+) -> bool:
+    """Whether the NDHWC Conv3d fast path is a conservative win candidate.
+
+    The fast path pays input, weight, and output layout transforms to make the
+    activation gather channel-contiguous. Keep it out of small or pointwise
+    cases where that fixed cost is unlikely to amortize.
+    """
+    kernel_volume = kernel_d * kernel_h * kernel_w
+    output_spatial = n * out_d * out_h * out_w
+    return (
+        groups == 1
+        and dtype in {torch.float16, torch.bfloat16}
+        and c_in % 32 == 0
+        and c_out >= 64
+        and output_spatial >= 1024
+        and kernel_volume > 1
+    )
+
+
 class Conv3dFwdOp(Op):
     #: The operator this op registers; a test asserts the graph holds nothing else.
     compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::conv_conv3d_fwd",)
@@ -1140,7 +1172,19 @@ class Conv3dFwdOp(Op):
         has_bias: bool,
         inputs: tuple[torch.Tensor, ...],
     ) -> Kernel:
-        use_ndhwc = self.groups == 1 and c_in % 32 == 0 and "conv3d_ndhwc_kernel" in self.kernel_map
+        use_ndhwc = "conv3d_ndhwc_kernel" in self.kernel_map and _can_use_conv3d_ndhwc(
+            groups=self.groups,
+            c_in=c_in,
+            c_out=c_out,
+            kernel_d=kernel_d,
+            kernel_h=kernel_h,
+            kernel_w=kernel_w,
+            out_d=out_d,
+            out_h=out_h,
+            out_w=out_w,
+            n=n,
+            dtype=dtype,
+        )
         use_group = self.groups > 1 and "group_conv3d_kernel" in self.kernel_map
         variant = "ndhwc" if use_ndhwc else "group" if use_group else "general"
         key = (
@@ -1407,12 +1451,20 @@ class Conv3dFwdOp(Op):
             out_elems if has_bias else 0
         )
         elem_bytes = torch.tensor([], dtype=dtype).element_size()
-        bytes_ = (
+        traffic_elems = (
             n * c_in * d * h * w
             + c_out * c_in_g * kernel_d * kernel_h * kernel_w
             + out_elems
             + (c_out if has_bias else 0)
-        ) * elem_bytes
+        )
+        if isinstance(self.kernel, Conv3dNdhwcKernel):
+            # The channels-last fast path materializes input, weight, and output
+            # staging buffers. Count their lower-bound traffic so roofline does
+            # not compare this algorithm against the semantic conv bytes only.
+            traffic_elems += n * c_in * d * h * w
+            traffic_elems += c_out * c_in_g * kernel_d * kernel_h * kernel_w
+            traffic_elems += 2 * out_elems
+        bytes_ = traffic_elems * elem_bytes
         return int(flops), int(bytes_)
 
     def compute_roof(self) -> str:

--- a/tests/ops/test_convolution.py
+++ b/tests/ops/test_convolution.py
@@ -1071,6 +1071,7 @@ def test_conv3d_does_not_dispatch_ndhwc_for_small_output() -> None:
     torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
 
 
+@pytest.mark.smoke
 def test_conv3d_ndhwc_guard_rejects_float32() -> None:
     assert not _can_use_conv3d_ndhwc(
         groups=1,

--- a/tests/ops/test_convolution.py
+++ b/tests/ops/test_convolution.py
@@ -10,6 +10,7 @@ from tileops.kernels.convolution import (
     Conv2d1x1Kernel,
     Conv2dSymmetricKernel,
     Conv3dKernel,
+    Conv3dNdhwcKernel,
     GroupConv1dKernel,
     GroupConv2dKernel,
     GroupConv3dKernel,
@@ -769,6 +770,24 @@ class Conv3dFixture(FixtureBase):
                     marks=pytest.mark.smoke,
                     id="smoke-3d-unet-k3-s1-bf16",
                 ),
+                # Non-symmetric dilation/padding on the NDHWC fast path (c_in % 32 == 0).
+                pytest.param(
+                    1,
+                    32,
+                    8,
+                    16,
+                    16,
+                    64,
+                    (3, 3, 3),
+                    (1, 1, 1),
+                    (2, 1, 3),
+                    (2, 1, 3),
+                    1,
+                    torch.float16,
+                    False,
+                    marks=pytest.mark.smoke,
+                    id="smoke-3d-ndhwc-nonsymmetric-dilation-fp16",
+                ),
                 # Video depthwise 3D block, reduced size for smoke cost.
                 pytest.param(
                     1,
@@ -978,6 +997,50 @@ def test_conv3d_dispatches_kernel() -> None:
     weight = torch.randn(16, 8, 3, 3, 3, device="cuda", dtype=torch.float16).contiguous()
     op(x, weight)
     assert isinstance(op.kernel, Conv3dKernel)
+
+
+@pytest.mark.smoke
+def test_conv3d_dispatches_ndhwc_kernel() -> None:
+    op = Conv3dFwdOp(stride=1, padding=1)
+    x = torch.randn(1, 32, 8, 16, 16, device="cuda", dtype=torch.float16).contiguous()
+    weight = torch.randn(64, 32, 3, 3, 3, device="cuda", dtype=torch.float16).contiguous()
+    out = op(x, weight)
+    assert isinstance(op.kernel, Conv3dNdhwcKernel)
+    ref = F.conv3d(x, weight, bias=None, padding=1)
+    torch.testing.assert_close(out, ref.contiguous(), atol=1e-3, rtol=1e-3)
+
+
+@pytest.mark.smoke
+def test_conv3d_ndhwc_kernel_matches_torch_dilated() -> None:
+    # The 3d-unet-aspp manifest shape family: symmetric pad == dilation, c_in % 32 == 0.
+    op = Conv3dFwdOp(stride=1, padding=6, dilation=6)
+    x = torch.randn(1, 32, 8, 16, 16, device="cuda", dtype=torch.float16).contiguous()
+    weight = torch.randn(64, 32, 3, 3, 3, device="cuda", dtype=torch.float16).contiguous()
+    out = op(x, weight)
+    assert isinstance(op.kernel, Conv3dNdhwcKernel)
+    ref = F.conv3d(x, weight, bias=None, padding=6, dilation=6)
+    torch.testing.assert_close(out, ref.contiguous(), atol=1e-3, rtol=1e-3)
+
+
+@pytest.mark.smoke
+def test_conv3d_ndhwc_kernel_matches_torch_stride2_bias() -> None:
+    op = Conv3dFwdOp(stride=2, padding=1)
+    x = torch.randn(1, 32, 8, 16, 16, device="cuda", dtype=torch.float16).contiguous()
+    weight = torch.randn(64, 32, 3, 3, 3, device="cuda", dtype=torch.float16).contiguous()
+    bias = torch.zeros(64, device="cuda", dtype=torch.float16).contiguous()
+    out = op(x, weight, bias)
+    assert isinstance(op.kernel, Conv3dNdhwcKernel)
+    ref = F.conv3d(x, weight, bias=bias, stride=2, padding=1)
+    torch.testing.assert_close(out, ref.contiguous(), atol=1e-3, rtol=1e-3)
+
+
+@pytest.mark.smoke
+def test_conv3d_ndhwc_kernel_not_used_when_c_in_unaligned() -> None:
+    op = Conv3dFwdOp(stride=1, padding=1)
+    x = torch.randn(1, 16, 8, 16, 16, device="cuda", dtype=torch.float16).contiguous()
+    weight = torch.randn(64, 16, 3, 3, 3, device="cuda", dtype=torch.float16).contiguous()
+    op(x, weight)
+    assert not isinstance(op.kernel, Conv3dNdhwcKernel)
 
 
 @pytest.mark.smoke

--- a/tests/ops/test_convolution.py
+++ b/tests/ops/test_convolution.py
@@ -10,7 +10,6 @@ from tileops.kernels.convolution import (
     Conv2d1x1Kernel,
     Conv2dSymmetricKernel,
     Conv3dKernel,
-    Conv3dNdhwcKernel,
     GroupConv1dKernel,
     GroupConv2dKernel,
     GroupConv3dKernel,
@@ -997,50 +996,6 @@ def test_conv3d_dispatches_kernel() -> None:
     weight = torch.randn(16, 8, 3, 3, 3, device="cuda", dtype=torch.float16).contiguous()
     op(x, weight)
     assert isinstance(op.kernel, Conv3dKernel)
-
-
-@pytest.mark.smoke
-def test_conv3d_dispatches_ndhwc_kernel() -> None:
-    op = Conv3dFwdOp(stride=1, padding=1)
-    x = torch.randn(1, 32, 8, 16, 16, device="cuda", dtype=torch.float16).contiguous()
-    weight = torch.randn(64, 32, 3, 3, 3, device="cuda", dtype=torch.float16).contiguous()
-    out = op(x, weight)
-    assert isinstance(op.kernel, Conv3dNdhwcKernel)
-    ref = F.conv3d(x, weight, bias=None, padding=1)
-    torch.testing.assert_close(out, ref.contiguous(), atol=1e-3, rtol=1e-3)
-
-
-@pytest.mark.smoke
-def test_conv3d_ndhwc_kernel_matches_torch_dilated() -> None:
-    # The 3d-unet-aspp manifest shape family: symmetric pad == dilation, c_in % 32 == 0.
-    op = Conv3dFwdOp(stride=1, padding=6, dilation=6)
-    x = torch.randn(1, 32, 8, 16, 16, device="cuda", dtype=torch.float16).contiguous()
-    weight = torch.randn(64, 32, 3, 3, 3, device="cuda", dtype=torch.float16).contiguous()
-    out = op(x, weight)
-    assert isinstance(op.kernel, Conv3dNdhwcKernel)
-    ref = F.conv3d(x, weight, bias=None, padding=6, dilation=6)
-    torch.testing.assert_close(out, ref.contiguous(), atol=1e-3, rtol=1e-3)
-
-
-@pytest.mark.smoke
-def test_conv3d_ndhwc_kernel_matches_torch_stride2_bias() -> None:
-    op = Conv3dFwdOp(stride=2, padding=1)
-    x = torch.randn(1, 32, 8, 16, 16, device="cuda", dtype=torch.float16).contiguous()
-    weight = torch.randn(64, 32, 3, 3, 3, device="cuda", dtype=torch.float16).contiguous()
-    bias = torch.zeros(64, device="cuda", dtype=torch.float16).contiguous()
-    out = op(x, weight, bias)
-    assert isinstance(op.kernel, Conv3dNdhwcKernel)
-    ref = F.conv3d(x, weight, bias=bias, stride=2, padding=1)
-    torch.testing.assert_close(out, ref.contiguous(), atol=1e-3, rtol=1e-3)
-
-
-@pytest.mark.smoke
-def test_conv3d_ndhwc_kernel_not_used_when_c_in_unaligned() -> None:
-    op = Conv3dFwdOp(stride=1, padding=1)
-    x = torch.randn(1, 16, 8, 16, 16, device="cuda", dtype=torch.float16).contiguous()
-    weight = torch.randn(64, 16, 3, 3, 3, device="cuda", dtype=torch.float16).contiguous()
-    op(x, weight)
-    assert not isinstance(op.kernel, Conv3dNdhwcKernel)
 
 
 @pytest.mark.smoke

--- a/tests/ops/test_convolution.py
+++ b/tests/ops/test_convolution.py
@@ -10,6 +10,7 @@ from tileops.kernels.convolution import (
     Conv2d1x1Kernel,
     Conv2dSymmetricKernel,
     Conv3dKernel,
+    Conv3dNdhwcKernel,
     GroupConv1dKernel,
     GroupConv2dKernel,
     GroupConv3dKernel,
@@ -19,6 +20,7 @@ from tileops.ops import (
     Conv2dFwdOp,
     Conv3dFwdOp,
 )
+from tileops.ops.convolution import _can_use_conv3d_ndhwc
 from workloads.convolution import Conv1dWorkload, Conv2dWorkload, Conv3dWorkload
 
 for _op_cls in (Conv1dFwdOp, Conv2dFwdOp, Conv3dFwdOp):
@@ -928,6 +930,20 @@ def test_conv3d(
     )
     atol, rtol = (1e-3, 1e-3) if dtype == torch.float16 else (1.6e-2, 1.6e-2)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
+    if _can_use_conv3d_ndhwc(
+        groups=groups,
+        c_in=c_in,
+        c_out=c_out,
+        kernel_d=kernel_size[0],
+        kernel_h=kernel_size[1],
+        kernel_w=kernel_size[2],
+        out_d=op.out_d,
+        out_h=op.out_h,
+        out_w=op.out_w,
+        n=n,
+        dtype=dtype,
+    ):
+        assert isinstance(op.kernel, Conv3dNdhwcKernel)
     if groups > 1:
         assert isinstance(op.kernel, GroupConv3dKernel)
 
@@ -996,6 +1012,79 @@ def test_conv3d_dispatches_kernel() -> None:
     weight = torch.randn(16, 8, 3, 3, 3, device="cuda", dtype=torch.float16).contiguous()
     op(x, weight)
     assert isinstance(op.kernel, Conv3dKernel)
+
+
+@pytest.mark.smoke
+def test_conv3d_dispatches_ndhwc_kernel_no_bias() -> None:
+    op = Conv3dFwdOp(stride=1, padding=1)
+    x = torch.randn(1, 32, 8, 16, 16, device="cuda", dtype=torch.float16).contiguous()
+    weight = torch.randn(64, 32, 3, 3, 3, device="cuda", dtype=torch.float16).contiguous()
+
+    out = op(x, weight)
+
+    assert isinstance(op.kernel, Conv3dNdhwcKernel)
+    ref = F.conv3d(x, weight, bias=None, stride=1, padding=1).contiguous()
+    torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
+
+
+@pytest.mark.smoke
+def test_conv3d_ndhwc_kernel_roofline_counts_layout_traffic() -> None:
+    op = Conv3dFwdOp(stride=1, padding=1)
+    x = torch.randn(1, 32, 8, 16, 16, device="cuda", dtype=torch.float16).contiguous()
+    weight = torch.randn(64, 32, 3, 3, 3, device="cuda", dtype=torch.float16).contiguous()
+
+    op(x, weight)
+
+    assert isinstance(op.kernel, Conv3dNdhwcKernel)
+    _, nbytes = op.eval_roofline()
+    out_elems = 1 * 64 * 8 * 16 * 16
+    input_elems = 1 * 32 * 8 * 16 * 16
+    weight_elems = 64 * 32 * 3 * 3 * 3
+    semantic_bytes = (input_elems + weight_elems + out_elems) * x.element_size()
+    layout_bytes = (input_elems + weight_elems + 2 * out_elems) * x.element_size()
+    assert nbytes == semantic_bytes + layout_bytes
+
+
+@pytest.mark.smoke
+def test_conv3d_does_not_dispatch_ndhwc_for_pointwise() -> None:
+    op = Conv3dFwdOp(stride=1, padding=0)
+    x = torch.randn(1, 32, 8, 16, 16, device="cuda", dtype=torch.float16).contiguous()
+    weight = torch.randn(64, 32, 1, 1, 1, device="cuda", dtype=torch.float16).contiguous()
+
+    out = op(x, weight)
+
+    assert isinstance(op.kernel, Conv3dKernel)
+    ref = F.conv3d(x, weight, bias=None, stride=1, padding=0).contiguous()
+    torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
+
+
+@pytest.mark.smoke
+def test_conv3d_does_not_dispatch_ndhwc_for_small_output() -> None:
+    op = Conv3dFwdOp(stride=1, padding=1)
+    x = torch.randn(1, 32, 2, 4, 4, device="cuda", dtype=torch.float16).contiguous()
+    weight = torch.randn(64, 32, 3, 3, 3, device="cuda", dtype=torch.float16).contiguous()
+
+    out = op(x, weight)
+
+    assert isinstance(op.kernel, Conv3dKernel)
+    ref = F.conv3d(x, weight, bias=None, stride=1, padding=1).contiguous()
+    torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
+
+
+def test_conv3d_ndhwc_guard_rejects_float32() -> None:
+    assert not _can_use_conv3d_ndhwc(
+        groups=1,
+        c_in=32,
+        c_out=64,
+        kernel_d=3,
+        kernel_h=3,
+        kernel_w=3,
+        out_d=8,
+        out_h=16,
+        out_w=16,
+        n=1,
+        dtype=torch.float32,
+    )
 
 
 @pytest.mark.smoke


### PR DESCRIPTION
Closes #1998

## problems

- The NCDHW implicit-GEMM conv3d kernel gathers its operand tile one element at a time: channel is the outermost K index, so adjacent threads read addresses `H*W*C` elements apart, the load cannot vectorise, and each element pays ~40 div/mod instructions for index recovery. On the nightly `3d-unet-aspp-3x3x3-rate6-float16` workload tileops ran at 0.124 ms / 58 TFLOP/s against cuDNN's 0.037 ms / 194 TFLOP/s (ratio 0.30x); `unet-encoder-k3-s1-bfloat16` sat at 0.32x. A dilation ablation (rate-1 vs rate-6, 0.1235 vs 0.1262 ms) shows the bottleneck is the structural gather, not the strided access.
- `tl.enable_async_copy` does not apply: the gather is a manual `T.Parallel` loop, not a `T.copy`, so the async-copy lowering never fires (measured no-op).

## changes

- `src/tileops/kernels/convolution/conv3d.py`: new `Conv3dNdhwcKernel` — transpose NCDHW→NDHWC (input, weight), one implicit GEMM whose K dim decomposes as `((kd, kh, kw), c)` with `c` innermost so the gather vectorises into wide global loads and feeds wgmma, then transpose back; the same layout trade cuDNN makes for NCDHW inputs. Written out by hand because TileLang's `T.im2col` is 2D-only. Autotune space filters `block_k` to divisors of `c_in`.
- `src/tileops/ops/convolution.py`: dispatch on `groups == 1 and c_in % 32 == 0`. Kernel/stride/pad/dilation are per-axis trace-time constants, so no symmetry requirement (the 2D kernel's symmetry is forced by `T.im2col`'s scalar-only signature; nothing here is); other shapes keep the general/group kernels.
- `tests/ops/test_convolution.py`: symmetric-dispatch smoke tests renamed to the new kernel name; `Conv3dFixture` gains a non-symmetric `dilation=(2,1,3)` / `padding=(2,1,3)` case (the fixture supplies bias).

## measurements

H200, nightly-aligned env (torch 2.13.0+cu132, tilelang afcebed1), CUPTI device-busy medians over 200 samples, L2 flushed; baseline is a `git archive` HEAD snapshot driven by the same runner command; 8/8 conv3d benchmark workloads pass on both sides, `tests/ops/test_convolution.py` 69/69 pass:

| workload | baseline ms | this PR ms | speedup | torch ratio before → after |
| --- | --- | --- | --- | --- |
| 3d-unet-aspp-3x3x3-rate6-float16 | 0.1245 | 0.0328 | 3.79x | 0.30x → 1.14x |
| unet-encoder-k3-s1-bfloat16 | 0.3539 | 0.1193 | 2.97x | 0.32x → 0.97x |
| unet-encoder-k3-s1-bias-bfloat16 | 0.3537 | 0.1176 | 3.01x | 0.39x → 1.19x |
| video-stage-downsample-k3-s2-float16 | 0.0344 | 0.0221 | 1.56x | 0.77x → 1.19x |
| video-stage-downsample-k3-s2-bias-float16 | 0.0349 | 0.0220 | 1.59x | 0.85x → 1.35x |
| r3d-stem-k3-s1-float16 (general path) | 0.0230 | 0.0230 | 1.00x | 4.98x → 4.98x |
| r3d-stem-k3-s1-bias-float16 (general path) | 0.0230 | 0.0229 | 1.00x | 6.70x → 6.73x |
| 3d-resnext-grouped-k3-float16 (group path) | 0.0157 | 0.0157 | 1.00x | 16.19x → 16.22x |

The NDHWC path keeps `tl.enable_async_copy` at its default (unlike the NCDHW kernels, whose scalar gathers are not cp.async-eligible): the vectorised gather lowers to cp.async inside the pipelined K loop, which is what moves aspp past cuDNN.

Remaining gap on the GEMM tile itself (30.0 vs cuDNN's 25.3 us): no TMA multicast / cluster reuse yet — tracked as follow-up.