### PR TITLE
[CI][Bench] Publish the nightly snapshot to TileOPs-nightly, with the image that produced it

### DIFF
--- a/.github/runner/README.md
+++ b/.github/runner/README.md
@@ -48,6 +48,18 @@ docker push "$IMG"
 **Point the runners at the new tag** — a maintainer task outside this repository. Merging a
 TileOPs PR only changes the recipe; the live runners keep their image until this happens.
 
+**Pass the digest to the runner.** The tag is a moving name; the digest is what identifies the
+image a night's numbers were produced on, and a container cannot read its own. The host that
+starts the runner reads it once and passes it in:
+
+```bash
+DIGEST="$(docker image inspect "$IMG" --format '{{index .RepoDigests 0}}')"
+docker run ... -e TILEOPS_RUNNER_IMAGE="$IMG" -e TILEOPS_RUNNER_IMAGE_DIGEST="${DIGEST#*@}" ...
+```
+
+`scripts/ci/collect_env.py` records it, and the published `meta.json` carries it beside the tag.
+Without it the nightly still publishes; the snapshot simply cannot say which image it ran on.
+
 What the flags are for:
 
 - `--user root` — `final` runs as `ci-runner`, which cannot write the editable install's

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -396,8 +396,10 @@ jobs:
     if: ${{ always() && github.repository == 'tile-ai/TileOPs' && (github.event_name == 'schedule' || github.ref == 'refs/heads/main') }}
     needs: [op_test]
     runs-on: ubuntu-latest
+    # Nothing is written to this repository any more: the data goes to
+    # TileOPs-nightly under a token of its own, and GITHUB_TOKEN only reads.
     permissions:
-      contents: write
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -448,15 +450,27 @@ jobs:
           echo "ok=${ok}" >> "$GITHUB_OUTPUT"
         shell: bash
 
-      - name: Publish to nightly-bench branch
+      # The only place the data is published. `nightly-bench` in this
+      # repository was rewritten every night and held no history; keeping the
+      # history there would cost 314 KB a night packed, 112 MB a year against a
+      # 9 MB repository that everyone clones. TileOPs-nightly carries one
+      # commit per night, and its size is nobody's clone cost.
+      #
+      # Failing here fails the job: this is the publish, not a copy of it.
+      - name: Publish the snapshot to TileOPs-nightly
         if: ${{ steps.assemble.outputs.ok == '1' }}
         uses: peaceiris/actions-gh-pages@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: nightly-bench
+          # Fine-grained PAT, `contents: write` on tile-ai/TileOPs-nightly and
+          # nothing else. GITHUB_TOKEN cannot reach another repository.
+          personal_token: ${{ secrets.BENCH_ARCHIVE_TOKEN }}
+          external_repository: tile-ai/TileOPs-nightly
+          publish_branch: main
           publish_dir: _publish
-          force_orphan: true
-          commit_message: "chore(bench): nightly benchmark data from ${{ github.sha }}"
+          # Three files, and no fourth: the action writes .nojekyll by default,
+          # which means nothing to a repository that serves no pages.
+          disable_nojekyll: true
+          full_commit_message: "bench: ${{ github.sha }} (run ${{ github.run_id }})"
           user_name: "github-actions[bot]"
           user_email: "41898282+github-actions[bot]@users.noreply.github.com"
 

--- a/scripts/ci/collect_env.py
+++ b/scripts/ci/collect_env.py
@@ -15,17 +15,46 @@ import sys
 HERE = os.path.dirname(os.path.abspath(__file__))
 
 
-def _driver() -> str | None:
+# What the card was set to, beside what it is: a run at a lower power cap or
+# clock is a different measurement, and nothing else in the snapshot says so.
+_GPU_FIELDS = (
+    ("driver", "driver_version"),
+    ("power_limit_w", "power.limit"),
+    ("sm_clock_mhz", "clocks.applications.graphics"),
+    ("memory_clock_mhz", "clocks.applications.memory"),
+    ("mig", "mig.mode.current"),
+)
+
+
+def _gpu_state() -> dict:
+    """What nvidia-smi reports for card 0. A field it cannot answer is dropped."""
+    query = ",".join(field for _, field in _GPU_FIELDS)
     try:
         out = subprocess.run(
-            ["nvidia-smi", "--query-gpu=driver_version", "--format=csv,noheader,nounits"],
+            ["nvidia-smi", f"--query-gpu={query}", "--format=csv,noheader,nounits", "-i", "0"],
             capture_output=True,
             text=True,
             timeout=10,
         )
     except (FileNotFoundError, subprocess.TimeoutExpired):
-        return None
-    return out.stdout.splitlines()[0].strip() if out.returncode == 0 else None
+        return {}
+    if out.returncode != 0 or not out.stdout.strip():
+        return {}
+    values = [v.strip() for v in out.stdout.splitlines()[0].split(",")]
+    if len(values) != len(_GPU_FIELDS):
+        print(
+            f"collect_env: nvidia-smi answered {len(values)} of "
+            f"{len(_GPU_FIELDS)} fields; card state not recorded",
+            file=sys.stderr,
+        )
+        return {}
+    state = {}
+    for (name, _), value in zip(_GPU_FIELDS, values, strict=True):
+        # `[N/A]` — an unset clock, an unsupported field — is not a fact.
+        if not value or value.startswith("[") or value == "N/A":
+            continue
+        state[name] = float(value) if name.endswith(("_w", "_mhz")) else value
+    return state
 
 
 def collect() -> dict:
@@ -33,6 +62,11 @@ def collect() -> dict:
     image = os.environ.get("TILEOPS_RUNNER_IMAGE", "").strip()
     if image:
         env["image"] = image
+    # A tag can be pushed again; the digest cannot. A container cannot read its
+    # own, so the host passes it in — see .github/runner/README.md.
+    digest = os.environ.get("TILEOPS_RUNNER_IMAGE_DIGEST", "").strip()
+    if digest:
+        env["image_digest"] = digest
 
     try:
         import torch
@@ -55,9 +89,7 @@ def collect() -> dict:
     except ImportError:
         pass
 
-    driver = _driver()
-    if driver:
-        env["driver"] = driver
+    env.update(_gpu_state())
 
     # Every installed distribution, not a chosen few: which library matters to
     # a number is the reader's question, and a list written here would answer it
@@ -84,7 +116,9 @@ def main() -> int:
     env = collect()
     json.dump(env, sys.stdout, indent=2, sort_keys=True)
     sys.stdout.write("\n")
-    missing = [k for k in ("image", "gpu", "driver", "cuda", "torch") if k not in env]
+    missing = [
+        k for k in ("image", "image_digest", "gpu", "driver", "cuda", "torch") if k not in env
+    ]
     if missing:
         print("collect_env: not recorded: " + ", ".join(missing), file=sys.stderr)
     return 0

--- a/scripts/ci/publish_meta.py
+++ b/scripts/ci/publish_meta.py
@@ -2,8 +2,7 @@
 """Write the meta.json that captions a published benchmark snapshot.
 
 The docs site reads it for the commit, the run, and the environment the
-benchmark job recorded. A missing environment stays missing.
-"""
+benchmark job recorded. A missing environment stays missing."""
 
 import argparse
 import contextlib

--- a/tests/test_bench_snapshot_meta.py
+++ b/tests/test_bench_snapshot_meta.py
@@ -1,0 +1,66 @@
+"""What captions a published benchmark snapshot.
+
+Nothing else checks it: the nightly runs once a night on a self-hosted GPU, and
+a mistake here does not fail, it publishes the wrong facts. One end-to-end pass
+— read the machine, write the caption, read it back — over synthetic input.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.smoke
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "ci"))
+
+import collect_env  # noqa: E402
+
+PUBLISH = REPO_ROOT / "scripts" / "ci" / "publish_meta.py"
+
+
+def test_the_caption_carries_what_the_run_cannot_be_reproduced_without(tmp_path, monkeypatch):
+    # The host passes the digest in, and the unset application clock reports
+    # `[N/A]` — which must not reach the page.
+    monkeypatch.setenv("TILEOPS_RUNNER_IMAGE", "ghcr.io/tile-ai/tileops-runner:cu132")
+    monkeypatch.setenv("TILEOPS_RUNNER_IMAGE_DIGEST", "sha256:" + "ab" * 32)
+    monkeypatch.setattr(
+        collect_env.subprocess,
+        "run",
+        lambda *a, **k: subprocess.CompletedProcess(
+            [], 0, stdout="595.71.05, 700.00, [N/A], 2619, Disabled\n", stderr=""
+        ),
+    )
+    env = tmp_path / "env.json"
+    env.write_text(json.dumps(collect_env.collect()))
+    # `collect_env.subprocess` is the module itself: the patch would reach the
+    # publisher below too.
+    monkeypatch.undo()
+
+    out = tmp_path / "meta.json"
+    subprocess.run(
+        [
+            sys.executable,
+            str(PUBLISH),
+            "--env-json",
+            str(env),
+            "--commit",
+            "abcdef1",
+            "--run-id",
+            "42",
+            "--date",
+            "2026-01-01",
+            "--out",
+            str(out),
+        ],
+        check=True,
+    )
+
+    environment = json.loads(out.read_text())["environment"]
+    assert environment["image_digest"] == "sha256:" + "ab" * 32
+    assert environment["power_limit_w"] == 700.0
+    assert environment["memory_clock_mhz"] == 2619.0
+    assert "sm_clock_mhz" not in environment


### PR DESCRIPTION
## Problems

- `nightly-bench` is an orphan branch rebuilt every run: tonight's snapshot, no history. A number published today cannot be reproduced tomorrow.
- The image is recorded by tag, and a tag can be pushed again under the same name.
- What the card was set to — power cap, clocks, MIG — is not recorded at all. A run at a lower cap is a different measurement.

## Changes

- Publish to **tile-ai/TileOPs-nightly**, one commit per run, README included so the target's contents are wholly this repository's to write. It is the publish, not a copy of one, so a failure fails the job.
- The token is a fine-grained PAT scoped to that repository alone and reaches only the step that needs it; `GITHUB_TOKEN` drops to `contents: read`.
- `collect_env.py` records `image_digest`, passed in by the host (a container cannot read its own) — the runner README documents the one line that reads it.
- `_driver()` becomes `_gpu_state()`: one `nvidia-smi` query for the driver, power cap, application clocks and MIG. `[N/A]` is dropped; a short answer records nothing rather than pairing a clock with a driver.
- One test: read the machine, write the caption, read back what a run cannot be reproduced without.

## Why a separate repository

Measured: 30 commits of a real snapshot, numbers jittered, `gc --aggressive` — **314 KB a night**, 112 MB a year against a 9 MB repository everyone clones. A slimmed JSON record costs 281 KB, so trimming the payload does not help: the entropy is in the numbers.

## Before merging

`BENCH_ARCHIVE_TOKEN` is set and verified: it can push to `TileOPs-nightly` and is refused everywhere else.

Then: run the nightly once, merge tile-ai/TileOPs.github.io#39, delete `nightly-bench`.

## Open question

`on:` carries only `workflow_dispatch` while the job conditions still test `event_name == 'schedule'`. If deliberate, the docs site's daily refresh is re-deploying the same snapshot every day and should change instead.