### PR TITLE
[CI][Bench] Publish to the snapshots branch, not over the repository

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -396,8 +396,7 @@ jobs:
     if: ${{ always() && github.repository == 'tile-ai/TileOPs' && (github.event_name == 'schedule' || github.ref == 'refs/heads/main') }}
     needs: [op_test]
     runs-on: ubuntu-latest
-    # Nothing is written to this repository any more: the data goes to
-    # TileOPs-nightly under a token of its own, and GITHUB_TOKEN only reads.
+    # The data goes elsewhere now, under a token of its own.
     permissions:
       contents: read
     steps:
@@ -450,25 +449,22 @@ jobs:
           echo "ok=${ok}" >> "$GITHUB_OUTPUT"
         shell: bash
 
-      # The only place the data is published. `nightly-bench` in this
-      # repository was rewritten every night and held no history; keeping the
-      # history there would cost 314 KB a night packed, 112 MB a year against a
-      # 9 MB repository that everyone clones. TileOPs-nightly carries one
-      # commit per night, and its size is nobody's clone cost.
-      #
-      # Failing here fails the job: this is the publish, not a copy of it.
+      # One commit per run, kept. On a branch of this repository the history
+      # would cost 314 KB a night packed — 112 MB a year against a 9 MB
+      # repository that everyone clones.
       - name: Publish the snapshot to TileOPs-nightly
         if: ${{ steps.assemble.outputs.ok == '1' }}
         uses: peaceiris/actions-gh-pages@v4
         with:
-          # Fine-grained PAT, `contents: write` on tile-ai/TileOPs-nightly and
-          # nothing else. GITHUB_TOKEN cannot reach another repository.
+          # GITHUB_TOKEN cannot reach another repository.
           personal_token: ${{ secrets.BENCH_ARCHIVE_TOKEN }}
           external_repository: tile-ai/TileOPs-nightly
-          publish_branch: main
+          # Not main: that branch is the repository's own. Everything not in
+          # _publish is deleted here, so a stale test_results.xml cannot pass
+          # for tonight's.
+          publish_branch: snapshots
           publish_dir: _publish
-          # Three files, and no fourth: the action writes .nojekyll by default,
-          # which means nothing to a repository that serves no pages.
+          # The action writes .nojekyll otherwise, which means nothing here.
           disable_nojekyll: true
           full_commit_message: "bench: ${{ github.sha }} (run ${{ github.run_id }})"
           user_name: "github-actions[bot]"

--- a/scripts/ci/collect_env.py
+++ b/scripts/ci/collect_env.py
@@ -15,8 +15,8 @@ import sys
 HERE = os.path.dirname(os.path.abspath(__file__))
 
 
-# What the card was set to, beside what it is: a run at a lower power cap or
-# clock is a different measurement, and nothing else in the snapshot says so.
+# What the card was set to: a run at a lower cap or clock is a different
+# measurement, and nothing else in the snapshot says so.
 _GPU_FIELDS = (
     ("driver", "driver_version"),
     ("power_limit_w", "power.limit"),
@@ -62,8 +62,8 @@ def collect() -> dict:
     image = os.environ.get("TILEOPS_RUNNER_IMAGE", "").strip()
     if image:
         env["image"] = image
-    # A tag can be pushed again; the digest cannot. A container cannot read its
-    # own, so the host passes it in — see .github/runner/README.md.
+    # A tag can be pushed again; the digest cannot. A container cannot read
+    # its own, so the host passes it in.
     digest = os.environ.get("TILEOPS_RUNNER_IMAGE_DIGEST", "").strip()
     if digest:
         env["image_digest"] = digest

--- a/tests/test_bench_snapshot_meta.py
+++ b/tests/test_bench_snapshot_meta.py
@@ -23,8 +23,7 @@ PUBLISH = REPO_ROOT / "scripts" / "ci" / "publish_meta.py"
 
 
 def test_the_caption_carries_what_the_run_cannot_be_reproduced_without(tmp_path, monkeypatch):
-    # The host passes the digest in, and the unset application clock reports
-    # `[N/A]` — which must not reach the page.
+    # An unset application clock reports `[N/A]`, which must not reach the page.
     monkeypatch.setenv("TILEOPS_RUNNER_IMAGE", "ghcr.io/tile-ai/tileops-runner:cu132")
     monkeypatch.setenv("TILEOPS_RUNNER_IMAGE_DIGEST", "sha256:" + "ab" * 32)
     monkeypatch.setattr(
@@ -36,7 +35,7 @@ def test_the_caption_carries_what_the_run_cannot_be_reproduced_without(tmp_path,
     )
     env = tmp_path / "env.json"
     env.write_text(json.dumps(collect_env.collect()))
-    # `collect_env.subprocess` is the module itself: the patch would reach the
+    # `collect_env.subprocess` is the module: the patch would reach the
     # publisher below too.
     monkeypatch.undo()
 


### PR DESCRIPTION
Follows #2008. Pairs with tile-ai/TileOPs.github.io#40; either order is safe.

## Problem

The publish replaces everything in the branch it writes. Pointed at `main`, the first run deleted TileOPs-nightly's README and licence — those belong to whoever maintains that repository, not to this job.

## Change

The snapshot goes to a `snapshots` branch of its own: one commit per run, three files, and everything not in the payload deleted there — which is what keeps a stale `test_results.xml` from passing for tonight's. `main` holds what the repository says about itself, and nothing publishes over it.

The branch already carries the snapshot from run 33289823876, and TileOPs-nightly's `main` has been restored.