### PR TITLE
[Perf][Elementwise] Pack a broadcast row's leftover columns and guard a reduction walk by the block

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -14,9 +14,9 @@
 
 - Promote overflow-prone fp16/bf16 math (cubic, division, `exp`, softmax accumulators) to fp32; cast back to storage dtype at the boundary.
 
-- Decorate each `_<op>_kernel` builder (the `@tilelang.jit`-wrapping `Callable`) with `@functools.lru_cache(maxsize=<N>)`; every parameter must be hashable. Default `maxsize=32`; use `64` only when the distinct-config working set demands it; `maxsize=None` only for intrinsically bounded config spaces. Document any non-default choice at the call site.
+- Decorate each `_<op>_kernel` builder (the `@tilelang.jit`-wrapping `Callable`) with `@functools.lru_cache(maxsize=<N>)`; every parameter must be hashable. `maxsize=32` needs no comment; `64` and `None` state above the decorator what makes the config space that wide or bounded.
 
-- Tag code degraded by something outside its own scope — a contract stub that cannot be made abstract until every op migrates, a benchmark that must skip a manifest workload no kernel can run — with `FIXME(staged-rollout)`. Cleanup line names the invariant to restore — never a PR number. Scan: `grep -rn 'FIXME(staged-rollout)'`.
+- Tag code degraded by something outside its own scope — a contract stub that cannot be made abstract until every op migrates, a benchmark that must skip a manifest workload no kernel can run — with `FIXME(staged-rollout)`. Scan: `grep -rn 'FIXME(staged-rollout)'`.
 
   ```python
   # FIXME(staged-rollout): <one-line summary of what's degraded>
@@ -28,18 +28,12 @@
 
 - PascalCase abbreviations stay fully uppercase: `RMSNormKernel`, `SSDDecodeFwdOp`, `FusedAddRMSNormFwdOp`.
 
-- Filenames: all-lowercase with underscores. Multi-letter abbreviations stay lowercase (`rms_norm.py`, `ssd_decode.py`); never capitalize a single letter. Never contract norm names (`rms_norm`, not `rmsnorm`).
+- Filenames: lowercase with underscores, abbreviations included (`rms_norm.py`, `ssd_decode.py`). Never contract a norm name (`rms_norm`, not `rmsnorm`).
 
 - An `optional: true` input defaults to `None` in `forward`, and presence is read from the call, not settled at construction. Where the presence changes what the kernel build produces, it goes in that kernel's cache key.
 
-- Docstrings: Google style. One-line summary, blank line, then optional `Args:` / `Returns:` / `Raises:` / `Example:`. Internal helpers may use a single-line summary. Never mix Sphinx (`:param:`) or NumPy headers in one file.
+- Docstrings: Google style. One-line summary, blank line, then optional `Args:` / `Returns:` / `Raises:` / `Example:`. Internal helpers may use a single-line summary. Never mix Sphinx (`:param:`, `#:`) or NumPy headers in one file; comment an attribute with `#` above its assignment.
 
-- The docs site renders the class, `__init__` and `forward` docstrings of the `src/tileops/ops/` classes `docs/api/*.md` collects, and nothing else. A guarantee a caller acts on -- an accuracy bound, a deviation from torch -- goes in the op's class docstring; a kernel comment does not reach them.
-
-- Comment an attribute with `#`, above its assignment. `#:` is Sphinx autodoc markup and the site is mkdocs; griffe reads a string literal under the assignment, never the comment above it.
+- The docs site renders the class, `__init__` and `forward` docstrings of the `src/tileops/ops/` classes `docs/api/*.md` collects, and nothing else. A guarantee a caller acts on — an accuracy bound, a deviation from torch — goes in the op's class docstring; a kernel comment does not reach them.
 
 - Expand domain abbreviations on first use in a docstring: `State Space Model (SSM)`, `State-Space Dual (SSD)`. Later uses may abbreviate.
-
-- Shipped source (code, docstrings, manifest YAML) must not reference issue/PR numbers, AC labels, round numbers, reviewer names, or `Follow-up: #N`. See [domain-rules/manifest-spec.md](../domain-rules/manifest-spec.md).
-
-  Discovery scan: `grep -rnE '(^|[^[:alnum:]])#[0-9]{3,}|AC-[0-9]+|round-[0-9]+ review|[Ff]ollow-up:[[:space:]]*#' --exclude-dir=manifest src/tileops/ tests/ benchmarks/ scripts/`

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -34,6 +34,10 @@
 
 - Docstrings: Google style. One-line summary, blank line, then optional `Args:` / `Returns:` / `Raises:` / `Example:`. Internal helpers may use a single-line summary. Never mix Sphinx (`:param:`) or NumPy headers in one file.
 
+- The docs site renders the class, `__init__` and `forward` docstrings of the `src/tileops/ops/` classes `docs/api/*.md` collects, and nothing else. A guarantee a caller acts on -- an accuracy bound, a deviation from torch -- goes in the op's class docstring; a kernel comment does not reach them.
+
+- Comment an attribute with `#`, above its assignment. `#:` is Sphinx autodoc markup and the site is mkdocs; griffe reads a string literal under the assignment, never the comment above it.
+
 - Expand domain abbreviations on first use in a docstring: `State Space Model (SSM)`, `State-Space Dual (SSD)`. Later uses may abbreviate.
 
 - Shipped source (code, docstrings, manifest YAML) must not reference issue/PR numbers, AC labels, round numbers, reviewer names, or `Follow-up: #N`. See [domain-rules/manifest-spec.md](../domain-rules/manifest-spec.md).

--- a/src/tileops/backend/protocol.py
+++ b/src/tileops/backend/protocol.py
@@ -20,19 +20,19 @@ class TensorSpec(NamedTuple):
         return TensorSpec(tensor.device, tensor.dtype, tuple(tensor.shape))
 
 
-#: One call's result. A purely mutating op returns ``None``: ``torch.library.custom_op``
-#: cannot express a return value aliasing an input.
+# One call's result. A purely mutating op returns ``None``: ``torch.library.custom_op``
+# cannot express a return value aliasing an input.
 KernelResult = Union[torch.Tensor, tuple[torch.Tensor, ...], None]
 
-#: Called ``build_kernel(*inputs, **params)``: a `TensorSpec` per input in
-#: ``signature.inputs`` order — ``None`` for an ``optional: true`` input the call did not
-#: pass, so presence is read off the slot rather than off how many slots there are — then
-#: ``signature.params`` by keyword. Both lists are per-op, which the type system cannot
-#: express, hence ``...``.
+# Called ``build_kernel(*inputs, **params)``: a `TensorSpec` per input in
+# ``signature.inputs`` order — ``None`` for an ``optional: true`` input the call did not
+# pass, so presence is read off the slot rather than off how many slots there are — then
+# ``signature.params`` by keyword. Both lists are per-op, which the type system cannot
+# express, hence ``...``.
 BuildKernel = Callable[..., Callable[..., KernelResult]]
 
-#: "Is this the kind of device my kernels are written for" — ``False``, not an exception,
-#: for the rest. Per-call support is ``build_kernel``'s answer; it sees the dtypes too.
+# "Is this the kind of device my kernels are written for" — ``False``, not an exception,
+# for the rest. Per-call support is ``build_kernel``'s answer; it sees the dtypes too.
 DetectFn = Callable[[torch.device], bool]
 
 
@@ -45,9 +45,9 @@ class _Builtin:
         return "BUILTIN"
 
 
-#: Ask for the in-tree implementation whatever is installed. Not a target name: unregistered
-#: and never in ``registered_targets()``.
+# Ask for the in-tree implementation whatever is installed. Not a target name: unregistered
+# and never in ``registered_targets()``.
 BUILTIN: Final = _Builtin()
 
-#: What ``target=`` and the process default accept.
+# What ``target=`` and the process default accept.
 Target = Union[str, _Builtin, None]

--- a/src/tileops/backend/registry.py
+++ b/src/tileops/backend/registry.py
@@ -15,27 +15,27 @@ from typing import Callable, NamedTuple
 from .errors import BackendError
 from .protocol import BuildKernel, DetectFn, Target
 
-#: The value names a *module*; importing it must perform the registration.
+# The value names a *module*; importing it must perform the registration.
 ENTRY_POINT_GROUP = "tileops.backends"
 
 DETECTORS: dict[str, DetectFn] = {}
 BUILDERS: dict[tuple[str, str], BuildKernel] = {}
 
-#: One line per backend that failed to import. Strings, not records: they are read to be
-#: printed.
+# One line per backend that failed to import. Strings, not records: they are read to be
+# printed.
 LOAD_FAILURES: list[str] = []
 
-#: Which target ops use when they name none. ``None`` replaces nothing.
+# Which target ops use when they name none. ``None`` replaces nothing.
 default_target: Target = None
 
-#: Set only once every entry point has been tried, so no thread sees a half-built registry.
+# Set only once every entry point has been tried, so no thread sees a half-built registry.
 _loaded = False
 
-#: Reentrant: discovery holds it while importing backends, whose top level registers.
+# Reentrant: discovery holds it while importing backends, whose top level registers.
 LOCK = threading.RLock()
 
-#: Set on the discovery thread, which reads the partial registry it is building while the
-#: others wait for the finished one.
+# Set on the discovery thread, which reads the partial registry it is building while the
+# others wait for the finished one.
 _LOADING = threading.local()
 
 

--- a/src/tileops/kernels/attention/call_spec.py
+++ b/src/tileops/kernels/attention/call_spec.py
@@ -30,9 +30,9 @@ ATTENTION_DTYPES = (torch.float16, torch.bfloat16)
 
 _WS_BLOCK_M = 128
 _H200_SMS = 132
-#: Architecture the warp-specialized prefill kernels are written for. The
-#: classes declare it as their ``supported_archs`` and the region below reads
-#: the same name, so the two statements of one fact cannot drift apart.
+# Architecture the warp-specialized prefill kernels are written for. The
+# classes declare it as their ``supported_archs`` and the region below reads
+# the same name, so the two statements of one fact cannot drift apart.
 WS_ARCH = 90
 
 
@@ -138,12 +138,12 @@ def causal_ws_prefill_region(call: AttentionCall) -> bool:
     )
 
 
-#: Tile heights the warp-specialized paged decode kernel can pick from. A tile
-#: divides the page size, so one tile never straddles two pages, and it splits
-#: evenly across the four consumer warps.
+# Tile heights the warp-specialized paged decode kernel can pick from. A tile
+# divides the page size, so one tile never straddles two pages, and it splits
+# evenly across the four consumer warps.
 _WS_DECODE_TILES = (16, 32, 64, 128)
-#: Head dims that map onto one warp: the score reduction is a shuffle chain over
-#: 32 lanes, so a lane owns ``dim / 32`` elements of the head vector.
+# Head dims that map onto one warp: the score reduction is a shuffle chain over
+# 32 lanes, so a lane owns ``dim / 32`` elements of the head vector.
 _WS_DECODE_LANES = 32
 
 

--- a/src/tileops/kernels/attention/gqa_decode.py
+++ b/src/tileops/kernels/attention/gqa_decode.py
@@ -414,7 +414,7 @@ def _(
 
 class GQADecodeKernel(Kernel):
     supported_archs: list[int] = [80, 89, 90]
-    #: The implementation behind the specialised ones for this key.
+    # The implementation behind the specialised ones for this key.
     general: bool = True
 
     @classmethod

--- a/src/tileops/kernels/attention/gqa_decode_paged.py
+++ b/src/tileops/kernels/attention/gqa_decode_paged.py
@@ -497,7 +497,7 @@ def _(
 
 class GQADecodePagedKernel(Kernel):
     supported_archs: list[int] = [80, 89, 90]
-    #: The implementation behind the specialised ones for this key.
+    # The implementation behind the specialised ones for this key.
     general: bool = True
 
     @classmethod

--- a/src/tileops/kernels/attention/gqa_fwd.py
+++ b/src/tileops/kernels/attention/gqa_fwd.py
@@ -525,7 +525,7 @@ class GQAPrefillFwdKernel(PackedPrefillKernel):
     """
 
     supported_archs: list[int] = [80, 89, 90]
-    #: The implementation behind the specialised ones for this key.
+    # The implementation behind the specialised ones for this key.
     general: bool = True
 
     @classmethod

--- a/src/tileops/kernels/attention/mha_decode_paged.py
+++ b/src/tileops/kernels/attention/mha_decode_paged.py
@@ -550,9 +550,9 @@ def _(
 
 class MHADecodePagedKernel(Kernel):
     supported_archs: list[int] = [80, 89, 90]
-    #: The implementation behind the specialised one for this key: it serves any
-    #: paged decode call, including the query lengths, head dims and page sizes
-    #: the warp-specialized Hopper kernel does not claim.
+    # The implementation behind the specialised one for this key: it serves any
+    # paged decode call, including the query lengths, head dims and page sizes
+    # the warp-specialized Hopper kernel does not claim.
     general: bool = True
 
     def __init__(

--- a/src/tileops/kernels/attention/mha_decode_paged_ws.py
+++ b/src/tileops/kernels/attention/mha_decode_paged_ws.py
@@ -39,23 +39,21 @@ from .call_spec import paged_decode_ws_region
 
 __all__ = ["MHADecodePagedWsKernel"]
 
-#: log2(e): the softmax runs on exp2, which is one instruction.
-
 WARP = 32
-#: Warps in the consumer group. One warp group of each role, 256 threads: two
-#: consumer groups deadlock the block-wide sync the layout pass inserts.
+# Warps in the consumer group. One warp group of each role, 256 threads: two
+# consumer groups deadlock the block-wide sync the layout pass inserts.
 CONS_WARPS = 4
 CONS = CONS_WARPS * WARP
 PROD = 128
-#: Named barrier the consumer group uses on its own, never block-wide.
+# Named barrier the consumer group uses on its own, never block-wide.
 _MERGE_BARRIER = 1
-#: Blocks to aim the split count at, so one wave covers the device.
+# Blocks to aim the split count at, so one wave covers the device.
 _TARGET_BLOCKS = 128
-#: Finite stand-in for -inf in the running max, so a fully masked tile rescales
-#: by exactly one instead of evaluating exp2(-inf - -inf).
+# Finite stand-in for -inf in the running max, so a fully masked tile rescales
+# by exactly one instead of evaluating exp2(-inf - -inf).
 _NEG_FLOOR = -1.0e38
-#: What an empty split publishes as its log-sum-exp: finite, so the cross-split
-#: merge gives it weight exp2(_EMPTY_LSE - peak) = 0 rather than 0 * NaN.
+# What an empty split publishes as its log-sum-exp: finite, so the cross-split
+# merge gives it weight exp2(_EMPTY_LSE - peak) = 0 rather than 0 * NaN.
 _EMPTY_LSE = -1.0e30
 
 
@@ -74,8 +72,8 @@ def _mha_decode_paged_ws_kernel(
     scale = dim**-0.5 * LOG2E
     accum = "float"
     num_pages = (seqlen_kv + page_size - 1) // page_size
-    #: Head-vector elements a lane owns. The dot product is a whole warp wide,
-    #: so this is what makes the shuffle chain exactly five steps.
+    # Head-vector elements a lane owns. The dot product is a whole warp wide,
+    # so this is what makes the shuffle chain exactly five steps.
     vec = dim // WARP
 
     @tilelang.jit(**_jit_kwargs())

--- a/src/tileops/kernels/elementwise/_base.py
+++ b/src/tileops/kernels/elementwise/_base.py
@@ -56,19 +56,19 @@ __all__ = [
 class _ElementwiseKernel(Kernel):
     """What every elementwise family shares: which dtypes it takes, and what it returns."""
 
-    #: Bytes each thread carries, which sets the default ``num_per_thread``. 16
-    #: is one vector load. A body the memory pipe waits on sets 32, keeping a
-    #: second load in flight while the first element's arithmetic runs.
+    # Bytes each thread carries, which sets the default ``num_per_thread``. 16
+    # is one vector load. A body the memory pipe waits on sets 32, keeping a
+    # second load in flight while the first element's arithmetic runs.
     BYTES_PER_THREAD: int = 16
-    #: Input dtypes admitted; ``None`` admits every dtype the builder handles.
+    # Input dtypes admitted; ``None`` admits every dtype the builder handles.
     SUPPORTED_DTYPES = None
-    #: Whether bool results are stored through an int8 buffer.
+    # Whether bool results are stored through an int8 buffer.
     _bool_via_int8: bool = False
-    #: Dtype the result is cast back to when the kernel writes a wider one.
+    # Dtype the result is cast back to when the kernel writes a wider one.
     _fp8_output_dtype = None
 
-    #: Extent of the row a broadcast block walks, or ``None`` where blocks are not
-    #: cut from rows. Only the binary families lay a grid out that way.
+    # Extent of the row a broadcast block walks, or ``None`` where blocks are not
+    # cut from rows. Only the binary families lay a grid out that way.
     row_broadcast_inner: int | None = None
 
     @property
@@ -99,6 +99,9 @@ class _ElementwiseKernel(Kernel):
 
 class _StrategyKernel(_ElementwiseKernel):
     """An elementwise family whose kernel body is picked by a named strategy."""
+
+    # Integer tensors are data; uint8 cond/mask tensors only select results.
+    autotune_accepts_random_int_inputs: bool = True
 
     @property
     def default_config(self) -> dict:
@@ -144,12 +147,9 @@ class UnaryKernel(_StrategyKernel):
             within the resolved strategy).
     """
 
-    #: Integer tensors are data; uint8 cond/mask tensors only select results.
-    autotune_accepts_random_int_inputs: bool = True
-
     supported_archs: list[int] = [80, 86, 89, 90]
     STRATEGIES = ["direct", "explicit_parallel", "register_copy"]
-    #: Fragment copy is the measured default for float unaries.
+    # Fragment copy is the measured default for float unaries.
     DEFAULT_STRATEGY = "register_copy"
     OUTPUT_DTYPE = None
     SUPPORTED_DTYPES = None
@@ -261,9 +261,6 @@ class BinaryKernel(_StrategyKernel):
         out_shape: Broadcast output shape.
         N_total: Total output elements.
     """
-
-    #: Integer tensors are data; uint8 cond/mask tensors only select results.
-    autotune_accepts_random_int_inputs: bool = True
 
     supported_archs: list[int] = [80, 86, 89, 90]
     STRATEGIES = ["direct", "explicit_parallel", "register_copy"]
@@ -407,9 +404,6 @@ class FusedGatedKernel(_StrategyKernel):
         tune: Whether to autotune (sweeps "threads" / "num_per_thread"
             within the resolved strategy).
     """
-
-    #: Integer tensors are data; uint8 cond/mask tensors only select results.
-    autotune_accepts_random_int_inputs: bool = True
 
     supported_archs: list[int] = [80, 86, 89, 90]
     STRATEGIES = ["direct", "explicit_parallel"]

--- a/src/tileops/kernels/elementwise/_builders.py
+++ b/src/tileops/kernels/elementwise/_builders.py
@@ -13,9 +13,9 @@ from ._broadcast import (
 )
 from ._op_body import op_func_for
 
-#: Largest share of a block the leftover columns of a broadcast row may take and
-#: still be packed across rows. Packing them costs a divmod per element; leaving
-#: them costs one block per row running a fraction of its lanes.
+# Largest share of a block the leftover columns of a broadcast row may take and
+# still be packed across rows. Packing them costs a divmod per element; leaving
+# them costs one block per row running a fraction of its lanes.
 _TAIL_PACK_RATIO = 4
 
 

--- a/src/tileops/kernels/elementwise/_builders.py
+++ b/src/tileops/kernels/elementwise/_builders.py
@@ -129,6 +129,16 @@ def _row_broadcast_prim(
     block_cols = threads * num_per_thread
     full_blocks = inner // block_cols
     exact = full_blocks * block_cols == inner
+    # Columns past the last full block. Left in place they each hold a block open
+    # for a fraction of its lanes; packed end to end across rows they fill whole
+    # blocks instead, at the cost of locating each column by divmod. That trade
+    # only pays while they are a small part of the row -- a wide remainder sends
+    # more elements down the divmod path than the idle lanes ever cost.
+    tail_cols = inner - full_blocks * block_cols
+    tail_slots = rows * tail_cols
+    body_blocks = full_blocks * rows
+    tail_blocks = -(-tail_slots // block_cols)
+    packed = not exact and full_blocks > 0 and tail_cols * 4 <= block_cols
 
     @T.macro
     def write_col(a, b, y, a_base, b_base, by, col):
@@ -157,6 +167,52 @@ def _row_broadcast_prim(
             )
         T.copy(y_reg, y[by * inner + col0 : by * inner + col0 + block_cols])
 
+    @T.macro
+    def write_full_block(a, b, y, a_base, b_base, by, bxc):
+        if stage:
+            write_block_staged(a, b, y, a_base, b_base, by, bxc)
+        else:
+            for i, j in T.Parallel(threads, num_per_thread):
+                write_col(a, b, y, a_base, b_base, by, (bxc * threads + i) * num_per_thread + j)
+
+    if packed:
+
+        @T.prim_func
+        def packed_main(
+            a: T.Tensor((a_numel,), dtype),
+            b: T.Tensor((b_numel,), dtype),
+            y: T.Tensor((N_total,), out_dtype),
+        ):
+            with T.Kernel(body_blocks + tail_blocks, threads=threads) as bx:  # noqa: SIM117
+                with T.If(bx < body_blocks):
+                    with T.Then():
+                        by = bx // full_blocks
+                        bxc = bx % full_blocks
+                        a_base, b_base = _compute_broadcast_offsets(
+                            by * inner, ndim, divisors, a_strides, b_strides
+                        )
+                        write_full_block(a, b, y, a_base, b_base, by, bxc)
+                    with T.Else():
+                        for i, j in T.Parallel(threads, num_per_thread):
+                            slot = (bx - body_blocks) * block_cols + i * num_per_thread + j
+                            with T.If(slot < tail_slots):  # noqa: SIM117
+                                with T.Then():
+                                    trow = slot // tail_cols
+                                    ta_base, tb_base = _compute_broadcast_offsets(
+                                        trow * inner, ndim, divisors, a_strides, b_strides
+                                    )
+                                    write_col(
+                                        a,
+                                        b,
+                                        y,
+                                        ta_base,
+                                        tb_base,
+                                        trow,
+                                        full_blocks * block_cols + slot % tail_cols,
+                                    )
+
+        return packed_main
+
     @T.prim_func
     def main(
         a: T.Tensor((a_numel,), dtype),
@@ -168,29 +224,11 @@ def _row_broadcast_prim(
                 by * inner, ndim, divisors, a_strides, b_strides
             )
             if exact:
-                if stage:
-                    write_block_staged(a, b, y, a_base, b_base, by, bx)
-                else:
-                    for i, j in T.Parallel(threads, num_per_thread):
-                        write_col(
-                            a, b, y, a_base, b_base, by, (bx * threads + i) * num_per_thread + j
-                        )
+                write_full_block(a, b, y, a_base, b_base, by, bx)
             else:
                 with T.If(bx < full_blocks):
                     with T.Then():
-                        if stage:
-                            write_block_staged(a, b, y, a_base, b_base, by, bx)
-                        else:
-                            for i, j in T.Parallel(threads, num_per_thread):
-                                write_col(
-                                    a,
-                                    b,
-                                    y,
-                                    a_base,
-                                    b_base,
-                                    by,
-                                    (bx * threads + i) * num_per_thread + j,
-                                )
+                        write_full_block(a, b, y, a_base, b_base, by, bx)
                     with T.Else():
                         for i, j in T.Parallel(threads, num_per_thread):
                             col = (bx * threads + i) * num_per_thread + j

--- a/src/tileops/kernels/elementwise/_builders.py
+++ b/src/tileops/kernels/elementwise/_builders.py
@@ -134,10 +134,8 @@ def _row_broadcast_prim(
     block_cols = threads * num_per_thread
     full_blocks = inner // block_cols
     exact = full_blocks * block_cols == inner
-    # Pack the leftover columns only while they fit _TAIL_PACK_RATIO of a block.
-    # Packing costs a row/column divmod per element; leaving them costs one block
-    # per row running a fraction of its lanes. A wide remainder sends more
-    # elements through the divmod than the idle lanes ever cost.
+    # Packing costs a row/column divmod per leftover element; leaving the columns
+    # in place costs one block per row running a fraction of its lanes.
     tail_cols = inner - full_blocks * block_cols
     tail_slots = rows * tail_cols
     body_blocks = full_blocks * rows

--- a/src/tileops/kernels/elementwise/_builders.py
+++ b/src/tileops/kernels/elementwise/_builders.py
@@ -13,6 +13,10 @@ from ._broadcast import (
 )
 from ._op_body import op_func_for
 
+#: Largest share of a block the leftover columns of a broadcast row may take
+#: and still be packed across rows rather than left to a guarded per-row block.
+_TAIL_PACK_RATIO = 4
+
 
 def _broadcast_index_terms(plan_name):
     """Return ``(ndim, divisors, a_strides, b_strides)`` for one broadcast plan.
@@ -112,12 +116,13 @@ def _row_broadcast_prim(
     One grid row per output row: the divmod chain that locates each operand
     runs once per block, and the inner loop indexes affinely, so it vectorizes.
     The generic path pays that chain per element and every access is a gather.
-    A ragged inner extent splits at trace time: full blocks run unguarded, the
-    one tail block guards each lane.
+    A ragged inner extent splits at trace time. Full blocks always run unguarded.
+    The columns past them go one of two ways: packed end to end across rows into
+    blocks of their own, or left in place as one guarded block per row.
 
     *stage* moves the full blocks through fragments, which keeps the copies wide
     when the body cannot vectorize. It is opt-in because a body that does
-    vectorize is slower for the round trip. The tail block stays scalar either way.
+    vectorize is slower for the round trip. Leftover columns stay scalar either way.
     """
     op_func = op_func_for(op_name)
     ndim, divisors, a_strides, b_strides = _broadcast_index_terms(plan_name)
@@ -129,16 +134,15 @@ def _row_broadcast_prim(
     block_cols = threads * num_per_thread
     full_blocks = inner // block_cols
     exact = full_blocks * block_cols == inner
-    # Columns past the last full block. Left in place they each hold a block open
-    # for a fraction of its lanes; packed end to end across rows they fill whole
-    # blocks instead, at the cost of locating each column by divmod. That trade
-    # only pays while they are a small part of the row -- a wide remainder sends
-    # more elements down the divmod path than the idle lanes ever cost.
+    # Pack the leftover columns only while they fit _TAIL_PACK_RATIO of a block.
+    # Packing costs a row/column divmod per element; leaving them costs one block
+    # per row running a fraction of its lanes. A wide remainder sends more
+    # elements through the divmod than the idle lanes ever cost.
     tail_cols = inner - full_blocks * block_cols
     tail_slots = rows * tail_cols
     body_blocks = full_blocks * rows
     tail_blocks = -(-tail_slots // block_cols)
-    packed = not exact and full_blocks > 0 and tail_cols * 4 <= block_cols
+    pack_tail = not exact and full_blocks > 0 and tail_cols <= block_cols // _TAIL_PACK_RATIO
 
     @T.macro
     def write_col(a, b, y, a_base, b_base, by, col):
@@ -175,7 +179,7 @@ def _row_broadcast_prim(
             for i, j in T.Parallel(threads, num_per_thread):
                 write_col(a, b, y, a_base, b_base, by, (bxc * threads + i) * num_per_thread + j)
 
-    if packed:
+    if pack_tail:
 
         @T.prim_func
         def packed_main(
@@ -197,9 +201,9 @@ def _row_broadcast_prim(
                             slot = (bx - body_blocks) * block_cols + i * num_per_thread + j
                             with T.If(slot < tail_slots):  # noqa: SIM117
                                 with T.Then():
-                                    trow = slot // tail_cols
+                                    tail_row = slot // tail_cols
                                     ta_base, tb_base = _compute_broadcast_offsets(
-                                        trow * inner, ndim, divisors, a_strides, b_strides
+                                        tail_row * inner, ndim, divisors, a_strides, b_strides
                                     )
                                     write_col(
                                         a,
@@ -207,7 +211,7 @@ def _row_broadcast_prim(
                                         y,
                                         ta_base,
                                         tb_base,
-                                        trow,
+                                        tail_row,
                                         full_blocks * block_cols + slot % tail_cols,
                                     )
 

--- a/src/tileops/kernels/elementwise/_builders.py
+++ b/src/tileops/kernels/elementwise/_builders.py
@@ -13,9 +13,11 @@ from ._broadcast import (
 )
 from ._op_body import op_func_for
 
-# Largest share of a block the leftover columns of a broadcast row may take and
-# still be packed across rows. Packing them costs a divmod per element; leaving
-# them costs one block per row running a fraction of its lanes.
+# Packing the leftover T columns of a W-wide block saves rows * (W - T) idle lane
+# slots and spends rows * T index chains, so it pays while T / (W - T) stays under
+# the lane slots one chain is worth. At W // 4 that ratio is 1/3 -- one chain per
+# three idle slots. The workloads sit either side of it: T/W = 0.125 packs and
+# gains, T/W = 0.53 with a single full block per row costs 8.0us -> 14.3us.
 _TAIL_PACK_RATIO = 4
 
 

--- a/src/tileops/kernels/elementwise/_builders.py
+++ b/src/tileops/kernels/elementwise/_builders.py
@@ -13,8 +13,9 @@ from ._broadcast import (
 )
 from ._op_body import op_func_for
 
-#: Largest share of a block the leftover columns of a broadcast row may take
-#: and still be packed across rows rather than left to a guarded per-row block.
+#: Largest share of a block the leftover columns of a broadcast row may take and
+#: still be packed across rows. Packing them costs a divmod per element; leaving
+#: them costs one block per row running a fraction of its lanes.
 _TAIL_PACK_RATIO = 4
 
 
@@ -134,8 +135,6 @@ def _row_broadcast_prim(
     block_cols = threads * num_per_thread
     full_blocks = inner // block_cols
     exact = full_blocks * block_cols == inner
-    # Packing costs a row/column divmod per leftover element; leaving the columns
-    # in place costs one block per row running a fraction of its lanes.
     tail_cols = inner - full_blocks * block_cols
     tail_slots = rows * tail_cols
     body_blocks = full_blocks * rows

--- a/src/tileops/kernels/elementwise/_dtype.py
+++ b/src/tileops/kernels/elementwise/_dtype.py
@@ -5,7 +5,7 @@ import math
 import tilelang.language as T
 import torch
 
-#: Bool has no vectorised CUDA type, so a bool result is stored one byte per element.
+# Bool has no vectorised CUDA type, so a bool result is stored one byte per element.
 BOOL_STORAGE_DTYPE = "int8"
 
 

--- a/src/tileops/kernels/elementwise/_erf.py
+++ b/src/tileops/kernels/elementwise/_erf.py
@@ -4,12 +4,12 @@ import tilelang.language as T
 
 __all__ = ["erf"]
 
-#: |x| taken as saturated. erf(3.6) = 1 - 7.4e-7, far below half a float16 ulp.
+# |x| taken as saturated. erf(3.6) = 1 - 7.4e-7, far below half a float16 ulp.
 _CLAMP = 3.6
 
-#: erf(x) = clip(t * P(w), -1, 1), t = clamp(x, -_CLAMP, _CLAMP), w = 1 - (t / _CLAMP)**2,
-#: highest degree first. Worst case over the real line is 1.7e-5, an order below half
-#: a float16 ulp at 1.0.
+# erf(x) = clip(t * P(w), -1, 1), t = clamp(x, -_CLAMP, _CLAMP), w = 1 - (t / _CLAMP)**2,
+# highest degree first. Worst case over the real line is 1.7e-5, an order below half
+# a float16 ulp at 1.0.
 _POLY_COEFFS = (
     8.971932411193848,
     -33.1397590637207,

--- a/src/tileops/kernels/elementwise/activations.py
+++ b/src/tileops/kernels/elementwise/activations.py
@@ -159,7 +159,7 @@ class HardsigmoidFwdKernel(FloatUnaryKernel):
 class MishFwdKernel(FloatUnaryKernel):
     """Element-wise Mish: x * tanh(softplus(x)) = x * tanh(log(1 + exp(x)))."""
 
-    #: Where Mish's tanh factor reaches 1 in fp32, and below where ``e**2`` overflows.
+    # Where Mish's tanh factor reaches 1 in fp32, and below where ``e**2`` overflows.
     _SATURATION: float = 20.0
 
     @staticmethod

--- a/src/tileops/kernels/elementwise/sinusoidal.py
+++ b/src/tileops/kernels/elementwise/sinusoidal.py
@@ -17,10 +17,10 @@ __all__ = [
 ]
 
 
-#: Positions and dimension pairs one block covers. The divisor depends on the pair
-#: and not the position, so a block spanning several positions calls ``pow`` once
-#: per pair instead of once per element. Both are capped to the tensor at build
-#: time.
+# Positions and dimension pairs one block covers. The divisor depends on the pair
+# and not the position, so a block spanning several positions calls ``pow`` once
+# per pair instead of once per element. Both are capped to the tensor at build
+# time.
 _ROWS, _COLS = 64, 32
 
 

--- a/src/tileops/kernels/gemm/w4a16_decode.py
+++ b/src/tileops/kernels/gemm/w4a16_decode.py
@@ -13,9 +13,9 @@ from .call_spec import GemmCall
 
 GROUP_SIZE = 128
 
-#: Packed bytes each carried partial sum covers. Four keeps the accumulator
-#: fragment small enough to stay in registers at the tile sizes that saturate
-#: the weight stream.
+# Packed bytes each carried partial sum covers. Four keeps the accumulator
+# fragment small enough to stay in registers at the tile sizes that saturate
+# the weight stream.
 BYTES_PER_SLOT = 4
 
 __all__ = ["GemmW4A16DecodeKernel"]
@@ -135,8 +135,8 @@ def _gemm_w4a16_decode_kernel(n: int, k: int, dtype: str) -> Callable:
 class GemmW4A16DecodeKernel(Kernel):
     """Fuse nibble unpacking, affine dequantization, and the M=1 GEMV."""
 
-    #: ``packed_weight`` and ``weight_zero`` are uint8 payloads; the K loop is
-    #: ``k // block_k``.
+    # ``packed_weight`` and ``weight_zero`` are uint8 payloads; the K loop is
+    # ``k // block_k``.
     autotune_accepts_random_int_inputs: bool = True
 
     supported_archs: list[int] = [80, 86, 89, 90]

--- a/src/tileops/kernels/grouped_gemm/call.py
+++ b/src/tileops/kernels/grouped_gemm/call.py
@@ -23,7 +23,7 @@ class GroupedGemmCall(CallSpec):
     n: int = 0
     k: int = 0
     dtype: Optional[torch.dtype] = None
-    #: Gated activation the caller wants applied, "" when the role has none.
+    # Gated activation the caller wants applied, "" when the role has none.
     activation: str = ""
     transpose_a: bool = False
     transpose_b: bool = True

--- a/src/tileops/kernels/grouped_gemm/grouped_gemm_persistent_3wg.py
+++ b/src/tileops/kernels/grouped_gemm/grouped_gemm_persistent_3wg.py
@@ -57,8 +57,8 @@ _DEFAULT_CONFIG = {
     "group_size_m": 8,
 }
 
-#: For shapes whose groups hold fewer rows than a default tile: shorter block, shorter
-#: pipeline. ``_config.rows_per_group_regime`` says which shapes those are.
+# For shapes whose groups hold fewer rows than a default tile: shorter block, shorter
+# pipeline. ``_config.rows_per_group_regime`` says which shapes those are.
 _DECODE_CONFIG = {
     "block_m": 64,
     "block_n": 256,

--- a/src/tileops/kernels/kernel_base.py
+++ b/src/tileops/kernels/kernel_base.py
@@ -6,8 +6,8 @@ from tilelang.autotuner import autotune
 
 __all__ = ["Kernel"]
 
-#: Sentinel for ``tune_jit_kernel(supply_prog=...)``: inherit the whole-kernel
-#: supplier. Distinct from ``None``, which means "no supplier".
+# Sentinel for ``tune_jit_kernel(supply_prog=...)``: inherit the whole-kernel
+# supplier. Distinct from ``None``, which means "no supplier".
 _INHERIT_SUPPLY_PROG = object()
 
 
@@ -61,18 +61,18 @@ class Kernel(ABC):
         self._check_arch()
         self.config = {}
 
-    #: Set True when this kernel's integer tensor inputs are data or masks, so
-    #: autotuning may generate them from ``randint(-2, 3)``. A kernel whose
-    #: integer values decide how much work runs overrides
-    #: ``autotune_supply_prog`` instead; left False, autotuning refuses.
+    # Set True when this kernel's integer tensor inputs are data or masks, so
+    # autotuning may generate them from ``randint(-2, 3)``. A kernel whose
+    # integer values decide how much work runs overrides
+    # ``autotune_supply_prog`` instead; left False, autotuning refuses.
     autotune_accepts_random_int_inputs: bool = False
 
-    #: Whether this implementation is the one behind the specialised ones.
-    #: A dispatch key may have at most one general implementation applying to a
-    #: call; it runs when no specialised implementation of that key serves it.
-    #: Stating it here rather than as an exclusion in every specialised sibling
-    #: is what lets a specialisation appear, or be replaced, without the general
-    #: implementation naming it.
+    # Whether this implementation is the one behind the specialised ones.
+    # A dispatch key may have at most one general implementation applying to a
+    # call; it runs when no specialised implementation of that key serves it.
+    # Stating it here rather than as an exclusion in every specialised sibling
+    # is what lets a specialisation appear, or be replaced, without the general
+    # implementation naming it.
     general: bool = False
 
     @classmethod
@@ -201,8 +201,8 @@ class Kernel(ABC):
         """Return the default config for the kernel"""
         return {}
 
-    #: Implementation serving bool operands, as ``(class, construction dtype)``.
-    #: Left unset by a backend whose general implementation handles bool.
+    # Implementation serving bool operands, as ``(class, construction dtype)``.
+    # Left unset by a backend whose general implementation handles bool.
     BOOL_IMPL: Optional[tuple] = None
 
     @classmethod

--- a/src/tileops/kernels/linear_attention/autotune.py
+++ b/src/tileops/kernels/linear_attention/autotune.py
@@ -23,25 +23,25 @@ __all__ = [
     "tune_delta_rule_fwd",
 ]
 
-#: ``num_stages`` / ``threads`` candidates for the two matmul-heavy sub-kernels.
+# ``num_stages`` / ``threads`` candidates for the two matmul-heavy sub-kernels.
 PIPELINE_CONFIGS: Tuple[Dict[str, int], ...] = tuple(
     {"num_stages": num_stages, "threads": threads}
     for num_stages in (1, 2)
     for threads in (128, 256)
 )
 
-#: ``threads`` candidates for the output projection, which takes no pipeline depth.
+# ``threads`` candidates for the output projection, which takes no pipeline depth.
 OUTPUT_CONFIGS: Tuple[Dict[str, int], ...] = tuple(
     {"threads": threads} for threads in (64, 128, 256)
 )
 
-#: V-tile widths the recurrence may be built with. 0 means one tile spanning dim_v.
-#: 16 is absent because it loses too much precision in fp16.
+# V-tile widths the recurrence may be built with. 0 means one tile spanning dim_v.
+# 16 is absent because it loses too much precision in fp16.
 H_BLOCK_V_WIDTHS: Tuple[int, ...] = (0, 32)
 
-#: Chunk length at or above which the untuned recurrence prefers a tiled width.
-#: Inherited from the per-kernel defaults with no reason stated; no builder
-#: enforces it, so it steers the default only, never the sweep.
+# Chunk length at or above which the untuned recurrence prefers a tiled width.
+# Inherited from the per-kernel defaults with no reason stated; no builder
+# enforces it, so it steers the default only, never the sweep.
 TILED_DEFAULT_MIN_CHUNK_SIZE: int = 64
 
 
@@ -267,9 +267,9 @@ def tune_delta_rule_fwd(
 
     h_config: Optional[Dict[str, int]] = None
     h_block_v: Optional[int] = None
-    #: Widths whose sweep returned, having compiled: the autotuner raises when
-    #: no candidate of a width compiles, and JIT-compiles directly when it skips
-    #: the search. Only a measurement, not membership here, says one is fast.
+    # Widths whose sweep returned, having compiled: the autotuner raises when
+    # no candidate of a width compiles, and JIT-compiles directly when it skips
+    # the search. Only a measurement, not membership here, says one is fast.
     compiled: List[int] = []
     failures: List[Tuple[str, Exception]] = []
     best_latency = float("inf")

--- a/src/tileops/kernels/mamba/da_cumsum.py
+++ b/src/tileops/kernels/mamba/da_cumsum.py
@@ -329,8 +329,8 @@ class DaCumsumFwdKernel(Kernel):
 
     supported_archs: list[int] = [80, 86, 89, 90]
 
-    #: This backend's own capability, which may be narrower than the manifest
-    #: union the op enforces.
+    # This backend's own capability, which may be narrower than the manifest
+    # union the op enforces.
     SUPPORTED_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
 
     def __init__(

--- a/src/tileops/kernels/mamba/ssd_chunk_state.py
+++ b/src/tileops/kernels/mamba/ssd_chunk_state.py
@@ -357,8 +357,8 @@ class SSDChunkStateFwdKernel(Kernel):
 
     supported_archs: list[int] = [80, 86, 89, 90]
 
-    #: ``seq_idx`` masks contributions; the trip count comes from the chunk
-    #: length.
+    # ``seq_idx`` masks contributions; the trip count comes from the chunk
+    # length.
     autotune_accepts_random_int_inputs: bool = True
 
     def __init__(

--- a/src/tileops/kernels/moe/moe_grouped_gemm_persistent_3wg_fused_act.py
+++ b/src/tileops/kernels/moe/moe_grouped_gemm_persistent_3wg_fused_act.py
@@ -69,7 +69,7 @@ class MoeGroupedGemmPersistent3WGFusedActKernel(Kernel):
 
     supported_archs: list[int] = [90]
 
-    #: Gated activations this kernel can carry in its epilogue.
+    # Gated activations this kernel can carry in its epilogue.
     SUPPORTED_ACTIVATIONS = ("gelu_and_mul", "silu_and_mul")
 
     def __init__(

--- a/src/tileops/kernels/moe/moe_grouped_gemm_separate_act.py
+++ b/src/tileops/kernels/moe/moe_grouped_gemm_separate_act.py
@@ -29,7 +29,7 @@ class MoeGroupedGemmSeparateActKernel(Kernel):
     general = True
     supported_archs: list[int] = [80, 86, 89, 90]
 
-    #: Gated activations this kernel can launch after the GEMM.
+    # Gated activations this kernel can launch after the GEMM.
     SUPPORTED_ACTIVATIONS = tuple(sorted(_ACTIVATIONS))
 
     @classmethod

--- a/src/tileops/kernels/reduction/_primitives.py
+++ b/src/tileops/kernels/reduction/_primitives.py
@@ -1143,9 +1143,8 @@ def _down_rows_kernel(
 
                 init_acc(acc)
 
-                # A bound that holds for the whole block guards the walk, not each
-                # lane: expressed as a per-lane select it scalarizes the loop and
-                # costs it its vector loads. Only a ragged column extent needs one.
+                # A per-lane select for a bound the whole block shares scalarizes
+                # the loop and costs it its vector loads.
                 for step in T.serial(rows_per_split):
                     row = pid_a * rows_per_split + step
                     if exact and rows_exact:

--- a/src/tileops/kernels/reduction/_primitives.py
+++ b/src/tileops/kernels/reduction/_primitives.py
@@ -1122,10 +1122,16 @@ def _down_rows_kernel(
     block_b = threads * _LEADING_POLICY.cols_per_thread
     rows_per_split = ceildiv_int(A, splits)
     exact = B % block_b == 0
+    rows_exact = rows_per_split * splits == A
     init_acc, combine, finish = _make_down_rows_ops(op_kind, divisor, out_dtype, epilogue)
 
     @tilelang.jit(out_idx=[1])
     def _func():
+        @T.macro
+        def walk_row(x, acc, row, pid_b):
+            for j in T.Parallel(block_b):
+                combine(acc, j, T.cast(x[row, pid_b * block_b + j], "float32"))
+
         @T.prim_func
         def main(
             x: T.Tensor[(A, B), in_dtype],
@@ -1137,17 +1143,26 @@ def _down_rows_kernel(
 
                 init_acc(acc)
 
+                # A bound that holds for the whole block guards the walk, not each
+                # lane: expressed as a per-lane select it scalarizes the loop and
+                # costs it its vector loads. Only a ragged column extent needs one.
                 for step in T.serial(rows_per_split):
                     row = pid_a * rows_per_split + step
-                    for j in T.Parallel(block_b):
-                        col = pid_b * block_b + j
-                        in_range = row < A if exact else T.And(row < A, col < B)
-                        val = T.if_then_else(
-                            in_range,
-                            T.cast(x[row, col], "float32"),
-                            T.cast(_down_rows_identity(op_kind), "float32"),
-                        )
-                        combine(acc, j, val)
+                    if exact and rows_exact:
+                        walk_row(x, acc, row, pid_b)
+                    elif exact:
+                        with T.If(row < A):  # noqa: SIM117
+                            with T.Then():
+                                walk_row(x, acc, row, pid_b)
+                    else:
+                        for j in T.Parallel(block_b):
+                            col = pid_b * block_b + j
+                            val = T.if_then_else(
+                                T.And(row < A, col < B),
+                                T.cast(x[row, col], "float32"),
+                                T.cast(_down_rows_identity(op_kind), "float32"),
+                            )
+                            combine(acc, j, val)
 
                 if exact:
                     for j in T.Parallel(block_b):

--- a/src/tileops/kernels/reduction/argreduce.py
+++ b/src/tileops/kernels/reduction/argreduce.py
@@ -28,25 +28,25 @@ __all__ = ["ArgreduceKernel"]
 _ARGREDUCE_KINDS = {"argmax", "argmin"}
 _NUM_ACCUMULATORS = 4
 
-#: Magnitude bits of a float32 pattern -- everything but the sign; see _ordering_key.
+# Magnitude bits of a float32 pattern -- everything but the sign; see _ordering_key.
 _KEY_MAGNITUDE = 0x7FFFFFFF
 
-#: The key every NaN takes: int32's largest, so no number outranks one and two NaNs tie.
+# The key every NaN takes: int32's largest, so no number outranks one and two NaNs tie.
 _KEY_NAN = 0x7FFFFFFF
 
-#: Below every float's key, so it loses to any candidate: -inf keys to -0x7F800000.
+# Below every float's key, so it loses to any candidate: -inf keys to -0x7F800000.
 _KEY_IDENTITY = -(2**31)
 # Row-splitting thresholds are measured defaults.
-#: A row shorter than this is a handful of passes; splitting cannot save more
-#: than the second pass costs.
+# A row shorter than this is a handful of passes; splitting cannot save more
+# than the second pass costs.
 _SPLIT_MIN_N = 32768
-#: Above this many rows the blocks already queue, and splitting only adds the
-#: final pass.
+# Above this many rows the blocks already queue, and splitting only adds the
+# final pass.
 _ROWS_SATURATED = 512
-#: A chunk shorter than this cannot amortize its share of the final pass.
+# A chunk shorter than this cannot amortize its share of the final pass.
 _MIN_CHUNK = 512
-#: Output-parallel gives a thread the whole axis to walk, so it pays only while
-#: that walk is short; it loses from N=32 up.
+# Output-parallel gives a thread the whole axis to walk, so it pays only while
+# that walk is short; it loses from N=32 up.
 _STRIDED_AXIS_MAX_N = 16
 
 

--- a/src/tileops/kernels/tiling.py
+++ b/src/tileops/kernels/tiling.py
@@ -2,8 +2,8 @@
 
 __all__ = ["ALIGNMENT", "align_up"]
 
-#: Element count a row is padded to before ``T.copy`` moves it through shared
-#: memory: 256 elements, i.e. 512 bytes for fp16/bf16 and 1024 for fp32.
+# Element count a row is padded to before ``T.copy`` moves it through shared
+# memory: 256 elements, i.e. 512 bytes for fp16/bf16 and 1024 for fp32.
 ALIGNMENT = 256
 
 

--- a/src/tileops/manifest/dtype_rules.py
+++ b/src/tileops/manifest/dtype_rules.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import re
 
-#: Group 1 is the referenced tensor name.
+# Group 1 is the referenced tensor name.
 SAME_AS_RE = re.compile(r"^same_as\(\s*(\w+)\s*\)$")
 PROMOTE_INT_TO_FLOAT_RE = re.compile(r"^promote_int_to_float\(\s*(\w+)\s*\)$")
 

--- a/src/tileops/ops/_output_dtype.py
+++ b/src/tileops/ops/_output_dtype.py
@@ -13,7 +13,7 @@ from tileops.manifest.dtype_rules import promote_int_to_float_ref, same_as_ref
 
 __all__ = ["resolve_output_dtype"]
 
-#: What ``promote_int_to_float`` promotes an integral input to.
+# What ``promote_int_to_float`` promotes an integral input to.
 _PROMOTED_FLOAT_DTYPE = torch.float32
 
 

--- a/src/tileops/ops/_params_codegen.py
+++ b/src/tileops/ops/_params_codegen.py
@@ -9,8 +9,8 @@ from __future__ import annotations
 
 from tileops.manifest import try_load_entry
 
-#: Attached to a class when its manifest entry declares ``signature.params``. The empty
-#: tuple is a real answer: plenty of ops take no params.
+# Attached to a class when its manifest entry declares ``signature.params``. The empty
+# tuple is a real answer: plenty of ops take no params.
 ATTRIBUTE = "__manifest_param_names__"
 
 

--- a/src/tileops/ops/attention/mha.py
+++ b/src/tileops/ops/attention/mha.py
@@ -36,7 +36,6 @@ class MultiHeadAttentionFwdOp(Op):
     maintained forward path through the GQA prefill dispatcher.
     """
 
-    #: The operator this op registers; a test asserts the graph holds nothing else.
     compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::mha_fwd",)
 
     def __init__(

--- a/src/tileops/ops/attention/selection.py
+++ b/src/tileops/ops/attention/selection.py
@@ -17,7 +17,7 @@ __all__ = [
     "fp8_dtype",
 ]
 
-#: Implementations of packed GQA prefill, as ``kernel_map`` keys.
+# Implementations of packed GQA prefill, as ``kernel_map`` keys.
 PACKED_PREFILL_KEYS = (
     "gqa_prefill_fp8_tensor_core_fwd_kernel",
     "gqa_sliding_window_varlen_fwd_kernel",
@@ -27,27 +27,27 @@ PACKED_PREFILL_KEYS = (
     "gqa_prefill_varlen_fwd_kernel",
 )
 
-#: The subset serving a uniform dense request, for the fixed-shape wrapper.
+# The subset serving a uniform dense request, for the fixed-shape wrapper.
 DENSE_PREFILL_KEYS = (
     "gqa_prefill_square_fwd_kernel",
     "gqa_prefill_causal_fwd_kernel",
     "gqa_prefill_fwd_kernel",
 )
 
-#: Implementations of paged GQA prefill.
+# Implementations of paged GQA prefill.
 PAGED_PREFILL_KEYS = (
     "gqa_prefill_paged_with_kv_cache_rope_fwd_kernel",
     "gqa_prefill_paged_with_fp8_kv_cache_fwd_kernel",
     "gqa_prefill_paged_with_kv_cache_fwd_kernel",
 )
 
-#: Implementations of contiguous GQA decode.
+# Implementations of contiguous GQA decode.
 DECODE_KEYS = ("gqa_decode_bs1_kernel", "gqa_decode_kernel")
 
-#: Implementations of paged GQA decode.
+# Implementations of paged GQA decode.
 PAGED_DECODE_KEYS = ("gqa_decode_paged_bs1_kernel", "gqa_decode_paged_kernel")
 
-#: Implementations of paged MHA decode.
+# Implementations of paged MHA decode.
 MHA_PAGED_DECODE_KEYS = ("mha_decode_paged_ws_kernel", "mha_decode_paged_kernel")
 
 

--- a/src/tileops/ops/convolution.py
+++ b/src/tileops/ops/convolution.py
@@ -229,7 +229,6 @@ def _conv1d_l_out(
 
 
 class Conv1dFwdOp(Op):
-    #: The operator this op registers; a test asserts the graph holds nothing else.
     compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::conv_conv1d_fwd",)
 
     def __init__(
@@ -576,7 +575,6 @@ def _conv_out_dim(
 
 
 class Conv2dFwdOp(Op):
-    #: The operator this op registers; a test asserts the graph holds nothing else.
     compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::conv_conv2d_fwd",)
 
     def __init__(
@@ -993,7 +991,6 @@ def _triple(value: int | Tuple[int, int, int]) -> Tuple[int, int, int]:
 
 
 class Conv3dFwdOp(Op):
-    #: The operator this op registers; a test asserts the graph holds nothing else.
     compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::conv_conv3d_fwd",)
 
     def __init__(

--- a/src/tileops/ops/elementwise/_base.py
+++ b/src/tileops/ops/elementwise/_base.py
@@ -827,11 +827,11 @@ class _ParametricActivationOp(_UnaryActivationMixin, UnaryOp):
     mixin and ``UnaryOp``.
     """
 
-    #: Names of the scalar parameters baked into the kernel; each names both the
-    #: attribute on ``self`` and the kernel kwarg. The entry builder validates
-    #: them against the element type before baking, which is why the check
-    #: cannot live in ``__init__``: it needs a dtype, and none exists until a
-    #: tensor arrives.
+    # Names of the scalar parameters baked into the kernel; each names both the
+    # attribute on ``self`` and the kernel kwarg. The entry builder validates
+    # them against the element type before baking, which is why the check
+    # cannot live in ``__init__``: it needs a dtype, and none exists until a
+    # tensor arrives.
     _scalar_params: tuple[str, ...] = ()
 
     def _build(self, dtype: torch.dtype, n_total: int):

--- a/src/tileops/ops/gemm/bmm.py
+++ b/src/tileops/ops/gemm/bmm.py
@@ -180,7 +180,7 @@ class BmmFp8KNFwdOp(Op):
 
     """
 
-    #: Whether ``b`` arrives with K innermost, which is what the kernel wants.
+    # Whether ``b`` arrives with K innermost, which is what the kernel wants.
     B_IS_NK: ClassVar[bool] = False
 
     def __init__(

--- a/src/tileops/ops/linear_attention/deltanet_recurrence.py
+++ b/src/tileops/ops/linear_attention/deltanet_recurrence.py
@@ -14,7 +14,7 @@ from ..op_base import Op
 
 __all__ = ["DeltaNetDecodeFwdOp"]
 
-#: Implementations of the DeltaNet decode slot.
+# Implementations of the DeltaNet decode slot.
 DELTANET_DECODE_KEYS = (
     "DeltaNetDecodeFP32Kernel",
     "DeltaNetDecodeRawCudaFlaStyleKernel",

--- a/src/tileops/ops/linear_attention/gated_deltanet.py
+++ b/src/tileops/ops/linear_attention/gated_deltanet.py
@@ -31,7 +31,7 @@ __all__ = [
     "GatedDeltaNetPrefillBTHDFwdOp",
 ]
 
-#: Implementations of the gated DeltaNet decode slot.
+# Implementations of the gated DeltaNet decode slot.
 GATED_DELTANET_DECODE_KEYS = (
     "GatedDeltaNetDecodeFP32Kernel",
     "GatedDeltaNetDecodeRawCudaFlaStyleKernel",
@@ -463,8 +463,8 @@ class GatedDeltaNetPrefillBTHDFwdOp(Op):
     otherwise 64.
     """
 
-    #: The memory order this op takes. One entry declares one order: the order changes
-    #: what an axis means, so an op serving two layouts is two entries.
+    # The memory order this op takes. One entry declares one order: the order changes
+    # what an axis means, so an op serving two layouts is two entries.
     LAYOUT: ClassVar[str] = "bthd"
 
     def __init__(

--- a/src/tileops/ops/moe/permute_align.py
+++ b/src/tileops/ops/moe/permute_align.py
@@ -27,7 +27,6 @@ class MoePermuteAlignFwdOp(Op):
         ```
     """
 
-    #: The operator this op registers; a test asserts the graph holds nothing else.
     compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::moe_permute_align_fwd",)
 
     def __init__(

--- a/src/tileops/ops/moe/routed_expert/gate_up.py
+++ b/src/tileops/ops/moe/routed_expert/gate_up.py
@@ -19,10 +19,10 @@ from ._common import GroupedOperandEagerForward
 
 __all__ = ["MoeGateUpFwdOp"]
 
-#: The implementations of this role; each states its own region.
+# The implementations of this role; each states its own region.
 _GATE_UP_KEYS = ("moe_grouped_gemm_fused_act_kernel", "moe_grouped_gemm_act_kernel")
 
-#: The grouped GEMM the separate-activation implementation composes with.
+# The grouped GEMM the separate-activation implementation composes with.
 _GEMM_KEYS = ("moe_grouped_gemm_kernel", "moe_grouped_gemm_persistent_kernel")
 
 
@@ -39,7 +39,6 @@ class MoeGateUpFwdOp(GroupedOperandEagerForward, Op):
         ```
     """
 
-    #: The operator this op registers; a test asserts the graph holds nothing else.
     compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::moe_gate_up_fwd",)
 
     def __init__(

--- a/src/tileops/ops/moe/routed_expert/moe_grouped_gemm_nopad.py
+++ b/src/tileops/ops/moe/routed_expert/moe_grouped_gemm_nopad.py
@@ -15,7 +15,7 @@ from ._common import GroupedOperandEagerForward
 
 __all__ = ["MoeGroupedGemmNopadFwdOp"]
 
-#: The implementations of this role; each states its own region.
+# The implementations of this role; each states its own region.
 _GEMM_KEYS = ("moe_grouped_gemm_kernel", "moe_grouped_gemm_persistent_kernel")
 
 
@@ -36,7 +36,6 @@ class MoeGroupedGemmNopadFwdOp(GroupedOperandEagerForward, Op):
         ```
     """
 
-    #: The operator this op registers; a test asserts the graph holds nothing else.
     compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::moe_grouped_gemm_nopad_fwd",)
 
     def __init__(

--- a/src/tileops/ops/moe/routed_expert/permute_nopad.py
+++ b/src/tileops/ops/moe/routed_expert/permute_nopad.py
@@ -36,7 +36,6 @@ class MoePermuteNopadFwdOp(Op):
         ```
     """
 
-    #: The operator this op registers; a test asserts the graph holds nothing else.
     compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::moe_permute_nopad_fwd",)
 
     def __init__(

--- a/src/tileops/ops/moe/routed_expert/unpermute.py
+++ b/src/tileops/ops/moe/routed_expert/unpermute.py
@@ -23,10 +23,10 @@ class MoeUnpermuteFwdOp(Op):
         ```
     """
 
-    #: Two operators, because ``mutates_args`` is fixed at registration while ``out``
-    #: decides per call whether this op writes a caller buffer. Same split as aten's
-    #: ``relu`` / ``relu_``: ``forward`` picks one, and a test asserts the graph holds
-    #: nothing else.
+    # Two operators, because ``mutates_args`` is fixed at registration while ``out``
+    # decides per call whether this op writes a caller buffer. Same split as aten's
+    # ``relu`` / ``relu_``: ``forward`` picks one, and a test asserts the graph holds
+    # nothing else.
     compile_op_names: ClassVar[Tuple[str, ...]] = (
         "tileops::moe_unpermute_fwd",
         "tileops::moe_unpermute_fwd_inplace",

--- a/src/tileops/ops/norm/ada_layer_norm.py
+++ b/src/tileops/ops/norm/ada_layer_norm.py
@@ -36,7 +36,6 @@ class AdaLayerNormFwdOp(Op):
 
     """
 
-    #: The operator this op registers; a test asserts the graph holds nothing else.
     compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::norm_ada_layer_norm_fwd",)
 
     def __init__(

--- a/src/tileops/ops/norm/ada_layer_norm_zero.py
+++ b/src/tileops/ops/norm/ada_layer_norm_zero.py
@@ -37,7 +37,6 @@ class AdaLayerNormZeroFwdOp(Op):
 
     """
 
-    #: The operator this op registers; a test asserts the graph holds nothing else.
     compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::norm_ada_layer_norm_zero_fwd",)
 
     def __init__(

--- a/src/tileops/ops/norm/batch_norm.py
+++ b/src/tileops/ops/norm/batch_norm.py
@@ -62,7 +62,6 @@ class BatchNormFwdOp(Op):
 
     """
 
-    #: The operator this op registers; a test asserts the graph holds nothing else.
     compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::norm_batch_norm_fwd",)
 
     def __init__(
@@ -253,7 +252,6 @@ class BatchNormBwdOp(Op):
 
     """
 
-    #: The operator this op registers; a test asserts the graph holds nothing else.
     compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::norm_batch_norm_bwd",)
 
     def __init__(

--- a/src/tileops/ops/norm/fused_add_layer_norm.py
+++ b/src/tileops/ops/norm/fused_add_layer_norm.py
@@ -39,7 +39,6 @@ class FusedAddLayerNormFwdOp(Op):
 
     """
 
-    #: The operator this op registers; a test asserts the graph holds nothing else.
     compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::norm_fused_add_layer_norm_fwd",)
 
     def __init__(

--- a/src/tileops/ops/norm/fused_add_rms_norm.py
+++ b/src/tileops/ops/norm/fused_add_rms_norm.py
@@ -38,7 +38,6 @@ class FusedAddRMSNormFwdOp(Op):
 
     """
 
-    #: The operator this op registers; a test asserts the graph holds nothing else.
     compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::norm_fused_add_rms_norm_fwd",)
 
     def __init__(

--- a/src/tileops/ops/norm/group_norm.py
+++ b/src/tileops/ops/norm/group_norm.py
@@ -55,7 +55,6 @@ class GroupNormFwdOp(Op):
 
     """
 
-    #: The operator this op registers; a test asserts the graph holds nothing else.
     compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::norm_group_norm_fwd",)
 
     def __init__(

--- a/src/tileops/ops/norm/instance_norm.py
+++ b/src/tileops/ops/norm/instance_norm.py
@@ -58,7 +58,6 @@ class InstanceNormFwdOp(Op):
 
     """
 
-    #: The operator this op registers; a test asserts the graph holds nothing else.
     compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::norm_instance_norm_fwd",)
 
     def __init__(

--- a/src/tileops/ops/norm/layer_norm.py
+++ b/src/tileops/ops/norm/layer_norm.py
@@ -32,11 +32,10 @@ class LayerNormFwdOp(Op):
 
     """
 
-    #: Manifest ``params.eps.default``, which PyTorch shares. The signature default and the
-    #: ``None`` normalization both read it, so the two cannot drift apart.
+    # Manifest ``params.eps.default``, which PyTorch shares. The signature default and the
+    # ``None`` normalization both read it, so the two cannot drift apart.
     DEFAULT_EPS = 1e-5
 
-    #: The operator this op registers; a test asserts the graph holds nothing else.
     compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::norm_layer_norm_fwd",)
 
     def __init__(

--- a/src/tileops/ops/norm/rms_norm.py
+++ b/src/tileops/ops/norm/rms_norm.py
@@ -49,11 +49,10 @@ class RMSNormFwdOp(Op):
         ```
     """
 
-    #: Manifest ``params.eps.default``. The signature default and the ``None``
-    #: normalization both read it, so the two cannot drift apart.
+    # Manifest ``params.eps.default``. The signature default and the ``None``
+    # normalization both read it, so the two cannot drift apart.
     DEFAULT_EPS = 1.0e-6
 
-    #: The operator this op registers; a test asserts the graph holds nothing else.
     compile_op_names: ClassVar[Tuple[str, ...]] = ("tileops::norm_rms_norm_fwd",)
 
     def __init__(

--- a/src/tileops/ops/op_base.py
+++ b/src/tileops/ops/op_base.py
@@ -45,8 +45,8 @@ class _Unresolved:
         return "<not resolved yet>"
 
 
-#: ``Op._builder`` before the first call. Distinct from ``None``, the decided answer
-#: "run the in-tree implementation".
+# ``Op._builder`` before the first call. Distinct from ``None``, the decided answer
+# "run the in-tree implementation".
 _UNRESOLVED = _Unresolved()
 
 
@@ -140,12 +140,12 @@ class Op(ABC):
     def default_kernel_map(self) -> dict[str, Kernel]:
         raise NotImplementedError("Op must implement default_kernel_map")
 
-    #: Operators this op registers on the torch.compile boundary. Naming them is what lets
-    #: a test assert the traced graph holds nothing else, which is what keeps the graph the
-    #: same when another target serves the op. A tuple because a conditional in-place write
-    #: registers two. Registration happens once per class, so this is class state; an op
-    #: that declares ``torch_compile_fullgraph`` names its operators, which
-    #: ``register_compile_contract`` requires.
+    # Operators this op registers on the torch.compile boundary. Naming them is what lets
+    # a test assert the traced graph holds nothing else, which is what keeps the graph the
+    # same when another target serves the op. A tuple because a conditional in-place write
+    # registers two. Registration happens once per class, so this is class state; an op
+    # that declares ``torch_compile_fullgraph`` names its operators, which
+    # ``register_compile_contract`` requires.
     compile_op_names: ClassVar[tuple[str, ...]] = ()
 
     @abstractmethod

--- a/src/tileops/ops/pool.py
+++ b/src/tileops/ops/pool.py
@@ -209,11 +209,11 @@ class _AvgPoolFwdOpBase(Op):
     """
 
     ndim: ClassVar[int]
-    #: Average pooling has one output; the registration below reads this.
+    # Average pooling has one output; the registration below reads this.
     _returns_indices: ClassVar[bool] = False
 
-    #: This op's operator, and its name; both set by the registrations at the bottom of
-    #: this module, one per concrete op class.
+    # This op's operator, and its name; both set by the registrations at the bottom of
+    # this module, one per concrete op class.
     _wrapped: ClassVar[Any]
     compile_op_names: ClassVar[Tuple[str, ...]] = ()
 
@@ -593,8 +593,8 @@ class _MaxPoolFwdOpBase(Op):
     _kernel_slot: ClassVar[str] = ""
     _returns_indices: ClassVar[bool] = False
 
-    #: This op's operator, and its name; both set by the registrations at the bottom of
-    #: this module, one per concrete op class.
+    # This op's operator, and its name; both set by the registrations at the bottom of
+    # this module, one per concrete op class.
     _wrapped: ClassVar[Any]
     compile_op_names: ClassVar[Tuple[str, ...]] = ()
 
@@ -1258,8 +1258,8 @@ class _AdaptivePool2dFwdOpBase(Op):
     _kernel_slot: ClassVar[str] = ""
     _returns_indices: ClassVar[bool] = False
 
-    #: This op's operator, and its name; both set by the registrations at the bottom of
-    #: this module, one per concrete op class.
+    # This op's operator, and its name; both set by the registrations at the bottom of
+    # this module, one per concrete op class.
     _wrapped: ClassVar[Any]
     compile_op_names: ClassVar[Tuple[str, ...]] = ()
 

--- a/src/tileops/ops/reduction/cumulative.py
+++ b/src/tileops/ops/reduction/cumulative.py
@@ -25,7 +25,7 @@ class CumulativeOp(Op):
 
     _op_kind: str
 
-    #: Set by ``register_reduction_op`` on each concrete op; a base registers none.
+    # Set by ``register_reduction_op`` on each concrete op; a base registers none.
     _wrapped = None
 
     def __init__(

--- a/src/tileops/ops/reduction/reduce.py
+++ b/src/tileops/ops/reduction/reduce.py
@@ -82,7 +82,7 @@ class _ReduceOpBase(Op):
     - ``_build_kernel_kwargs(x, axes)``: extra kwargs for the kernel constructor.
     """
 
-    #: Set by ``register_reduction_op`` on each concrete op; a base registers none.
+    # Set by ``register_reduction_op`` on each concrete op; a base registers none.
     _wrapped = None
 
     _op_kind: str = ""  # overridden by subclasses

--- a/src/tileops/ops/reduction/softmax.py
+++ b/src/tileops/ops/reduction/softmax.py
@@ -41,7 +41,7 @@ class _SoftmaxBaseOp(Op):
 
     """
 
-    #: Set by ``register_reduction_op`` on each concrete op; a base registers none.
+    # Set by ``register_reduction_op`` on each concrete op; a base registers none.
     _wrapped = None
 
     _op_kind: str  # set by subclass

--- a/tests/ops/test_elementwise_binary_broadcast.py
+++ b/tests/ops/test_elementwise_binary_broadcast.py
@@ -185,3 +185,23 @@ def test_staged_row_broadcast_matches_torch(a_shape, b_shape):
     out = GtFwdOp()(a, b)
     assert out.dtype == torch.bool
     assert torch.equal(out, torch.gt(a, b))
+
+
+# A row extent of 1088 leaves 64 columns past two full blocks of 512, which is
+# within the share the builder packs across rows; 5000 leaves 392, which is not.
+_TAIL_SHAPES = [
+    pytest.param((4, 1088), (4, 1), id="packed-tail-inner-stride-0"),
+    pytest.param((5, 1088), (1, 1088), id="packed-tail-inner-stride-1"),
+    pytest.param((3, 5000), (3, 1), id="guarded-tail"),
+]
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("a_shape, b_shape", _TAIL_SHAPES)
+def test_row_broadcast_tail_matches_torch(a_shape, b_shape):
+    """Both endings of a ragged row write every element torch writes."""
+    from tileops.ops.elementwise import AddFwdOp
+
+    a = torch.randn(a_shape, device="cuda", dtype=torch.float32)
+    b = torch.randn(b_shape, device="cuda", dtype=torch.float32)
+    assert torch.equal(AddFwdOp()(a, b), a + b)

--- a/tests/ops/test_elementwise_binary_broadcast.py
+++ b/tests/ops/test_elementwise_binary_broadcast.py
@@ -187,8 +187,6 @@ def test_staged_row_broadcast_matches_torch(a_shape, b_shape):
     assert torch.equal(out, torch.gt(a, b))
 
 
-# A row extent of 1088 leaves 64 columns past two full blocks of 512, which is
-# within the share the builder packs across rows; 5000 leaves 392, which is not.
 _TAIL_SHAPES = [
     pytest.param((4, 1088), (4, 1), id="packed-tail-inner-stride-0"),
     pytest.param((5, 1088), (1, 1088), id="packed-tail-inner-stride-1"),

--- a/tests/ops/test_reduce_multidim.py
+++ b/tests/ops/test_reduce_multidim.py
@@ -655,3 +655,13 @@ def test_edge_axis_reduce_returns_the_storage_dtype(dtype: torch.dtype) -> None:
     counted = CountNonzeroFwdOp(dim=[0, 2])(x)
     assert counted.dtype == torch.int64
     assert torch.equal(counted, torch.count_nonzero(x, dim=[0, 2]))
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("shape", [(768, 512), (1536, 512)], ids=["ragged-split", "exact-split"])
+def test_leading_axis_split_reduces_every_row(shape):
+    """A split that does not divide the reduced extent still sums every row."""
+    from tileops.ops.reduction.reduce import SumFwdOp
+
+    x = torch.randn(shape, dtype=torch.float32, device="cuda")
+    torch.testing.assert_close(SumFwdOp(dim=0)(x), x.sum(dim=0), rtol=1e-4, atol=1e-4)


### PR DESCRIPTION
H200, CI image, CUPTI device-busy median, `benchmarks/` timing. Ratio is against the fastest baseline tag on each row.

## problems

- A row-broadcast block covers one row's columns, so a row extent the block width does not divide left every row holding one more block open for a fraction of its lanes. On `cnn-feat-broadcast` that was a quarter of the blocks carrying two percent of the elements.
- A leading-axis split that does not divide the reduced extent expressed its short last slice as a per-lane select inside the element loop, which scalarizes the walk.
- No test reached either ending of a ragged broadcast row.
- 163 `#:` attribute comments reached nothing: the docs site builds from griffe, which reads a string literal under an assignment, not the comment above it.
- Eighteen op classes each restated what `Op.compile_op_names` documents; three elementwise families each restated one reason for `autotune_accepts_random_int_inputs`; a comment for `LOG2E` stayed behind when the constant moved.

## changes

| op / workload | before | after | ratio |
| --- | --- | --- | --- |
| Eq / Ne / Lt / Le / Gt / Ge, LogicalAnd / Or, `(16,256,56,56)` vs `(256,1,1)` | 12.4-12.6us | 11.9-12.2us | 0.927 -> 0.96 |
| Pow, same broadcast | 44.9us | 41.3us | 1.049 -> 1.14 |
| Minimum, same broadcast | 15.8us | 15.5us | 0.899 -> 0.92 |
| Sum `(2048,4096)` float16, ragged split | 9.28us | 7.78us | nearest exact split is 7.36us |

- Leftover columns of a broadcast row run end to end across rows in blocks of their own while they stay within `_TAIL_PACK_RATIO` of a block. A wider remainder keeps the guarded per-row block: packing one of 1088 columns of 3136 cost 8.0us -> 14.3us.
- The leading-axis row bound guards the walk rather than each lane. Splits that divide the extent are unchanged.
- Attributes are commented with `#`. The `autotune_accepts_random_int_inputs` override moved to the parent the three families share; every class keeps the value it had.
- code-style.md states which docstrings reach the docs site, and that `#:` is not read.
- Test node delta: +8.
