### PR TITLE
[BugFix][Attention] Remove duplicated V copy in generic paged GQA decode

### DIFF
--- a/src/tileops/kernels/attention/gqa_decode_paged.py
+++ b/src/tileops/kernels/attention/gqa_decode_paged.py
@@ -147,14 +147,6 @@ def _gqa_decode_no_split_paged_kernel(
                     )
                     T.copy(acc_s, acc_s_cast)
                     rescale(acc_o, scores_scale)
-                    T.copy(
-                        V[
-                            blockn_num_offset * block_N : (blockn_num_offset + 1) * block_N,
-                            cur_kv_head,
-                            :,
-                        ],
-                        V_shared,
-                    )
                     T.gemm(acc_s_cast, V_shared, acc_o, policy=T.GemmWarpPolicy.FullRow)
                 for i, j in T.Parallel(block_H, dim):
                     acc_o[i, j] = T.if_then_else(logsum[i] == 0, 0, acc_o[i, j] / logsum[i])
@@ -315,14 +307,6 @@ def _gqa_decode_split_paged_kernel(
                     )
                     T.copy(acc_s, acc_s_cast)
                     rescale(acc_o, scores_scale)
-                    T.copy(
-                        V[
-                            blockn_num_offset * block_N : (blockn_num_offset + 1) * block_N,
-                            cur_kv_head,
-                            :,
-                        ],
-                        V_shared,
-                    )
                     T.gemm(acc_s_cast, V_shared, acc_o, policy=T.GemmWarpPolicy.FullRow)
                 for i, j in T.Parallel(block_H, dim):
                     # When loop_range was 0 (split entirely beyond real_seqlen_kv), logsum=0 -> avoid 0/0


### PR DESCRIPTION
A rebase typo in 8cd7ead (#1783) unintentionally revived the post-softmax V_shared copy that db4494c (#1787) had removed, so both the no-split and split pipelined loops issued two copies of the same KV tile into the same V_shared region per iteration.

The redundant copy is idempotent and results stay correct, but it doubles the HBM traffic for V for no benefit.

Keep only the early K/V issue before QK, restoring the db4494c schedule, matching gqa_fwd.py and gqa_prefill_varlen_fwd.py.