### PR TITLE
[Refactor][Conv] Select variants from kernel regions

### DIFF
--- a/src/tileops/kernels/convolution/call_spec.py
+++ b/src/tileops/kernels/convolution/call_spec.py
@@ -9,11 +9,86 @@ import torch
 from tileops.kernels.call_spec import CallSpec
 
 __all__ = [
+    "Conv1dCall",
+    "Conv2dCall",
     "Conv3dCall",
+    "conv1d_dense_region",
+    "conv1d_group_region",
+    "conv1d_pointwise_region",
+    "conv2d_dense_region",
+    "conv2d_group_region",
+    "conv2d_pointwise_region",
+    "conv2d_symmetric_region",
     "conv3d_dense_region",
     "conv3d_group_region",
     "conv3d_ndhwc_region",
 ]
+
+
+@dataclasses.dataclass(frozen=True)
+class Conv1dCall(CallSpec):
+    """Semantic and shape facts used to select a Conv1d implementation.
+
+    The operator has already validated that the public input is NCL, the weight
+    is OIL, and the output length is positive. The output length is::
+
+        out_l = floor((l_in + pad_left + pad_right
+                       - dilation_l * (kernel_l - 1) - 1)
+                      / stride_l) + 1
+
+    Implementations state positive regions over these fields, and the general
+    dense implementation serves only ``groups == 1``.
+    """
+
+    n: int = 1
+    c_in: int = 1
+    c_out: int = 1
+    c_in_g: int = 1
+    l_in: int = 1
+    kernel_l: int = 1
+    stride_l: int = 1
+    pad_left: int = 0
+    pad_right: int = 0
+    dilation_l: int = 1
+    groups: int = 1
+    out_l: int = 1
+    dtype: torch.dtype = torch.float16
+    has_bias: bool = False
+
+
+@dataclasses.dataclass(frozen=True)
+class Conv2dCall(CallSpec):
+    """Semantic and shape facts used to select a Conv2d implementation.
+
+    The operator has already validated that the public input is NCHW, the weight
+    is OIHW, and the output dimensions are positive. For each spatial axis the
+    output size is::
+
+        out_axis = floor((in_axis + 2 * pad_axis
+                          - dilation_axis * (kernel_axis - 1) - 1)
+                         / stride_axis) + 1
+
+    Implementations state positive regions over these fields. Specialized
+    regions are deliberately disjoint; for example the symmetric implicit-GEMM
+    path excludes 1x1 pointwise calls.
+    """
+
+    n: int = 1
+    c_in: int = 1
+    c_out: int = 1
+    c_in_g: int = 1
+    h: int = 1
+    w: int = 1
+    kernel_h: int = 1
+    kernel_w: int = 1
+    stride: tuple[int, int] = (1, 1)
+    padding: tuple[int, int] = (0, 0)
+    dilation: tuple[int, int] = (1, 1)
+    groups: int = 1
+    out_h: int = 1
+    out_w: int = 1
+    dtype: torch.dtype = torch.float16
+    has_bias: bool = False
 
 
 @dataclasses.dataclass(frozen=True)
@@ -60,6 +135,70 @@ class Conv3dCall(CallSpec):
     @property
     def output_spatial(self) -> int:
         return self.n * self.out_d * self.out_h * self.out_w
+
+
+def conv1d_dense_region(call: Conv1dCall) -> bool:
+    """The dense Conv1d fallback region."""
+
+    return call.groups == 1
+
+
+def conv1d_group_region(call: Conv1dCall) -> bool:
+    """The grouped Conv1d region."""
+
+    return call.groups > 1
+
+
+def conv1d_pointwise_region(call: Conv1dCall) -> bool:
+    """The dense 1x1 Conv1d region that lowers to a pointwise GEMM."""
+
+    return (
+        conv1d_dense_region(call)
+        and call.kernel_l == 1
+        and call.stride_l == 1
+        and call.pad_left == 0
+        and call.pad_right == 0
+        and call.dilation_l == 1
+    )
+
+
+def conv2d_dense_region(call: Conv2dCall) -> bool:
+    """The dense Conv2d fallback region."""
+
+    return call.groups == 1
+
+
+def conv2d_group_region(call: Conv2dCall) -> bool:
+    """The grouped Conv2d region."""
+
+    return call.groups > 1
+
+
+def conv2d_pointwise_region(call: Conv2dCall) -> bool:
+    """The dense 1x1 Conv2d region that lowers to a pointwise GEMM."""
+
+    return (
+        conv2d_dense_region(call)
+        and call.kernel_h == 1
+        and call.kernel_w == 1
+        and call.stride == (1, 1)
+        and call.padding == (0, 0)
+        and call.dilation == (1, 1)
+    )
+
+
+def conv2d_symmetric_region(call: Conv2dCall) -> bool:
+    """The dense symmetric Conv2d region staged through NHWC implicit GEMM."""
+
+    return (
+        conv2d_dense_region(call)
+        and not conv2d_pointwise_region(call)
+        and call.kernel_h == call.kernel_w
+        and call.stride[0] == call.stride[1]
+        and call.padding[0] == call.padding[1]
+        and call.dilation[0] == call.dilation[1]
+        and call.c_in % 32 == 0
+    )
 
 
 def conv3d_dense_region(call: Conv3dCall) -> bool:

--- a/src/tileops/kernels/convolution/call_spec.py
+++ b/src/tileops/kernels/convolution/call_spec.py
@@ -1,0 +1,93 @@
+"""Call records and implementation regions for convolution kernels."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import torch
+
+from tileops.kernels.call_spec import CallSpec
+
+__all__ = [
+    "Conv3dCall",
+    "conv3d_dense_region",
+    "conv3d_group_region",
+    "conv3d_ndhwc_region",
+]
+
+
+@dataclasses.dataclass(frozen=True)
+class Conv3dCall(CallSpec):
+    """Semantic and shape facts used to select a Conv3d implementation.
+
+    The operator has already validated that the public input is NCDHW, the
+    weight is OIDHW, and the output dimensions are positive. For each spatial
+    axis the output size is::
+
+        out_axis = floor((in_axis + 2 * pad_axis
+                          - dilation_axis * (kernel_axis - 1) - 1)
+                         / stride_axis) + 1
+
+    Implementations state positive regions over these fields. Architecture is
+    inherited from :class:`tileops.kernels.call_spec.CallSpec` and checked by
+    ``Kernel.refusal()`` before an implementation's region is evaluated.
+    """
+
+    n: int = 1
+    c_in: int = 1
+    c_out: int = 1
+    c_in_g: int = 1
+    d: int = 1
+    h: int = 1
+    w: int = 1
+    kernel_d: int = 1
+    kernel_h: int = 1
+    kernel_w: int = 1
+    stride: tuple[int, int, int] = (1, 1, 1)
+    padding: tuple[int, int, int] = (0, 0, 0)
+    dilation: tuple[int, int, int] = (1, 1, 1)
+    groups: int = 1
+    out_d: int = 1
+    out_h: int = 1
+    out_w: int = 1
+    dtype: torch.dtype = torch.float16
+    has_bias: bool = False
+
+    @property
+    def kernel_volume(self) -> int:
+        return self.kernel_d * self.kernel_h * self.kernel_w
+
+    @property
+    def output_spatial(self) -> int:
+        return self.n * self.out_d * self.out_h * self.out_w
+
+
+def conv3d_dense_region(call: Conv3dCall) -> bool:
+    """The dense Conv3d fallback region."""
+
+    return call.groups == 1
+
+
+def conv3d_group_region(call: Conv3dCall) -> bool:
+    """The grouped Conv3d region."""
+
+    return call.groups > 1
+
+
+def conv3d_ndhwc_region(call: Conv3dCall) -> bool:
+    """The conservative NDHWC-staged dense Conv3d fast-path region.
+
+    This region is a performance heuristic layered on top of dense Conv3d
+    correctness. The implementation pays input, weight, and output layout
+    transforms to make the activation gather channel-contiguous, so pointwise
+    and small-output calls remain on the dense fallback.
+    """
+
+    return (
+        conv3d_dense_region(call)
+        and call.dtype in {torch.float16, torch.bfloat16}
+        and call.c_in % 32 == 0
+        and call.c_out >= 64
+        and call.output_spatial >= 1024
+        and call.kernel_volume > 1
+    )

--- a/src/tileops/kernels/convolution/conv1d.py
+++ b/src/tileops/kernels/convolution/conv1d.py
@@ -11,6 +11,7 @@ from tileops.kernels.kernel_base import Kernel
 from tileops.utils import get_sm_version
 
 from ._common import _launch, conv_autotune_configs
+from .call_spec import Conv1dCall, conv1d_dense_region, conv1d_group_region, conv1d_pointwise_region
 
 __all__ = [
     "Conv1dKernel",
@@ -471,6 +472,10 @@ def _conv1d_pointwise_kernel(
 class Conv1dPointwiseKernel(Kernel):
     supported_archs: list[int] = [80, 86, 89, 90]
 
+    @classmethod
+    def applies(cls, call: Conv1dCall) -> bool:
+        return conv1d_pointwise_region(call)
+
     def __init__(
         self,
         n: int,
@@ -537,7 +542,12 @@ class Conv1dPointwiseKernel(Kernel):
 
 
 class Conv1dKernel(Kernel):
+    general = True
     supported_archs: list[int] = [80, 86, 89, 90]
+
+    @classmethod
+    def applies(cls, call: Conv1dCall) -> bool:
+        return conv1d_dense_region(call)
 
     def __init__(
         self,
@@ -644,6 +654,10 @@ class Conv1dKernel(Kernel):
 
 class GroupConv1dKernel(Kernel):
     supported_archs: list[int] = [80, 86, 89, 90]
+
+    @classmethod
+    def applies(cls, call: Conv1dCall) -> bool:
+        return conv1d_group_region(call)
 
     def __init__(
         self,

--- a/src/tileops/kernels/convolution/conv2d.py
+++ b/src/tileops/kernels/convolution/conv2d.py
@@ -11,6 +11,13 @@ from tileops.kernels.kernel_base import Kernel
 from tileops.utils import get_sm_version
 
 from ._common import _launch, conv_autotune_configs
+from .call_spec import (
+    Conv2dCall,
+    conv2d_dense_region,
+    conv2d_group_region,
+    conv2d_pointwise_region,
+    conv2d_symmetric_region,
+)
 
 __all__ = [
     "Conv2d1x1Kernel",
@@ -720,6 +727,10 @@ def _conv2d_symmetric_kernel(
 class Conv2dSymmetricKernel(Kernel):
     supported_archs: list[int] = [80, 86, 89, 90]
 
+    @classmethod
+    def applies(cls, call: Conv2dCall) -> bool:
+        return conv2d_symmetric_region(call)
+
     def __init__(
         self,
         n: int,
@@ -813,7 +824,12 @@ class Conv2dSymmetricKernel(Kernel):
 
 
 class Conv2dKernel(Kernel):
+    general = True
     supported_archs: list[int] = [80, 86, 89, 90]
+
+    @classmethod
+    def applies(cls, call: Conv2dCall) -> bool:
+        return conv2d_dense_region(call)
 
     def __init__(
         self,
@@ -924,6 +940,10 @@ class Conv2dKernel(Kernel):
 
 class GroupConv2dKernel(Kernel):
     supported_archs: list[int] = [80, 86, 89, 90]
+
+    @classmethod
+    def applies(cls, call: Conv2dCall) -> bool:
+        return conv2d_group_region(call)
 
     def __init__(
         self,
@@ -1073,6 +1093,10 @@ class GroupConv2dKernel(Kernel):
 
 class Conv2d1x1Kernel(Kernel):
     supported_archs: list[int] = [80, 86, 89, 90]
+
+    @classmethod
+    def applies(cls, call: Conv2dCall) -> bool:
+        return conv2d_pointwise_region(call)
 
     def __init__(
         self,

--- a/src/tileops/kernels/convolution/conv3d.py
+++ b/src/tileops/kernels/convolution/conv3d.py
@@ -11,6 +11,7 @@ from tileops.kernels.kernel_base import Kernel
 from tileops.utils import get_sm_version
 
 from ._common import _launch, conv_autotune_configs
+from .call_spec import Conv3dCall, conv3d_dense_region, conv3d_group_region, conv3d_ndhwc_region
 
 __all__ = [
     "Conv3dKernel",
@@ -614,7 +615,12 @@ def _conv3d_ndhwc_kernel(
 
 
 class Conv3dKernel(Kernel):
+    general = True
     supported_archs: list[int] = [80, 86, 89, 90]
+
+    @classmethod
+    def applies(cls, call: Conv3dCall) -> bool:
+        return conv3d_dense_region(call)
 
     def __init__(
         self,
@@ -731,6 +737,10 @@ class Conv3dKernel(Kernel):
 
 class GroupConv3dKernel(Kernel):
     supported_archs: list[int] = [80, 86, 89, 90]
+
+    @classmethod
+    def applies(cls, call: Conv3dCall) -> bool:
+        return conv3d_group_region(call)
 
     def __init__(
         self,
@@ -890,6 +900,10 @@ class Conv3dNdhwcKernel(Kernel):
     """
 
     supported_archs: list[int] = [80, 86, 89, 90]
+
+    @classmethod
+    def applies(cls, call: Conv3dCall) -> bool:
+        return conv3d_ndhwc_region(call)
 
     def __init__(
         self,

--- a/src/tileops/ops/convolution.py
+++ b/src/tileops/ops/convolution.py
@@ -15,7 +15,12 @@ from tileops.kernels.convolution import (
     GroupConv2dKernel,
     GroupConv3dKernel,
 )
-from tileops.kernels.convolution.call_spec import Conv3dCall, conv3d_ndhwc_region
+from tileops.kernels.convolution.call_spec import (
+    Conv1dCall,
+    Conv2dCall,
+    Conv3dCall,
+    conv3d_ndhwc_region,
+)
 from tileops.kernels.kernel_base import Kernel
 from tileops.perf.profile import tensor_core_roof
 
@@ -230,6 +235,42 @@ def _conv1d_l_out(
     return l_out
 
 
+def _conv1d_call(
+    *,
+    n: int,
+    c_in: int,
+    l_in: int,
+    c_out: int,
+    c_in_g: int,
+    kernel_l: int,
+    stride_l: int,
+    pad_left: int,
+    pad_right: int,
+    dilation_l: int,
+    groups: int,
+    out_l: int,
+    dtype: torch.dtype,
+    has_bias: bool,
+) -> Conv1dCall:
+    """Build the Conv1d dispatch record after op-level validation."""
+    return Conv1dCall(
+        n=n,
+        c_in=c_in,
+        c_out=c_out,
+        c_in_g=c_in_g,
+        l_in=l_in,
+        kernel_l=kernel_l,
+        stride_l=stride_l,
+        pad_left=pad_left,
+        pad_right=pad_right,
+        dilation_l=dilation_l,
+        groups=groups,
+        out_l=out_l,
+        dtype=dtype,
+        has_bias=has_bias,
+    )
+
+
 class Conv1dFwdOp(Op):
     #: The operator this op registers; a test asserts the graph holds nothing else.
     compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::conv_conv1d_fwd",)
@@ -331,24 +372,28 @@ class Conv1dFwdOp(Op):
         has_bias: bool,
         inputs: tuple[torch.Tensor, ...],
     ) -> Kernel:
-        use_pointwise = (
-            self.groups == 1
-            and kernel_l == 1
-            and self.stride == 1
-            and pad_left == 0
-            and pad_right == 0
-            and self.dilation == 1
-            and "conv1d_pointwise_kernel" in self.kernel_map
+        call = _conv1d_call(
+            n=n,
+            c_in=c_in,
+            l_in=l_in,
+            c_out=c_out,
+            c_in_g=c_in_g,
+            kernel_l=kernel_l,
+            stride_l=self.stride,
+            pad_left=pad_left,
+            pad_right=pad_right,
+            dilation_l=self.dilation,
+            groups=self.groups,
+            out_l=out_l,
+            dtype=dtype,
+            has_bias=has_bias,
         )
-        use_group = self.groups > 1 and "group_conv1d_kernel" in self.kernel_map
-        if use_pointwise:
-            variant = "pointwise"
-        elif use_group:
-            variant = "group"
-        else:
-            variant = "general"
+        selected_key = self.select_kernel_key(
+            ("conv1d_pointwise_kernel", "group_conv1d_kernel", "conv1d_kernel"),
+            call,
+        )
         key = (
-            variant,
+            selected_key,
             n,
             c_in,
             l_in,
@@ -376,9 +421,9 @@ class Conv1dFwdOp(Op):
                 has_bias=has_bias,
                 tune=self.tune,
             )
-            if use_pointwise:
+            if selected_key == "conv1d_pointwise_kernel":
                 return self.kernel_map["conv1d_pointwise_kernel"](**kernel_kwargs)
-            elif use_group:
+            elif selected_key == "group_conv1d_kernel":
                 return self.kernel_map["group_conv1d_kernel"](
                     **kernel_kwargs,
                     kernel_l=kernel_l,
@@ -577,6 +622,46 @@ def _conv_out_dim(
     return (input_size + 2 * padding - dilation * (kernel_size - 1) - 1) // stride + 1
 
 
+def _conv2d_call(
+    *,
+    n: int,
+    c_in: int,
+    h: int,
+    w: int,
+    c_out: int,
+    c_in_g: int,
+    kernel_h: int,
+    kernel_w: int,
+    stride: tuple[int, int],
+    padding: tuple[int, int],
+    dilation: tuple[int, int],
+    groups: int,
+    out_h: int,
+    out_w: int,
+    dtype: torch.dtype,
+    has_bias: bool,
+) -> Conv2dCall:
+    """Build the Conv2d dispatch record after op-level validation."""
+    return Conv2dCall(
+        n=n,
+        c_in=c_in,
+        c_out=c_out,
+        c_in_g=c_in_g,
+        h=h,
+        w=w,
+        kernel_h=kernel_h,
+        kernel_w=kernel_w,
+        stride=stride,
+        padding=padding,
+        dilation=dilation,
+        groups=groups,
+        out_h=out_h,
+        out_w=out_w,
+        dtype=dtype,
+        has_bias=has_bias,
+    )
+
+
 class Conv2dFwdOp(Op):
     #: The operator this op registers; a test asserts the graph holds nothing else.
     compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::conv_conv2d_fwd",)
@@ -709,39 +794,35 @@ class Conv2dFwdOp(Op):
         has_bias: bool,
         inputs: tuple[torch.Tensor, ...],
     ) -> Kernel:
-        is_symmetric = (
-            kernel_h == kernel_w
-            and self.stride[0] == self.stride[1]
-            and pad_h == pad_w
-            and self.dilation[0] == self.dilation[1]
+        call = _conv2d_call(
+            n=n,
+            c_in=c_in,
+            h=h,
+            w=w,
+            c_out=c_out,
+            c_in_g=c_in_g,
+            kernel_h=kernel_h,
+            kernel_w=kernel_w,
+            stride=self.stride,
+            padding=(pad_h, pad_w),
+            dilation=self.dilation,
+            groups=self.groups,
+            out_h=out_h,
+            out_w=out_w,
+            dtype=dtype,
+            has_bias=has_bias,
         )
-        can_use_symmetric_kernel = is_symmetric and c_in % 32 == 0
-        use_pointwise = (
-            self.groups == 1
-            and kernel_h == 1
-            and kernel_w == 1
-            and self.stride == (1, 1)
-            and pad_h == 0
-            and pad_w == 0
-            and self.dilation == (1, 1)
-            and "conv2d_1x1_kernel" in self.kernel_map
+        selected_key = self.select_kernel_key(
+            (
+                "conv2d_1x1_kernel",
+                "conv2d_symmetric_kernel",
+                "group_conv2d_kernel",
+                "conv2d_kernel",
+            ),
+            call,
         )
-        use_symmetric = (
-            self.groups == 1
-            and can_use_symmetric_kernel
-            and "conv2d_symmetric_kernel" in self.kernel_map
-        )
-        use_group = self.groups > 1 and "group_conv2d_kernel" in self.kernel_map
-        if use_pointwise:
-            variant = "1x1"
-        elif use_symmetric:
-            variant = "symmetric"
-        elif use_group:
-            variant = "group"
-        else:
-            variant = "general"
         key = (
-            variant,
+            selected_key,
             n,
             c_in,
             h,
@@ -775,9 +856,9 @@ class Conv2dFwdOp(Op):
                 has_bias=has_bias,
                 tune=self.tune,
             )
-            if use_pointwise:
+            if selected_key == "conv2d_1x1_kernel":
                 return self.kernel_map["conv2d_1x1_kernel"](**kernel_kwargs)
-            elif use_symmetric:
+            elif selected_key == "conv2d_symmetric_kernel":
                 return self.kernel_map["conv2d_symmetric_kernel"](
                     n=n,
                     c_in=c_in,
@@ -792,7 +873,7 @@ class Conv2dFwdOp(Op):
                     has_bias=has_bias,
                     tune=self.tune,
                 )
-            elif use_group:
+            elif selected_key == "group_conv2d_kernel":
                 return self.kernel_map["group_conv2d_kernel"](
                     **kernel_kwargs,
                     kernel_h=kernel_h,

--- a/src/tileops/ops/convolution.py
+++ b/src/tileops/ops/convolution.py
@@ -15,6 +15,7 @@ from tileops.kernels.convolution import (
     GroupConv2dKernel,
     GroupConv3dKernel,
 )
+from tileops.kernels.convolution.call_spec import Conv3dCall, conv3d_ndhwc_region
 from tileops.kernels.kernel_base import Kernel
 from tileops.perf.profile import tensor_core_roof
 
@@ -1022,15 +1023,73 @@ def _can_use_conv3d_ndhwc(
     dense, 16-bit, non-pointwise calls large enough to amortize that fixed
     layout-transform cost.
     """
-    kernel_volume = kernel_d * kernel_h * kernel_w
-    output_spatial = n * out_d * out_h * out_w
-    return (
-        groups == 1
-        and dtype in {torch.float16, torch.bfloat16}
-        and c_in % 32 == 0
-        and c_out >= 64
-        and output_spatial >= 1024
-        and kernel_volume > 1
+    return conv3d_ndhwc_region(
+        Conv3dCall(
+            arch=0,
+            n=n,
+            c_in=c_in,
+            c_out=c_out,
+            kernel_d=kernel_d,
+            kernel_h=kernel_h,
+            kernel_w=kernel_w,
+            out_d=out_d,
+            out_h=out_h,
+            out_w=out_w,
+            groups=groups,
+            dtype=dtype,
+        )
+    )
+
+
+def _conv3d_call(
+    *,
+    n: int,
+    c_in: int,
+    d: int,
+    h: int,
+    w: int,
+    c_out: int,
+    c_in_g: int,
+    kernel_d: int,
+    kernel_h: int,
+    kernel_w: int,
+    stride: tuple[int, int, int],
+    padding: tuple[int, int, int],
+    dilation: tuple[int, int, int],
+    groups: int,
+    out_d: int,
+    out_h: int,
+    out_w: int,
+    dtype: torch.dtype,
+    has_bias: bool,
+) -> Conv3dCall:
+    """Build the Conv3d dispatch record after op-level validation.
+
+    The record carries the public NCDHW/OIDHW convolution semantics and the
+    resolved output shape. Kernel classes use it to state positive regions, so
+    adding a specialized Conv3d implementation does not require the dense
+    fallback to know that implementation by name.
+    """
+    return Conv3dCall(
+        n=n,
+        c_in=c_in,
+        c_out=c_out,
+        c_in_g=c_in_g,
+        d=d,
+        h=h,
+        w=w,
+        kernel_d=kernel_d,
+        kernel_h=kernel_h,
+        kernel_w=kernel_w,
+        stride=stride,
+        padding=padding,
+        dilation=dilation,
+        groups=groups,
+        out_d=out_d,
+        out_h=out_h,
+        out_w=out_w,
+        dtype=dtype,
+        has_bias=has_bias,
     )
 
 
@@ -1181,23 +1240,33 @@ class Conv3dFwdOp(Op):
         has_bias: bool,
         inputs: tuple[torch.Tensor, ...],
     ) -> Kernel:
-        use_ndhwc = "conv3d_ndhwc_kernel" in self.kernel_map and _can_use_conv3d_ndhwc(
-            groups=self.groups,
+        call = _conv3d_call(
+            n=n,
             c_in=c_in,
+            d=d,
+            h=h,
+            w=w,
             c_out=c_out,
+            c_in_g=c_in_g,
             kernel_d=kernel_d,
             kernel_h=kernel_h,
             kernel_w=kernel_w,
+            stride=self.stride,
+            padding=(pad_d, pad_h, pad_w),
+            dilation=self.dilation,
+            groups=self.groups,
             out_d=out_d,
             out_h=out_h,
             out_w=out_w,
-            n=n,
             dtype=dtype,
+            has_bias=has_bias,
         )
-        use_group = self.groups > 1 and "group_conv3d_kernel" in self.kernel_map
-        variant = "ndhwc" if use_ndhwc else "group" if use_group else "general"
+        selected_key = self.select_kernel_key(
+            ("conv3d_ndhwc_kernel", "group_conv3d_kernel", "conv3d_kernel"),
+            call,
+        )
         key = (
-            variant,
+            selected_key,
             n,
             c_in,
             d,
@@ -1242,7 +1311,7 @@ class Conv3dFwdOp(Op):
                 has_bias=has_bias,
                 tune=self.tune,
             )
-            if use_ndhwc:
+            if selected_key == "conv3d_ndhwc_kernel":
                 return self.kernel_map["conv3d_ndhwc_kernel"](
                     n=n,
                     c_in=c_in,
@@ -1266,7 +1335,7 @@ class Conv3dFwdOp(Op):
                     has_bias=has_bias,
                     tune=self.tune,
                 )
-            if use_group:
+            if selected_key == "group_conv3d_kernel":
                 return self.kernel_map["group_conv3d_kernel"](
                     **kernel_kwargs,
                     groups=self.groups,


### PR DESCRIPTION
## Summary

- Add convolution call records for Conv1d/Conv2d/Conv3d dispatch facts and documented output-size formulas.
- Move convolution variant eligibility into kernel-owned region predicates via Kernel.applies()/general.
- Replace Conv1d/Conv2d/Conv3d op-layer use_* dispatch branches with Op.select_kernel_key().

## Notes

This keeps the existing kernel implementations and autotune spaces intact. The change only moves variant selection ownership from the op layer to kernel region predicates, matching the selection model already used by other kernel families.

## Testing

- ruff format --check src/tileops/kernels/convolution/call_spec.py src/tileops/kernels/convolution/conv1d.py src/tileops/kernels/convolution/conv2d.py src/tileops/kernels/convolution/conv3d.py src/tileops/ops/convolution.py tests/ops/test_convolution.py
- ruff check src/tileops/kernels/convolution/call_spec.py src/tileops/kernels/convolution/conv1d.py src/tileops/kernels/convolution/conv2d.py src/tileops/kernels/convolution/conv3d.py src/tileops/ops/convolution.py tests/ops/test_convolution.py
- python -m compileall -q src/tileops/kernels/convolution/call_spec.py src/tileops/kernels/convolution/conv1d.py src/tileops/kernels/convolution/conv2d.py src/tileops/kernels/convolution/conv3d.py src/tileops/ops/convolution.py tests/ops/test_convolution.py

Local pytest is blocked in this environment: python reports No module named pytest.