### PR TITLE
[CI][Runner] Install nvmath-python in the runner image

### DIFF
--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -170,6 +170,9 @@ RUN if [ -n "${TILELANG_GIT_SHA}" ]; then \
     fi
 # --no-deps: it must not re-resolve a CUDA wheel under torch.
 RUN uv pip install --no-deps cupti-python
+# Deps resolved, unlike cupti-python: all four are already pinned in the lock. Fatal, unlike the
+# bench baselines: the GEMM benchmark imports it with no fallback, so its absence fails rows.
+RUN uv pip install nvmath-python
 COPY scripts/ci/verify_runtime_stack.py /tmp/verify_runtime_stack.py
 RUN python /tmp/verify_runtime_stack.py
 

--- a/.github/runner/README.md
+++ b/.github/runner/README.md
@@ -76,7 +76,7 @@ Three files. `PIP_CONSTRAINT` hands the latter two to every `pip install` in the
 
 | File                          | Written by | Holds                                                    |
 | ----------------------------- | ---------- | -------------------------------------------------------- |
-| `requirements.in`             | by hand    | What the image installs directly.                        |
+| `requirements.in`             | by hand    | Direct requirements, for the lock compile alone.         |
 | `constraints.txt`             | by hand    | Chosen versions and why. Also used by the CPU preflight. |
 | `constraints-runner-lock.txt` | generated  | The transitive closure of both.                          |
 

--- a/.github/runner/requirements.in
+++ b/.github/runner/requirements.in
@@ -39,5 +39,6 @@ py-spy
 flash-linear-attention
 vllm
 cupti-python
+nvmath-python
 # For flag_gems, which cannot be listed here.
 sqlalchemy

--- a/constraints-runner-lock.txt
+++ b/constraints-runner-lock.txt
@@ -119,6 +119,7 @@ nvidia-nvjitlink==13.3.33
 nvidia-nvshmem-cu13==3.4.5
 nvidia-nvtx==13.2.75
 nvidia-nvvm==13.3.73
+nvmath-python==1.0.0
 nvtx==0.2.15
 openai==2.53.0
 openai-harmony==0.0.8

--- a/constraints.txt
+++ b/constraints.txt
@@ -40,6 +40,9 @@ vllm==0.27.1
 flag_gems==5.0.2
 # flag_gems imports it at module load.
 sqlalchemy==2.0.52
+# cuBLASLt's algorithm-selection API for the GEMM benchmark. Bare, not `[cu13]`: it maps torch's
+# own libcublasLt through cuda-pathfinder, where the extra installs a second CUDA-13 wheel set.
+nvmath-python==1.0.0
 # Tracks the image CUDA version; bump with it.
 cupti-python==13.2.0
 # Stack dump of a hung benchmark child before the runner kills it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ bench = [
     "flashinfer>=0.6.6",
     "vllm==0.27.1",
     "sgl-kernel==0.3.21",
+    "nvmath-python==1.0.0",
 ]
 
 [build-system]

--- a/scripts/ci/verify_runner_image.py
+++ b/scripts/ci/verify_runner_image.py
@@ -54,6 +54,15 @@ def main() -> int:
     assert torch.einsum("bik,bkj->bij", ab, ab).isfinite().all()
     print("cuBLAS matmul / bmm / einsum OK")
 
+    # Whether nvmath resolves torch's libcublasLt through cuda-pathfinder needs a GPU to answer.
+    from nvmath.linalg.advanced import Matmul, MatmulComputeType, MatmulOptions
+
+    with Matmul(a, a, options=MatmulOptions(compute_type=MatmulComputeType.COMPUTE_32F)) as mm:
+        algorithms = mm.plan()
+        assert algorithms, "cuBLASLt returned no algorithm"
+        assert mm.execute(algorithm=algorithms[0]).isfinite().all()
+    print(f"nvmath cuBLASLt plan OK ({len(algorithms)} algorithms)")
+
     print("image OK")
     return 0
 

--- a/scripts/ci/verify_runtime_stack.py
+++ b/scripts/ci/verify_runtime_stack.py
@@ -84,6 +84,7 @@ for dist, why in (
     ("flag_gems", "the flaggems columns"),
     ("flashinfer-python", "the flashinfer columns"),
     ("flash-linear-attention", "the linear-attention columns"),
+    ("nvmath-python", "the cuBLASLt-search GEMM baseline"),
 ):
     try:
         md.version(dist)


### PR DESCRIPTION
## Problems

- The GEMM benchmark's cuBLASLt algorithm-search baseline needs `nvmath-python`, and no image installs it.
- A package added to `.github/runner/requirements.in` alone reaches the lock and no image, though the README says that file is what the image installs.
- `.[bench]` does not carry it, so a local bench run cannot reproduce a column the image can.

## Changes

- The Dockerfile installs `nvmath-python` in the `tilelang` stage. Dependencies resolved, not `--no-deps`: all four are already pinned in the lock. Fatal, unlike the bench baselines: the baseline imports it with no fallback, so its absence fails rows rather than dropping a column.
- `constraints.txt` pins `1.0.0`; `requirements.in` and the lock carry it. Bare, not `[cu13]`, which would install a second CUDA-13 wheel set: measured one package, +21 MB.
- `pyproject.toml`'s `[bench]` extra adds it, so `.[dev,bench]` reaches the same baselines as the image.
- `verify_runtime_stack.py` checks presence at build time; `verify_runner_image.py` plans and executes a cuBLASLt matmul, which needs a GPU and is where a broken `cuda-pathfinder` mapping shows.
- `README.md` said `requirements.in` is what the image installs, which is how the package reached the lock and no image. It holds direct requirements for the lock compile.

Both tags are rebuilt at the same tilelang commit and pushed. `verify_runner_image.py` passes on both; a scoped smoke over gemm, bmm, norm, reduce, dispatch and attention ran 322 passed. The benchmark baseline that consumes this lands separately.
