### PR TITLE
[Refactor][Bench] Derive the benchmark's op name from the op it wraps

### DIFF
--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -344,15 +344,14 @@ class ManifestBenchmark(BenchmarkBase[Any]):
     roofline variables during ``forward()``.
     """
 
-    def __init__(
-        self,
-        # Nothing reads it at run time; validate_manifest parses this argument to
-        # tie the benchmark file to a manifest entry, so it must stay a literal.
-        op_name: str,
-        op: Any,
-        workload: Any,
-    ):
+    def __init__(self, op: Any, workload: Any):
         super().__init__(workload)
+        self.op_name = type(op).__name__
+        if self.op_name not in load_manifest():
+            raise KeyError(
+                f"{self.op_name} is not a manifest op; a benchmark reports under the name the "
+                "manifest declares, so a wrapper or a subclass cannot stand in for one"
+            )
         self._op = op
         self._roofline_cache: Optional[tuple[float, float]] = None
 

--- a/benchmarks/ops/attention/bench_deepseek_dsa_decode.py
+++ b/benchmarks/ops/attention/bench_deepseek_dsa_decode.py
@@ -132,7 +132,7 @@ def test_dsa_decode_bench(
         sm_scale=sm_scale,
         tune=tune,
     )
-    bm = ManifestBenchmark(_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
 
     baselines = {}
     sdpa_fn = _torch_sdpa_dsa(test)

--- a/benchmarks/ops/attention/bench_deepseek_mla_decode.py
+++ b/benchmarks/ops/attention/bench_deepseek_mla_decode.py
@@ -40,7 +40,7 @@ def test_mla_decode_bench(
     op = MultiHeadLatentAttentionDecodeWithKVCacheFwdOp(
         batch, heads, heads_kv, seq_len_kv, dim, dim_pe, tune=tune
     )
-    bm = ManifestBenchmark(_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
 
     bm.compare(
         {

--- a/benchmarks/ops/attention/bench_gqa.py
+++ b/benchmarks/ops/attention/bench_gqa.py
@@ -287,7 +287,7 @@ def test_gqa_fwd_bench(
     inputs = test.gen_inputs()
 
     op = GroupedQueryAttentionFwdOp(batch, heads, heads_kv, seq_len, dim, causal, tune=tune)
-    bm = ManifestBenchmark(_GQA_FWD_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     tileops_variant = _tileops_gqa_variant(op, dtype)
     functors = {f"tileops_{tileops_variant}": op}
 
@@ -331,7 +331,7 @@ def test_gqa_bwd_bench(
     inputs = test.gen_inputs()
 
     op = GroupedQueryAttentionBwdOp(batch, heads, heads_kv, seq_len, dim, causal, tune=tune)
-    bm = ManifestBenchmark(_GQA_BWD_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     functors = {"tileops": op}
 
     fa3_fn = _fa3_gqa_bwd(test)
@@ -398,7 +398,7 @@ def test_gqa_prefill_fwd_bench(
         sm_scale=sm_scale,
         softcap=softcap,
     )
-    bm = ManifestBenchmark(_GQA_PREFILL_FWD_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     functors = {"tileops": op}
 
     functors["torch-ref"] = (_torch_gqa_prefill_ref(test), (*inputs,))
@@ -667,7 +667,7 @@ def test_gqa_prefill_paged_with_kv_cache_fwd_bench(
     op.q_lens = q_lens
     op.cache_lens = cache_lens
     op.max_seqlen_q = test.max_seqlen_q
-    bm = ManifestBenchmark(_GQA_PREFILL_PAGED_WITH_KV_CACHE_FWD_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     fa3_fn = _fa3_gqa_prefill_paged(test, cache_dtype, fuse_rope, softcap)
     if fa3_fn is None:
         # FIXME(staged-rollout): this row records no baseline.

--- a/benchmarks/ops/attention/bench_gqa_decode.py
+++ b/benchmarks/ops/attention/bench_gqa_decode.py
@@ -154,7 +154,7 @@ def test_gqa_decode_bench(
         softcap=softcap,
         tune=tune,
     )
-    bm = ManifestBenchmark(_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
     functors = {"tileops": op}
 
     fa3_fn = _fa3_gqa_decode_fwd(test)

--- a/benchmarks/ops/attention/bench_gqa_decode_paged.py
+++ b/benchmarks/ops/attention/bench_gqa_decode_paged.py
@@ -190,7 +190,7 @@ def test_gqa_decode_paged_bench(
         softcap=softcap,
         tune=tune,
     )
-    bm = ManifestBenchmark(_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
     functors = {"tileops": op}
 
     fa3_fn = _fa3_gqa_decode_paged(test, k, v)

--- a/benchmarks/ops/attention/bench_gqa_fp8.py
+++ b/benchmarks/ops/attention/bench_gqa_fp8.py
@@ -156,7 +156,7 @@ def test_gqa_prefill_fp8_tensor_core_bench(case: GQAFp8TensorCoreBenchCase) -> N
     op(*inputs)
     torch.cuda.synchronize()
 
-    bm = ManifestBenchmark(_OP_NAME, op, case)
+    bm = ManifestBenchmark(op, case)
     sdpa_fn = _torch_sdpa_dequant_fwd(case)
     # The tolerance tests/ops/attention/test_gqa_fp8.py holds its own dequantized
     # reference to: fp8 quantization is the whole difference between the two.

--- a/benchmarks/ops/attention/bench_gqa_sliding_window.py
+++ b/benchmarks/ops/attention/bench_gqa_sliding_window.py
@@ -141,7 +141,7 @@ def test_gqa_sliding_window_fwd_bench(
         window_size_right=wr,
         tune=tune,
     )
-    bm = ManifestBenchmark(_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
 
     # Warmup: trigger JIT compilation before timed profiling
     op(*inputs)

--- a/benchmarks/ops/attention/bench_gqa_sliding_window_varlen.py
+++ b/benchmarks/ops/attention/bench_gqa_sliding_window_varlen.py
@@ -182,7 +182,7 @@ def test_gqa_sliding_window_varlen_fwd_bench(
     op.k_lens = seqlens_k
     op.max_seqlen_q = max(seqlens_q)
     op.max_seqlen_k = max(seqlens_k)
-    bm = ManifestBenchmark(_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
 
     # Warmup: trigger JIT compilation before timed profiling
     op(*inputs)

--- a/benchmarks/ops/attention/bench_mha.py
+++ b/benchmarks/ops/attention/bench_mha.py
@@ -128,7 +128,7 @@ def test_mha_fwd_bench(
     inputs = test.gen_inputs()
 
     op = MultiHeadAttentionFwdOp(batch, heads, seq_len, dim, causal, tune=tune)
-    bm = ManifestBenchmark(_MHA_FWD_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     functors = {"tileops": op}
 
     fa3_fn = _fa3_mha_fwd(test)
@@ -158,7 +158,7 @@ def test_mha_bwd_bench(
     inputs = test.gen_inputs()
 
     op = MultiHeadAttentionBwdOp(batch, heads, seq_len, dim, causal, tune=tune)
-    bm = ManifestBenchmark(_MHA_BWD_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     functors = {"tileops": op}
 
     fa3_fn = _fa3_mha_bwd(test)

--- a/benchmarks/ops/attention/bench_mha_decode.py
+++ b/benchmarks/ops/attention/bench_mha_decode.py
@@ -74,7 +74,7 @@ def test_mha_decode_bench(
     inputs = test.gen_inputs()
 
     op = MultiHeadAttentionDecodeWithKVCacheFwdOp(b, h, s_q, s_kv, d, tune=tune)
-    bm = ManifestBenchmark(_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
     functors = {"tileops": op}
 
     fa3_fn = _fa3_mha_decode_fwd(test)

--- a/benchmarks/ops/attention/bench_mha_decode_paged.py
+++ b/benchmarks/ops/attention/bench_mha_decode_paged.py
@@ -112,7 +112,7 @@ def test_mha_decode_paged_bench(
     op = MultiHeadAttentionDecodePagedWithKVCacheFwdOp(
         batch, heads, seqlen_q, seqlen_kv, dim, page_size, is_causal, tune=tune
     )
-    bm = ManifestBenchmark(_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
     functors = {"tileops": op}
 
     fa3_fn = _fa3_mha_decode_paged(test, k, v)

--- a/benchmarks/ops/bench_ada_layer_norm.py
+++ b/benchmarks/ops/bench_ada_layer_norm.py
@@ -24,7 +24,7 @@ def test_ada_layer_norm_bench(m: int, n: int, dtype: torch.dtype) -> None:
     inputs = test.gen_inputs()
 
     op = AdaLayerNormFwdOp()
-    bm = ManifestBenchmark(_ADA_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
 
     # Baseline: PyTorch composite F.layer_norm + arithmetic
     def baseline_fn(x, scale, shift):
@@ -51,7 +51,7 @@ def test_ada_layer_norm_zero_bench(m: int, n: int, dtype: torch.dtype) -> None:
     inputs = test.gen_inputs()
 
     op = AdaLayerNormZeroFwdOp()
-    bm = ManifestBenchmark(_ADA_ZERO_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
 
     # Baseline: PyTorch composite F.layer_norm + arithmetic + gate
     def baseline_fn(x, scale, shift, gate):

--- a/benchmarks/ops/bench_argreduce.py
+++ b/benchmarks/ops/bench_argreduce.py
@@ -55,7 +55,7 @@ def test_argmax_bench(shape: tuple, dtype: torch.dtype, extra: dict) -> None:
     inputs = workload.gen_inputs()
 
     op = ArgmaxFwdOp(**extra)
-    bm = ManifestBenchmark(_ARGMAX_OP, op, workload)
+    bm = ManifestBenchmark(op, workload)
 
     dim = extra["dim"]
 
@@ -79,7 +79,7 @@ def test_argmin_bench(shape: tuple, dtype: torch.dtype, extra: dict) -> None:
     inputs = workload.gen_inputs()
 
     op = ArgminFwdOp(**extra)
-    bm = ManifestBenchmark(_ARGMIN_OP, op, workload)
+    bm = ManifestBenchmark(op, workload)
 
     dim = extra["dim"]
 

--- a/benchmarks/ops/bench_batch_norm.py
+++ b/benchmarks/ops/bench_batch_norm.py
@@ -139,7 +139,7 @@ def test_batch_norm_fwd_bench(N, C, spatial, dtype, training, tune):
     op = BatchNormFwdOp(training=training, tune=tune)
 
     test = BatchNormFwdWorkload(N, C, spatial, dtype, training)
-    bm = ManifestBenchmark(_FWD_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
 
     spatial = str(spatial)  # stringify tuple so it survives BenchmarkReport.record filtering
 
@@ -172,7 +172,7 @@ def test_batch_norm_bwd_bench(N, C, spatial, dtype):
     op = BatchNormBwdOp()
 
     test = BatchNormBwdWorkload(N, C, spatial, dtype)
-    bm = ManifestBenchmark(_BWD_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
 
     spatial = str(spatial)  # stringify tuple so it survives BenchmarkReport.record filtering
 

--- a/benchmarks/ops/bench_binary_elementwise.py
+++ b/benchmarks/ops/bench_binary_elementwise.py
@@ -664,7 +664,7 @@ def _profile_fused_gated(bm: ManifestBenchmark, op, test, baseline_key: str, par
 def test_silu_and_mul_bench(M: int, N: int, dtype: torch.dtype) -> None:
     test = FusedGatedBenchCase(M, N, dtype)
     op = SiluAndMulFwdOp()
-    bm = ManifestBenchmark(_SILU_AND_MUL_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _profile_fused_gated(bm, op, test, "silu_and_mul", {"M": M, "N": N, "dtype": dtype})
 
 
@@ -672,7 +672,7 @@ def test_silu_and_mul_bench(M: int, N: int, dtype: torch.dtype) -> None:
 def test_gelu_and_mul_bench(M: int, N: int, dtype: torch.dtype) -> None:
     test = FusedGatedBenchCase(M, N, dtype)
     op = GeluAndMulFwdOp()
-    bm = ManifestBenchmark(_GELU_AND_MUL_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _profile_fused_gated(bm, op, test, "gelu_and_mul", {"M": M, "N": N, "dtype": dtype})
 
 
@@ -680,7 +680,7 @@ def test_gelu_and_mul_bench(M: int, N: int, dtype: torch.dtype) -> None:
 def test_gelu_tanh_and_mul_bench(M: int, N: int, dtype: torch.dtype) -> None:
     test = FusedGatedBenchCase(M, N, dtype)
     op = GeluTanhAndMulFwdOp()
-    bm = ManifestBenchmark(_GELU_TANH_AND_MUL_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _profile_fused_gated(bm, op, test, "gelu_tanh_and_mul", {"M": M, "N": N, "dtype": dtype})
 
 

--- a/benchmarks/ops/bench_bmm.py
+++ b/benchmarks/ops/bench_bmm.py
@@ -67,7 +67,7 @@ def test_bmm_bench(batch: int, m: int, n: int, k: int, dtype: torch.dtype) -> No
     a, b = workload.gen_inputs()
 
     op = BmmFwdOp(tune=True)
-    bm = ManifestBenchmark(_OP_NAME, op, workload)
+    bm = ManifestBenchmark(op, workload)
 
     # eval_roofline() is read lazily after profiling, by which point
     # forward() has bound the dims.
@@ -105,7 +105,7 @@ def test_bmm_fp8_kn_bench(
     a, b_kn, scale_a, scale_b = workload.gen_inputs()
 
     op = BmmFp8KNFwdOp(out_dtype=out_dtype, tune=True)
-    bm = ManifestBenchmark(_FP8_KN_OP_NAME, op, workload)
+    bm = ManifestBenchmark(op, workload)
     functors = {
         "tileops": (op, (a, b_kn, scale_a, scale_b)),
         "torch-fp32-ref": (workload.torch_fp32_bmm_ref, (a, b_kn, scale_a, scale_b)),
@@ -144,7 +144,7 @@ def test_bmm_fp8_nk_bench(
 
     # Fast path: feed [B, N, K] (K-innermost) using BmmFp8NKFwdOp.
     op = BmmFp8NKFwdOp(out_dtype=out_dtype, tune=True)
-    bm = ManifestBenchmark(_FP8_NK_OP_NAME, op, workload)
+    bm = ManifestBenchmark(op, workload)
     functors = {
         "tileops": (op, (a, b_nk, scale_a, scale_b)),
         "torch-fp32-ref": (workload.torch_fp32_bmm_ref, (a, b_kn, scale_a, scale_b)),

--- a/benchmarks/ops/bench_convolution.py
+++ b/benchmarks/ops/bench_convolution.py
@@ -201,9 +201,8 @@ def _run_conv(
 ) -> None:
     """Profile op against flag_gems and torch on the same inputs, recording all.
 
-    One caller per manifest op, so each keeps a literal
-    ``ManifestBenchmark(<op name>, ...)`` the manifest validator matches
-    statically.
+    One caller per manifest op, so each ``ManifestBenchmark`` wraps the op the
+    manifest validator matches it against statically.
     """
     inputs = _conv_inputs(
         case.input_shape,
@@ -309,7 +308,7 @@ def test_conv1d_bench(case: ConvCase) -> None:
         groups=case.groups,
         tune=_TUNE,
     )
-    bm = ManifestBenchmark(_CONV1D_OP, op, ConvWorkload(case.input_shape, case.dtype))
+    bm = ManifestBenchmark(op, ConvWorkload(case.input_shape, case.dtype))
     _run_conv(op, bm, F.conv1d, case, rank=1, with_bias=case.with_bias, static_weight=True)
 
 
@@ -335,7 +334,7 @@ def test_conv2d_bench(case: ConvCase) -> None:
         groups=case.groups,
         tune=_TUNE,
     )
-    bm = ManifestBenchmark(_CONV2D_OP, op, ConvWorkload(case.input_shape, case.dtype))
+    bm = ManifestBenchmark(op, ConvWorkload(case.input_shape, case.dtype))
     _run_conv(op, bm, F.conv2d, case, rank=2, with_bias=case.with_bias)
 
 
@@ -361,5 +360,5 @@ def test_conv3d_bench(case: ConvCase) -> None:
         groups=case.groups,
         tune=_TUNE,
     )
-    bm = ManifestBenchmark(_CONV3D_OP, op, ConvWorkload(case.input_shape, case.dtype))
+    bm = ManifestBenchmark(op, ConvWorkload(case.input_shape, case.dtype))
     _run_conv(op, bm, F.conv3d, case, rank=3, with_bias=case.with_bias)

--- a/benchmarks/ops/bench_cumulative.py
+++ b/benchmarks/ops/bench_cumulative.py
@@ -23,22 +23,11 @@ from benchmarks.benchmark_base import (
     ManifestBenchmark,
     workloads_to_params,
 )
+from tileops.ops.reduction.cumulative import CumprodFwdOp, CumsumFwdOp
 from workloads.reduction import CumulativeWorkload
 
 _CUMSUM_OP = "CumsumFwdOp"
 _CUMPROD_OP = "CumprodFwdOp"
-
-
-def _make_op(shape: tuple, dtype: torch.dtype, op_kind: str):
-    """Create the appropriate Op for the given op_kind."""
-    from tileops.ops.reduction.cumulative import CumprodFwdOp, CumsumFwdOp
-
-    op_map = {
-        "cumsum": CumsumFwdOp,
-        "cumprod": CumprodFwdOp,
-    }
-    cls = op_map[op_kind]
-    return cls(dim=-1)
 
 
 class CumulativeBenchmarkWorkload(CumulativeWorkload):
@@ -56,8 +45,8 @@ def test_cumsum_bench(shape: tuple, dtype: torch.dtype) -> None:
     test = CumulativeBenchmarkWorkload(shape, dtype, "cumsum")
     inputs = test.gen_inputs()
 
-    op = _make_op(shape, dtype, "cumsum")
-    bm = ManifestBenchmark(_CUMSUM_OP, op, test)
+    op = CumsumFwdOp(dim=-1)
+    bm = ManifestBenchmark(op, test)
 
     flaggems_cumsum = flaggems_op("cumsum")
 
@@ -84,8 +73,8 @@ def test_cumprod_bench(shape: tuple, dtype: torch.dtype) -> None:
     test = CumulativeBenchmarkWorkload(shape, dtype, "cumprod")
     inputs = test.gen_inputs()
 
-    op = _make_op(shape, dtype, "cumprod")
-    bm = ManifestBenchmark(_CUMPROD_OP, op, test)
+    op = CumprodFwdOp(dim=-1)
+    bm = ManifestBenchmark(op, test)
 
     bm.compare(
         {

--- a/benchmarks/ops/bench_deltanet.py
+++ b/benchmarks/ops/bench_deltanet.py
@@ -69,7 +69,7 @@ def test_deltanet_vs_fla_fwd(
 
     # --- TileOPs (BHSD) ---
     op = DeltaNetFwdOp(chunk_size=chunk_size, tune=tune)
-    bm = ManifestBenchmark(_FWD_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
     functors = {"tileops": op}
 
     # --- FLA (BTHK) ---
@@ -116,7 +116,7 @@ def test_deltanet_vs_fla_bwd(
     _o, S_fwd, Aw, Au, w_fwd, u_fwd = fwd_op.forward(q, k, v, beta)
 
     bwd_op = DeltaNetBwdOp(chunk_size=BC, tune=tune)
-    bm = ManifestBenchmark(_BWD_OP_NAME, bwd_op, test)
+    bm = ManifestBenchmark(bwd_op, test)
     functors = {"tileops": bwd_op.forward}
 
     # --- FLA (BTHK layout) ---

--- a/benchmarks/ops/bench_deltanet_recurrence.py
+++ b/benchmarks/ops/bench_deltanet_recurrence.py
@@ -89,7 +89,7 @@ def test_deltanet_decode_bench(
     inputs = test.gen_inputs()
 
     op = DeltaNetDecodeFwdOp(tune=tune)
-    bm = ManifestBenchmark(_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
 
     bm.compare(
         {

--- a/benchmarks/ops/bench_dropout.py
+++ b/benchmarks/ops/bench_dropout.py
@@ -34,7 +34,7 @@ def test_dropout_bench(shape: tuple, dtype: torch.dtype) -> None:
     (x,) = test.gen_inputs()
 
     op = DropoutFwdOp(p=test.p, seed=42)
-    bm = ManifestBenchmark(_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
 
     bm.compare(
         {

--- a/benchmarks/ops/bench_elementwise_manifest.py
+++ b/benchmarks/ops/bench_elementwise_manifest.py
@@ -229,7 +229,7 @@ def test_relu_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> None
     test = ShapedRandnWorkload(shape, dtype)
     inputs = test.gen_inputs()
     op = ReluFwdOp()
-    bm = ManifestBenchmark(_RELU_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _record_unary(op, bm, inputs, F.relu)
 
 
@@ -240,7 +240,7 @@ def test_gelu_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> None
     test = ShapedRandnWorkload(shape, dtype)
     inputs = test.gen_inputs()
     op = GeluFwdOp()
-    bm = ManifestBenchmark(_GELU_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _record_unary(op, bm, inputs, lambda x: F.gelu(x, approximate="none"))
 
 
@@ -251,7 +251,7 @@ def test_silu_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> None
     test = ShapedRandnWorkload(shape, dtype)
     inputs = test.gen_inputs()
     op = SiluFwdOp()
-    bm = ManifestBenchmark(_SILU_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _record_unary(op, bm, inputs, F.silu)
 
 
@@ -262,7 +262,7 @@ def test_hardswish_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) ->
     test = ShapedRandnWorkload(shape, dtype)
     inputs = test.gen_inputs()
     op = HardswishFwdOp()
-    bm = ManifestBenchmark(_HARDSWISH_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _record_unary(op, bm, inputs, F.hardswish)
 
 
@@ -273,7 +273,7 @@ def test_hardsigmoid_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) 
     test = ShapedRandnWorkload(shape, dtype)
     inputs = test.gen_inputs()
     op = HardsigmoidFwdOp()
-    bm = ManifestBenchmark(_HARDSIGMOID_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _record_unary(op, bm, inputs, F.hardsigmoid)
 
 
@@ -284,7 +284,7 @@ def test_mish_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> None
     test = ShapedRandnWorkload(shape, dtype)
     inputs = test.gen_inputs()
     op = MishFwdOp()
-    bm = ManifestBenchmark(_MISH_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _record_unary(op, bm, inputs, F.mish)
 
 
@@ -295,7 +295,7 @@ def test_selu_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> None
     test = ShapedRandnWorkload(shape, dtype)
     inputs = test.gen_inputs()
     op = SeluFwdOp()
-    bm = ManifestBenchmark(_SELU_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _record_unary(op, bm, inputs, F.selu)
 
 
@@ -306,7 +306,7 @@ def test_leaky_relu_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -
     test = ShapedRandnWorkload(shape, dtype)
     inputs = test.gen_inputs()
     op = LeakyReluFwdOp()
-    bm = ManifestBenchmark(_LEAKY_RELU_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _record_unary(op, bm, inputs, lambda x: F.leaky_relu(x, 0.01))
 
 
@@ -317,7 +317,7 @@ def test_elu_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> None:
     test = ShapedRandnWorkload(shape, dtype)
     inputs = test.gen_inputs()
     op = EluFwdOp()
-    bm = ManifestBenchmark(_ELU_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _record_unary(op, bm, inputs, lambda x: F.elu(x, 1.0))
 
 
@@ -328,7 +328,7 @@ def test_hardtanh_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> 
     test = ShapedRandnWorkload(shape, dtype)
     inputs = test.gen_inputs()
     op = HardtanhFwdOp()
-    bm = ManifestBenchmark(_HARDTANH_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _record_unary(op, bm, inputs, lambda x: F.hardtanh(x, -1.0, 1.0))
 
 
@@ -339,7 +339,7 @@ def test_softplus_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> 
     test = ShapedRandnWorkload(shape, dtype)
     inputs = test.gen_inputs()
     op = SoftplusFwdOp()
-    bm = ManifestBenchmark(_SOFTPLUS_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _record_unary(op, bm, inputs, lambda x: F.softplus(x, 1.0, 20.0))
 
 
@@ -350,7 +350,7 @@ def test_sigmoid_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> N
     test = ShapedRandnWorkload(shape, dtype)
     inputs = test.gen_inputs()
     op = SigmoidFwdOp()
-    bm = ManifestBenchmark(_SIGMOID_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _record_unary(op, bm, inputs, torch.sigmoid)
 
 
@@ -361,7 +361,7 @@ def test_tanh_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> None
     test = ShapedRandnWorkload(shape, dtype)
     inputs = test.gen_inputs()
     op = TanhFwdOp()
-    bm = ManifestBenchmark(_TANH_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _record_unary(op, bm, inputs, torch.tanh)
 
 
@@ -372,7 +372,7 @@ def test_clamp_scalar_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype)
     test = ShapedRandnWorkload(shape, dtype)
     inputs = test.gen_inputs()
     op = ClampScalarFwdOp(min=-0.5, max=0.5)
-    bm = ManifestBenchmark(_CLAMP_SCALAR_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _record_unary(op, bm, inputs, lambda x: torch.clamp(x, -0.5, 0.5))
 
 
@@ -383,7 +383,7 @@ def test_nan_to_num_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -
     test = ShapedRandnWorkload(shape, dtype)
     inputs = test.gen_inputs()
     op = NanToNumFwdOp()
-    bm = ManifestBenchmark(_NAN_TO_NUM_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _record_unary(op, bm, inputs, torch.nan_to_num)
 
 
@@ -402,7 +402,7 @@ def test_prelu_manifest_bench(
     test = PreluManifestWorkload(input_shape, weight_shape, dtype)
     x, weight = test.gen_inputs()
     op = PreluFwdOp()
-    bm = ManifestBenchmark(_PRELU_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     bm.compare(
         {
             "tileops": op,
@@ -433,7 +433,7 @@ def test_masked_fill_tensor_manifest_bench(
     test = MaskedFillTensorManifestWorkload(input_shape, mask_shape, value_shape, dtype)
     x, mask, value = test.gen_inputs()
     op = MaskedFillFwdOp()
-    bm = ManifestBenchmark(_MASKED_FILL_OP, op, test)
+    bm = ManifestBenchmark(op, test)
 
     def baseline_fn(a, m, v):
         return a.masked_fill(m, v)
@@ -466,7 +466,7 @@ def test_masked_fill_scalar_manifest_bench(
     test = MaskedFillScalarManifestWorkload(shape, dtype)
     x, mask = test.gen_inputs()
     op = MaskedFillScalarFwdOp(value=-100.0)
-    bm = ManifestBenchmark(_MASKED_FILL_SCALAR_OP, op, test)
+    bm = ManifestBenchmark(op, test)
 
     def baseline_fn(a, m):
         return a.masked_fill(m, -100.0)
@@ -506,7 +506,7 @@ def test_add_manifest_bench(input_shape: tuple, other_shape: tuple, dtype: torch
     test = BinaryManifestWorkload(input_shape, other_shape, dtype)
     inputs = test.gen_inputs()
     op = AddFwdOp()
-    bm = ManifestBenchmark(_ADD_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _record_binary(op, bm, inputs, torch.add)
 
 
@@ -518,7 +518,7 @@ def test_sub_manifest_bench(input_shape: tuple, other_shape: tuple, dtype: torch
     test = BinaryManifestWorkload(input_shape, other_shape, dtype)
     inputs = test.gen_inputs()
     op = SubFwdOp()
-    bm = ManifestBenchmark(_SUB_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _record_binary(op, bm, inputs, torch.sub)
 
 
@@ -530,7 +530,7 @@ def test_mul_manifest_bench(input_shape: tuple, other_shape: tuple, dtype: torch
     test = BinaryManifestWorkload(input_shape, other_shape, dtype)
     inputs = test.gen_inputs()
     op = MulFwdOp()
-    bm = ManifestBenchmark(_MUL_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _record_binary(op, bm, inputs, torch.mul)
 
 
@@ -542,7 +542,7 @@ def test_div_manifest_bench(input_shape: tuple, other_shape: tuple, dtype: torch
     test = BinaryManifestWorkload(input_shape, other_shape, dtype, positive=True)
     inputs = test.gen_inputs()
     op = DivFwdOp()
-    bm = ManifestBenchmark(_DIV_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _record_binary(op, bm, inputs, torch.div)
 
 
@@ -558,7 +558,7 @@ def test_remainder_manifest_bench(
     test = BinaryManifestWorkload(input_shape, other_shape, dtype, positive=True)
     inputs = test.gen_inputs()
     op = RemainderFwdOp()
-    bm = ManifestBenchmark(_REMAINDER_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _record_binary(op, bm, inputs, torch.remainder)
 
 
@@ -578,7 +578,7 @@ def test_pow_manifest_bench(
     test = BinaryManifestWorkload(input_shape, exponent_shape, dtype, positive=True)
     inputs = test.gen_inputs()
     op = PowFwdOp()
-    bm = ManifestBenchmark(_POW_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _record_binary(op, bm, inputs, torch.pow)
 
 
@@ -594,7 +594,7 @@ def test_floor_divide_manifest_bench(
     test = BinaryManifestWorkload(input_shape, other_shape, dtype, positive=True)
     inputs = test.gen_inputs()
     op = FloorDivideFwdOp()
-    bm = ManifestBenchmark(_FLOOR_DIVIDE_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _record_binary(op, bm, inputs, torch.floor_divide)
 
 
@@ -610,7 +610,7 @@ def test_lerp_manifest_bench(input_shape: tuple, end_shape: tuple, dtype: torch.
     test = BinaryManifestWorkload(input_shape, end_shape, dtype)
     inputs = test.gen_inputs()
     op = LerpFwdOp()
-    bm = ManifestBenchmark(_LERP_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _record_binary(op, bm, inputs, lambda a, b: torch.lerp(a, b, 0.5))
 
 
@@ -622,7 +622,7 @@ def test_maximum_manifest_bench(input_shape: tuple, other_shape: tuple, dtype: t
     test = BinaryManifestWorkload(input_shape, other_shape, dtype)
     inputs = test.gen_inputs()
     op = MaximumFwdOp()
-    bm = ManifestBenchmark(_MAXIMUM_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _record_binary(op, bm, inputs, torch.maximum)
 
 
@@ -634,7 +634,7 @@ def test_minimum_manifest_bench(input_shape: tuple, other_shape: tuple, dtype: t
     test = BinaryManifestWorkload(input_shape, other_shape, dtype)
     inputs = test.gen_inputs()
     op = MinimumFwdOp()
-    bm = ManifestBenchmark(_MINIMUM_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _record_binary(op, bm, inputs, torch.minimum)
 
 
@@ -659,7 +659,7 @@ def test_eq_manifest_bench(input_shape: tuple, other_shape: tuple, dtype: torch.
     test = BinaryManifestWorkload(input_shape, other_shape, dtype)
     inputs = test.gen_inputs()
     op = EqFwdOp()
-    bm = ManifestBenchmark(_EQ_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _record_binary(op, bm, inputs, torch.eq)
 
 
@@ -671,7 +671,7 @@ def test_ne_manifest_bench(input_shape: tuple, other_shape: tuple, dtype: torch.
     test = BinaryManifestWorkload(input_shape, other_shape, dtype)
     inputs = test.gen_inputs()
     op = NeFwdOp()
-    bm = ManifestBenchmark(_NE_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _record_binary(op, bm, inputs, torch.ne)
 
 
@@ -683,7 +683,7 @@ def test_gt_manifest_bench(input_shape: tuple, other_shape: tuple, dtype: torch.
     test = BinaryManifestWorkload(input_shape, other_shape, dtype)
     inputs = test.gen_inputs()
     op = GtFwdOp()
-    bm = ManifestBenchmark(_GT_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _record_binary(op, bm, inputs, torch.gt)
 
 
@@ -695,7 +695,7 @@ def test_lt_manifest_bench(input_shape: tuple, other_shape: tuple, dtype: torch.
     test = BinaryManifestWorkload(input_shape, other_shape, dtype)
     inputs = test.gen_inputs()
     op = LtFwdOp()
-    bm = ManifestBenchmark(_LT_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _record_binary(op, bm, inputs, torch.lt)
 
 
@@ -707,7 +707,7 @@ def test_ge_manifest_bench(input_shape: tuple, other_shape: tuple, dtype: torch.
     test = BinaryManifestWorkload(input_shape, other_shape, dtype)
     inputs = test.gen_inputs()
     op = GeFwdOp()
-    bm = ManifestBenchmark(_GE_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _record_binary(op, bm, inputs, torch.ge)
 
 
@@ -719,7 +719,7 @@ def test_le_manifest_bench(input_shape: tuple, other_shape: tuple, dtype: torch.
     test = BinaryManifestWorkload(input_shape, other_shape, dtype)
     inputs = test.gen_inputs()
     op = LeFwdOp()
-    bm = ManifestBenchmark(_LE_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _record_binary(op, bm, inputs, torch.le)
 
 
@@ -733,7 +733,7 @@ def test_logical_and_manifest_bench(
     test = BinaryManifestWorkload(input_shape, other_shape, dtype, logical=True)
     inputs = test.gen_inputs()
     op = LogicalAndFwdOp()
-    bm = ManifestBenchmark(_LOGICAL_AND_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _record_binary(op, bm, inputs, torch.logical_and)
 
 
@@ -747,7 +747,7 @@ def test_logical_or_manifest_bench(
     test = BinaryManifestWorkload(input_shape, other_shape, dtype, logical=True)
     inputs = test.gen_inputs()
     op = LogicalOrFwdOp()
-    bm = ManifestBenchmark(_LOGICAL_OR_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _record_binary(op, bm, inputs, torch.logical_or)
 
 
@@ -761,7 +761,7 @@ def test_bitwise_and_manifest_bench(
     test = BinaryManifestWorkload(input_shape, other_shape, dtype, integer=True)
     inputs = test.gen_inputs()
     op = BitwiseAndFwdOp()
-    bm = ManifestBenchmark(_BITWISE_AND_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _record_binary(op, bm, inputs, torch.bitwise_and)
 
 
@@ -775,7 +775,7 @@ def test_bitwise_or_manifest_bench(
     test = BinaryManifestWorkload(input_shape, other_shape, dtype, integer=True)
     inputs = test.gen_inputs()
     op = BitwiseOrFwdOp()
-    bm = ManifestBenchmark(_BITWISE_OR_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _record_binary(op, bm, inputs, torch.bitwise_or)
 
 
@@ -789,7 +789,7 @@ def test_bitwise_xor_manifest_bench(
     test = BinaryManifestWorkload(input_shape, other_shape, dtype, integer=True)
     inputs = test.gen_inputs()
     op = BitwiseXorFwdOp()
-    bm = ManifestBenchmark(_BITWISE_XOR_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     _record_binary(op, bm, inputs, torch.bitwise_xor)
 
 
@@ -804,7 +804,7 @@ def test_where_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> Non
     test = WhereManifestWorkload(shape, dtype)
     cond, x, other = test.gen_inputs()
     op = WhereFwdOp()
-    bm = ManifestBenchmark(_WHERE_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     bm.compare(
         {
             "tileops": op,
@@ -826,7 +826,7 @@ def test_lerp_tensor_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) 
     test = LerpTensorManifestWorkload(shape, dtype)
     x, end, weight = test.gen_inputs()
     op = LerpTensorFwdOp()
-    bm = ManifestBenchmark(_LERP_TENSOR_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     bm.compare(
         {
             "tileops": op,

--- a/benchmarks/ops/bench_engram.py
+++ b/benchmarks/ops/bench_engram.py
@@ -45,7 +45,7 @@ def test_engram_gate_conv_fwd_bench(M, seq_len, d, dtype):
     inputs = test.gen_inputs()
 
     op = EngramGateConvFwdOp(M, seq_len, d, tune=_TUNE)
-    bm = ManifestBenchmark(_ENGRAM_GATE_CONV_FWD_OP, op, test)
+    bm = ManifestBenchmark(op, test)
 
     bm.compare(
         {
@@ -73,7 +73,7 @@ def test_engram_gate_conv_bwd_bench(M, seq_len, d, dtype):
     inputs = test.gen_inputs()
 
     op = EngramGateConvBwdOp(M, seq_len, d, tune=_TUNE)
-    bm = ManifestBenchmark(_ENGRAM_GATE_CONV_BWD_OP, op, test)
+    bm = ManifestBenchmark(op, test)
 
     @torch.enable_grad()
     def ref_with_grad(*args):
@@ -116,7 +116,7 @@ def test_engram_decode_bench(batch, d_mem, d, max_conv_len, conv_kernel_size, di
         dilation,
         tune=_TUNE,
     )
-    bm = ManifestBenchmark(_ENGRAM_DECODE_OP, op, test)
+    bm = ManifestBenchmark(op, test)
 
     bm.compare(
         {

--- a/benchmarks/ops/bench_fft.py
+++ b/benchmarks/ops/bench_fft.py
@@ -25,7 +25,7 @@ def test_fft_bench(shape: tuple, dtype: torch.dtype) -> None:
     op(*inputs)
     torch.cuda.synchronize()
 
-    bm = ManifestBenchmark(_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
 
     bm.compare(
         {

--- a/benchmarks/ops/bench_fp8_lightning_indexer.py
+++ b/benchmarks/ops/bench_fp8_lightning_indexer.py
@@ -74,7 +74,7 @@ def test_fp8_lightning_indexer_bench(
     inputs = test.gen_inputs()
 
     op = FP8LightningIndexerFwdOp(clean_logits=clean_logits, config=_CONFIG, tune=_TUNE)
-    bm = ManifestBenchmark(_FP8_LIGHTNING_INDEXER_OP, op, test)
+    bm = ManifestBenchmark(op, test)
 
     bm.compare(
         {

--- a/benchmarks/ops/bench_fp8_quant.py
+++ b/benchmarks/ops/bench_fp8_quant.py
@@ -39,7 +39,7 @@ def test_fp8_quant_bench(
     inputs = test.gen_inputs()
 
     op = FP8QuantFwdOp(tune=_TUNE)
-    bm = ManifestBenchmark(_FP8_QUANT_OP, op, test)
+    bm = ManifestBenchmark(op, test)
 
     bm.compare(
         {

--- a/benchmarks/ops/bench_fused_moe_experts.py
+++ b/benchmarks/ops/bench_fused_moe_experts.py
@@ -126,7 +126,7 @@ def test_moe_experts_nopad_bench(
         hidden_size=hidden_size,
         ffn_size=ffn_size,
     )
-    bm = ManifestBenchmark(_OP_NAME, nopad, test)
+    bm = ManifestBenchmark(nopad, test)
 
     def _nopad_fn(hidden, w1, w2, topk_weights, topk_ids):
         nopad.forward(

--- a/benchmarks/ops/bench_gated_deltanet.py
+++ b/benchmarks/ops/bench_gated_deltanet.py
@@ -81,7 +81,7 @@ def test_gated_deltanet_vs_fla_fwd(
     bthd = _to_fla_layout(q, k, v, g, beta)
 
     op = GatedDeltaNetBTHDFwdOp(chunk_size=chunk_size, tune=tune)
-    bm = ManifestBenchmark(_FWD_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
 
     def fla_fwd():
         return chunk_gated_delta_rule(*bthd, scale=1.0)
@@ -109,7 +109,7 @@ def test_gated_deltanet_bhtd_vs_fla_fwd(
     bthd = _to_fla_layout(*inputs)
 
     op = GatedDeltaNetBHTDFwdOp(chunk_size=chunk_size, tune=tune)
-    bm = ManifestBenchmark(_BHTD_FWD_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
 
     def fla_fwd():
         return chunk_gated_delta_rule(*bthd, scale=1.0)
@@ -149,7 +149,7 @@ def test_gated_deltanet_vs_fla_bwd(
     _o, S_fwd, _Aw, _Au = fwd_op.forward(q, k, v, g, beta)
 
     bwd_op = GatedDeltaNetBwdOp(chunk_size=BC, tune=tune)
-    bm = ManifestBenchmark(_BWD_OP_NAME, bwd_op, test)
+    bm = ManifestBenchmark(bwd_op, test)
     functors = {"tileops": bwd_op.forward}
 
     # --- FLA (BTHK layout) ---

--- a/benchmarks/ops/bench_gated_deltanet_prefill.py
+++ b/benchmarks/ops/bench_gated_deltanet_prefill.py
@@ -148,7 +148,7 @@ def test_gated_deltanet_prefill_bhtd_bench(
     inputs = test.gen_inputs()
 
     op = GatedDeltaNetPrefillBHTDFwdOp(chunk_size=chunk_size, tune=tune)
-    bm = ManifestBenchmark(_BHTD_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
     fla_inputs = convert_gdn_prefill_layout(inputs, layout, "bthd")
     bm.compare(
         {"tileops": op, "fla": (_fla_prefill_fwd(), fla_inputs)},
@@ -180,7 +180,7 @@ def test_gated_deltanet_prefill_fwd_bench(
     inputs = test.gen_inputs()
 
     op = GatedDeltaNetPrefillBTHDFwdOp(chunk_size=chunk_size, tune=tune)
-    bm = ManifestBenchmark(_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
     fla_inputs = convert_gdn_prefill_layout(inputs, layout, "bthd")
     functors = {"tileops": op, "fla": (fla_fn, fla_inputs)}
 

--- a/benchmarks/ops/bench_gated_deltanet_recurrence.py
+++ b/benchmarks/ops/bench_gated_deltanet_recurrence.py
@@ -98,7 +98,7 @@ def test_gated_deltanet_decode_bench(
     inputs = test.gen_inputs()
 
     op = GatedDeltaNetDecodeFwdOp(tune=tune)
-    bm = ManifestBenchmark(_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
     functors = {"tileops": op}
 
     if fused_recurrent_gated_delta_rule is not None:

--- a/benchmarks/ops/bench_gemm.py
+++ b/benchmarks/ops/bench_gemm.py
@@ -422,7 +422,7 @@ def test_gemm_bench(
     a, b = workload.gen_inputs()
 
     op = GemmFwdOp(trans_a=trans_a, trans_b=trans_b)
-    bm = ManifestBenchmark(_OP_NAME, op, workload)
+    bm = ManifestBenchmark(op, workload)
 
     # The benchmark framework warms up internally; eval_roofline() is read
     # lazily after profiling, by which point forward() has bound the dims.
@@ -467,7 +467,7 @@ def test_gemm_fp8_bench(
     inputs = workload.gen_inputs()
 
     op = GemmFp8FwdOp(out_dtype=out_dtype)
-    bm = ManifestBenchmark(_FP8_OP_NAME, op, workload)
+    bm = ManifestBenchmark(op, workload)
 
     if scale_mode not in ("per_tensor", "block128"):
         raise ValueError(f"unsupported FP8 GEMM scale_mode for benchmark: {scale_mode!r}")
@@ -535,7 +535,7 @@ def test_gemm_w4a16_bench(
     inputs = workload.gen_inputs()
 
     op = GemmW4A16FwdOp(group_size=group_size)
-    bm = ManifestBenchmark(_W4A16_OP_NAME, op, workload)
+    bm = ManifestBenchmark(op, workload)
 
     expected = workload.ref_program(*inputs)
     torch.testing.assert_close(op(*inputs), expected, atol=7e-2, rtol=5e-2)

--- a/benchmarks/ops/bench_gla_chunkwise.py
+++ b/benchmarks/ops/bench_gla_chunkwise.py
@@ -78,7 +78,7 @@ def test_gla_fwd_bench(
     # --- TileOPs ---
     scale = dim_k**-0.5
     op = GLAFwdOp(chunk_size=chunk_size, scale=scale, tune=tune)
-    bm = ManifestBenchmark(_FWD_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
     functors = {"tileops": op.forward}
 
     # --- FLA ---
@@ -132,7 +132,7 @@ def test_gla_bwd_bench(
     dht = torch.zeros(B, H, K, V, device="cuda", dtype=torch.float32)
 
     bwd_op = GLABwdOp(chunk_size=BC, scale=scale, tune=tune)
-    bm = ManifestBenchmark(_BWD_OP_NAME, bwd_op, test)
+    bm = ManifestBenchmark(bwd_op, test)
     functors = {"tileops": (bwd_op.forward, (q, k, v, g, h, do, dht))}
 
     # --- FLA: the backward node, called directly ---

--- a/benchmarks/ops/bench_gla_recurrence.py
+++ b/benchmarks/ops/bench_gla_recurrence.py
@@ -109,7 +109,7 @@ def test_gla_decode_bench(
 
     # --- TileOPs ---
     op = GLADecodeFwdOp(scale=scale, tune=tune)
-    bm = ManifestBenchmark(_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
     functors = {"tileops": op}
 
     if fused_recurrent_gla is not None:

--- a/benchmarks/ops/bench_group_norm.py
+++ b/benchmarks/ops/bench_group_norm.py
@@ -44,7 +44,7 @@ def test_group_norm_bench(
     x, weight, bias = test.gen_inputs()
 
     op = GroupNormFwdOp(num_groups=num_groups, tune=tune)
-    bm = ManifestBenchmark(_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
 
     # Baseline: torch.nn.functional.group_norm
     def baseline_fn(x, weight, bias):
@@ -78,7 +78,7 @@ def test_group_norm_no_affine_bench(
     x, _, _ = test.gen_inputs()
 
     op = GroupNormFwdOp(num_groups=num_groups, tune=tune)
-    bm = ManifestBenchmark(_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
 
     def baseline_no_affine(x):
         return F.group_norm(x, num_groups, weight=None, bias=None, eps=1e-5)

--- a/benchmarks/ops/bench_grouped_gemm.py
+++ b/benchmarks/ops/bench_grouped_gemm.py
@@ -93,7 +93,7 @@ def test_grouped_gemm_bench(
     inputs = test.gen_inputs()
 
     op = GroupedGemmFwdOp(transpose_a=transpose_a, transpose_b=transpose_b, tune=_TUNE)
-    bm = ManifestBenchmark(_GROUPED_GEMM_OP, op, test)
+    bm = ManifestBenchmark(op, test)
 
     functors = {
         "tileops": op,

--- a/benchmarks/ops/bench_independent_elementwise.py
+++ b/benchmarks/ops/bench_independent_elementwise.py
@@ -103,7 +103,7 @@ def test_clamp_tensor_bench(
     t_max = bounds.pop(0) if max_shape is not None else None
 
     op = ClampFwdOp()
-    bm = ManifestBenchmark(_CLAMP_FWD_OP, op, test)
+    bm = ManifestBenchmark(op, test)
 
     def baseline_fn(x, t_min, t_max):
         return torch.clamp(x, t_min, t_max)
@@ -180,7 +180,7 @@ def _sinusoidal_reference(seq_len: int, d_model: int, dtype: torch.dtype) -> tor
 def test_alibi_bench(seq_len: int, num_heads: int, dtype: torch.dtype) -> None:
     op = AlibiFwdOp(seq_len=seq_len, num_heads=num_heads, dtype=dtype)
     workload = _GenerativeWorkload((num_heads, seq_len, seq_len), dtype)
-    bm = ManifestBenchmark(_ALIBI_OP, op, workload)
+    bm = ManifestBenchmark(op, workload)
 
     def baseline_fn():
         return _alibi_reference(seq_len, num_heads, dtype)
@@ -200,7 +200,7 @@ def test_alibi_bench(seq_len: int, num_heads: int, dtype: torch.dtype) -> None:
 def test_sinusoidal_bench(seq_len: int, d_model: int, dtype: torch.dtype) -> None:
     op = SinusoidalFwdOp(seq_len=seq_len, d_model=d_model, dtype=dtype)
     workload = _GenerativeWorkload((seq_len, d_model), dtype)
-    bm = ManifestBenchmark(_SINUSOIDAL_OP, op, workload)
+    bm = ManifestBenchmark(op, workload)
 
     def baseline_fn():
         return _sinusoidal_reference(seq_len, d_model, dtype)

--- a/benchmarks/ops/bench_instance_norm.py
+++ b/benchmarks/ops/bench_instance_norm.py
@@ -47,7 +47,7 @@ def test_instance_norm_bench(
         weight = bias = None
 
     op = InstanceNormFwdOp(tune=tune)
-    bm = ManifestBenchmark(_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
 
     # Baseline: torch.nn.functional.instance_norm
     def baseline_fn(x, running_mean, running_var, weight, bias):

--- a/benchmarks/ops/bench_logical_reduce.py
+++ b/benchmarks/ops/bench_logical_reduce.py
@@ -62,7 +62,7 @@ def test_any_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> None:
 
     op_params.setdefault("dim", -1)
     op = AnyFwdOp(**op_params)
-    bm = ManifestBenchmark(_ANY_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     dim = op_params["dim"]
     keepdim = op_params.get("keepdim", False)
 
@@ -95,7 +95,7 @@ def test_all_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> None:
 
     op_params.setdefault("dim", -1)
     op = AllFwdOp(**op_params)
-    bm = ManifestBenchmark(_ALL_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     dim = op_params["dim"]
     keepdim = op_params.get("keepdim", False)
 
@@ -128,7 +128,7 @@ def test_count_nonzero_bench(shape: tuple, dtype: torch.dtype, op_params: dict) 
 
     op_params.setdefault("dim", -1)
     op = CountNonzeroFwdOp(**op_params)
-    bm = ManifestBenchmark(_COUNT_NONZERO_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     dim = op_params["dim"]
 
     def baseline_fn(x):

--- a/benchmarks/ops/bench_mamba.py
+++ b/benchmarks/ops/bench_mamba.py
@@ -58,7 +58,7 @@ def test_cb_producer_fwd_bench(
     inputs = test.gen_inputs()
 
     op = CBProducerFwdOp(batch, num_chunks, n_groups, chunk_len, d_state, tune=tune)
-    bm = ManifestBenchmark(_CB_PRODUCER_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
 
     bm.compare(
         {"tileops": op, "torch": (test.ref_program, inputs)}, *inputs, record_as=op, params=locals()
@@ -190,7 +190,7 @@ def test_da_cumsum_fwd_bench(
         dtype=dtype,
         tune=tune,
     )
-    bm = ManifestBenchmark(_DA_CUMSUM_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
     functors = {"tileops": op}
 
     # ── Mamba-2 Triton baseline ──
@@ -328,7 +328,7 @@ def test_ssd_chunk_scan_fwd_bench(
 
     # ── TileOPs kernel ──
     op = SSDChunkScanFwdOp(tune=tune)
-    bm = ManifestBenchmark(_CHUNK_SCAN_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
     functors = {"tileops": op}
 
     # ── Mamba-2 Triton baseline ──
@@ -420,7 +420,7 @@ def test_ssd_chunk_state_fwd_bench(
     inputs = test.gen_inputs()
 
     op = SSDChunkStateFwdOp(tune=tune)
-    bm = ManifestBenchmark(_CHUNK_STATE_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
     functors = {"tileops": op}
 
     if _mamba_chunk_state_fwd is not None:
@@ -480,7 +480,7 @@ def test_ssd_state_passing_fwd_bench(
     states, dA_chunk_cumsum, initial_states = inputs
 
     op = SSDStatePassingFwdOp(tune=tune)
-    bm = ManifestBenchmark(_STATE_PASSING_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
     functors = {"tileops": op}
 
     if _mamba_state_passing_fwd is not None:
@@ -575,7 +575,7 @@ def test_ssd_decode_bench(
     state_bl = state.clone()
 
     op = SSDDecodeFwdOp(tune=tune)
-    bm = ManifestBenchmark(_DECODE_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
     functors = {"tileops": op}
 
     def baseline(A, dt, x, B_in, C_in, state):

--- a/benchmarks/ops/bench_mamba2_e2e.py
+++ b/benchmarks/ops/bench_mamba2_e2e.py
@@ -134,8 +134,6 @@ def mamba2_fwd_ref(
 
 # Benchmark test
 
-_OP_NAME = "Mamba2FwdOp"
-
 
 def _mamba2_args(workload: dict) -> tuple:
     """Constructor arguments for one manifest workload row."""
@@ -203,7 +201,7 @@ def test_mamba2_fwd_bench(
         dt_softplus=dt_softplus,
         tune=tune,
     )
-    bm = ManifestBenchmark(_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
 
     # Pass inputs directly so bench_kernel clones them each iteration,
     # giving accurate per-clone addressing and fair kernel-only timing.

--- a/benchmarks/ops/bench_mhc.py
+++ b/benchmarks/ops/bench_mhc.py
@@ -65,7 +65,7 @@ def test_mhc_pre_bench(
     inputs = (phi, x, b, alpha_pre, alpha_post, alpha_res, sinkhorn_repeat, _SINKHORN_EPS)
 
     op = MHCPreFwdOp(tune=_TUNE)
-    bm = ManifestBenchmark(_MHC_PRE_OP, op, test)
+    bm = ManifestBenchmark(op, test)
 
     bm.compare(
         {
@@ -93,7 +93,7 @@ def test_mhc_post_bench(batch: int, n_expand: int, c_x: int, dtype: torch.dtype)
     inputs = test.gen_inputs()
 
     op = MHCPostFwdOp(tune=_TUNE)
-    bm = ManifestBenchmark(_MHC_POST_OP, op, test)
+    bm = ManifestBenchmark(op, test)
 
     bm.compare(
         {

--- a/benchmarks/ops/bench_moe_gate_up.py
+++ b/benchmarks/ops/bench_moe_gate_up.py
@@ -49,7 +49,7 @@ def test_moe_gate_up_bench(
     a, b, true_sizes, true_offsets = workload.gen_inputs()
 
     op = MoeGateUpFwdOp(numel, num_experts, ffn, k)
-    bm = ManifestBenchmark(_OP_NAME, op, workload)
+    bm = ManifestBenchmark(op, workload)
 
     # Warmup: trigger JIT compilation before timed profiling.
     op(a, b, true_sizes, true_offsets)

--- a/benchmarks/ops/bench_moe_grouped_gemm_nopad.py
+++ b/benchmarks/ops/bench_moe_grouped_gemm_nopad.py
@@ -37,7 +37,7 @@ def test_moe_grouped_gemm_nopad_bench(
     a, b, true_sizes, true_offsets = workload.gen_inputs()
 
     op = MoeGroupedGemmNopadFwdOp(numel, num_experts, n, k)
-    bm = ManifestBenchmark(_OP_NAME, op, workload)
+    bm = ManifestBenchmark(op, workload)
 
     # Warmup: trigger JIT compilation before timed profiling.
     op(a, b, true_sizes, true_offsets)

--- a/benchmarks/ops/bench_moe_permute_align.py
+++ b/benchmarks/ops/bench_moe_permute_align.py
@@ -163,7 +163,7 @@ def test_permute_align_bench(
 
     # TileOPs
     op = MoePermuteAlignFwdOp(total_tokens, top_k, num_experts, block_size)
-    bm = ManifestBenchmark(_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
 
     # Warmup: trigger JIT compilation before timed profiling
     op(*inputs)

--- a/benchmarks/ops/bench_moe_permute_nopad.py
+++ b/benchmarks/ops/bench_moe_permute_nopad.py
@@ -70,7 +70,7 @@ def test_moe_permute_nopad_bench(
 
     # TileOPs
     op = MoePermuteNopadFwdOp(num_experts=num_experts, num_experts_local=num_experts_local)
-    bm = ManifestBenchmark(_OP_NAME, op, workload)
+    bm = ManifestBenchmark(op, workload)
     op(hidden_states, topk_ids, expert_map)  # warmup / JIT compile
     torch.cuda.synchronize()
 

--- a/benchmarks/ops/bench_moe_unpermute.py
+++ b/benchmarks/ops/bench_moe_unpermute.py
@@ -55,7 +55,7 @@ def test_moe_unpermute_bench(total_tokens: int, top_k: int, hidden_size: int) ->
 
     # TileOPs
     op = MoeUnpermuteFwdOp(total_tokens, top_k, hidden_size)
-    bm = ManifestBenchmark(_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
     op(mm2_pad, fwd_idx, topk_weights)  # warmup / JIT compile
     torch.cuda.synchronize()
 

--- a/benchmarks/ops/bench_norm.py
+++ b/benchmarks/ops/bench_norm.py
@@ -118,7 +118,7 @@ def test_rms_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
     inputs = test.gen_inputs()
 
     op = RMSNormFwdOp(normalized_shape=(n,), tune=tune)
-    bm = ManifestBenchmark(_RMS_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
 
     tolerance = reference_tolerance(dtype)
     library = {
@@ -153,7 +153,7 @@ def test_fused_add_rms_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool
     inputs = test.gen_inputs()
 
     op = FusedAddRMSNormFwdOp(tune=tune)
-    bm = ManifestBenchmark(_FUSED_RMS_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
 
     # Baseline: add + manual rmsnorm (separate ops)
     def baseline_fn(x, residual, weight):
@@ -188,7 +188,7 @@ def test_layer_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool) -> Non
     inputs = test.gen_inputs()
 
     op = LayerNormFwdOp(normalized_shape=(n,), tune=tune)
-    bm = ManifestBenchmark(_LN_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
 
     # Baseline uses torch.nn.functional.layer_norm
     def baseline_fn(x, weight, bias):
@@ -233,7 +233,7 @@ def test_fused_add_layer_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bo
     inputs = test.gen_inputs()
 
     op = FusedAddLayerNormFwdOp(tune=tune)
-    bm = ManifestBenchmark(_FUSED_LN_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
 
     # Baseline: add + F.layer_norm (separate ops)
     def baseline_fn(x, residual, weight, bias):

--- a/benchmarks/ops/bench_pool.py
+++ b/benchmarks/ops/bench_pool.py
@@ -740,7 +740,7 @@ def test_avg_pool1d_bench(
         count_include_pad=count_include_pad,
         tune=tune,
     )
-    bm = ManifestBenchmark(_AVG_POOL1D_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
 
     _tag, _baseline_fn = pool_baseline(type(op).__name__, test, *inputs)
     # torch stays alongside the library baseline: it is what the nightly's ratio alert and
@@ -826,7 +826,7 @@ def test_avg_pool2d_bench(
         divisor_override=divisor_override,
         tune=tune,
     )
-    bm = ManifestBenchmark(_AVG_POOL2D_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
 
     _tag, _baseline_fn = pool_baseline(type(op).__name__, test, *inputs)
     bm.compare(
@@ -913,7 +913,7 @@ def test_avg_pool3d_bench(
         divisor_override=divisor_override,
         tune=tune,
     )
-    bm = ManifestBenchmark(_AVG_POOL3D_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
 
     _tag, _baseline_fn = pool_baseline(type(op).__name__, test, *inputs)
     bm.compare(
@@ -1000,7 +1000,7 @@ def test_max_pool2d_bench(
         ceil_mode=ceil_mode,
         tune=tune,
     )
-    bm = ManifestBenchmark(_MAX_POOL2D_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
 
     _tag, _baseline_fn = pool_baseline(type(op).__name__, test, *inputs)
     bm.compare(
@@ -1056,7 +1056,7 @@ def test_max_pool2d_indices_bench(
         ceil_mode=ceil_mode,
         tune=tune,
     )
-    bm = ManifestBenchmark(_MAX_POOL2D_INDICES_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
 
     _tag, _baseline_fn = pool_baseline(type(op).__name__, test, *inputs)
     bm.compare(
@@ -1143,7 +1143,7 @@ def test_max_pool1d_bench(
         ceil_mode=ceil_mode,
         tune=tune,
     )
-    bm = ManifestBenchmark(_MAX_POOL1D_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
 
     _tag, _baseline_fn = pool_baseline(type(op).__name__, test, *inputs)
     bm.compare(
@@ -1197,7 +1197,7 @@ def test_max_pool1d_indices_bench(
         ceil_mode=ceil_mode,
         tune=tune,
     )
-    bm = ManifestBenchmark(_MAX_POOL1D_INDICES_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
 
     _tag, _baseline_fn = pool_baseline(type(op).__name__, test, *inputs)
     bm.compare(
@@ -1290,7 +1290,7 @@ def test_max_pool3d_bench(
         ceil_mode=ceil_mode,
         tune=tune,
     )
-    bm = ManifestBenchmark(_MAX_POOL3D_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
 
     _tag, _baseline_fn = pool_baseline(type(op).__name__, test, *inputs)
     bm.compare(
@@ -1348,7 +1348,7 @@ def test_max_pool3d_indices_bench(
         ceil_mode=ceil_mode,
         tune=tune,
     )
-    bm = ManifestBenchmark(_MAX_POOL3D_INDICES_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
 
     _tag, _baseline_fn = pool_baseline(type(op).__name__, test, *inputs)
     bm.compare(
@@ -1413,7 +1413,7 @@ def test_adaptive_avg_pool2d_bench(
     inputs = test.gen_inputs()
 
     op = AdaptiveAvgPool2dFwdOp(output_size=output_size, tune=tune)
-    bm = ManifestBenchmark(_ADAPTIVE_AVG_POOL2D_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
 
     _tag, _baseline_fn = pool_baseline(type(op).__name__, test, *inputs)
     bm.compare(
@@ -1446,7 +1446,7 @@ def test_adaptive_max_pool2d_bench(
     inputs = test.gen_inputs()
 
     op = AdaptiveMaxPool2dFwdOp(output_size=output_size, tune=tune)
-    bm = ManifestBenchmark(_ADAPTIVE_MAX_POOL2D_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
 
     _tag, _baseline_fn = pool_baseline(type(op).__name__, test, *inputs)
     bm.compare(
@@ -1481,7 +1481,7 @@ def test_adaptive_max_pool2d_indices_bench(
     inputs = test.gen_inputs()
 
     op = AdaptiveMaxPool2dIndicesFwdOp(output_size=output_size, tune=tune)
-    bm = ManifestBenchmark(_ADAPTIVE_MAX_POOL2D_INDICES_OP_NAME, op, test)
+    bm = ManifestBenchmark(op, test)
 
     _tag, _baseline_fn = pool_baseline(type(op).__name__, test, *inputs)
     bm.compare(

--- a/benchmarks/ops/bench_reduce.py
+++ b/benchmarks/ops/bench_reduce.py
@@ -81,7 +81,7 @@ def test_sum_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> None:
 
     op_params.setdefault("dim", -1)  # baseline below reduces dim=-1
     op = SumFwdOp(**op_params)
-    bm = ManifestBenchmark(_SUM_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     dim = op_params.get("dim", -1)
     keepdim = op_params.get("keepdim", False)
 
@@ -119,7 +119,7 @@ def test_mean_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> None:
 
     op_params.setdefault("dim", -1)  # baseline below mirrors the op's dim
     op = MeanFwdOp(**op_params)
-    bm = ManifestBenchmark(_MEAN_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     dim = op_params["dim"]
     keepdim = op_params.get("keepdim", False)
 
@@ -157,7 +157,7 @@ def test_amax_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> None:
 
     op_params.setdefault("dim", -1)
     op = AmaxFwdOp(**op_params)
-    bm = ManifestBenchmark(_AMAX_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     dim = op_params["dim"]
     keepdim = op_params.get("keepdim", False)
 
@@ -195,7 +195,7 @@ def test_amin_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> None:
 
     op_params.setdefault("dim", -1)
     op = AminFwdOp(**op_params)
-    bm = ManifestBenchmark(_AMIN_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     dim = op_params["dim"]
     keepdim = op_params.get("keepdim", False)
 
@@ -224,7 +224,7 @@ def test_prod_bench(shape: tuple, dtype: torch.dtype) -> None:
     inputs = test.gen_inputs()
 
     op = ProdFwdOp()
-    bm = ManifestBenchmark(_PROD_OP, op, test)
+    bm = ManifestBenchmark(op, test)
 
     def baseline_fn(x):
         return x.float().prod(dim=-1).to(x.dtype)
@@ -260,7 +260,7 @@ def test_std_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> None:
 
     op_params.setdefault("dim", -1)
     op = StdFwdOp(correction=1, **op_params)
-    bm = ManifestBenchmark(_STD_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     dim = op_params["dim"]
     keepdim = op_params.get("keepdim", False)
 
@@ -298,7 +298,7 @@ def test_var_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> None:
 
     op_params.setdefault("dim", -1)
     op = VarFwdOp(correction=1, **op_params)
-    bm = ManifestBenchmark(_VAR_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     dim = op_params["dim"]
     keepdim = op_params.get("keepdim", False)
 
@@ -336,7 +336,7 @@ def test_var_mean_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> No
 
     op_params.setdefault("dim", -1)
     op = VarMeanFwdOp(correction=1, **op_params)
-    bm = ManifestBenchmark(_VAR_MEAN_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     dim = op_params["dim"]
     keepdim = op_params.get("keepdim", False)
 

--- a/benchmarks/ops/bench_rope.py
+++ b/benchmarks/ops/bench_rope.py
@@ -159,7 +159,7 @@ def test_rope_neox_bench(
     layout: str,
 ) -> None:
     op = RopeNeoxFwdOp(layout=layout, base=_BASE)
-    bm = ManifestBenchmark(_NEOX_OP, op, RopeWorkload(shape, dtype))
+    bm = ManifestBenchmark(op, RopeWorkload(shape, dtype))
     _profile_rope(op, bm, shape, dtype, layout)
 
 
@@ -176,7 +176,7 @@ def test_rope_non_neox_bench(
     layout: str,
 ) -> None:
     op = RopeNonNeoxFwdOp(layout=layout, base=_BASE)
-    bm = ManifestBenchmark(_NON_NEOX_OP, op, RopeWorkload(shape, dtype))
+    bm = ManifestBenchmark(op, RopeWorkload(shape, dtype))
     _profile_rope(op, bm, shape, dtype, layout)
 
 
@@ -193,7 +193,7 @@ def test_rope_llama31_bench(
     layout: str,
 ) -> None:
     op = RopeLlama31FwdOp(layout=layout, base=_BASE)
-    bm = ManifestBenchmark(_LLAMA31_OP, op, RopeWorkload(shape, dtype))
+    bm = ManifestBenchmark(op, RopeWorkload(shape, dtype))
     _profile_rope(op, bm, shape, dtype, layout)
 
 
@@ -210,7 +210,7 @@ def test_rope_yarn_bench(
     layout: str,
 ) -> None:
     op = RopeYarnFwdOp(layout=layout, base=_BASE)
-    bm = ManifestBenchmark(_YARN_OP, op, RopeWorkload(shape, dtype))
+    bm = ManifestBenchmark(op, RopeWorkload(shape, dtype))
     _profile_rope(op, bm, shape, dtype, layout)
 
 
@@ -227,7 +227,7 @@ def test_rope_longrope_bench(
     layout: str,
 ) -> None:
     op = RopeLongRopeFwdOp(layout=layout, base=_BASE)
-    bm = ManifestBenchmark(_LONGROPE_OP, op, RopeWorkload(shape, dtype))
+    bm = ManifestBenchmark(op, RopeWorkload(shape, dtype))
     _profile_rope(op, bm, shape, dtype, layout)
 
 
@@ -255,7 +255,7 @@ def test_rope_neox_position_ids_bench(
     )
 
     op = RopeNeoxPositionIdsFwdOp(max_position=max_position, base=_BASE)
-    bm = ManifestBenchmark(_POSITION_IDS_OP, op, RopeWorkload(shape, dtype))
+    bm = ManifestBenchmark(op, RopeWorkload(shape, dtype))
     params = {"shape": shape, "dtype": dtype, "max_position": max_position}
 
     cos, sin = _rope_tables(max_position, head_dim, dtype)

--- a/benchmarks/ops/bench_softmax.py
+++ b/benchmarks/ops/bench_softmax.py
@@ -53,7 +53,7 @@ def test_softmax_bench(shape: tuple, dtype: torch.dtype) -> None:
     inputs = test.gen_inputs()
 
     op = SoftmaxFwdOp(dim=-1, tune=True)
-    bm = ManifestBenchmark(_SOFTMAX_OP, op, test)
+    bm = ManifestBenchmark(op, test)
 
     def baseline_fn(x):
         return F.softmax(x, dim=-1)
@@ -88,7 +88,7 @@ def test_log_softmax_bench(shape: tuple, dtype: torch.dtype) -> None:
     inputs = test.gen_inputs()
 
     op = LogSoftmaxFwdOp(dim=-1, tune=True)
-    bm = ManifestBenchmark(_LOG_SOFTMAX_OP, op, test)
+    bm = ManifestBenchmark(op, test)
 
     def baseline_fn(x):
         return F.log_softmax(x, dim=-1)
@@ -127,7 +127,7 @@ def test_logsumexp_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> N
 
     op_params.setdefault("dim", -1)
     op = LogSumExpFwdOp(tune=True, **op_params)
-    bm = ManifestBenchmark(_LOGSUMEXP_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     dim = op_params["dim"]
     keepdim = op_params.get("keepdim", False)
 

--- a/benchmarks/ops/bench_topk_selector.py
+++ b/benchmarks/ops/bench_topk_selector.py
@@ -97,7 +97,7 @@ def test_topk_selector_bench(
     inputs = test.gen_inputs()
 
     op = TopkSelectorFwdOp(topk=topk, tune=_TUNE)
-    bm = ManifestBenchmark(_TOPK_SELECTOR_OP, op, test)
+    bm = ManifestBenchmark(op, test)
 
     functors = {
         "tileops": op,

--- a/benchmarks/ops/bench_unary_elementwise.py
+++ b/benchmarks/ops/bench_unary_elementwise.py
@@ -80,9 +80,9 @@ def _profile_and_record(
     """Profile op and torch baseline against the same inputs and record both.
 
     ``ManifestBenchmark`` must be constructed at the call site of each per-op
-    test (with the literal op-name constant) so that the manifest validator's
-    AST check can tie ``ManifestBenchmark("<OpName>FwdOp", ...)`` to the
-    intended op. This helper only handles the profile + record pair.
+    test, wrapping that test's own op, so the manifest validator's AST check can
+    tie the call to the op it measures. This helper only handles the profile +
+    record pair.
 
     ``params`` is the workload metadata (shape / dtype / n_total) from the
     caller's scope; passing it explicitly keeps the report rows distinguishable
@@ -101,9 +101,9 @@ def _profile_and_record(
         raise
 
 
-# Per-op constants and tests — one block per manifest entry so the
-# validator AST check ties each ``load_workloads(<OpName>)`` /
-# ``ManifestBenchmark(<OpName>, ...)`` call to its op.
+# Per-op constants and tests — one block per manifest entry so the validator AST
+# check ties each ``load_workloads(<OpName>)`` call, and the op each
+# ``ManifestBenchmark`` wraps, to that entry.
 
 _EXP_OP = "ExpFwdOp"
 
@@ -113,7 +113,7 @@ def test_exp_bench(shape: tuple, dtype: torch.dtype) -> None:
     inputs = draw_normal(shape, dtype)
     n_total = inputs[0].numel()
     op = ExpFwdOp()
-    bm = ManifestBenchmark(_EXP_OP, op, UnaryWorkload(shape, dtype))
+    bm = ManifestBenchmark(op, UnaryWorkload(shape, dtype))
     _profile_and_record(
         op, bm, inputs, torch.exp, {"shape": shape, "dtype": dtype, "n_total": n_total}
     )
@@ -127,7 +127,7 @@ def test_log_bench(shape: tuple, dtype: torch.dtype) -> None:
     inputs = draw_positive_away_from_zero(shape, dtype)
     n_total = inputs[0].numel()
     op = LogFwdOp()
-    bm = ManifestBenchmark(_LOG_OP, op, UnaryWorkload(shape, dtype))
+    bm = ManifestBenchmark(op, UnaryWorkload(shape, dtype))
     _profile_and_record(
         op, bm, inputs, torch.log, {"shape": shape, "dtype": dtype, "n_total": n_total}
     )
@@ -141,7 +141,7 @@ def test_sqrt_bench(shape: tuple, dtype: torch.dtype) -> None:
     inputs = draw_positive_away_from_zero(shape, dtype)
     n_total = inputs[0].numel()
     op = SqrtFwdOp()
-    bm = ManifestBenchmark(_SQRT_OP, op, UnaryWorkload(shape, dtype))
+    bm = ManifestBenchmark(op, UnaryWorkload(shape, dtype))
     _profile_and_record(
         op, bm, inputs, torch.sqrt, {"shape": shape, "dtype": dtype, "n_total": n_total}
     )
@@ -155,7 +155,7 @@ def test_rsqrt_bench(shape: tuple, dtype: torch.dtype) -> None:
     inputs = draw_positive_away_from_zero(shape, dtype)
     n_total = inputs[0].numel()
     op = RsqrtFwdOp()
-    bm = ManifestBenchmark(_RSQRT_OP, op, UnaryWorkload(shape, dtype))
+    bm = ManifestBenchmark(op, UnaryWorkload(shape, dtype))
     _profile_and_record(
         op, bm, inputs, torch.rsqrt, {"shape": shape, "dtype": dtype, "n_total": n_total}
     )
@@ -169,7 +169,7 @@ def test_abs_bench(shape: tuple, dtype: torch.dtype) -> None:
     inputs = draw_normal(shape, dtype)
     n_total = inputs[0].numel()
     op = AbsFwdOp()
-    bm = ManifestBenchmark(_ABS_OP, op, UnaryWorkload(shape, dtype))
+    bm = ManifestBenchmark(op, UnaryWorkload(shape, dtype))
     _profile_and_record(
         op, bm, inputs, torch.abs, {"shape": shape, "dtype": dtype, "n_total": n_total}
     )
@@ -183,7 +183,7 @@ def test_neg_bench(shape: tuple, dtype: torch.dtype) -> None:
     inputs = draw_normal(shape, dtype)
     n_total = inputs[0].numel()
     op = NegFwdOp()
-    bm = ManifestBenchmark(_NEG_OP, op, UnaryWorkload(shape, dtype))
+    bm = ManifestBenchmark(op, UnaryWorkload(shape, dtype))
     _profile_and_record(
         op, bm, inputs, torch.neg, {"shape": shape, "dtype": dtype, "n_total": n_total}
     )
@@ -197,7 +197,7 @@ def test_reciprocal_bench(shape: tuple, dtype: torch.dtype) -> None:
     inputs = draw_positive_away_from_zero(shape, dtype)
     n_total = inputs[0].numel()
     op = ReciprocalFwdOp()
-    bm = ManifestBenchmark(_RECIPROCAL_OP, op, UnaryWorkload(shape, dtype))
+    bm = ManifestBenchmark(op, UnaryWorkload(shape, dtype))
     _profile_and_record(
         op, bm, inputs, torch.reciprocal, {"shape": shape, "dtype": dtype, "n_total": n_total}
     )
@@ -211,7 +211,7 @@ def test_sign_bench(shape: tuple, dtype: torch.dtype) -> None:
     inputs = draw_normal(shape, dtype)
     n_total = inputs[0].numel()
     op = SignFwdOp()
-    bm = ManifestBenchmark(_SIGN_OP, op, UnaryWorkload(shape, dtype))
+    bm = ManifestBenchmark(op, UnaryWorkload(shape, dtype))
     _profile_and_record(
         op, bm, inputs, torch.sign, {"shape": shape, "dtype": dtype, "n_total": n_total}
     )
@@ -225,7 +225,7 @@ def test_sin_bench(shape: tuple, dtype: torch.dtype) -> None:
     inputs = draw_normal(shape, dtype)
     n_total = inputs[0].numel()
     op = SinFwdOp()
-    bm = ManifestBenchmark(_SIN_OP, op, UnaryWorkload(shape, dtype))
+    bm = ManifestBenchmark(op, UnaryWorkload(shape, dtype))
     _profile_and_record(
         op, bm, inputs, torch.sin, {"shape": shape, "dtype": dtype, "n_total": n_total}
     )
@@ -239,7 +239,7 @@ def test_cos_bench(shape: tuple, dtype: torch.dtype) -> None:
     inputs = draw_normal(shape, dtype)
     n_total = inputs[0].numel()
     op = CosFwdOp()
-    bm = ManifestBenchmark(_COS_OP, op, UnaryWorkload(shape, dtype))
+    bm = ManifestBenchmark(op, UnaryWorkload(shape, dtype))
     _profile_and_record(
         op, bm, inputs, torch.cos, {"shape": shape, "dtype": dtype, "n_total": n_total}
     )
@@ -253,7 +253,7 @@ def test_floor_bench(shape: tuple, dtype: torch.dtype) -> None:
     inputs = draw_normal(shape, dtype)
     n_total = inputs[0].numel()
     op = FloorFwdOp()
-    bm = ManifestBenchmark(_FLOOR_OP, op, UnaryWorkload(shape, dtype))
+    bm = ManifestBenchmark(op, UnaryWorkload(shape, dtype))
     _profile_and_record(
         op, bm, inputs, torch.floor, {"shape": shape, "dtype": dtype, "n_total": n_total}
     )
@@ -267,7 +267,7 @@ def test_ceil_bench(shape: tuple, dtype: torch.dtype) -> None:
     inputs = draw_normal(shape, dtype)
     n_total = inputs[0].numel()
     op = CeilFwdOp()
-    bm = ManifestBenchmark(_CEIL_OP, op, UnaryWorkload(shape, dtype))
+    bm = ManifestBenchmark(op, UnaryWorkload(shape, dtype))
     _profile_and_record(
         op, bm, inputs, torch.ceil, {"shape": shape, "dtype": dtype, "n_total": n_total}
     )
@@ -281,7 +281,7 @@ def test_round_bench(shape: tuple, dtype: torch.dtype) -> None:
     inputs = draw_normal(shape, dtype)
     n_total = inputs[0].numel()
     op = RoundFwdOp()
-    bm = ManifestBenchmark(_ROUND_OP, op, UnaryWorkload(shape, dtype))
+    bm = ManifestBenchmark(op, UnaryWorkload(shape, dtype))
     _profile_and_record(
         op, bm, inputs, torch.round, {"shape": shape, "dtype": dtype, "n_total": n_total}
     )
@@ -295,7 +295,7 @@ def test_trunc_bench(shape: tuple, dtype: torch.dtype) -> None:
     inputs = draw_normal(shape, dtype)
     n_total = inputs[0].numel()
     op = TruncFwdOp()
-    bm = ManifestBenchmark(_TRUNC_OP, op, UnaryWorkload(shape, dtype))
+    bm = ManifestBenchmark(op, UnaryWorkload(shape, dtype))
     _profile_and_record(
         op, bm, inputs, torch.trunc, {"shape": shape, "dtype": dtype, "n_total": n_total}
     )
@@ -309,7 +309,7 @@ def test_erf_bench(shape: tuple, dtype: torch.dtype) -> None:
     inputs = draw_normal(shape, dtype)
     n_total = inputs[0].numel()
     op = ErfFwdOp()
-    bm = ManifestBenchmark(_ERF_OP, op, UnaryWorkload(shape, dtype))
+    bm = ManifestBenchmark(op, UnaryWorkload(shape, dtype))
     _profile_and_record(
         op, bm, inputs, torch.erf, {"shape": shape, "dtype": dtype, "n_total": n_total}
     )
@@ -323,7 +323,7 @@ def test_log1p_bench(shape: tuple, dtype: torch.dtype) -> None:
     inputs = draw_positive_away_from_zero(shape, dtype)
     n_total = inputs[0].numel()
     op = Log1pFwdOp()
-    bm = ManifestBenchmark(_LOG1P_OP, op, UnaryWorkload(shape, dtype))
+    bm = ManifestBenchmark(op, UnaryWorkload(shape, dtype))
     _profile_and_record(
         op, bm, inputs, torch.log1p, {"shape": shape, "dtype": dtype, "n_total": n_total}
     )
@@ -337,7 +337,7 @@ def test_expm1_bench(shape: tuple, dtype: torch.dtype) -> None:
     inputs = draw_normal(shape, dtype)
     n_total = inputs[0].numel()
     op = Expm1FwdOp()
-    bm = ManifestBenchmark(_EXPM1_OP, op, UnaryWorkload(shape, dtype))
+    bm = ManifestBenchmark(op, UnaryWorkload(shape, dtype))
     _profile_and_record(
         op, bm, inputs, torch.expm1, {"shape": shape, "dtype": dtype, "n_total": n_total}
     )
@@ -355,7 +355,7 @@ def test_logical_not_bench(shape: tuple, dtype: torch.dtype) -> None:
     inputs = draw_bool(shape, dtype)
     n_total = inputs[0].numel()
     op = LogicalNotFwdOp()
-    bm = ManifestBenchmark(_LOGICAL_NOT_OP, op, UnaryWorkload(shape, dtype))
+    bm = ManifestBenchmark(op, UnaryWorkload(shape, dtype))
     _profile_and_record(
         op, bm, inputs, torch.logical_not, {"shape": shape, "dtype": dtype, "n_total": n_total}
     )
@@ -369,7 +369,7 @@ def test_bitwise_not_bench(shape: tuple, dtype: torch.dtype) -> None:
     inputs = draw_int(shape, dtype)
     n_total = inputs[0].numel()
     op = BitwiseNotFwdOp()
-    bm = ManifestBenchmark(_BITWISE_NOT_OP, op, UnaryWorkload(shape, dtype))
+    bm = ManifestBenchmark(op, UnaryWorkload(shape, dtype))
     _profile_and_record(
         op, bm, inputs, torch.bitwise_not, {"shape": shape, "dtype": dtype, "n_total": n_total}
     )
@@ -383,7 +383,7 @@ def test_isnan_bench(shape: tuple, dtype: torch.dtype) -> None:
     inputs = draw_special_floats(shape, dtype)
     n_total = inputs[0].numel()
     op = IsnanFwdOp()
-    bm = ManifestBenchmark(_ISNAN_OP, op, UnaryWorkload(shape, dtype))
+    bm = ManifestBenchmark(op, UnaryWorkload(shape, dtype))
     _profile_and_record(
         op, bm, inputs, torch.isnan, {"shape": shape, "dtype": dtype, "n_total": n_total}
     )
@@ -397,7 +397,7 @@ def test_isinf_bench(shape: tuple, dtype: torch.dtype) -> None:
     inputs = draw_special_floats(shape, dtype)
     n_total = inputs[0].numel()
     op = IsinfFwdOp()
-    bm = ManifestBenchmark(_ISINF_OP, op, UnaryWorkload(shape, dtype))
+    bm = ManifestBenchmark(op, UnaryWorkload(shape, dtype))
     _profile_and_record(
         op, bm, inputs, torch.isinf, {"shape": shape, "dtype": dtype, "n_total": n_total}
     )
@@ -411,7 +411,7 @@ def test_isfinite_bench(shape: tuple, dtype: torch.dtype) -> None:
     inputs = draw_special_floats(shape, dtype)
     n_total = inputs[0].numel()
     op = IsfiniteFwdOp()
-    bm = ManifestBenchmark(_ISFINITE_OP, op, UnaryWorkload(shape, dtype))
+    bm = ManifestBenchmark(op, UnaryWorkload(shape, dtype))
     _profile_and_record(
         op, bm, inputs, torch.isfinite, {"shape": shape, "dtype": dtype, "n_total": n_total}
     )

--- a/benchmarks/ops/bench_vector_norm.py
+++ b/benchmarks/ops/bench_vector_norm.py
@@ -64,7 +64,7 @@ def test_l1_norm_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> Non
 
     op_params.setdefault("dim", -1)
     op = L1NormFwdOp(**op_params)
-    bm = ManifestBenchmark(_L1_NORM_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     dim = op_params["dim"]
     keepdim = op_params.get("keepdim", False)
 
@@ -104,7 +104,7 @@ def test_l2_norm_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> Non
 
     op_params.setdefault("dim", -1)
     op = L2NormFwdOp(**op_params)
-    bm = ManifestBenchmark(_L2_NORM_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     dim = op_params["dim"]
     keepdim = op_params.get("keepdim", False)
 
@@ -144,7 +144,7 @@ def test_inf_norm_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> No
 
     op_params.setdefault("dim", -1)
     op = InfNormFwdOp(**op_params)
-    bm = ManifestBenchmark(_INF_NORM_OP, op, test)
+    bm = ManifestBenchmark(op, test)
     dim = op_params["dim"]
     keepdim = op_params.get("keepdim", False)
 

--- a/benchmarks/tests/test_benchmark_base.py
+++ b/benchmarks/tests/test_benchmark_base.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 import torch
 
-from benchmarks.benchmark_base import workloads_to_params
+from benchmarks.benchmark_base import ManifestBenchmark, workloads_to_params
 from benchmarks.timing import (
     Trace,
     _attributed_samples,
@@ -247,3 +247,24 @@ def test_kernel_runtime_error_propagates():
 
     with pytest.raises(RuntimeError, match="kernel failure"):
         bench_kernel(boom)
+
+
+class SumFwdOp:
+    """Stands in for the manifest op of that name; only the class name is read."""
+
+
+class NotAManifestOp:
+    """A wrapper of the kind a benchmark must not report under."""
+
+
+@pytest.mark.smoke
+def test_manifest_benchmark_takes_its_name_from_the_op():
+    """The report name is the op's class, so it cannot disagree with what ran."""
+    assert ManifestBenchmark(SumFwdOp(), object()).op_name == "SumFwdOp"
+
+
+@pytest.mark.smoke
+def test_manifest_benchmark_refuses_an_op_the_manifest_does_not_declare():
+    """A wrapper or a subclass would report numbers under a name no spec knows."""
+    with pytest.raises(KeyError, match="NotAManifestOp"):
+        ManifestBenchmark(NotAManifestOp(), object())

--- a/docs/design/manifest.md
+++ b/docs/design/manifest.md
@@ -585,13 +585,13 @@ workloads:
 
 [`scripts/validate_manifest.py`](../../scripts/validate_manifest.py) runs five levels:
 
-| Level | Check     | Description                                                                                                                 |
-| ----- | --------- | --------------------------------------------------------------------------------------------------------------------------- |
-| L0    | Schema    | Required fields exist, correct types                                                                                        |
-| L1    | Signature | Params ⊆ `__init__()` ∪ `forward()` names; `forward()` order matches                                                        |
-| L2    | Shape     | `shape_rules` are valid Python expressions                                                                                  |
-| L3    | Dtype     | dtype strings are valid torch types, `same_as()` refs, or `promote_int_to_float()` refs                                     |
-| L4    | Benchmark | Bench file imports/calls `load_workloads` and `eval_roofline` (directly or via `workloads_to_params` / `ManifestBenchmark`) |
+| Level | Check     | Description                                                                                  |
+| ----- | --------- | -------------------------------------------------------------------------------------------- |
+| L0    | Schema    | Required fields exist, correct types                                                         |
+| L1    | Signature | Params ⊆ `__init__()` ∪ `forward()` names; `forward()` order matches                         |
+| L2    | Shape     | `shape_rules` are valid Python expressions                                                   |
+| L3    | Dtype     | dtype strings are valid torch types, `same_as()` refs, or `promote_int_to_float()` refs      |
+| L4    | Benchmark | Bench file calls `load_workloads` with the op name, and hands that op to `ManifestBenchmark` |
 
 `spec-only` ops → L0 only. `implemented` ops → all levels. `--check-op <name>` forces L0-L4 on the targeted entry. L2 and L3 additionally run parity extensions against the implemented Op's `_infer_output_shapes` / `_validate_dtypes` methods; see [ops-design.md](ops-design.md).
 

--- a/docs/design/roofline.md
+++ b/docs/design/roofline.md
@@ -135,7 +135,7 @@ Validator holds no callables, no sample bindings, no `__builtins__` sandbox. Add
 Contract:
 
 - Instantiate the Op for each workload and call `op.eval_roofline()` to obtain `(flops, bytes)`. No manifest-level helper exists — roofline evaluation lives only inside each Op's generated method.
-- `ManifestBenchmark` and `workloads_to_params(..., include_extra=True)` are the canonical consumers; non-reserved workload keys forward as op-call params passed to the Op's `__init__`.
+- `ManifestBenchmark(op, workload)` and `workloads_to_params(..., include_extra=True)` are the canonical consumers; non-reserved workload keys forward as op-call params passed to the Op's `__init__`.
 - A benchmark file that computes FLOPs or bytes locally is a CI failure.
 - Benchmark output must record the `(flops, bytes)` from `op.eval_roofline()` and the roof key from `op.compute_roof()` (§1.4), so M5 reads the numbers without re-instantiating ops.
 

--- a/docs/design/testing.md
+++ b/docs/design/testing.md
@@ -124,9 +124,9 @@ python scripts/test_node_delta.py --base origin/release   # different base branc
 ### Workloads
 
 Import the op's workload from `workloads/`. `BenchmarkBase[W]` is generic over
-workload type and reads no attribute off it — `ManifestBenchmark` takes its
-roofline from `op.eval_roofline()` — so a workload needs nothing beyond the
-fields its own benchmark reads.
+workload type and reads no attribute off it — `ManifestBenchmark(op, workload)`
+takes its roofline from `op.eval_roofline()` and its report name from the op's
+class — so a workload needs nothing beyond the fields its own benchmark reads.
 
 ### File checklist
 

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -3543,26 +3543,107 @@ def _call_uses_expected_op_name(
     return False
 
 
+def _op_classes_benchmarked(tree: ast.Module, known_ops: set) -> tuple[set[str], bool]:
+    """Op classes the file's ``ManifestBenchmark`` calls wrap, and whether all resolved.
+
+    Benchmarks are written one way: the test builds its op and hands it over, so the
+    op argument is ``N(...)``, or a name the enclosing function assigns once to
+    ``N(...)``. Those two shapes resolve. Anything else — a factory, a loop variable,
+    a name assigned twice — does not, and an unresolved call fails the check rather
+    than falling back: the benchmark is not written the way the check reads, and the
+    fix is to write it that way.
+
+    Returns:
+        The resolved class names, and whether every ``ManifestBenchmark`` call in the
+        file resolved. A file with no such call reports ``True``: it satisfies the
+        roofline half another way, which is what the caller falls back on.
+    """
+    resolved: set[str] = set()
+    all_resolved = True
+
+    def assigned_class(name: str, scopes: list) -> "str | None":
+        """The class *name* is assigned, when one scope assigns it exactly once."""
+        for body in scopes:
+            assigns = [
+                node
+                for node in ast.walk(ast.Module(body=body, type_ignores=[]))
+                if isinstance(node, ast.Assign)
+                and any(isinstance(t, ast.Name) and t.id == name for t in node.targets)
+            ]
+            if not assigns:
+                continue
+            if len(assigns) != 1:
+                return None
+            value = assigns[0].value
+            if isinstance(value, ast.Call) and isinstance(value.func, ast.Name):
+                return value.func.id
+            return None
+        return None
+
+    def visit(node: ast.AST, scopes: list) -> None:
+        nonlocal all_resolved
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                visit(child, [child.body] + scopes)
+                continue
+            if (
+                isinstance(child, ast.Call)
+                and isinstance(child.func, ast.Name)
+                and child.func.id == "ManifestBenchmark"
+                and child.args
+            ):
+                arg = child.args[0]
+                if isinstance(arg, ast.Call) and isinstance(arg.func, ast.Name):
+                    name = arg.func.id
+                elif isinstance(arg, ast.Name):
+                    name = assigned_class(arg.id, scopes)
+                else:
+                    name = None
+                if name in known_ops:
+                    resolved.add(name)
+                else:
+                    all_resolved = False
+            visit(child, scopes)
+
+    visit(tree, [tree.body])
+    return resolved, all_resolved
+
+
+def _file_builds_class(tree: ast.Module, op_name: str) -> bool:
+    """Whether the file constructs *op_name*.
+
+    The tie for a file with its own ``BenchmarkBase`` subclass, which takes its op
+    somewhere this check does not read. Importing the class is not enough: a file
+    imports what it names in a type hint or a comparison too.
+    """
+    return any(
+        isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == op_name
+        for node in ast.walk(tree)
+    )
+
+
 def _ast_manifest_call_usage(
     tree: ast.Module,
     op_name: str,
     target_names: set[str],
+    known_ops: set,
 ) -> dict[str, bool]:
-    """Check whether target functions are imported and called with this op name.
+    """Check whether target functions are imported and used for this op.
 
-    Recognises the direct pattern (``load_workloads`` from
-    ``tileops.manifest`` called with the op name + ``op.eval_roofline()``)
-    and the indirect one (``workloads_to_params`` / ``ManifestBenchmark``
-    from ``benchmarks.benchmark_base``, op name as first argument).
+    ``load_workloads`` matches on the op name it is called with, directly or
+    through ``workloads_to_params``. ``eval_roofline`` matches on the op class a
+    ``ManifestBenchmark`` call wraps; where no call in the file resolves to a
+    class, on the file naming that class.
     """
     # Maps from the indirect helper name → the direct target it satisfies.
-    _INDIRECT_EQUIV: dict[str, str] = {
-        "workloads_to_params": "load_workloads",
-        "ManifestBenchmark": "eval_roofline",
-    }
+    # workloads_to_params wraps load_workloads and carries the same op-name argument.
+    # ManifestBenchmark is not here: it no longer takes a name, and the op it wraps is
+    # read by _op_classes_benchmarked instead.
+    _INDIRECT_EQUIV: dict[str, str] = {"workloads_to_params": "load_workloads"}
 
     imported: set[str] = set()
     matched_calls: set[str] = set()
+    direct_roofline = False
     bindings = _resolve_constant_str_bindings(tree)
 
     for node in ast.walk(tree):
@@ -3605,7 +3686,23 @@ def _ast_manifest_call_usage(
             and "eval_roofline" in target_names
         ):
             imported.add("eval_roofline")
+            direct_roofline = True
+
+    if "eval_roofline" in target_names:
+        # The roofline half ties to the op class the benchmark wraps. Falling back on the
+        # file naming the class is for a file where nothing resolves at all: a file that
+        # resolves other classes and not this one is benchmarking the wrong op.
+        resolved, all_resolved = _op_classes_benchmarked(tree, known_ops)
+        # No ManifestBenchmark call to read means a file with its own BenchmarkBase
+        # subclass; it ties to the op by naming that class. A call this check cannot
+        # read is a failure, not a fallback.
+        ties = op_name in resolved or (
+            all_resolved and not resolved and direct_roofline and _file_builds_class(tree, op_name)
+        )
+        if ties:
+            imported.add("eval_roofline")
             matched_calls.add("eval_roofline")
+
     return {name: (name in imported and name in matched_calls) for name in target_names}
 
 
@@ -3613,6 +3710,7 @@ def check_l4_benchmark(
     op_name: str,
     bench_path: str,
     repo_root: Path,
+    known_ops: set,
 ) -> list[str]:
     """Check that the benchmark file uses manifest workloads and op roofline.
 
@@ -3639,7 +3737,7 @@ def check_l4_benchmark(
         return errors
 
     targets = {"load_workloads", "eval_roofline"}
-    usage = _ast_manifest_call_usage(tree, op_name, targets)
+    usage = _ast_manifest_call_usage(tree, op_name, targets, known_ops)
 
     if not usage["load_workloads"]:
         errors.append(
@@ -3648,9 +3746,10 @@ def check_l4_benchmark(
         )
     if not usage["eval_roofline"]:
         errors.append(
-            f"[bench] {op_name}: bench file {bench_path} must call "
-            "eval_roofline() on an Op instance or use ManifestBenchmark "
-            f"with op name {op_name!r}"
+            f"[bench] {op_name}: bench file {bench_path} must hand a {op_name} to "
+            f"ManifestBenchmark — built in the call, or assigned once in the test: "
+            f"op = {op_name}(...); ManifestBenchmark(op, workload). A file with its own "
+            f"BenchmarkBase subclass names {op_name} instead"
         )
     return errors
 
@@ -4265,7 +4364,7 @@ def validate_manifest(
             all_errors.extend(check_bench_declaration(op_name, entry))
             bench_path = entry.get("source", {}).get("bench", "")
             if bench_path:
-                bench_errors = check_l4_benchmark(op_name, bench_path, repo_root)
+                bench_errors = check_l4_benchmark(op_name, bench_path, repo_root, set(ops))
                 if _is_bench_manifest_driven(entry):
                     all_errors.extend(bench_errors)
                 else:

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -3667,7 +3667,7 @@ def _ast_manifest_call_usage(
                 bindings,
             ):
                 matched_calls.add(func_name)
-            # Indirect call (workloads_to_params / ManifestBenchmark).
+            # Indirect call (workloads_to_params).
             equiv = _INDIRECT_EQUIV.get(func_name)
             if (
                 equiv
@@ -3685,17 +3685,13 @@ def _ast_manifest_call_usage(
             and node.func.attr == "eval_roofline"
             and "eval_roofline" in target_names
         ):
-            imported.add("eval_roofline")
             direct_roofline = True
 
     if "eval_roofline" in target_names:
-        # The roofline half ties to the op class the benchmark wraps. Falling back on the
-        # file naming the class is for a file where nothing resolves at all: a file that
-        # resolves other classes and not this one is benchmarking the wrong op.
+        # The roofline half ties to the op the benchmark wraps. A call this check cannot
+        # read fails; only a file with no such call at all — its own BenchmarkBase
+        # subclass — ties by building the op instead.
         resolved, all_resolved = _op_classes_benchmarked(tree, known_ops)
-        # No ManifestBenchmark call to read means a file with its own BenchmarkBase
-        # subclass; it ties to the op by naming that class. A call this check cannot
-        # read is a failure, not a fallback.
         ties = op_name in resolved or (
             all_resolved and not resolved and direct_roofline and _file_builds_class(tree, op_name)
         )

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -2653,30 +2653,73 @@ class TestBench:
         cases = [
             # (description, bench file text, expected substrings or None)
             (
-                "direct load_workloads + eval_roofline passes",
+                "ManifestBenchmark wrapping the declared op passes",
                 """\
-                from tileops.manifest import load_workloads
-                workloads = load_workloads('test_op')
-                op.eval_roofline()
+                from benchmarks.benchmark_base import workloads_to_params, ManifestBenchmark
+                from tileops.ops import TestFwdOp
+                params = workloads_to_params('TestFwdOp')
+                def test_bench():
+                    op = TestFwdOp()
+                    ManifestBenchmark(op, params[0])
             """,
                 None,
             ),
             (
-                "indirect base helpers pass",
+                "direct load_workloads with the op built in the file passes",
                 """\
-                from benchmarks.benchmark_base import workloads_to_params, ManifestBenchmark
-                params = workloads_to_params('test_op')
-                ManifestBenchmark('test_op', op, params[0])
+                from tileops.manifest import load_workloads
+                from tileops.ops import TestFwdOp
+                workloads = load_workloads('TestFwdOp')
+                def test_bench():
+                    op = TestFwdOp()
+                    op.eval_roofline()
             """,
                 None,
+            ),
+            (
+                "a factory-built op fails: the call is not written to the standard",
+                """\
+                from benchmarks.benchmark_base import workloads_to_params, ManifestBenchmark
+                from tileops.ops import TestFwdOp
+                params = workloads_to_params('TestFwdOp')
+                def _make():
+                    return TestFwdOp()
+                def test_bench():
+                    op = _make()
+                    ManifestBenchmark(op, params[0])
+            """,
+                ["ManifestBenchmark"],
+            ),
+            (
+                "wrapping another op fails even with the declared class imported",
+                """\
+                from benchmarks.benchmark_base import workloads_to_params, ManifestBenchmark
+                from tileops.ops import TestFwdOp, OtherFwdOp
+                params = workloads_to_params('TestFwdOp')
+                def test_bench():
+                    op = OtherFwdOp()
+                    ManifestBenchmark(op, params[0])
+            """,
+                ["ManifestBenchmark"],
+            ),
+            (
+                "eval_roofline reached while naming no class of the declared op fails",
+                """\
+                from tileops.manifest import load_workloads
+                workloads = load_workloads('TestFwdOp')
+                def test_bench():
+                    op = build()
+                    op.eval_roofline()
+            """,
+                ["ManifestBenchmark"],
             ),
             (
                 "load_workloads without eval_roofline fails",
                 """\
                 from tileops.manifest import load_workloads
-                workloads = load_workloads('test_op')
+                workloads = load_workloads('TestFwdOp')
             """,
-                ["eval_roofline"],
+                ["ManifestBenchmark"],
             ),
             (
                 "no load_workloads fails",
@@ -2690,8 +2733,11 @@ class TestBench:
                 "wrong op name fails (direct path)",
                 """\
                 from tileops.manifest import load_workloads
-                workloads = load_workloads('wrong_op')
-                op.eval_roofline()
+                from tileops.ops import TestFwdOp
+                workloads = load_workloads('OtherFwdOp')
+                def test_bench():
+                    op = TestFwdOp()
+                    op.eval_roofline()
             """,
                 ["load_workloads"],
             ),
@@ -2699,10 +2745,13 @@ class TestBench:
                 "wrong op name fails (indirect path)",
                 """\
                 from benchmarks.benchmark_base import workloads_to_params, ManifestBenchmark
-                params = workloads_to_params('wrong_op')
-                ManifestBenchmark('wrong_op', op, params[0])
+                from tileops.ops import TestFwdOp
+                params = workloads_to_params('OtherFwdOp')
+                def test_bench():
+                    op = TestFwdOp()
+                    ManifestBenchmark(op, params[0])
             """,
-                ["load_workloads", "eval_roofline"],
+                ["load_workloads"],
             ),
             ("syntax error fails", "def broken(\n", ["syntax error"]),
         ]
@@ -2710,9 +2759,10 @@ class TestBench:
             bench_file = tmp_path / "bench_test.py"
             bench_file.write_text(textwrap.dedent(text))
             errors = validator.check_l4_benchmark(
-                "test_op",
+                "TestFwdOp",
                 str(bench_file),
                 REPO_ROOT,
+                {"TestFwdOp", "OtherFwdOp"},
             )
             if expected is None:
                 assert errors == [], (desc, errors)
@@ -2721,6 +2771,87 @@ class TestBench:
                     assert any(substring in e for e in errors), (
                         f"{desc}: expected {substring!r} in errors, got: {errors}"
                     )
+
+    def test_l4_reads_only_the_standard_call_form(self, validator, tmp_path):
+        """A benchmark states its op by building it; L4 reads that and nothing else.
+
+        The two readable shapes are the op constructed in the call and a name the
+        test assigns once. A loop variable, a factory or a name assigned twice is
+        not a benchmark written to the standard, so it fails rather than falling
+        back on the file naming the class somewhere.
+        """
+        header = (
+            "from tileops.ops import TestFwdOp, OtherFwdOp\n"
+            "from benchmarks.benchmark_base import ManifestBenchmark, workloads_to_params\n"
+            "params = workloads_to_params('TestFwdOp')\n"
+        )
+        cases = [
+            (
+                "the standard form",
+                "def t():\n    op = TestFwdOp()\n    ManifestBenchmark(op, params)\n",
+                True,
+            ),
+            (
+                "constructed in the call",
+                "def t():\n    ManifestBenchmark(TestFwdOp(), params)\n",
+                True,
+            ),
+            (
+                "an attribute assignment is not a rebinding",
+                "def t():\n    op = TestFwdOp()\n    op.total_q = 3\n    ManifestBenchmark(op, params)\n",
+                True,
+            ),
+            (
+                "two tests keep their own op",
+                "def a():\n    op = TestFwdOp()\n    ManifestBenchmark(op, params)\ndef b():\n    op = OtherFwdOp()\n    ManifestBenchmark(op, params)\n",
+                True,
+            ),
+            (
+                "a file with its own benchmark class names the op",
+                "class B:\n    def f(self):\n        return self._op.eval_roofline()\ndef t():\n    op = TestFwdOp()\n",
+                True,
+            ),
+            (
+                "wrapping another op fails",
+                "def t():\n    op = OtherFwdOp()\n    ManifestBenchmark(op, params)\n",
+                False,
+            ),
+            (
+                "a name assigned twice fails",
+                "def t():\n    op = OtherFwdOp()\n    ManifestBenchmark(op, params)\n    op = TestFwdOp()\n",
+                False,
+            ),
+            (
+                "a loop variable fails",
+                "def t():\n    for op in [OtherFwdOp()]:\n        ManifestBenchmark(op, params)\n",
+                False,
+            ),
+            (
+                "a comprehension variable fails",
+                "def t():\n    xs = [ManifestBenchmark(op, params) for op in [OtherFwdOp()]]\n",
+                False,
+            ),
+            (
+                "a with-item target fails",
+                "def t():\n    with ctx(OtherFwdOp()) as op:\n        ManifestBenchmark(op, params)\n",
+                False,
+            ),
+            (
+                "a factory fails",
+                "def t():\n    op = _make()\n    ManifestBenchmark(op, params)\n",
+                False,
+            ),
+        ]
+        for desc, body, passes in cases:
+            bench_file = tmp_path / "bench_case.py"
+            bench_file.write_text(header + body)
+            errors = validator.check_l4_benchmark(
+                "TestFwdOp",
+                str(bench_file),
+                REPO_ROOT,
+                {"TestFwdOp", "OtherFwdOp"},
+            )
+            assert (errors == []) is passes, (desc, errors)
 
     # --check-op: force all levels on a specific op, ignoring status
 


### PR DESCRIPTION
Closes #2004.

## Problems

- `ManifestBenchmark`'s `op_name` was a run-time argument nothing read at run time; only `scripts/validate_manifest.py` parsed it.
- It was never checked against the op beside it, so `ManifestBenchmark("AFwdOp", b_op, workload)` timed B under A's name and no run-time or static check disagreed.
- It constrained the call form: only a string constant or a module-level `NAME = "..."` binding validated, and anything else failed with a message about the manifest rather than about the call.
- L4's `eval_roofline` half tied to that string, so it tied to nothing on the direct `<expr>.eval_roofline()` path.

## Changes

- `ManifestBenchmark(op, workload)`. `op_name` is `type(op).__name__`, which `_resolve_op_class` already requires to equal the manifest key; construction raises `KeyError` when that name is not a manifest op, so a wrapper or a subclass cannot report under a name no spec declares.
- 179 call sites in 54 files drop the first argument. The `_OP_NAME` constants a `load_workloads` / `workloads_to_params` call still reads all stay; the one left unreferenced is deleted.
- L4's roofline half reads the op the call wraps. Benchmarks are written one way — the test builds its op and hands it over — so two shapes resolve: `ManifestBenchmark(<Op>(...), workload)`, and a name the enclosing scope assigns once to `<Op>(...)`. Anything else fails and the message names the form to write. There is no fallback for an unreadable call.
- A file with its own `BenchmarkBase` subclass ties by building the op class. `bench_moe_fused_moe.py` is the only one, and it is the path L4 could not tie at all before.
- `ManifestBenchmark` leaves `_INDIRECT_EQUIV`: it no longer carries a name, so the removed three-argument form cannot satisfy the check.
- `bench_cumulative.py`'s `_make_op` is deleted; each test constructs the op its own name declares.
