### PR TITLE
[Refactor][Bench] Check the benchmarked op against the run, not the source

### DIFF
--- a/.claude/domain-rules/benchmark.md
+++ b/.claude/domain-rules/benchmark.md
@@ -12,4 +12,5 @@ ______________________________________________________________________
 - A timed callable launches its own work. Gradients come from `backward_of`, never `Tensor.backward`: autograd's engine thread carries no iteration id, so the timer cannot attribute what it launches.
 - Name the scenario (`serving-130m-4k`), not the parameters; a `label` omits the dtype, the case id appends it. The `workload-names-lint` hook checks a name exists, not that it reads as one.
 - Tag names: lowercase, hyphen-separated. A `tileops` prefix marks a TileOPs entry; everything else is a baseline.
+- Every op records at least one row under its own instance (`record_as=op`); what distinguishes cases goes in `params`, never into the row's name. A study of something other than the op — a kernel strategy, a broadcast pattern — may take a name of its own beside those rows. `scripts/check_bench_coverage.py` fails an op whose benchmark passed without recording it.
 - Benchmark shapes reflect real DNN workloads (LLaMA-family by default). Annotate shape constants with the model/scenario; never arbitrary flat numbers (262K, 1M, 4M).

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -171,6 +171,20 @@ jobs:
           fi
         shell: bash
 
+      - name: Check benchmark coverage
+        id: bench_coverage
+        if: ${{ always() }}
+        run: |
+          set -euo pipefail
+          export PYTHONPATH="${GITHUB_WORKSPACE}${PYTHONPATH:+:$PYTHONPATH}"
+          # Which op each bench file measured is read off the run's own report:
+          # a benchmark that passes without benchmarking the op its manifest
+          # entry declares is a coverage gap no static check can see.
+          python3 scripts/check_bench_coverage.py \
+            --bench-xml bench_results.xml \
+            --output bench_coverage.md
+        shell: bash
+
       - name: Record the run environment
         if: ${{ always() }}
         run: |
@@ -188,13 +202,16 @@ jobs:
           path: |
             tileops_benchmarks.log
             bench_results.xml
+            bench_coverage.md
             env.json
             bench_stack_dumps/
           if-no-files-found: warn
           retention-days: 14
 
-      - name: Fail benchmark job if pytest failed
-        if: ${{ always() && steps.benchmark_tests.outcome == 'failure' }}
+      - name: Fail benchmark job if pytest or the coverage check failed
+        if: >-
+          ${{ always() && (steps.benchmark_tests.outcome == 'failure'
+          || steps.bench_coverage.outcome == 'failure') }}
         run: exit 1
         shell: bash
 

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -321,7 +321,9 @@ jobs:
         run: pip install -e ".[dev]" -c constraints.txt
 
       - name: Run manifest and compile-contract structural tests
-        run: python -m pytest -q tests/test_validate_manifest.py
+        run: |
+          python -m pytest -q tests/test_validate_manifest.py \
+            tests/test_check_bench_coverage.py
 
   packaging-check:
     # Build-and-inspect only: keep torch/tilelang and GPU needs out of here.

--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -342,6 +342,9 @@ class ManifestBenchmark(BenchmarkBase[Any]):
 
     Called lazily while building a result, because a dynamic-shape op binds its
     roofline variables during ``forward()``.
+
+    The benchmark reads its op's name off the instance: ``self.op_name`` is the
+    wrapped class's name, which every manifest key equals by validator rule.
     """
 
     def __init__(self, op: Any, workload: Any):

--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -31,7 +31,7 @@ def pytest_make_parametrize_id(config, val, argname):
 
 
 # Set by the recorder, not measurements.
-_NOT_A_MEASUREMENT = frozenset({"tag", "op", "op_module"})
+_NOT_A_MEASUREMENT = frozenset({"tag", "op", "op_module", "ops"})
 
 
 def _prop(value) -> str:
@@ -106,6 +106,11 @@ def pytest_runtest_call(item):
 
         if tileops_entry:
             item.user_properties.append(("op", tileops_entry["op"]))
+            # Every op this case benchmarked, for the coverage gate: one case
+            # may time more than one, and the row properties above describe
+            # only the first.
+            benchmarked = sorted({e["op"] for e in entries if e["tag"].startswith("tileops")})
+            item.user_properties.append(("ops", ",".join(benchmarked)))
             if "op_module" in tileops_entry:
                 item.user_properties.append(("op_module", tileops_entry["op_module"]))
             tag = tileops_entry["tag"]

--- a/benchmarks/ops/bench_convolution.py
+++ b/benchmarks/ops/bench_convolution.py
@@ -5,8 +5,8 @@ are loaded from the ops manifest (``src/tileops/manifest/convolution.yaml``);
 FLOP/byte counts come from each op's ``eval_roofline()`` via
 :class:`ManifestBenchmark`.
 
-One ``test_*_bench`` per op, so the validator's L4 AST check can tie each
-``load_workloads("<OpName>")`` call to its manifest entry. A row passes bias
+One ``test_*_bench`` per op, so every op this file is declared the benchmark
+of records a row of its own. A row passes bias
 when it declares ``bias_shape``.
 
 Every row is timed against flag_gems' Triton convolutions, ``F.convNd`` eager
@@ -201,8 +201,8 @@ def _run_conv(
 ) -> None:
     """Profile op against flag_gems and torch on the same inputs, recording all.
 
-    One caller per manifest op, so each ``ManifestBenchmark`` wraps the op the
-    manifest validator matches it against statically.
+    One caller per manifest op, so every op the manifest declares this file for
+    records a row of its own.
     """
     inputs = _conv_inputs(
         case.input_shape,

--- a/benchmarks/ops/bench_engram.py
+++ b/benchmarks/ops/bench_engram.py
@@ -4,8 +4,8 @@ Workload shapes and dtypes come from the ops manifest; roofline FLOP and
 byte counts come from each op's ``eval_roofline()`` via
 :class:`ManifestBenchmark`.
 
-One ``test_*_bench`` per op, so the validator's L4 AST check can tie each
-``load_workloads("<OpName>")`` call to its manifest entry.
+One ``test_*_bench`` per op, so every op this file is declared the benchmark
+of records a row of its own.
 """
 
 import pytest

--- a/benchmarks/ops/bench_grouped_gemm.py
+++ b/benchmarks/ops/bench_grouped_gemm.py
@@ -87,7 +87,6 @@ def test_grouped_gemm_bench(
     transpose_b: bool,
 ) -> None:
     layout = ("T" if transpose_a else "N") + ("T" if transpose_b else "N")
-    name = f"grouped_gemm_{layout.lower()}"
 
     test = GroupedGemmWorkload(batch_sum, batch_count, N, K, dtype, transpose_a, transpose_b)
     inputs = test.gen_inputs()
@@ -106,4 +105,6 @@ def test_grouped_gemm_bench(
             grouped_mm_fn, test.ref_program, *inputs, **reference_tolerance(dtype)
         )
         functors["torch"] = grouped_mm_fn
-    bm.compare(functors, *inputs, record_as=name, params=locals())
+    # Rows are named by the op, with the layout among their params: a row named
+    # for the layout leaves the op it measured out of the report.
+    bm.compare(functors, *inputs, record_as=op, params=locals())

--- a/benchmarks/ops/bench_rope.py
+++ b/benchmarks/ops/bench_rope.py
@@ -4,8 +4,8 @@ Workload shapes, dtypes, layouts, and roofline formulas are loaded from the
 ops manifest (``src/tileops/manifest/position_encoding.yaml``); nothing about a
 workload is hard-coded here.
 
-One ``test_*_bench`` per op, so the validator's L4 AST check can tie each
-``load_workloads("<OpName>")`` call to its manifest entry.
+One ``test_*_bench`` per op, so every op this file is declared the benchmark
+of records a row of its own.
 
 Baselines build their cos/sin tables outside the timed window, so only the
 rotation itself is measured.

--- a/benchmarks/ops/bench_unary_elementwise.py
+++ b/benchmarks/ops/bench_unary_elementwise.py
@@ -4,8 +4,8 @@ Measures latency, FLOPS, and DRAM bandwidth against PyTorch baselines.
 Workload shapes, dtypes, and roofline formulas are loaded from the ops
 manifest (``src/tileops/manifest/elementwise_unary_math.yaml``).
 
-One ``test_*_bench`` per op, so the validator's L4 AST check can tie each
-``load_workloads("<OpName>")`` call to its manifest entry. A shared
+One ``test_*_bench`` per op, so every op this file is declared the benchmark
+of records a row of its own. A shared
 ``_profile_and_record`` helper handles the profile + record pair so the
 per-op functions stay tiny and intentional.
 
@@ -79,10 +79,9 @@ def _profile_and_record(
 ) -> None:
     """Profile op and torch baseline against the same inputs and record both.
 
-    ``ManifestBenchmark`` must be constructed at the call site of each per-op
-    test, wrapping that test's own op, so the manifest validator's AST check can
-    tie the call to the op it measures. This helper only handles the profile +
-    record pair.
+    ``ManifestBenchmark`` is constructed at the call site of each per-op test,
+    over the op that test builds. This helper only handles the profile + record
+    pair.
 
     ``params`` is the workload metadata (shape / dtype / n_total) from the
     caller's scope; passing it explicitly keeps the report rows distinguishable
@@ -101,9 +100,8 @@ def _profile_and_record(
         raise
 
 
-# Per-op constants and tests — one block per manifest entry so the validator AST
-# check ties each ``load_workloads(<OpName>)`` call, and the op each
-# ``ManifestBenchmark`` wraps, to that entry.
+# Per-op constants and tests — one block per manifest entry, so each op loads
+# its own workloads and records a row of its own.
 
 _EXP_OP = "ExpFwdOp"
 

--- a/docs/design/manifest.md
+++ b/docs/design/manifest.md
@@ -585,13 +585,13 @@ workloads:
 
 [`scripts/validate_manifest.py`](../../scripts/validate_manifest.py) runs five levels:
 
-| Level | Check     | Description                                                                                  |
-| ----- | --------- | -------------------------------------------------------------------------------------------- |
-| L0    | Schema    | Required fields exist, correct types                                                         |
-| L1    | Signature | Params ⊆ `__init__()` ∪ `forward()` names; `forward()` order matches                         |
-| L2    | Shape     | `shape_rules` are valid Python expressions                                                   |
-| L3    | Dtype     | dtype strings are valid torch types, `same_as()` refs, or `promote_int_to_float()` refs      |
-| L4    | Benchmark | Bench file calls `load_workloads` with the op name, and hands that op to `ManifestBenchmark` |
+| Level | Check     | Description                                                                                                                                                                                                                                                                  |
+| ----- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| L0    | Schema    | Required fields exist, correct types                                                                                                                                                                                                                                         |
+| L1    | Signature | Params ⊆ `__init__()` ∪ `forward()` names; `forward()` order matches                                                                                                                                                                                                         |
+| L2    | Shape     | `shape_rules` are valid Python expressions                                                                                                                                                                                                                                   |
+| L3    | Dtype     | dtype strings are valid torch types, `same_as()` refs, or `promote_int_to_float()` refs                                                                                                                                                                                      |
+| L4    | Benchmark | Bench file calls `load_workloads` / `workloads_to_params` and takes its roofline off an Op — `eval_roofline()` or a `ManifestBenchmark`. It matches no op name: which entry a file benchmarks is settled by a run, see [trust-model.md §Benchmark](trust-model.md#benchmark) |
 
 `spec-only` ops → L0 only. `implemented` ops → all levels. `--check-op <name>` forces L0-L4 on the targeted entry. L2 and L3 additionally run parity extensions against the implemented Op's `_infer_output_shapes` / `_validate_dtypes` methods; see [ops-design.md](ops-design.md).
 

--- a/docs/design/trust-model.md
+++ b/docs/design/trust-model.md
@@ -57,6 +57,17 @@ A baseline that is a different implementation is timed under its own tag next
 to the reference: the tag is what names it in the report, so it is checked
 against the reference before the case is timed.
 
+Which manifest entry a benchmark measures is settled by running it, not by
+reading it. The op is whatever class the benchmark constructs, so the run's
+report carries that class's name and is compared against the entries declaring a
+benchmark. A source check can only look for a marker, and a marker is not the op:
+it goes unchecked against what ran, and it makes the shape of the source — a
+literal here, a construction there — a condition of passing.
+
+What the source does answer is the file's own contract: workloads from the
+manifest, roofline from the op. That needs no op name, so no benchmark shape is
+illegal.
+
 [`benchmarks/tests/test_benchmark_boundaries.py`](../../benchmarks/tests/test_benchmark_boundaries.py)
 checks the `tests/` import and a locally defined `gen_inputs`, both by literal
 name.

--- a/scripts/check_bench_coverage.py
+++ b/scripts/check_bench_coverage.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Check that every implemented op's benchmark actually benchmarked it.
+
+Which op a bench file measures is a run-time fact: the op the benchmark wraps is
+the class it constructs, and ``benchmarks/conftest.py`` records that class's name
+as the ``op`` property of every benchmark testcase. This script reads those
+properties out of a benchmark run's JUnit report and compares them with the ops
+the manifest declares a benchmark for.
+
+``scripts/validate_manifest.py`` covers the other half — that a bench file takes
+its workloads from the manifest and its roofline off the op — from the source,
+without naming an op.
+
+Only a file whose testcases all passed and still recorded nothing for its op
+fails this check. A file that failed, errored, was skipped or never ran is
+reported and left to the benchmark job's own exit code, which already fails on
+it; failing twice for one cause buries the row this check exists to surface.
+
+Usage:
+    python scripts/check_bench_coverage.py --bench-xml bench_results.xml \\
+        [--output bench_coverage.md]
+
+Exit code 0 = every declared op was benchmarked, or its run says why not;
+1 = a benchmark passed without benchmarking the op it is declared for;
+2 = the report is missing or unusable, which is not a pass.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from tileops.manifest import load_manifest  # noqa: E402
+
+EXIT_OK = 0
+EXIT_GAP = 1
+EXIT_NO_REPORT = 2
+
+FAIL = "FAIL"
+NO_VERDICT = "NO VERDICT"
+NOT_RUN = "NOT RUN"
+SKIPPED = "SKIPPED"
+OK = "OK"
+
+# Listing order: what needs acting on first.
+_ORDER = {FAIL: 0, NO_VERDICT: 1, NOT_RUN: 2, SKIPPED: 3, OK: 4}
+
+
+class FileRun:
+    """What one bench file's testcases did in a run."""
+
+    __slots__ = ("broken_reasons", "passed", "recorded", "skip_reasons", "testcases")
+
+    def __init__(self) -> None:
+        self.testcases = 0
+        self.passed = 0
+        self.recorded: set[str] = set()
+        self.skip_reasons: list[str] = []
+        self.broken_reasons: list[str] = []
+
+    def absorb(self, other: "FileRun") -> None:
+        self.testcases += other.testcases
+        self.passed += other.passed
+        self.recorded |= other.recorded
+        self.skip_reasons.extend(other.skip_reasons)
+        self.broken_reasons.extend(other.broken_reasons)
+
+
+def _properties(testcase: ET.Element) -> dict[str, str]:
+    return {
+        p.attrib["name"]: p.attrib.get("value", "")
+        for props in testcase.iter("properties")
+        for p in props.iter("property")
+    }
+
+
+def _reason(element: ET.Element) -> str:
+    return (element.attrib.get("message") or element.attrib.get("type") or "").strip()
+
+
+def _module_of(bench_path: str) -> str:
+    """``benchmarks/ops/bench_x.py`` -> ``benchmarks.ops.bench_x``."""
+    return bench_path.removesuffix(".py").replace("/", ".")
+
+
+def parse_run(xml_path: Path) -> dict[str, FileRun]:
+    """Group a benchmark report's testcases by the class name that holds them."""
+    runs: dict[str, FileRun] = {}
+    for testcase in ET.parse(xml_path).iter("testcase"):
+        run = runs.setdefault(testcase.attrib.get("classname", ""), FileRun())
+        run.testcases += 1
+        skipped = testcase.find("skipped")
+        if skipped is not None:
+            run.skip_reasons.append(_reason(skipped))
+            continue
+        broken = testcase.find("failure")
+        if broken is None:
+            broken = testcase.find("error")
+        if broken is not None:
+            run.broken_reasons.append(_reason(broken))
+            continue
+        run.passed += 1
+        # Op names reach the report only from recorded tileops rows: a case
+        # timing a baseline alone records none. ``ops`` lists every op the case
+        # benchmarked; ``op`` is the first, kept for older reports.
+        props = _properties(testcase)
+        recorded = props.get("ops") or props.get("op") or ""
+        run.recorded.update(name for name in recorded.split(",") if name)
+    return runs
+
+
+def _run_of(module: str, runs: dict[str, FileRun]) -> FileRun:
+    """Fold every testcase of *module*, including those a class in it holds."""
+    folded = FileRun()
+    for classname, run in runs.items():
+        if classname == module or classname.startswith(f"{module}."):
+            folded.absorb(run)
+    return folded
+
+
+def _verdict(op_name: str, run: FileRun) -> tuple[str, str]:
+    """Judge one op against its bench file's run.
+
+    A testcase that failed or was skipped carries no op name, so which op it
+    belonged to is unknown; a file holding one answers for none of the ops it
+    did not record. Only a file whose every testcase passed accuses an
+    unrecorded op — there, nothing is left that could have benchmarked it.
+    """
+    if op_name in run.recorded:
+        return OK, f"{run.passed} testcases passed"
+    if run.broken_reasons:
+        return NO_VERDICT, f"{len(run.broken_reasons)} failed: {run.broken_reasons[0]}"
+    if run.skip_reasons:
+        return SKIPPED, f"{len(run.skip_reasons)} skipped: {run.skip_reasons[0]}"
+    if run.passed:
+        return FAIL, f"{run.passed} testcases passed, recording {sorted(run.recorded) or 'no op'}"
+    return NOT_RUN, "no testcases in the report"
+
+
+def verdicts(runs: dict[str, FileRun], manifest: dict) -> list[tuple[str, str, str, str]]:
+    """One ``(op, bench, verdict, detail)`` row per op declaring a benchmark."""
+    rows = []
+    for op_name, entry in sorted(manifest.items()):
+        if entry.get("status") != "implemented":
+            continue
+        bench = (entry.get("source") or {}).get("bench")
+        if not bench:
+            continue
+        verdict, detail = _verdict(op_name, _run_of(_module_of(bench), runs))
+        rows.append((op_name, bench, verdict, detail))
+    return rows
+
+
+def render(rows: list[tuple[str, str, str, str]]) -> str:
+    """A markdown summary listing every row that is not OK."""
+    counts = {v: sum(1 for r in rows if r[2] == v) for v in _ORDER}
+    lines = [
+        "# Benchmark coverage",
+        "",
+        f"{len(rows)} implemented ops declare a benchmark: "
+        + ", ".join(f"{n} {v}" for v, n in counts.items() if n),
+        "",
+    ]
+    listed = sorted((r for r in rows if r[2] != OK), key=lambda r: (_ORDER[r[2]], r[0]))
+    if listed:
+        lines += ["| Op | Verdict | Bench | Detail |", "| --- | --- | --- | --- |"]
+        lines += [
+            f"| `{op}` | {verdict} | `{bench}` | {detail} |"
+            for op, bench, verdict, detail in listed
+        ]
+        lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bench-xml", required=True, help="benchmark run's JUnit report")
+    parser.add_argument("--output", help="write the markdown summary here as well")
+    args = parser.parse_args(argv)
+
+    xml_path = Path(args.bench_xml)
+    if not xml_path.is_file():
+        print(f"[coverage] benchmark report not found: {xml_path}", file=sys.stderr)
+        return EXIT_NO_REPORT
+    try:
+        runs = parse_run(xml_path)
+    except ET.ParseError as exc:
+        print(f"[coverage] benchmark report {xml_path} is unusable: {exc}", file=sys.stderr)
+        return EXIT_NO_REPORT
+
+    rows = verdicts(runs, load_manifest())
+    summary = render(rows)
+    print(summary)
+    if args.output:
+        Path(args.output).write_text(summary, encoding="utf-8")
+
+    failures = [r for r in rows if r[2] == FAIL]
+    for op_name, bench, _, detail in failures:
+        print(
+            f"[coverage] {op_name}: {bench} — {detail}; it passed without "
+            "benchmarking the op it is declared for",
+            file=sys.stderr,
+        )
+    return EXIT_GAP if failures else EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -3513,205 +3513,63 @@ def _honours_same_as(sig: dict, candidate: dict[str, str]) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _resolve_constant_str_bindings(tree: ast.Module) -> dict[str, str]:
-    """Collect simple module-level string constants: NAME = 'value'."""
-    bindings: dict[str, str] = {}
-    for node in tree.body:
-        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
-            continue
-        target = node.targets[0]
-        if not isinstance(target, ast.Name):
-            continue
-        if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
-            bindings[target.id] = node.value.value
-    return bindings
+def _reads_manifest_workloads(tree: ast.Module) -> bool:
+    """Whether the file loads its workloads from the manifest.
 
-
-def _call_uses_expected_op_name(
-    call: ast.Call,
-    expected_op_name: str,
-    bindings: dict[str, str],
-) -> bool:
-    """Return True when call(arg0, ...) uses the expected op name."""
-    if not call.args:
-        return False
-    first_arg = call.args[0]
-    if isinstance(first_arg, ast.Constant) and isinstance(first_arg.value, str):
-        return first_arg.value == expected_op_name
-    if isinstance(first_arg, ast.Name):
-        return bindings.get(first_arg.id) == expected_op_name
-    return False
-
-
-def _op_classes_benchmarked(tree: ast.Module, known_ops: set) -> tuple[set[str], bool]:
-    """Op classes the file's ``ManifestBenchmark`` calls wrap, and whether all resolved.
-
-    Benchmarks are written one way: the test builds its op and hands it over, so the
-    op argument is ``N(...)``, or a name the enclosing function assigns once to
-    ``N(...)``. Those two shapes resolve. Anything else — a factory, a loop variable,
-    a name assigned twice — does not, and an unresolved call fails the check rather
-    than falling back: the benchmark is not written the way the check reads, and the
-    fix is to write it that way.
-
-    Returns:
-        The resolved class names, and whether every ``ManifestBenchmark`` call in the
-        file resolved. A file with no such call reports ``True``: it satisfies the
-        roofline half another way, which is what the caller falls back on.
+    Either ``load_workloads`` from ``tileops.manifest`` or the
+    ``workloads_to_params`` wrapper in ``benchmarks.benchmark_base``, imported
+    and called. Which op it names is a run-time fact, checked against a
+    benchmark run by ``scripts/check_bench_coverage.py``, never against the
+    source: a bench file may reach its op through a loop, a factory or a
+    helper, and none of those shapes is worse than a literal.
     """
-    resolved: set[str] = set()
-    all_resolved = True
-
-    def assigned_class(name: str, scopes: list) -> "str | None":
-        """The class *name* is assigned, when one scope assigns it exactly once."""
-        for body in scopes:
-            assigns = [
-                node
-                for node in ast.walk(ast.Module(body=body, type_ignores=[]))
-                if isinstance(node, ast.Assign)
-                and any(isinstance(t, ast.Name) and t.id == name for t in node.targets)
-            ]
-            if not assigns:
-                continue
-            if len(assigns) != 1:
-                return None
-            value = assigns[0].value
-            if isinstance(value, ast.Call) and isinstance(value.func, ast.Name):
-                return value.func.id
-            return None
-        return None
-
-    def visit(node: ast.AST, scopes: list) -> None:
-        nonlocal all_resolved
-        for child in ast.iter_child_nodes(node):
-            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
-                visit(child, [child.body] + scopes)
-                continue
-            if (
-                isinstance(child, ast.Call)
-                and isinstance(child.func, ast.Name)
-                and child.func.id == "ManifestBenchmark"
-                and child.args
-            ):
-                arg = child.args[0]
-                if isinstance(arg, ast.Call) and isinstance(arg.func, ast.Name):
-                    name = arg.func.id
-                elif isinstance(arg, ast.Name):
-                    name = assigned_class(arg.id, scopes)
-                else:
-                    name = None
-                if name in known_ops:
-                    resolved.add(name)
-                else:
-                    all_resolved = False
-            visit(child, scopes)
-
-    visit(tree, [tree.body])
-    return resolved, all_resolved
-
-
-def _file_builds_class(tree: ast.Module, op_name: str) -> bool:
-    """Whether the file constructs *op_name*.
-
-    The tie for a file with its own ``BenchmarkBase`` subclass, which takes its op
-    somewhere this check does not read. Importing the class is not enough: a file
-    imports what it names in a type hint or a comparison too.
-    """
-    return any(
-        isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == op_name
-        for node in ast.walk(tree)
-    )
-
-
-def _ast_manifest_call_usage(
-    tree: ast.Module,
-    op_name: str,
-    target_names: set[str],
-    known_ops: set,
-) -> dict[str, bool]:
-    """Check whether target functions are imported and used for this op.
-
-    ``load_workloads`` matches on the op name it is called with, directly or
-    through ``workloads_to_params``. ``eval_roofline`` matches on the op class a
-    ``ManifestBenchmark`` call wraps; where no call in the file resolves to a
-    class, on the file naming that class.
-    """
-    # Maps from the indirect helper name → the direct target it satisfies.
-    # workloads_to_params wraps load_workloads and carries the same op-name argument.
-    # ManifestBenchmark is not here: it no longer takes a name, and the op it wraps is
-    # read by _op_classes_benchmarked instead.
-    _INDIRECT_EQUIV: dict[str, str] = {"workloads_to_params": "load_workloads"}
-
-    imported: set[str] = set()
-    matched_calls: set[str] = set()
-    direct_roofline = False
-    bindings = _resolve_constant_str_bindings(tree)
-
+    imported = False
+    called = False
     for node in ast.walk(tree):
-        if isinstance(node, ast.ImportFrom):
-            if node.module == "tileops.manifest" and node.names:
-                for alias in node.names:
-                    if alias.name in target_names:
-                        imported.add(alias.name)
-            # Indirect helpers live in benchmarks.benchmark_base.
-            if node.module == "benchmarks.benchmark_base" and node.names:
-                for alias in node.names:
-                    equiv = _INDIRECT_EQUIV.get(alias.name)
-                    if equiv and equiv in target_names:
-                        imported.add(equiv)
+        if isinstance(node, ast.ImportFrom) and node.names:
+            module_targets = {
+                "tileops.manifest": "load_workloads",
+                "benchmarks.benchmark_base": "workloads_to_params",
+            }
+            target = module_targets.get(node.module or "")
+            if target and any(alias.name == target for alias in node.names):
+                imported = True
         elif isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
-            func_name = node.func.id
-            # Direct call (load_workloads).
-            if func_name in target_names and _call_uses_expected_op_name(
-                node,
-                op_name,
-                bindings,
-            ):
-                matched_calls.add(func_name)
-            # Indirect call (workloads_to_params).
-            equiv = _INDIRECT_EQUIV.get(func_name)
-            if (
-                equiv
-                and equiv in target_names
-                and _call_uses_expected_op_name(
-                    node,
-                    op_name,
-                    bindings,
-                )
-            ):
-                matched_calls.add(equiv)
-        elif (
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Attribute)
-            and node.func.attr == "eval_roofline"
-            and "eval_roofline" in target_names
-        ):
-            direct_roofline = True
-
-    if "eval_roofline" in target_names:
-        # The roofline half ties to the op the benchmark wraps. A call this check cannot
-        # read fails; only a file with no such call at all — its own BenchmarkBase
-        # subclass — ties by building the op instead.
-        resolved, all_resolved = _op_classes_benchmarked(tree, known_ops)
-        ties = op_name in resolved or (
-            all_resolved and not resolved and direct_roofline and _file_builds_class(tree, op_name)
-        )
-        if ties:
-            imported.add("eval_roofline")
-            matched_calls.add("eval_roofline")
-
-    return {name: (name in imported and name in matched_calls) for name in target_names}
+            if node.func.id in ("load_workloads", "workloads_to_params"):
+                called = True
+    return imported and called
 
 
-def check_l4_benchmark(
-    op_name: str,
-    bench_path: str,
-    repo_root: Path,
-    known_ops: set,
-) -> list[str]:
-    """Check that the benchmark file uses manifest workloads and op roofline.
+def _reads_op_roofline(tree: ast.Module) -> bool:
+    """Whether the file takes its roofline off an Op, not off its own arithmetic.
+
+    ``<expr>.eval_roofline()`` directly, or a ``ManifestBenchmark`` — which
+    reads the roofline off the op it wraps — imported and constructed.
+    """
+    imported = False
+    called = False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == "benchmarks.benchmark_base":
+            if any(alias.name == "ManifestBenchmark" for alias in node.names):
+                imported = True
+        elif isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name) and node.func.id == "ManifestBenchmark":
+                called = True
+            elif isinstance(node.func, ast.Attribute) and node.func.attr == "eval_roofline":
+                return True
+    return imported and called
+
+
+def check_l4_benchmark(op_name: str, bench_path: str, repo_root: Path) -> list[str]:
+    """Check that the benchmark file obeys the benchmark contract.
 
     Uses Python AST parsing (no execution) to verify actual import and usage,
     rather than raw substring matching which can be fooled by comments.
+
+    This is a property of the file: its workloads come from the manifest and
+    its roofline comes from the op. Which manifest entry the file benchmarks is
+    a separate question, answered from a run's report by
+    ``scripts/check_bench_coverage.py``.
 
     Returns a list of hard validation errors.
     """
@@ -3724,28 +3582,23 @@ def check_l4_benchmark(
         errors.append(f"[bench] {op_name}: bench file not found: {bench_path}")
         return errors
 
-    content = full_path.read_text(encoding="utf-8")
-
     try:
-        tree = ast.parse(content, filename=bench_path)
+        tree = ast.parse(full_path.read_text(encoding="utf-8"), filename=bench_path)
     except SyntaxError as exc:
         errors.append(f"[bench] {op_name}: bench file {bench_path} has syntax error: {exc}")
         return errors
 
-    targets = {"load_workloads", "eval_roofline"}
-    usage = _ast_manifest_call_usage(tree, op_name, targets, known_ops)
-
-    if not usage["load_workloads"]:
+    if not _reads_manifest_workloads(tree):
         errors.append(
-            f"[bench] {op_name}: bench file {bench_path} must import "
-            f"load_workloads from tileops.manifest and call it with op name {op_name!r}"
+            f"[bench] {op_name}: bench file {bench_path} must import and call "
+            "load_workloads from tileops.manifest, or workloads_to_params from "
+            "benchmarks.benchmark_base"
         )
-    if not usage["eval_roofline"]:
+    if not _reads_op_roofline(tree):
         errors.append(
-            f"[bench] {op_name}: bench file {bench_path} must hand a {op_name} to "
-            f"ManifestBenchmark — built in the call, or assigned once in the test: "
-            f"op = {op_name}(...); ManifestBenchmark(op, workload). A file with its own "
-            f"BenchmarkBase subclass names {op_name} instead"
+            f"[bench] {op_name}: bench file {bench_path} must take its roofline "
+            "off the op — eval_roofline() on an Op instance, or a "
+            "ManifestBenchmark construction"
         )
     return errors
 
@@ -4360,7 +4213,7 @@ def validate_manifest(
             all_errors.extend(check_bench_declaration(op_name, entry))
             bench_path = entry.get("source", {}).get("bench", "")
             if bench_path:
-                bench_errors = check_l4_benchmark(op_name, bench_path, repo_root, set(ops))
+                bench_errors = check_l4_benchmark(op_name, bench_path, repo_root)
                 if _is_bench_manifest_driven(entry):
                     all_errors.extend(bench_errors)
                 else:

--- a/tests/test_check_bench_coverage.py
+++ b/tests/test_check_bench_coverage.py
@@ -1,0 +1,163 @@
+"""The benchmark-coverage gate's verdicts.
+
+Which op a bench file measured is read out of a run's JUnit report, so the
+cases here are reports: one per state a declared benchmark can be in.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.smoke
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+_spec = importlib.util.spec_from_file_location(
+    "check_bench_coverage", REPO_ROOT / "scripts" / "check_bench_coverage.py"
+)
+coverage = importlib.util.module_from_spec(_spec)
+sys.modules["check_bench_coverage"] = coverage
+_spec.loader.exec_module(coverage)
+
+MANIFEST = {
+    "FooOp": {"status": "implemented", "source": {"bench": "benchmarks/ops/bench_foo.py"}},
+    "BarOp": {"status": "implemented", "source": {"bench": "benchmarks/ops/bench_foo.py"}},
+    "SpecOp": {"status": "spec-only", "source": {"bench": "benchmarks/ops/bench_foo.py"}},
+    "NoBenchOp": {"status": "implemented", "source": {}},
+}
+
+
+def _report(tmp_path: Path, *testcases: str) -> Path:
+    """A JUnit report whose testcases all belong to ``bench_foo``."""
+    body = "".join(testcases)
+    path = tmp_path / "bench_results.xml"
+    path.write_text(f'<?xml version="1.0"?><testsuites><testsuite>{body}</testsuite></testsuites>')
+    return path
+
+
+def _passed(name: str, op: str | None = None, classname: str = "benchmarks.ops.bench_foo") -> str:
+    """A passing testcase; *op* may name several ops the case benchmarked."""
+    props = ""
+    if op:
+        first = op.split(",")[0]
+        props = (
+            "<properties>"
+            f'<property name="op" value="{first}"/>'
+            f'<property name="ops" value="{op}"/>'
+            "</properties>"
+        )
+    return f'<testcase classname="{classname}" name="{name}">{props}</testcase>'
+
+
+def _skipped(name: str, message: str) -> str:
+    return (
+        f'<testcase classname="benchmarks.ops.bench_foo" name="{name}">'
+        f'<skipped message="{message}"/></testcase>'
+    )
+
+
+def _failed(name: str, message: str, tag: str = "failure") -> str:
+    return (
+        f'<testcase classname="benchmarks.ops.bench_foo" name="{name}">'
+        f'<{tag} message="{message}"/></testcase>'
+    )
+
+
+def _verdicts(path: Path) -> dict[str, str]:
+    rows = coverage.verdicts(coverage.parse_run(path), MANIFEST)
+    return {op: verdict for op, _, verdict, _ in rows}
+
+
+class TestVerdicts:
+    """One case per state of the table in scripts/check_bench_coverage.py."""
+
+    def test_recorded_op_passes_and_an_unrecorded_sibling_fails(self, tmp_path):
+        """A green file that never records an op it is declared for is the gap."""
+        path = _report(tmp_path, _passed("test_foo", op="FooOp"), _passed("test_other"))
+        assert _verdicts(path) == {"FooOp": coverage.OK, "BarOp": coverage.FAIL}
+
+    def test_a_failing_testcase_leaves_no_verdict(self, tmp_path):
+        """The benchmark job's own exit code already reports a failed run."""
+        for tag in ("failure", "error"):
+            path = _report(
+                tmp_path, _passed("test_foo", op="FooOp"), _failed("test_bar", "boom", tag)
+            )
+            assert _verdicts(path)["BarOp"] == coverage.NO_VERDICT
+
+    def test_all_skipped_states_its_reason(self, tmp_path):
+        path = _report(tmp_path, _skipped("test_foo", "flag_gems missing"))
+        assert _verdicts(path) == {"FooOp": coverage.SKIPPED, "BarOp": coverage.SKIPPED}
+
+    def test_a_skip_beside_a_pass_is_not_a_gap(self, tmp_path):
+        """A skipped testcase carries no op name, so it could have been this one.
+
+        27 bench files are shared by several ops; a sibling passing there says
+        nothing about the op whose case was skipped.
+        """
+        path = _report(
+            tmp_path,
+            _passed("test_foo", op="FooOp"),
+            _skipped("test_bar", "bar dependency missing"),
+        )
+        assert _verdicts(path) == {"FooOp": coverage.OK, "BarOp": coverage.SKIPPED}
+
+    def test_a_file_absent_from_the_report_never_ran(self, tmp_path):
+        path = _report(
+            tmp_path, _passed("test_x", op="OtherOp", classname="benchmarks.ops.bench_x")
+        )
+        assert _verdicts(path) == {"FooOp": coverage.NOT_RUN, "BarOp": coverage.NOT_RUN}
+
+    def test_a_class_holds_its_testcases_for_the_module(self, tmp_path):
+        """pytest names a test inside a class ``module.ClassName``."""
+        path = _report(
+            tmp_path,
+            _passed("test_foo", op="FooOp", classname="benchmarks.ops.bench_foo.TestFoo"),
+            _passed("test_bar", op="BarOp", classname="benchmarks.ops.bench_foo.TestBar"),
+        )
+        assert _verdicts(path) == {"FooOp": coverage.OK, "BarOp": coverage.OK}
+
+    def test_one_testcase_may_benchmark_several_ops(self, tmp_path):
+        """``op`` alone names the first; the gate reads them all off ``ops``."""
+        path = _report(tmp_path, _passed("test_both", op="BarOp,FooOp"))
+        assert _verdicts(path) == {"FooOp": coverage.OK, "BarOp": coverage.OK}
+
+    def test_a_report_without_the_ops_property_still_attributes(self, tmp_path):
+        """A report predating ``ops`` carries ``op`` only."""
+        case = (
+            '<testcase classname="benchmarks.ops.bench_foo" name="test_foo">'
+            '<properties><property name="op" value="FooOp"/></properties></testcase>'
+        )
+        path = _report(tmp_path, case)
+        assert _verdicts(path)["FooOp"] == coverage.OK
+
+    def test_only_implemented_ops_declaring_a_bench_are_expected(self, tmp_path):
+        """A spec-only op and an op without a bench pointer are not rows."""
+        path = _report(tmp_path, _passed("test_foo", op="FooOp"))
+        assert set(_verdicts(path)) == {"FooOp", "BarOp"}
+
+
+class TestExitCodes:
+    """An audit that reached no conclusion must not read as a passed one."""
+
+    def test_exit_codes_follow_the_worst_verdict(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setattr(coverage, "load_manifest", lambda: MANIFEST)
+
+        gap = _report(tmp_path, _passed("test_foo", op="FooOp"))
+        assert coverage.main(["--bench-xml", str(gap)]) == coverage.EXIT_GAP
+
+        covered = _report(
+            tmp_path, _passed("test_foo", op="FooOp"), _passed("test_bar", op="BarOp")
+        )
+        out = tmp_path / "coverage.md"
+        assert (
+            coverage.main(["--bench-xml", str(covered), "--output", str(out)]) == coverage.EXIT_OK
+        )
+        assert "2 OK" in out.read_text()
+
+    @pytest.mark.parametrize("content", [None, "<testsuites><broken"])
+    def test_a_missing_or_unusable_report_is_not_a_pass(self, tmp_path, content):
+        path = tmp_path / "bench_results.xml"
+        if content is not None:
+            path.write_text(content)
+        assert coverage.main(["--bench-xml", str(path)]) == coverage.EXIT_NO_REPORT

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -2641,12 +2641,13 @@ class TestRequiredParamWitness:
 
 # Bench checks
 class TestBench:
-    """bench checks that bench files use manifest workloads and op roofline.
+    """bench checks that a bench file obeys the benchmark contract.
 
-    Case table: direct (``load_workloads`` + ``op.eval_roofline()``) and
-    indirect (``benchmarks.benchmark_base`` helpers) usage passes; missing
-    helpers, wrong op names, and syntax errors fail with the named
-    diagnostics. Rows with ``None`` expect a clean pass.
+    Workloads come from the manifest and the roofline comes from the op. Which
+    op the file benchmarks is a run-time fact, checked against a benchmark run
+    by ``scripts/check_bench_coverage.py``, so no case here names an op: a file
+    reaching its op through a loop, a factory or a helper is as good as one
+    naming it.
     """
 
     def test_bench_file_usage_matrix(self, validator, tmp_path):
@@ -2655,71 +2656,38 @@ class TestBench:
             (
                 "ManifestBenchmark wrapping the declared op passes",
                 """\
-                from benchmarks.benchmark_base import workloads_to_params, ManifestBenchmark
-                from tileops.ops import TestFwdOp
-                params = workloads_to_params('TestFwdOp')
-                def test_bench():
-                    op = TestFwdOp()
-                    ManifestBenchmark(op, params[0])
+                from tileops.manifest import load_workloads
+                workloads = load_workloads('TestOp')
+                op.eval_roofline()
             """,
                 None,
             ),
             (
                 "direct load_workloads with the op built in the file passes",
                 """\
-                from tileops.manifest import load_workloads
-                from tileops.ops import TestFwdOp
-                workloads = load_workloads('TestFwdOp')
-                def test_bench():
-                    op = TestFwdOp()
-                    op.eval_roofline()
+                from benchmarks.benchmark_base import workloads_to_params, ManifestBenchmark
+                params = workloads_to_params('TestOp')
+                ManifestBenchmark(op, params[0])
             """,
                 None,
             ),
             (
-                "a factory-built op fails: the call is not written to the standard",
+                "an op reached through a loop passes",
                 """\
                 from benchmarks.benchmark_base import workloads_to_params, ManifestBenchmark
-                from tileops.ops import TestFwdOp
-                params = workloads_to_params('TestFwdOp')
-                def _make():
-                    return TestFwdOp()
-                def test_bench():
-                    op = _make()
-                    ManifestBenchmark(op, params[0])
+                for name, cls in FAMILY:
+                    params = workloads_to_params(name)
+                    ManifestBenchmark(cls(), params[0])
             """,
-                ["ManifestBenchmark"],
+                None,
             ),
             (
-                "wrapping another op fails even with the declared class imported",
-                """\
-                from benchmarks.benchmark_base import workloads_to_params, ManifestBenchmark
-                from tileops.ops import TestFwdOp, OtherFwdOp
-                params = workloads_to_params('TestFwdOp')
-                def test_bench():
-                    op = OtherFwdOp()
-                    ManifestBenchmark(op, params[0])
-            """,
-                ["ManifestBenchmark"],
-            ),
-            (
-                "eval_roofline reached while naming no class of the declared op fails",
+                "load_workloads without a roofline fails",
                 """\
                 from tileops.manifest import load_workloads
-                workloads = load_workloads('TestFwdOp')
-                def test_bench():
-                    op = build()
-                    op.eval_roofline()
+                workloads = load_workloads('TestOp')
             """,
-                ["ManifestBenchmark"],
-            ),
-            (
-                "load_workloads without eval_roofline fails",
-                """\
-                from tileops.manifest import load_workloads
-                workloads = load_workloads('TestFwdOp')
-            """,
-                ["ManifestBenchmark"],
+                ["roofline"],
             ),
             (
                 "no load_workloads fails",
@@ -2730,40 +2698,20 @@ class TestBench:
                 ["load_workloads"],
             ),
             (
-                "wrong op name fails (direct path)",
+                "importing the helpers without calling them fails",
                 """\
                 from tileops.manifest import load_workloads
-                from tileops.ops import TestFwdOp
-                workloads = load_workloads('OtherFwdOp')
-                def test_bench():
-                    op = TestFwdOp()
-                    op.eval_roofline()
+                from benchmarks.benchmark_base import ManifestBenchmark
+                shapes = [(1024, 4096)]
             """,
-                ["load_workloads"],
-            ),
-            (
-                "wrong op name fails (indirect path)",
-                """\
-                from benchmarks.benchmark_base import workloads_to_params, ManifestBenchmark
-                from tileops.ops import TestFwdOp
-                params = workloads_to_params('OtherFwdOp')
-                def test_bench():
-                    op = TestFwdOp()
-                    ManifestBenchmark(op, params[0])
-            """,
-                ["load_workloads"],
+                ["load_workloads", "roofline"],
             ),
             ("syntax error fails", "def broken(\n", ["syntax error"]),
         ]
         for desc, text, expected in cases:
             bench_file = tmp_path / "bench_test.py"
             bench_file.write_text(textwrap.dedent(text))
-            errors = validator.check_l4_benchmark(
-                "TestFwdOp",
-                str(bench_file),
-                REPO_ROOT,
-                {"TestFwdOp", "OtherFwdOp"},
-            )
+            errors = validator.check_l4_benchmark("TestOp", str(bench_file), REPO_ROOT)
             if expected is None:
                 assert errors == [], (desc, errors)
             else:
@@ -2771,87 +2719,6 @@ class TestBench:
                     assert any(substring in e for e in errors), (
                         f"{desc}: expected {substring!r} in errors, got: {errors}"
                     )
-
-    def test_l4_reads_only_the_standard_call_form(self, validator, tmp_path):
-        """A benchmark states its op by building it; L4 reads that and nothing else.
-
-        The two readable shapes are the op constructed in the call and a name the
-        test assigns once. A loop variable, a factory or a name assigned twice is
-        not a benchmark written to the standard, so it fails rather than falling
-        back on the file naming the class somewhere.
-        """
-        header = (
-            "from tileops.ops import TestFwdOp, OtherFwdOp\n"
-            "from benchmarks.benchmark_base import ManifestBenchmark, workloads_to_params\n"
-            "params = workloads_to_params('TestFwdOp')\n"
-        )
-        cases = [
-            (
-                "the standard form",
-                "def t():\n    op = TestFwdOp()\n    ManifestBenchmark(op, params)\n",
-                True,
-            ),
-            (
-                "constructed in the call",
-                "def t():\n    ManifestBenchmark(TestFwdOp(), params)\n",
-                True,
-            ),
-            (
-                "an attribute assignment is not a rebinding",
-                "def t():\n    op = TestFwdOp()\n    op.total_q = 3\n    ManifestBenchmark(op, params)\n",
-                True,
-            ),
-            (
-                "two tests keep their own op",
-                "def a():\n    op = TestFwdOp()\n    ManifestBenchmark(op, params)\ndef b():\n    op = OtherFwdOp()\n    ManifestBenchmark(op, params)\n",
-                True,
-            ),
-            (
-                "a file with its own benchmark class names the op",
-                "class B:\n    def f(self):\n        return self._op.eval_roofline()\ndef t():\n    op = TestFwdOp()\n",
-                True,
-            ),
-            (
-                "wrapping another op fails",
-                "def t():\n    op = OtherFwdOp()\n    ManifestBenchmark(op, params)\n",
-                False,
-            ),
-            (
-                "a name assigned twice fails",
-                "def t():\n    op = OtherFwdOp()\n    ManifestBenchmark(op, params)\n    op = TestFwdOp()\n",
-                False,
-            ),
-            (
-                "a loop variable fails",
-                "def t():\n    for op in [OtherFwdOp()]:\n        ManifestBenchmark(op, params)\n",
-                False,
-            ),
-            (
-                "a comprehension variable fails",
-                "def t():\n    xs = [ManifestBenchmark(op, params) for op in [OtherFwdOp()]]\n",
-                False,
-            ),
-            (
-                "a with-item target fails",
-                "def t():\n    with ctx(OtherFwdOp()) as op:\n        ManifestBenchmark(op, params)\n",
-                False,
-            ),
-            (
-                "a factory fails",
-                "def t():\n    op = _make()\n    ManifestBenchmark(op, params)\n",
-                False,
-            ),
-        ]
-        for desc, body, passes in cases:
-            bench_file = tmp_path / "bench_case.py"
-            bench_file.write_text(header + body)
-            errors = validator.check_l4_benchmark(
-                "TestFwdOp",
-                str(bench_file),
-                REPO_ROOT,
-                {"TestFwdOp", "OtherFwdOp"},
-            )
-            assert (errors == []) is passes, (desc, errors)
 
     # --check-op: force all levels on a specific op, ignoring status
 


### PR DESCRIPTION
Follows #2006. Finishes #2004.

## Problems

- L4 answers two questions from one source scan: the file's contract (workloads from the manifest, roofline from the op), and which op the file benchmarks. The second is a run-time fact.
- Answering it from the source means matching a marker. The marker is never compared with what the benchmark measured, and it makes the source's shape a condition of passing — a family loop, a factory or a parametrized helper fails L4 while benchmarking correctly.
- `bench_grouped_gemm.py` records its rows under layout aliases, so `GroupedGemmFwdOp` is absent from the report the nightly groups by op, and the rows lose `op_module` and the kernel config. The scan cannot see it: the file does construct that op.

## Changes

- L4 keeps the file's contract alone and matches no op name; the op-name scanning goes, with the test pinning its call-form rule.
- `benchmarks/conftest.py` records every op a testcase measured as its `ops` property; `op` named only the first `tileops*` row.
- New `scripts/check_bench_coverage.py` reads those off `bench_results.xml` and fails a bench file that passed without benchmarking the op it is declared for. The nightly benchmark job runs it with `if: always()`, uploads `bench_coverage.md`, and fails on its exit code. Its tests run in preflight's compile-contract gate.
- `bench_grouped_gemm.py` records `record_as=op`, layout in the row's params. Perf history for those four rows restarts under the op's name.

| State of the declared bench file in the report | Verdict | Fails |
| --- | --- | --- |
| some testcase recorded this op | OK | no |
| every testcase passed, none recorded this op | FAIL | yes |
| some testcase failed, errored or was skipped, none recorded this op | NO VERDICT / SKIPPED | no — the job's exit code reports it |
| no testcases, or the file absent | NOT RUN | no |
| the report missing or unparseable | — | yes |

A failed or skipped testcase carries no op name, so a file holding one accuses none of the ops it did not record; 27 bench files are shared by several ops.

Cost: a wrong-op benchmark now fails a night later instead of at PR stage, and L4's 66 deleted lines are replaced by 377 in the gate and its tests. What the gate gets wrong, it gets wrong by reporting a gap, not by passing a benchmark that measured nothing.