### PR TITLE
[Perf][Elementwise] Reuse the sinusoidal divisor down the rows, and clamp Mish

### DIFF
--- a/src/tileops/kernels/elementwise/_erf.py
+++ b/src/tileops/kernels/elementwise/_erf.py
@@ -4,31 +4,13 @@ import tilelang.language as T
 
 __all__ = ["erf"]
 
-#: |x| at which erf is taken as saturated. erf(3.6) = 1 - 7.4e-7, three hundred
-#: times finer than half a float16 ulp at 1.0, so the clamp costs neither dtype
-#: anything it could store.
+#: |x| taken as saturated. erf(3.6) = 1 - 7.4e-7, far below half a float16 ulp.
 _CLAMP = 3.6
 
-#: erf(x) = clip(t * P(w), -1, 1) for t = clamp(x, -_CLAMP, _CLAMP) and
-#: w = 1 - (t / _CLAMP)**2, coefficients highest degree first. Three properties of
-#: this form, in this order:
-#:
-#: - erf saturates to exactly +-1 at the clamp, which GELU depends on: it scales
-#:   the 1 - erf(x) residual by x, so a tail off by eps carries an error of
-#:   |x| * eps / 2, unbounded in |x|. Two things make it exact. _CLAMP is scaled
-#:   out of x before squaring rather than after, so w is exactly zero at the clamp
-#:   and P is exactly its constant term float32(1 / _CLAMP), whose product with
-#:   _CLAMP is 1.0; and the clip stops the backend contracting that product into
-#:   the caller's add, which would evaluate it to full width and land 7e-9 short.
-#: - w rather than x**2 as the polynomial variable keeps the Horner chain
-#:   conditioned in float32. The same fit in unnormalised x**2 loses four digits
-#:   to cancellation at the clamp.
-#: - t * P(w) rather than a polynomial in x alone keeps the *relative* error small
-#:   near zero, where erf(x) -> x.
-#:
-#: Worst case over the real line is 1.7e-5, an order below half a float16 ulp at
-#: 1.0 (2.4e-4). tests/ops/test_unary_math.py measures the resulting ulp distance
-#: on device, over every float16 and every bfloat16 value.
+#: erf(x) = clip(t * P(w), -1, 1), t = clamp(x, -_CLAMP, _CLAMP), w = 1 - (t / _CLAMP)**2,
+#: highest degree first. Worst case over the real line is 1.7e-5, an order below half
+#: a float16 ulp at 1.0; tests/ops/test_unary_math.py measures the ulp distance on
+#: device over every float16 and every bfloat16 value.
 _POLY_COEFFS = (
     8.971932411193848,
     -33.1397590637207,
@@ -48,14 +30,7 @@ def erf(x, out_dtype):
     """Element-wise erf(x), evaluated and returned in float32.
 
     ``erff`` is correct to 2 ulp of float32 and costs roughly twice the
-    polynomial's instruction count. A float16 or bfloat16 result cannot hold that
-    accuracy, so only float32 pays for it.
-
-    NaN is not preserved: the clamp lowers to ``fminf``/``fmaxf``, which return
-    their non-NaN operand, so a NaN argument reads back as +-1. That matches what
-    the other clamp-shaped bodies in this package already do -- relu, hardtanh and
-    hardsigmoid all answer a NaN input with a finite value. Guarding it costs 23%,
-    because ``T.if_then_else`` in an element body scalarises the loop.
+    polynomial's instruction count, which only a float32 result can hold.
 
     Args:
         x: The argument. Any float dtype; promoted to float32 before evaluation.
@@ -73,9 +48,18 @@ def erf(x, out_dtype):
         return T.erf(wide)
     one = T.cast(1.0, "float32")
     clamped = T.min(T.max(wide, T.cast(-_CLAMP, "float32")), T.cast(_CLAMP, "float32"))
+    # Scaling the clamp out before squaring, not after, is what makes w exactly zero
+    # at the clamp: float32(1 / _CLAMP) * _CLAMP is 1.0, where 1 - x**2 / _CLAMP**2
+    # leaves 1e-8 once the backend contracts it into an FMA.
     scaled = clamped * T.cast(1.0 / _CLAMP, "float32")
     w = one - scaled * scaled
     acc = T.cast(_POLY_COEFFS[0], "float32")
     for coeff in _POLY_COEFFS[1:]:
         acc = acc * w + T.cast(coeff, "float32")
-    return T.min(T.max(clamped * acc, -one), one)
+    # The clip keeps the backend from contracting the product into a caller's add,
+    # which would evaluate it to full width and land the tail 7e-9 short of +-1.
+    # GELU scales the 1 - erf(x) residual by x, so that error is unbounded in |x|.
+    saturated = T.min(T.max(clamped * acc, -one), one)
+    # fminf and fmaxf return their non-NaN operand, so the clamp above has already
+    # lost a NaN argument by here.
+    return T.if_then_else(T.isnan(wide), T.cast(float("nan"), "float32"), saturated)

--- a/src/tileops/kernels/elementwise/_erf.py
+++ b/src/tileops/kernels/elementwise/_erf.py
@@ -1,0 +1,81 @@
+"""erf(x) at the accuracy the result's storage dtype can hold."""
+
+import tilelang.language as T
+
+__all__ = ["erf"]
+
+#: |x| at which erf is taken as saturated. erf(3.6) = 1 - 7.4e-7, three hundred
+#: times finer than half a float16 ulp at 1.0, so the clamp costs neither dtype
+#: anything it could store.
+_CLAMP = 3.6
+
+#: erf(x) = clip(t * P(w), -1, 1) for t = clamp(x, -_CLAMP, _CLAMP) and
+#: w = 1 - (t / _CLAMP)**2, coefficients highest degree first. Three properties of
+#: this form, in this order:
+#:
+#: - erf saturates to exactly +-1 at the clamp, which GELU depends on: it scales
+#:   the 1 - erf(x) residual by x, so a tail off by eps carries an error of
+#:   |x| * eps / 2, unbounded in |x|. Two things make it exact. _CLAMP is scaled
+#:   out of x before squaring rather than after, so w is exactly zero at the clamp
+#:   and P is exactly its constant term float32(1 / _CLAMP), whose product with
+#:   _CLAMP is 1.0; and the clip stops the backend contracting that product into
+#:   the caller's add, which would evaluate it to full width and land 7e-9 short.
+#: - w rather than x**2 as the polynomial variable keeps the Horner chain
+#:   conditioned in float32. The same fit in unnormalised x**2 loses four digits
+#:   to cancellation at the clamp.
+#: - t * P(w) rather than a polynomial in x alone keeps the *relative* error small
+#:   near zero, where erf(x) -> x.
+#:
+#: Worst case over the real line is 1.7e-5, an order below half a float16 ulp at
+#: 1.0 (2.4e-4). tests/ops/test_unary_math.py measures the resulting ulp distance
+#: on device, over every float16 and every bfloat16 value.
+_POLY_COEFFS = (
+    8.971932411193848,
+    -33.1397590637207,
+    53.60123062133789,
+    -48.02798080444336,
+    26.02545738220215,
+    -8.488715171813965,
+    1.7499406337738037,
+    -0.09359221160411835,
+    0.11330155283212662,
+    0.1387363225221634,
+    0.2777777910232544,
+)
+
+
+def erf(x, out_dtype):
+    """Element-wise erf(x), evaluated and returned in float32.
+
+    ``erff`` is correct to 2 ulp of float32 and costs roughly twice the
+    polynomial's instruction count. A float16 or bfloat16 result cannot hold that
+    accuracy, so only float32 pays for it.
+
+    NaN is not preserved: the clamp lowers to ``fminf``/``fmaxf``, which return
+    their non-NaN operand, so a NaN argument reads back as +-1. That matches what
+    the other clamp-shaped bodies in this package already do -- relu, hardtanh and
+    hardsigmoid all answer a NaN input with a finite value. Guarding it costs 23%,
+    because ``T.if_then_else`` in an element body scalarises the loop.
+
+    Args:
+        x: The argument. Any float dtype; promoted to float32 before evaluation.
+        out_dtype: The dtype the caller stores the result in. It selects the
+            evaluation, not the return dtype.
+
+    Returns:
+        erf(x) in float32.
+
+    Example:
+        >>> erf(T.cast(x, "float32") * inv_sqrt_2, x.dtype)  # doctest: +SKIP
+    """
+    wide = T.cast(x, "float32")
+    if out_dtype == "float32":
+        return T.erf(wide)
+    one = T.cast(1.0, "float32")
+    clamped = T.min(T.max(wide, T.cast(-_CLAMP, "float32")), T.cast(_CLAMP, "float32"))
+    scaled = clamped * T.cast(1.0 / _CLAMP, "float32")
+    w = one - scaled * scaled
+    acc = T.cast(_POLY_COEFFS[0], "float32")
+    for coeff in _POLY_COEFFS[1:]:
+        acc = acc * w + T.cast(coeff, "float32")
+    return T.min(T.max(clamped * acc, -one), one)

--- a/src/tileops/kernels/elementwise/activations.py
+++ b/src/tileops/kernels/elementwise/activations.py
@@ -114,7 +114,8 @@ class HardswishFwdKernel(FloatUnaryKernel):
     """Element-wise HardSwish: x * clamp(x + 3, 0, 6) * (1 / 6).
 
     Scaling by the reciprocal is what ``torch.nn.functional.hardswish`` does, so
-    the result is bit-identical to it; dividing by 6 lowers to ``div.rn.f32``.
+    finite inputs come out bit-identical to it; dividing by 6 lowers to
+    ``div.rn.f32``.
     """
 
     @staticmethod
@@ -131,7 +132,9 @@ class HardsigmoidFwdKernel(FloatUnaryKernel):
     """Element-wise HardSigmoid: clamp(x + 3, 0, 6) * (1 / 6).
 
     Scaling by the reciprocal is what ``torch.nn.functional.hardsigmoid`` does, so
-    the result is bit-identical to it; dividing by 6 lowers to ``div.rn.f32``.
+    finite inputs come out bit-identical to it; dividing by 6 lowers to
+    ``div.rn.f32``. A NaN input reads back as 0, since the clamp lowers to
+    ``fminf``/``fmaxf``, which return their non-NaN operand.
     """
 
     @staticmethod

--- a/src/tileops/kernels/elementwise/activations.py
+++ b/src/tileops/kernels/elementwise/activations.py
@@ -113,9 +113,8 @@ class TanhFwdKernel(FloatUnaryKernel):
 class HardswishFwdKernel(FloatUnaryKernel):
     """Element-wise HardSwish: x * clamp(x + 3, 0, 6) * (1 / 6).
 
-    ``torch.nn.functional.hardswish`` scales by the reciprocal too, so the result
-    is bit-identical to it. An IEEE divide by 6 is neither that nor cheap: it
-    lowers to ``div.rn.f32``, several instructions per element.
+    Scaling by the reciprocal is what ``torch.nn.functional.hardswish`` does, so
+    the result is bit-identical to it; dividing by 6 lowers to ``div.rn.f32``.
     """
 
     @staticmethod
@@ -131,9 +130,8 @@ class HardswishFwdKernel(FloatUnaryKernel):
 class HardsigmoidFwdKernel(FloatUnaryKernel):
     """Element-wise HardSigmoid: clamp(x + 3, 0, 6) * (1 / 6).
 
-    ``torch.nn.functional.hardsigmoid`` scales by the reciprocal too, so the
-    result is bit-identical to it. An IEEE divide by 6 is neither that nor cheap:
-    it lowers to ``div.rn.f32``, several instructions per element.
+    Scaling by the reciprocal is what ``torch.nn.functional.hardsigmoid`` does, so
+    the result is bit-identical to it; dividing by 6 lowers to ``div.rn.f32``.
     """
 
     @staticmethod

--- a/src/tileops/kernels/elementwise/activations.py
+++ b/src/tileops/kernels/elementwise/activations.py
@@ -159,17 +159,15 @@ class MishFwdKernel(FloatUnaryKernel):
         With ``e = exp(x)``, ``tanh(log(1 + e))`` is exactly ``(e^2 + 2e)/(e^2 + 2e + 2)``:
         this avoids extra transcendentals and keeps the small values ``log(1 + e)``
         rounds away. Past ``_SATURATION`` the ratio is 1 to every bit fp32 carries,
-        which is also what keeps ``e^2`` finite.
+        so clamping the exponent's argument there returns ``x`` on its own and keeps
+        ``e^2`` finite. Clamping rather than selecting on it also keeps the element
+        loop vectorised, which ``T.if_then_else`` does not.
         """
         two = T.cast(2.0, "float32")
         wide = T.cast(x, "float32")
-        e = T.exp(wide)
+        e = T.exp(T.min(wide, T.cast(MishFwdKernel._SATURATION, "float32")))
         saturated = e * e + two * e
-        return T.if_then_else(
-            wide > T.cast(MishFwdKernel._SATURATION, "float32"),
-            wide,
-            wide * saturated / (saturated + two),
-        )
+        return wide * saturated / (saturated + two)
 
 
 class SeluFwdKernel(FloatUnaryKernel):

--- a/src/tileops/kernels/elementwise/activations.py
+++ b/src/tileops/kernels/elementwise/activations.py
@@ -14,6 +14,7 @@ from ._base import (
     ParametricUnaryKernel,
 )
 from ._dtype import _fp8_accum_dtype_str, log_for_output_precision
+from ._erf import erf
 
 __all__ = [
     "EluFwdKernel",
@@ -52,7 +53,8 @@ class GeluFwdKernel(FloatUnaryKernel):
         inv_sqrt_2 = T.cast(INV_SQRT2, "float32")
         half = T.cast(0.5, "float32")
         one = T.cast(1.0, "float32")
-        return half * x * (one + T.erf(T.cast(x, "float32") * inv_sqrt_2))
+        wide = T.cast(x, "float32")
+        return half * wide * (one + erf(wide * inv_sqrt_2, x.dtype))
 
 
 class GeluTanhFwdKernel(FloatUnaryKernel):
@@ -109,26 +111,38 @@ class TanhFwdKernel(FloatUnaryKernel):
 
 
 class HardswishFwdKernel(FloatUnaryKernel):
-    """Element-wise HardSwish: x * clamp(x + 3, 0, 6) / 6."""
+    """Element-wise HardSwish: x * clamp(x + 3, 0, 6) * (1 / 6).
+
+    ``torch.nn.functional.hardswish`` scales by the reciprocal too, so the result
+    is bit-identical to it. An IEEE divide by 6 is neither that nor cheap: it
+    lowers to ``div.rn.f32``, several instructions per element.
+    """
 
     @staticmethod
     def op_func(x):
         three = T.cast(3.0, "float32")
         six = T.cast(6.0, "float32")
         zero = T.cast(0.0, "float32")
+        one_sixth = T.cast(1.0 / 6.0, "float32")
         clamped = T.min(T.max(x + three, zero), six)
-        return x * clamped / six
+        return x * clamped * one_sixth
 
 
 class HardsigmoidFwdKernel(FloatUnaryKernel):
-    """Element-wise HardSigmoid: clamp(x + 3, 0, 6) / 6."""
+    """Element-wise HardSigmoid: clamp(x + 3, 0, 6) * (1 / 6).
+
+    ``torch.nn.functional.hardsigmoid`` scales by the reciprocal too, so the
+    result is bit-identical to it. An IEEE divide by 6 is neither that nor cheap:
+    it lowers to ``div.rn.f32``, several instructions per element.
+    """
 
     @staticmethod
     def op_func(x):
         three = T.cast(3.0, "float32")
         six = T.cast(6.0, "float32")
         zero = T.cast(0.0, "float32")
-        return T.min(T.max(x + three, zero), six) / six
+        one_sixth = T.cast(1.0 / 6.0, "float32")
+        return T.min(T.max(x + three, zero), six) * one_sixth
 
 
 class MishFwdKernel(FloatUnaryKernel):
@@ -485,7 +499,6 @@ class GeluAndMulFwdKernel(FusedGatedKernel):
     """GELU-and-Mul: y = gelu(gate) * value.
 
     Uses exact GELU: gelu(x) = x * 0.5 * (1 + erf(x / sqrt(2))).
-    erf is computed in float32 to avoid missing half-precision intrinsic.
     """
 
     SUPPORTED_DTYPES = _FLOAT_DTYPES
@@ -496,7 +509,7 @@ class GeluAndMulFwdKernel(FusedGatedKernel):
         half = T.cast(0.5, x.dtype)
         one = T.cast(1.0, x.dtype)
         x_f32 = T.Cast("float32", x)
-        erf_val = T.Cast(x.dtype, T.erf(x_f32 * inv_sqrt2))
+        erf_val = T.Cast(x.dtype, erf(x_f32 * inv_sqrt2, x.dtype))
         return x * half * (one + erf_val)
 
 

--- a/src/tileops/kernels/elementwise/math_unary.py
+++ b/src/tileops/kernels/elementwise/math_unary.py
@@ -7,6 +7,7 @@ from ._base import (
     FloatUnaryKernel,
 )
 from ._dtype import log_for_output_precision
+from ._erf import erf
 
 __all__ = [
     "AbsFwdKernel",
@@ -109,13 +110,20 @@ class SignFwdKernel(FloatUnaryKernel):
 
     @staticmethod
     def op_func(x):
-        zero = T.cast(0.0, x.dtype)
-        one = T.cast(1.0, x.dtype)
-        neg_one = T.cast(-1.0, x.dtype)
+        """The three-way select, in float32.
+
+        The comparisons are exact in either width, and float32 is what the
+        backend vectorises: a half-native select lowers to scalar code and runs
+        the kernel 5% off the copy roof.
+        """
+        zero = T.cast(0.0, "float32")
+        one = T.cast(1.0, "float32")
+        neg_one = T.cast(-1.0, "float32")
+        wide = T.cast(x, "float32")
         return T.if_then_else(
-            x > zero,
+            wide > zero,
             one,
-            T.if_then_else(x < zero, neg_one, zero),
+            T.if_then_else(wide < zero, neg_one, zero),
         )
 
 
@@ -185,15 +193,11 @@ class TruncFwdKernel(FloatUnaryKernel):
 
 
 class ErfFwdKernel(FloatUnaryKernel):
-    """Element-wise erf(x).
-
-    Casts to fp32 before calling ``T.erf`` because the half-precision
-    intrinsic ``herf`` is not a valid CUDA built-in.
-    """
+    """Element-wise erf(x)."""
 
     @staticmethod
     def op_func(x):
-        return T.erf(T.cast(x, "float32"))
+        return erf(x, x.dtype)
 
 
 class Log1pFwdKernel(FloatUnaryKernel):

--- a/src/tileops/kernels/elementwise/math_unary.py
+++ b/src/tileops/kernels/elementwise/math_unary.py
@@ -110,12 +110,8 @@ class SignFwdKernel(FloatUnaryKernel):
 
     @staticmethod
     def op_func(x):
-        """The three-way select, in float32.
-
-        The comparisons are exact in either width, and float32 is what the
-        backend vectorises: a half-native select lowers to scalar code and runs
-        the kernel 5% off the copy roof.
-        """
+        # In float32, not x.dtype: the comparisons are exact in either width, and a
+        # half-native select lowers to scalar code instead of vectorising.
         zero = T.cast(0.0, "float32")
         one = T.cast(1.0, "float32")
         neg_one = T.cast(-1.0, "float32")

--- a/src/tileops/kernels/elementwise/sinusoidal.py
+++ b/src/tileops/kernels/elementwise/sinusoidal.py
@@ -4,14 +4,12 @@ import functools
 
 import tilelang
 import tilelang.language as T
-import torch
 
 from tileops.kernels.kernel_base import Kernel
 
 from ._base import (
     _FLOAT_DTYPES,
     _get_fp8_output_dtypes,
-    _is_fp8,
 )
 
 __all__ = [
@@ -19,43 +17,56 @@ __all__ = [
 ]
 
 
+#: Positions and dimension pairs one block covers. The divisor depends on the pair
+#: and not the position, so a block spanning several positions calls ``pow`` once
+#: per pair instead of once per element; 64 x 32 measured fastest on H200 across
+#: the manifest shapes. Both are capped to the tensor at build time.
+_ROWS, _COLS = 64, 32
+
+
 @functools.lru_cache(maxsize=32)
-def _make_sinusoidal_kernel(seq_len, d_model, dtype, threads=256, npt=8):
+def _make_sinusoidal_kernel(seq_len, d_model, dtype, threads=256, rows=_ROWS, cols=_COLS):
     """Build sinusoidal positional encoding kernel.
 
     PE(pos, 2i) = sin(pos / 10000^(2i/d_model))
     PE(pos, 2i+1) = cos(pos / 10000^(2i/d_model))
     Output shape: (seq_len, d_model).
     """
-    N_total = seq_len * d_model
+    half = d_model // 2
+    rows, cols = min(rows, seq_len), min(cols, half)
+    width = cols * 2
 
     @tilelang.jit(out_idx=[0])
-    def kernel(threads_arg, npt_arg):
-        block_size = threads_arg * npt_arg
-
+    def kernel(threads_arg):
         @T.prim_func
-        def main(out: T.Tensor((N_total,), dtype)):
-            with T.Kernel(T.ceildiv(N_total, block_size), threads=threads_arg) as bx:
-                for i, j in T.Parallel(threads_arg, npt_arg):
-                    flat = (bx * threads_arg + i) * npt_arg + j
-                    if flat < N_total:
-                        pos = flat // d_model
-                        dim = flat % d_model
-                        # dim_pair = dim // 2 (the "i" in the formula)
-                        dim_pair = dim // 2
-                        # angle = pos / 10000^(2*dim_pair / d_model)
-                        base = T.cast(10000.0, "float32")
-                        exp_frac = (
-                            T.cast(dim_pair, "float32")
-                            * T.cast(2.0, "float32")
-                            / T.cast(d_model, "float32")
-                        )
-                        divisor = T.pow(base, exp_frac)
-                        angle = T.cast(pos, "float32") / divisor
-                        # Even dim -> sin, odd dim -> cos
-                        is_even = dim % 2 == 0
-                        result = T.if_then_else(is_even, T.sin(angle), T.cos(angle))
-                        out[flat] = T.Cast(dtype, result)
+        def main(out: T.Tensor((seq_len, d_model), dtype)):
+            with T.Kernel(T.ceildiv(half, cols), T.ceildiv(seq_len, rows), threads=threads_arg) as (
+                bc,
+                br,
+            ):
+                # Named `divisor`, not `div`: stdlib.h declares a `div` the emitted
+                # CUDA would collide with.
+                divisor = T.alloc_shared((cols,), "float32")
+                angle = T.alloc_fragment((rows, cols), "float32")
+                pe = T.alloc_fragment((rows, width), dtype)
+                for c in T.Parallel(cols):
+                    exponent = (
+                        T.cast(bc * cols + c, "float32")
+                        * T.cast(2.0, "float32")
+                        / T.cast(d_model, "float32")
+                    )
+                    divisor[c] = T.pow(T.cast(10000.0, "float32"), exponent)
+                for r, c in T.Parallel(rows, cols):
+                    angle[r, c] = T.cast(br * rows + r, "float32") / divisor[c]
+                # Even dim -> sin, odd dim -> cos, both of the angle its pair shares.
+                for r, c in T.Parallel(rows, width):
+                    pe[r, c] = T.Cast(
+                        dtype,
+                        T.if_then_else(
+                            c % 2 == 0, T.sin(angle[r, c // 2]), T.cos(angle[r, c // 2])
+                        ),
+                    )
+                T.copy(pe, out[br * rows : (br + 1) * rows, bc * width : (bc + 1) * width])
 
         return main
 
@@ -87,30 +98,25 @@ class SinusoidalFwdKernel(Kernel):
             raise ValueError(
                 f"{self.__class__.__name__} only supports dtypes [{supported}], got {dtype}"
             )
+        if d_model % 2:
+            raise ValueError(f"{type(self).__name__} needs an even d_model, got {d_model}")
         self.seq_len = seq_len
         self.d_model = d_model
         self.dtype = dtype
         self._fp8_output_dtype, self.output_dtype = _get_fp8_output_dtypes(dtype)
-        cfg = self.default_config
         self.kernel = _make_sinusoidal_kernel(
-            seq_len,
-            d_model,
-            self.dtype_to_str(self.output_dtype),
-            cfg["threads"],
-            cfg["num_per_thread"],
+            seq_len, d_model, self.dtype_to_str(self.output_dtype)
         )
         self.init_config(config, tune)
 
     @property
     def default_config(self):
-        npt = 4 if self.dtype == torch.float32 else (16 if _is_fp8(self.dtype) else 8)
-        return {"threads": 256, "num_per_thread": npt}
+        return {"threads": 256}
 
     def init_config(self, config=None, tune=False):
         """Override to cache the compiled kernel function after config is set."""
         super().init_config(config, tune)
-        cfg = self.config
-        self._compiled_fn = self.kernel(cfg["threads"], cfg["num_per_thread"])
+        self._compiled_fn = self.kernel(self.config["threads"])
 
     def forward(self):
         return self._compiled_fn()

--- a/src/tileops/manifest/elementwise_generative.yaml
+++ b/src/tileops/manifest/elementwise_generative.yaml
@@ -80,8 +80,11 @@ SinusoidalFwdOp:
     vars:
       S: "output.shape[0]"
       D: "output.shape[1]"
-    # FLOPs per output element: dim_pair (1) + 2 * dim_pair / d_model (2) +
-    # pow (1) + div (1) + sin/cos select (1) = 6 per element.
+    # Per roofline.md §1.3, a per-element count and not an instruction count:
+    # dim_pair (1) + 2 * dim_pair / d_model (2) + pow (1) + div (1) +
+    # sin/cos (1) = 6. Every term before the division depends on the pair alone,
+    # so a kernel may evaluate them once per pair and reuse them down the
+    # positions without changing what this counts.
     flops: "6 * S * D"
     bytes: "S * D * elem_bytes"
 

--- a/tests/ops/test_activation.py
+++ b/tests/ops/test_activation.py
@@ -247,16 +247,22 @@ def test_tanh_edge(n_total: int, dtype: torch.dtype) -> None:
 def test_gelu_tails_are_exact(dtype: torch.dtype) -> None:
     """Edge: GELU reaches exactly 0 below its tail and exactly x above it.
 
-    float16 and bfloat16 evaluate a polynomial erf, and GELU scales the
-    1 - erf(x / sqrt(2)) residual by x. A tail off by eps therefore costs
-    |x| * eps / 2, which at the dtype's largest finite value is not small; only
-    an erf that saturates exactly keeps it at zero.
+    It scales the 1 - erf(x / sqrt(2)) residual by x, so an erf tail off by eps
+    costs |x| * eps / 2 -- unbounded in |x| unless erf saturates exactly. The
+    non-finite cases ride on the same saturation: -inf reaches 0 * -inf.
     """
     from tileops.ops.elementwise import GeluFwdOp
 
     largest = torch.finfo(dtype).max
-    x = torch.tensor([-largest, -1000.0, -8.0, 8.0, 1000.0, largest], device="cuda", dtype=dtype)
-    torch.testing.assert_close(GeluFwdOp()(x), F.gelu(x.float()).to(dtype), rtol=0, atol=0)
+    inf, nan = float("inf"), float("nan")
+    x = torch.tensor(
+        [-largest, -1000.0, -8.0, 8.0, 1000.0, largest, -inf, inf, nan],
+        device="cuda",
+        dtype=dtype,
+    )
+    torch.testing.assert_close(
+        GeluFwdOp()(x), F.gelu(x.float()).to(dtype), rtol=0, atol=0, equal_nan=True
+    )
 
 
 # Independent activation ops

--- a/tests/ops/test_activation.py
+++ b/tests/ops/test_activation.py
@@ -242,6 +242,23 @@ def test_tanh_edge(n_total: int, dtype: torch.dtype) -> None:
     _make_activation_test(n_total, dtype, _extreme, torch.tanh, TanhFwdOp)
 
 
+@pytest.mark.smoke
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_gelu_tails_are_exact(dtype: torch.dtype) -> None:
+    """Edge: GELU reaches exactly 0 below its tail and exactly x above it.
+
+    float16 and bfloat16 evaluate a polynomial erf, and GELU scales the
+    1 - erf(x / sqrt(2)) residual by x. A tail off by eps therefore costs
+    |x| * eps / 2, which at the dtype's largest finite value is not small; only
+    an erf that saturates exactly keeps it at zero.
+    """
+    from tileops.ops.elementwise import GeluFwdOp
+
+    largest = torch.finfo(dtype).max
+    x = torch.tensor([-largest, -1000.0, -8.0, 8.0, 1000.0, largest], device="cuda", dtype=dtype)
+    torch.testing.assert_close(GeluFwdOp()(x), F.gelu(x.float()).to(dtype), rtol=0, atol=0)
+
+
 # Independent activation ops
 
 

--- a/tests/ops/test_special_elementwise.py
+++ b/tests/ops/test_special_elementwise.py
@@ -284,6 +284,9 @@ class SinusoidalFixture(FixtureBase):
             [
                 pytest.param(512, 256, torch.float16, marks=pytest.mark.smoke),
                 pytest.param(512, 256, torch.float32, marks=pytest.mark.smoke),
+                # Neither extent divides the block tile: covers the partial tile
+                # on both axes, which the aligned cases above never reach.
+                pytest.param(65, 130, torch.float16, marks=pytest.mark.smoke),
             ],
         ),
     ]
@@ -310,6 +313,15 @@ def test_sinusoidal(seq_len: int, d_model: int, dtype: torch.dtype) -> None:
     else:
         tol = {"atol": 1e-5, "rtol": 1e-5}
     torch.testing.assert_close(out, ref, **tol)
+
+
+@pytest.mark.smoke
+def test_sinusoidal_rejects_odd_d_model() -> None:
+    """An odd d_model has a dimension with no pair, which the kernel cannot place."""
+    from tileops.kernels.elementwise import SinusoidalFwdKernel
+
+    with pytest.raises(ValueError, match="even d_model"):
+        SinusoidalFwdKernel(8, 7, torch.float16)
 
 
 # L2 — Dtype x Size (4 cases for clamp)

--- a/tests/ops/test_unary_math.py
+++ b/tests/ops/test_unary_math.py
@@ -412,6 +412,41 @@ def test_erf_edge(n_total: int, dtype: torch.dtype) -> None:
     )
 
 
+def _representable_steps(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    """How many values of their shared 16-bit dtype separate *a* and *b*, elementwise.
+
+    Sign-magnitude bit patterns do not order like the values they encode, so map
+    each to the monotone integer that does. Both zeros land on 0, which is what
+    the count should say about them.
+    """
+
+    def ordered(t: torch.Tensor) -> torch.Tensor:
+        code = t.view(torch.int16).to(torch.int32)
+        return torch.where(code < 0, -32768 - code, code)
+
+    return (ordered(a) - ordered(b)).abs()
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_erf_matches_rounded_erf_over_every_value(dtype: torch.dtype) -> None:
+    """erf lands within one representable step of the rounded value, at every input.
+
+    float16 and bfloat16 evaluate a polynomial instead of ``erff``, saturated past
+    a clamp. Normal inputs reach neither the clamp nor the subnormals, and the op
+    tolerance is a whole ulp wider than the polynomial needs, so it would admit a
+    refit that had drifted. Enumerate the dtype instead: 16 bits is small enough
+    to leave nothing untested, and count steps rather than distance so the bound
+    means the same thing at every magnitude.
+    """
+    codes = torch.arange(1 << 16, dtype=torch.int32, device="cuda").to(torch.int16)
+    x = codes.view(dtype)
+    x = x[torch.isfinite(x)]
+    out = ErfFwdOp()(x)
+    ref = torch.erf(x.float()).to(dtype)
+    assert _representable_steps(out, ref).max().item() <= 1
+
+
 @MathEdgeFixture
 def test_reciprocal_edge(n_total: int, dtype: torch.dtype) -> None:
     _make_math_test(

--- a/tests/ops/test_unary_math.py
+++ b/tests/ops/test_unary_math.py
@@ -413,14 +413,10 @@ def test_erf_edge(n_total: int, dtype: torch.dtype) -> None:
 
 
 def _representable_steps(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
-    """How many values of their shared 16-bit dtype separate *a* and *b*, elementwise.
-
-    Sign-magnitude bit patterns do not order like the values they encode, so map
-    each to the monotone integer that does. Both zeros land on 0, which is what
-    the count should say about them.
-    """
+    """How many values of their shared 16-bit dtype separate *a* and *b*, elementwise."""
 
     def ordered(t: torch.Tensor) -> torch.Tensor:
+        """Sign-magnitude patterns do not sort like the values; these do. Zeros meet at 0."""
         code = t.view(torch.int16).to(torch.int32)
         return torch.where(code < 0, -32768 - code, code)
 
@@ -432,12 +428,9 @@ def _representable_steps(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
 def test_erf_matches_rounded_erf_over_every_value(dtype: torch.dtype) -> None:
     """erf lands within one representable step of the rounded value, at every input.
 
-    float16 and bfloat16 evaluate a polynomial instead of ``erff``, saturated past
-    a clamp. Normal inputs reach neither the clamp nor the subnormals, and the op
-    tolerance is a whole ulp wider than the polynomial needs, so it would admit a
-    refit that had drifted. Enumerate the dtype instead: 16 bits is small enough
-    to leave nothing untested, and count steps rather than distance so the bound
-    means the same thing at every magnitude.
+    float16 and bfloat16 evaluate a polynomial, saturated past a clamp that normal
+    inputs never reach, and the op tolerance is a whole ulp wider than the fit
+    needs. Enumerating the dtype is cheap enough to leave nothing untested.
     """
     codes = torch.arange(1 << 16, dtype=torch.int32, device="cuda").to(torch.int16)
     x = codes.view(dtype)

--- a/tests/ops/test_unary_math.py
+++ b/tests/ops/test_unary_math.py
@@ -430,14 +430,16 @@ def test_erf_matches_rounded_erf_over_every_value(dtype: torch.dtype) -> None:
 
     float16 and bfloat16 evaluate a polynomial, saturated past a clamp that normal
     inputs never reach, and the op tolerance is a whole ulp wider than the fit
-    needs. Enumerating the dtype is cheap enough to leave nothing untested.
+    needs. Enumerating the dtype is cheap enough to leave nothing untested -- the
+    non-finite inputs included, which the clamp would otherwise swallow.
     """
     codes = torch.arange(1 << 16, dtype=torch.int32, device="cuda").to(torch.int16)
     x = codes.view(dtype)
-    x = x[torch.isfinite(x)]
     out = ErfFwdOp()(x)
     ref = torch.erf(x.float()).to(dtype)
-    assert _representable_steps(out, ref).max().item() <= 1
+    finite = torch.isfinite(x)
+    assert _representable_steps(out[finite], ref[finite]).max().item() <= 1
+    torch.testing.assert_close(out[~finite], ref[~finite], rtol=0, atol=0, equal_nan=True)
 
 
 @MathEdgeFixture


### PR DESCRIPTION
Stacked on #1997, whose commits this PR's diff also contains. The part to review here is the last two commits:

```
git diff perf/elementwise-transcendental...perf/elementwise-roofline-2
```

which touches `kernels/elementwise/sinusoidal.py`, `MishFwdKernel` in `kernels/elementwise/activations.py`, `manifest/elementwise_generative.yaml` and `tests/ops/test_special_elementwise.py`. Merge #1997 first and this rebases to just those.

## problems

The five ops #1997 fixed were the ones losing to their PyTorch baseline. Ranking the same nightly (run 33134732113, H200) by achieved bandwidth against the copy roof instead turns up ops that beat torch comfortably and are still nowhere near the hardware:

| op | achieved / roof | vs torch |
| --- | --- | --- |
| SinusoidalFwdOp | 9.6% | 2.43x |
| LogSumExpFwdOp | 58.1% | 6.36x |
| PowFwdOp | 61.0% (worst row 20.5%) | 1.20x |
| MishFwdOp | 61.1% | 1.57x |
| LogSoftmaxFwdOp | 68.4% | 8.17x |

Sinusoidal writes 33.6 MB in 81.8us. Stripping it one operation at a time against a write-only kernel at the same launch config put 8.2us on the store, 20.4us on `pow` plus the division, and 53.2us on trigonometry — the last because `T.if_then_else(is_even, sin, cos)` evaluates both and discards one.

The `pow` is worse than it looks: the divisor depends on the dimension pair, not the position, so 2048 distinct values were being recomputed 8.4M times.

Mish spent 9.5% of its kernel on a `T.if_then_else` guarding the saturation point. `T.if_then_else` in an element body makes TileLang emit a scalar loop instead of float4 lanes.

## changes

- `sinusoidal.py`: one block now covers 64 positions by 32 dimension pairs. `pow` runs once per pair into shared memory and is reused down the rows; the angle is staged in a fragment so each pair computes it once; the tile leaves through a single `T.copy`. The arithmetic per element is unchanged, so the output is bit-identical — including on a ragged shape, where it reproduces the current kernel's own 1-ulp disagreement with `torch.pow` exactly (52378 differing elements at 500x250, before and after).
- `sinusoidal.py`: an odd `d_model` now raises. The manifest already declared `d_model % 2 == 0`; the kernel silently dropped the unpaired dimension.
- `activations.py`: Mish clamps the exponential's argument at the saturation point instead of selecting on it. Past that point the rational is 1 to every bit fp32 carries, so `x * 1.0` is what the discarded branch returned anyway. Bit-identical, and NaN still propagates through the outer multiply.
- Two tests, node delta +2 (73 -> 75 on `test_special_elementwise.py`): a sinusoidal shape where neither extent divides the block tile — the aligned cases never reach the partial tile — and the odd-`d_model` rejection.
- The manifest's `flops` comment read as an account of what the kernel issues per element, which stopped being true. `6 * S * D` is unchanged: roofline.md §1.3 fixes it as a per-element convention count and §1.2 says the implementation's instruction mix does not feed back into it. Only the wording moved.

## measured

H200, CI image, CUPTI device-busy median, `benchmarks/` timing. "roof" is a TileLang kernel at the same shape and launch config doing only the store.

| op / workload | before | after | roof | baseline |
| --- | --- | --- | --- | --- |
| Sinusoidal 4096x4096 float16 | 81.8us | 25.2us | 8.2us | 111.6us |
| Sinusoidal 2048x4096 float16 | 42.4us | 13.6us | 4.1us | 56.7us |
| Mish 16x256x80x80 float16 | 40.2us | 36.2us | 26.3us | 63.6us |
| Mish 16x512x40x40 float16 | 21.5us | 19.2us | 14.3us | 33.2us |

Sinusoidal goes from 9.6% of the write roof to 31%, ratio 2.43 -> 4.43. Mish from 61% to 68%, ratio 1.58 -> 1.76.

## the other three, and why they are not here

- **PowFwdOp** is `powf`-bound and cannot be fixed without changing what the op computes. It costs 4.4 ns/element on both the broadcast and the same-shape rows, so the two rows differ only in byte accounting, not in per-element cost — there is no broadcast-path defect behind the 20.5% row. `exp2(b * log2(a))` would be an order cheaper and would return NaN for `pow(-2.0, 3.0)`, which `torch.pow` answers -8.0; the pow tests draw positive bases only, so nothing would have caught it. This is the case roofline.md §1.2 already carves out: the FLOP convention counts a transcendental as 1, and the metric does not certify an SFU-bound kernel as at its limit.
- **LogSumExpFwdOp** and **LogSoftmaxFwdOp** are reductions, and their worst rows are parallelism-bound rather than instruction-bound: `lm-head-logits` is 4 rows of 102400, so the whole GPU gets 4 units of work and reads 1.6 MB in 10.5us. That is a split-reduction question, in a family that has had six perf PRs land in the last week. Left alone deliberately rather than half-done.
