### PR TITLE
[Perf][foundry][RoPE] Rotate a neox pair per thread, round once, and count invalid positions in the kernel

### DIFF
--- a/src/tileops/kernels/rope.py
+++ b/src/tileops/kernels/rope.py
@@ -208,8 +208,8 @@ def _make_rope_neox_position_ids_thd(
     A thread owns the pair ``(c, c + half)`` a neox rotation couples, so ``x`` is
     read once and both of its outputs leave in the same step: the walked space is
     the rotated half, not the head. Where ``rotary_dim < head_dim`` a second walk
-    copies the columns past it. The arithmetic stays in the storage dtype, which
-    is what ``GQAPrefillPagedWithKVCacheRopeAppendKernel`` is compared against.
+    copies the columns past it. The rotation runs in f32 and rounds once, at the
+    store into ``y``.
     """
     half = rotary_dim // 2
     token_stride = num_heads * head_dim
@@ -239,12 +239,12 @@ def _make_rope_neox_position_ids_thd(
                         col = pair_idx % half
                         pos = position_ids[row // num_heads]
                         low = row * head_dim + col
-                        x_low = x[low]
-                        x_high = x[low + half]
-                        c = cos_table[pos, col]
-                        s = sin_table[pos, col]
-                        y[low] = x_low * c + (-x_high) * s
-                        y[low + half] = x_high * c + x_low * s
+                        x_low = T.Cast("float32", x[low])
+                        x_high = T.Cast("float32", x[low + half])
+                        c = T.Cast("float32", cos_table[pos, col])
+                        s = T.Cast("float32", sin_table[pos, col])
+                        y[low] = T.Cast(dtype, x_low * c - x_high * s)
+                        y[low + half] = T.Cast(dtype, x_high * c + x_low * s)
                 if n_tail > 0:
                     for i, j in T.Parallel(threads_arg, npt_arg):
                         tail_idx = (bx * threads_arg + i) * npt_arg + j

--- a/src/tileops/kernels/rope.py
+++ b/src/tileops/kernels/rope.py
@@ -203,11 +203,23 @@ def _make_rope_neox_position_ids_thd(
     threads: int = 256,
     num_per_thread: int = 8,
 ) -> object:
-    """THD neox RoPE kernel with explicit absolute position ids."""
+    """THD neox RoPE kernel with explicit absolute position ids.
+
+    A thread owns the pair ``(c, c + half)`` a neox rotation couples, so ``x`` is
+    read once and both of its outputs leave in the same step: the walked space is
+    the rotated half, not the head. Where ``rotary_dim < head_dim`` a second walk
+    copies the columns past it. The arithmetic stays in the storage dtype, which
+    is what ``GQAPrefillPagedWithKVCacheRopeAppendKernel`` is compared against.
+    """
     half = rotary_dim // 2
     token_stride = num_heads * head_dim
     n_total = num_tokens * token_stride
+    n_pairs = num_tokens * num_heads * half
+    n_tail = num_tokens * num_heads * (head_dim - rotary_dim)
     block_size = threads * num_per_thread
+    # One grid covers both walks, so the copied columns get blocks of their own
+    # where there are more of them than there are rotated pairs.
+    n_walked = max(n_pairs, n_tail)
 
     @tilelang.jit(out_idx=[4])
     def kernel(threads_arg, npt_arg):
@@ -219,29 +231,28 @@ def _make_rope_neox_position_ids_thd(
             position_ids: T.Tensor((num_tokens,), "int32"),
             y: T.Tensor((n_total,), dtype),
         ):
-            with T.Kernel(T.ceildiv(n_total, block_size), threads=threads_arg) as bx:
+            with T.Kernel(T.ceildiv(n_walked, block_size), threads=threads_arg) as bx:
                 for i, j in T.Parallel(threads_arg, npt_arg):
-                    flat_idx = (bx * threads_arg + i) * npt_arg + j
-                    if flat_idx < n_total:
-                        token_idx = flat_idx // token_stride
-                        col = flat_idx % head_dim
-                        pos = position_ids[token_idx]
-
-                        freq_idx = col % half
-                        c = cos_table[pos, freq_idx]
-                        s = sin_table[pos, freq_idx]
-                        val = x[flat_idx]
-
-                        paired_col = T.if_then_else(
-                            col < half,
-                            col + half,
-                            T.if_then_else(col < rotary_dim, col - half, col),
-                        )
-                        head_base = flat_idx - col
-                        paired_idx = head_base + paired_col
-                        paired_val = x[paired_idx]
-                        rotated = T.if_then_else(col < half, -paired_val, paired_val)
-                        y[flat_idx] = T.if_then_else(col < rotary_dim, val * c + rotated * s, val)
+                    pair_idx = (bx * threads_arg + i) * npt_arg + j
+                    if pair_idx < n_pairs:
+                        row = pair_idx // half
+                        col = pair_idx % half
+                        pos = position_ids[row // num_heads]
+                        low = row * head_dim + col
+                        x_low = x[low]
+                        x_high = x[low + half]
+                        c = cos_table[pos, col]
+                        s = sin_table[pos, col]
+                        y[low] = x_low * c + (-x_high) * s
+                        y[low + half] = x_high * c + x_low * s
+                if n_tail > 0:
+                    for i, j in T.Parallel(threads_arg, npt_arg):
+                        tail_idx = (bx * threads_arg + i) * npt_arg + j
+                        if tail_idx < n_tail:
+                            row = tail_idx // (head_dim - rotary_dim)
+                            col = tail_idx % (head_dim - rotary_dim)
+                            kept = row * head_dim + rotary_dim + col
+                            y[kept] = x[kept]
 
         return main
 

--- a/src/tileops/kernels/rope.py
+++ b/src/tileops/kernels/rope.py
@@ -210,6 +210,13 @@ def _make_rope_neox_position_ids_thd(
     the rotated half, not the head. Where ``rotary_dim < head_dim`` a second walk
     copies the columns past it. The rotation runs in f32 and rounds once, at the
     store into ``y``.
+
+    ``status`` counts the positions seen outside ``[0, max_position)``. It is
+    reported from a walk over the token axis, which is ``num_heads * half`` times
+    shorter than the rotation's, so the rotation stays branch-free; the rotation
+    clamps its own table index so an out-of-range position cannot fault before the
+    caller reads the count back. The count only grows, which is what lets one
+    buffer serve every call without a reset: a caller raises when it moves.
     """
     half = rotary_dim // 2
     token_stride = num_heads * head_dim
@@ -221,7 +228,7 @@ def _make_rope_neox_position_ids_thd(
     # where there are more of them than there are rotated pairs.
     n_walked = max(n_pairs, n_tail)
 
-    @tilelang.jit(out_idx=[4])
+    @tilelang.jit(out_idx=[5])
     def kernel(threads_arg, npt_arg):
         @T.prim_func
         def main(
@@ -229,15 +236,22 @@ def _make_rope_neox_position_ids_thd(
             cos_table: T.Tensor((max_position, half), dtype),
             sin_table: T.Tensor((max_position, half), dtype),
             position_ids: T.Tensor((num_tokens,), "int32"),
+            status: T.Tensor((1,), "int32"),
             y: T.Tensor((n_total,), dtype),
         ):
             with T.Kernel(T.ceildiv(n_walked, block_size), threads=threads_arg) as bx:
+                for i, j in T.Parallel(threads_arg, npt_arg):
+                    token = (bx * threads_arg + i) * npt_arg + j
+                    if token < num_tokens:
+                        seen = position_ids[token]
+                        if seen != T.max(0, T.min(seen, max_position - 1)):
+                            T.atomic_add(status[0], 1)
                 for i, j in T.Parallel(threads_arg, npt_arg):
                     pair_idx = (bx * threads_arg + i) * npt_arg + j
                     if pair_idx < n_pairs:
                         row = pair_idx // half
                         col = pair_idx % half
-                        pos = position_ids[row // num_heads]
+                        pos = T.max(0, T.min(position_ids[row // num_heads], max_position - 1))
                         low = row * head_dim + col
                         x_low = T.Cast("float32", x[low])
                         x_high = T.Cast("float32", x[low + half])
@@ -492,6 +506,11 @@ class RopeNeoxPositionIdsKernel(Kernel):
         self.rotary_dim = rotary_dim
         self.max_position = max_position
         self.dtype = dtype
+        #: Grows by one per position seen outside ``[0, max_position)``. One buffer
+        #: serves every call because the count is never reset; ``out_of_range_since``
+        #: answers whether it moved.
+        self._status: torch.Tensor | None = None
+        self._seen_out_of_range = 0
         self.kernel = self._build_kernel()
         self.init_config(config, tune)
 
@@ -513,16 +532,32 @@ class RopeNeoxPositionIdsKernel(Kernel):
         npt = 4 if self.dtype == torch.float32 else 8
         return {"threads": 256, "num_per_thread": npt}
 
+    def take_out_of_range(self) -> bool:
+        """Whether a call since the previous ask saw a position outside the table.
+
+        One device read per ask, and the count it compares against is held here, so
+        a caller pays one synchronisation rather than one before and one after.
+        """
+        if self._status is None:
+            return False
+        count = int(self._status.item())
+        moved = count != self._seen_out_of_range
+        self._seen_out_of_range = count
+        return moved
+
     def forward(
         self, x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor, position_ids: torch.Tensor
     ) -> torch.Tensor:
         cfg = self.config
         orig_shape = x.shape
+        if self._status is None:
+            self._status = torch.zeros(1, device=x.device, dtype=torch.int32)
         result = self.kernel(cfg["threads"], cfg["num_per_thread"])(
             x.contiguous().reshape(-1),
             cos,
             sin,
             position_ids.contiguous(),
+            self._status,
         )
         return result.reshape(orig_shape)
 

--- a/src/tileops/ops/rope.py
+++ b/src/tileops/ops/rope.py
@@ -679,11 +679,10 @@ class RopeNeoxPositionIdsFwdOp(Op):
             raise ValueError(
                 f"Expected position_ids.dtype int32 or int64, got {position_ids.dtype}"
             )
-        if position_ids.numel() and (
-            bool(torch.any(position_ids < 0).item())
-            or bool(torch.any(position_ids >= self.max_position).item())
-        ):
-            raise ValueError("position_ids must be in [0, max_position)")
+        if position_ids.numel():
+            lowest, highest = torch.stack(torch.aminmax(position_ids)).tolist()
+            if lowest < 0 or highest >= self.max_position:
+                raise ValueError("position_ids must be in [0, max_position)")
         self.kernel = self._get_kernel((x, position_ids), x.device.index)
         return x.contiguous(), position_ids.to(torch.int32).contiguous()
 

--- a/src/tileops/ops/rope.py
+++ b/src/tileops/ops/rope.py
@@ -679,10 +679,6 @@ class RopeNeoxPositionIdsFwdOp(Op):
             raise ValueError(
                 f"Expected position_ids.dtype int32 or int64, got {position_ids.dtype}"
             )
-        if position_ids.numel():
-            lowest, highest = torch.stack(torch.aminmax(position_ids)).tolist()
-            if lowest < 0 or highest >= self.max_position:
-                raise ValueError("position_ids must be in [0, max_position)")
         self.kernel = self._get_kernel((x, position_ids), x.device.index)
         return x.contiguous(), position_ids.to(torch.int32).contiguous()
 
@@ -711,8 +707,16 @@ class RopeNeoxPositionIdsFwdOp(Op):
         x, position_ids = self._validate_and_prepare(x, position_ids)
         wrapped = type(self)._wrapped
         if wrapped is not None:
-            return wrapped(x, position_ids, self._instance_key)
-        return self._eager_forward(x, position_ids)
+            output = wrapped(x, position_ids, self._instance_key)
+        else:
+            output = self._eager_forward(x, position_ids)
+        # The kernel counts the positions it found outside the table rather than the
+        # op proving they are inside it first: two reductions and two launches in
+        # front of every call cost more device time than the rotation they guard.
+        # It clamps its own table index, so this call read nothing out of bounds.
+        if self.kernel.take_out_of_range():
+            raise ValueError("position_ids must be in [0, max_position)")
+        return output
 
 
 class RopeNonNeoxFwdOp(_RopeOpBase):

--- a/tests/ops/test_rope.py
+++ b/tests/ops/test_rope.py
@@ -390,13 +390,20 @@ def test_rope_neox_2d(
 
 
 @pytest.mark.smoke
-@pytest.mark.parametrize("rotary_dim", [None, 32])
-def test_rope_neox_position_ids_thd(rotary_dim: int | None) -> None:
+@pytest.mark.parametrize(
+    "rotary_dim, dtype",
+    [
+        (None, torch.float16),
+        (32, torch.float16),
+        (None, torch.bfloat16),
+        (None, torch.float32),
+    ],
+)
+def test_rope_neox_position_ids_thd(rotary_dim: int | None, dtype: torch.dtype) -> None:
     from tileops.ops.rope import RopeNeoxPositionIdsFwdOp
 
     num_tokens, num_heads, head_dim, max_position = 96, 8, 64, 512
     table_dim = head_dim if rotary_dim is None else rotary_dim
-    dtype = torch.float16
     x = torch.randn(num_tokens, num_heads, head_dim, device="cuda", dtype=dtype)
     position_ids = (
         torch.arange(num_tokens, device="cuda", dtype=torch.int32) * 3 + 17
@@ -409,7 +416,8 @@ def test_rope_neox_position_ids_thd(rotary_dim: int | None) -> None:
         rotary_dim=rotary_dim,
     )
     output = op(x, position_ids)
-    torch.testing.assert_close(output, ref, atol=5e-3, rtol=1e-5)
+    atol, rtol = _get_tolerances(dtype)
+    torch.testing.assert_close(output, ref, atol=atol, rtol=rtol)
 
 
 @pytest.mark.smoke


### PR DESCRIPTION
## Problems

- The kernel read `x` twice. A neox rotation couples column `c` with column `c + half`, and the walk was one output element per thread, so every thread loaded its own value and then its partner's — the partner load a per-element scalar behind two `if_then_else` chains, not a vector.
- `cos_table[pos, freq_idx]`, `sin_table[pos, freq_idx]` and `position_ids[token_idx]` were re-read once per output element rather than once per pair.
- The rotation ran in the storage dtype, rounding the product and the sum separately where the operator's contract rounds once. Where the two products cancel that loses up to 16 ulps.
- The op proved `0 <= pos < max_position` with two `torch.any` reductions before every call: four kernel launches and two host synchronisations, 5.9 us of device time at this device's empty-kernel floor, guarding a rotation that costs 10.4 us. A quarter of the operator's device time went to deciding whether to run it.

## Changes

- A thread owns the pair `(c, c + half)`, so the walked space is the rotated half rather than the head: `x` is read once, both outputs leave in the same step, and the frequency row and the position id are read once per pair. Where `rotary_dim < head_dim` a second walk copies the columns past it, and the grid is sized on whichever walk is larger.
- The rotation carries f32 and rounds once at the store, which is what the operator's TileFoundry description states and what `.claude/rules/code-style.md` asks for.
- The range check moves inside the kernel, onto the token axis. That axis is `num_heads * half` times shorter than the rotation's, so the rotation stays branch-free and vectorised and the count costs 0.064 us (float16) and 0.096 us (bfloat16). The rotation clamps its own table index, so an out-of-range position cannot fault before the host reads the count back. The count only grows and is never reset — one buffer serves every call, and the kernel answers whether it moved. The `ValueError` and its message are unchanged; it is raised after the rotation rather than before it.
- Kernels per call go from 5 to 1, and host synchronisations from 2 to 1.
- Test-node delta: +2 nodes (53 to 55). `test_rope_neox_position_ids_thd` gains a bfloat16 and a float32 case and takes its tolerance from `_get_tolerances`: the manifest declares three dtypes for this op, the test covered one, and float32 is the only dtype that reaches the `num_per_thread = 4` config.

## TileFoundry Description

Placed over CTAs with the intermediates in registers, so the reported traffic is the fused kernel's and not a chain of materialised temporaries. `analyze` on this module is what the implementation was written against: `bound-by=memory`, `ideal-ns=7977` for the float16 row and `15954` for the bfloat16 row.

```python
"""The operator placed on CTAs, its intermediates in registers: the fused floor."""

from __future__ import annotations

from tilefoundry import func, module
from tilefoundry.dsl import Mesh, Tensor, tf
from tilefoundry.ir.types.shard import Topology
from tilefoundry.target import CudaTarget

T, H, D = 2048, 32, 128
MAX_POS = 4096
HALF = D // 2
CTAS = 1024


@module(
    entry="rope_neox_position_ids",
    target=CudaTarget("nvidia.h200_sxm"),
    topologies=(Topology("cta", CTAS),),
)
class RopeNeoxPositionIdsPlaced:
    @func
    def rope_neox_position_ids(
        x: Tensor[(1, T, H, D), "f16"],
        cos_table: Tensor[(MAX_POS, HALF), "f16"],
        sin_table: Tensor[(MAX_POS, HALF), "f16"],
        position_ids: Tensor[(T,), "i32"],
    ) -> Tensor[(1, T, H, D), "f16"]:
        with Mesh(("cta",), layout=(CTAS,), names=("tile",)) as cta:
            # Bound once, then duplicated. Spelling the gather twice inside the
            # concat is two gathers in the graph, and the analysis charges for both.
            cos_rows = tf.index_select(cos_table, position_ids, dim=0)
            sin_rows = tf.index_select(sin_table, position_ids, dim=0)
            cos_full = tf.reshape(
                tf.concat([cos_rows, cos_rows], axis=-1), new_shape=(1, T, 1, D)
            )
            sin_full = tf.reshape(
                tf.concat([sin_rows, sin_rows], axis=-1), new_shape=(1, T, 1, D)
            )
            x_reg = tf.reshard(x, (1, T @ cta.tile, H, D), "rmem")
            cos = tf.reshard(cos_full, (1, T @ cta.tile, 1, D), "rmem")
            sin = tf.reshard(sin_full, (1, T @ cta.tile, 1, D), "rmem")
            low = x_reg[:, :, :, 0:HALF]
            high = x_reg[:, :, :, HALF:D]
            rotated = tf.concat([tf.neg(high), low], axis=-1)
            return tf.reshard(x_reg * cos + rotated * sin, (1, T @ cta.tile, H, D), "gmem")
```

The same graph written unplaced reports `ideal-ns=35939`, four times the placed figure, because every intermediate lands in gmem. The distance between the two is the fusion this kernel performs.

A second module states the operator's rounding contract — the table read at `x`'s dtype, the rotation in f32, one rounding on the way out — and `check` runs the shipped kernel against it as a runtime twin, on the manifest's own shapes with a real frequency table and in-range positions:

| Row | Predicate | Result |
| --- | --- | --- |
| float16 `(1, 2048, 32, 128)` | `equal` | 0 of 8388608 elements differ, **PASS** |
| bfloat16 `(1, 4096, 32, 128)` | `equal` | 0 of 16777216 elements differ, **PASS** |
| both | `nan_inf` | PASS |

The same check against this branch's base commit fails with 1809000 of 8388608 elements differing at one float16 ulp, so `equal` is discriminating here rather than vacuous.

## Performance

Operator: `RopeNeoxPositionIdsFwdOp`

| Environment | Value |
| --- | --- |
| image | `ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-afcebed1-dev` |
| digest | `sha256:8b0bc9414d6f3d22e984d988f85766bd044b6ff23c0e8e1c42e4f3a61d163db6` |
| gpu | `NVIDIA H200` (one device, idle, not the CI runners') |
| driver | `595.71.05` |
| cuda | `13.2` |
| torch | `2.13.0+cu132` |
| tilelang | `0.1.11+cu132.gitafcebed1` |
| vllm | `0.27.1` |
| timer | native CUPTI device-busy time |

Method: `benchmarks/ops/bench_rope.py` unmodified, both manifest workloads, candidate and incumbent measured in separate runs of the same file on the same idle device. `ManifestBenchmark.compare` supplies the warmup and repeat budget, the L2 flush before every iteration and the CUPTI attribution; the candidate is reached by constructing the public Op, with no candidate-only switch.

Ratio in comparator columns: implementation / candidate. &#x1F7E2; > 1 means the candidate is faster; &#x1F534; <= 1 means it is not.

| Workload | tokens | heads | head_dim | max_position | Dtype | This PR (ms) | TileOPs incumbent (ms)<br>/ candidate | vLLM (ms)<br>/ candidate | torch-compile (ms)<br>/ candidate | torch-ref (ms)<br>/ candidate |
| --- | ---: | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: |
| position-ids-s2k-h32-d128 | 2048 | 32 | 128 | 4096 | float16 | 0.0104 | **0.0237<br>&#x1F7E2;&nbsp;2.2788x** | **0.0216<br>&#x1F7E2;&nbsp;2.0769x** | **0.0114<br>&#x1F7E2;&nbsp;1.0962x** | **0.1068<br>&#x1F7E2;&nbsp;10.2692x** |
| position-ids-s4k-h32-d128 | 4096 | 32 | 128 | 8192 | bfloat16 | 0.0186 | **0.0390<br>&#x1F7E2;&nbsp;2.0968x** | **0.0396<br>&#x1F7E2;&nbsp;2.1290x** | **0.0208<br>&#x1F7E2;&nbsp;1.1183x** | **0.2096<br>&#x1F7E2;&nbsp;11.2688x** |
| geometric mean |  |  |  |  |  | 0.013908 | **0.030402<br>&#x1F7E2;&nbsp;2.1859x** | **0.029247<br>&#x1F7E2;&nbsp;2.1028x** | **0.015399<br>&#x1F7E2;&nbsp;1.1072x** | **0.149617<br>&#x1F7E2;&nbsp;10.7574x** |

## Result And Limitations

**measured SOTA**

- Every-row SOTA: both manifest workloads are faster than every comparator the benchmark runs, by 9.6% to 12% against the fastest of them. Candidate p10-to-p90 widths are 6.7% and 4.8% of the median; the torch-compile margin sits inside that spread on the float16 row and outside it on the bfloat16 row, so read the float16 win as a tie-or-better and the bfloat16 win as a win.
- Against the incumbent the operator is 2.1859x faster by geometric mean, and kernels per call go from 5 to 1.
- The rotation kernel is at its stream ceiling, measured rather than argued. A twin with the same grid, the same pair-per-thread walk and the same vector width, with the rotation and the table reads removed, runs the float16 row in 10.208 us against the shipped kernel's 10.464; `torch`'s own device-to-device copy of the same bytes runs it in 9.984. The rotation costs 2.4% over a pure copy of its own access pattern, and 4.6% over the fastest copy this device performs.
- The floor ratio of 1.308x is therefore nominal bandwidth, not kernel inefficiency: `analyze` divides traffic by the device's 4.8 TB/s, and a copy reaches 3.3 TB/s. torch's memcpy sits at 1.252x of the same floor.
- The in-kernel range check is what closed the gap to torch-compile. On the token axis it costs 0.064 us and 0.096 us; the two reductions it replaces cost 5.9 us and 6.3 us. Both spellings raise the same `ValueError` on the same inputs, and `test_rope_neox_position_ids_validates_range` covers both an out-of-range and a negative position.
- One host synchronisation per call remains, reading the count back. The op made two before this PR, so this is a reduction, but it is not zero: an out-of-range position is a `ValueError`, and only the host can raise one.
- Scope is this op. The `_make_rope_neox_1d` / `_make_rope_neox_2d` builders the other five RoPE ops share read `x` twice the same way, and the paged-GQA fused rope path rotates in the storage dtype at six sites; neither is touched here.
