### PR TITLE
[Perf][Reduction] Fold a logical reduce's leading axis into its trailing pass

### DIFF
--- a/src/tileops/kernels/reduction/__init__.py
+++ b/src/tileops/kernels/reduction/__init__.py
@@ -16,7 +16,7 @@ from ._primitives import (
 )
 from .argreduce import ArgreduceKernel
 from .cumulative import CumulativeKernel
-from .logical_reduce import LogicalReduceKernel
+from .logical_reduce import LogicalReduceEdgeFusedKernel, LogicalReduceKernel
 from .logsumexp import LogSumExpKernel
 from .reduce import ReduceKernel
 from .softmax import SoftmaxKernel
@@ -31,6 +31,7 @@ __all__: list[str] = [
     "ArgreduceKernel",
     "CumulativeKernel",
     "LogSumExpKernel",
+    "LogicalReduceEdgeFusedKernel",
     "LogicalReduceKernel",
     "ReduceKernel",
     "SoftmaxKernel",

--- a/src/tileops/kernels/reduction/call_spec.py
+++ b/src/tileops/kernels/reduction/call_spec.py
@@ -1,0 +1,58 @@
+"""Call records and implementation regions for reduction kernels."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import torch
+
+from tileops.kernels.call_spec import CallSpec
+
+__all__ = [
+    "LogicalReduceCall",
+    "logical_edge_fused_region",
+    "logical_reduce_region",
+]
+
+
+@dataclasses.dataclass(frozen=True)
+class LogicalReduceCall(CallSpec):
+    """Semantic and shape facts used to select a logical reduction implementation."""
+
+    shape: tuple[int, ...] = ()
+    axes: tuple[int, ...] = ()
+    op_kind: str = ""
+    dtype: torch.dtype = torch.float16
+    keepdim: bool = False
+    edge_axes: bool = False
+    kept: int = 0
+    trail_needs_tiling: bool = False
+    reduced_count: int = 0
+    tune: bool = False
+
+
+def logical_reduce_region(call: LogicalReduceCall) -> bool:
+    """The general logical reduction region."""
+
+    return call.op_kind in {"any", "all", "count_nonzero"}
+
+
+# The fused pass runs one block per kept column and has no other parallelism, so
+# it takes over only where that alone is enough. Measured on an H200 with
+# lead=4, trail=4096. Other devices use the general implementation until they
+# have their own measured region.
+_EDGE_FUSED_MIN_KEPT_H200 = 32
+
+
+def logical_edge_fused_region(call: LogicalReduceCall) -> bool:
+    """The H200 edge-axis logical reduction region served by the fused pass."""
+
+    if not logical_reduce_region(call):
+        return False
+    if not call.h200 or call.tune:
+        return False
+    if not call.edge_axes or call.trail_needs_tiling:
+        return False
+    if call.kept < _EDGE_FUSED_MIN_KEPT_H200:
+        return False
+    return call.op_kind != "count_nonzero" or call.reduced_count <= 1 << 24

--- a/src/tileops/kernels/reduction/logical_reduce.py
+++ b/src/tileops/kernels/reduction/logical_reduce.py
@@ -102,6 +102,81 @@ def _logical_out_dtype(op_kind: str, partial: bool) -> str:
     return "float32" if partial else "int64"
 
 
+# The fused pass runs one block per kept column and has no other parallelism, so
+# it takes over only where that alone is enough. Measured on an H200 (lead 4,
+# trail 4096, bool): fused wins from kept 32 up and ties below it.
+_FUSE_MIN_KEPT = 32
+
+
+@functools.lru_cache(maxsize=32)
+def _logical_reduce_edge_fused(lead: int, kept: int, trail: int, op_kind: str, dtype: str):
+    """Build an any/all/count_nonzero kernel reducing a leading and a trailing axis.
+
+    One block per kept column, walking the leading axis in serial and reducing
+    each of its contiguous rows. The two-pass form writes ``lead * kept``
+    partials and launches again to fold them; at these sizes that launch is most
+    of the time.
+
+    Args:
+        lead: Extent of the leading axes, already folded into one.
+        kept: Extent of the axis that survives.
+        trail: Extent of the trailing axes, already folded into one.
+        op_kind: One of "any", "all", "count_nonzero".
+        dtype: TileLang dtype string of the input.
+
+    Returns:
+        A TileLang JIT-compiled kernel factory accepting (threads).
+    """
+    trail_padded = align_up(trail, DEFAULT_ALIGNMENT)
+    needs_pad = trail_padded != trail
+    pad_val = _pad_value_for_op(op_kind)
+    out_dtype = _logical_out_dtype(op_kind, partial=False)
+    # any is a max and all is a min over 0/1, so each starts from its identity;
+    # a count sums from zero.
+    init_val = {"any": 0.0, "all": 1.0, "count_nonzero": 0.0}[op_kind]
+
+    @tilelang.jit(out_idx=[1])
+    def _func(threads):
+        @T.prim_func
+        def main(
+            x: T.Tensor[(lead, kept, trail), dtype],
+            out: T.Tensor[(kept,), out_dtype],
+        ):
+            with T.Kernel(kept, threads=threads) as pid_k:
+                vals = T.alloc_fragment((1, trail_padded), "float32")
+                row = T.alloc_fragment((1,), "float32")
+                acc = T.alloc_fragment((1,), "float32")
+                acc[0] = init_val
+                for lead_idx in T.serial(lead):
+                    for j in T.Parallel(trail_padded):
+                        if needs_pad:
+                            val = T.if_then_else(
+                                j < trail,
+                                T.cast(x[lead_idx, pid_k, j], "float32"),
+                                T.cast(pad_val, "float32"),
+                            )
+                        else:
+                            val = T.cast(x[lead_idx, pid_k, j], "float32")
+                        vals[0, j] = T.if_then_else(val != 0.0, 1.0, 0.0)
+                    if op_kind == "any":
+                        T.reduce_max(vals, row, dim=1)
+                        acc[0] = T.max(acc[0], row[0])
+                    elif op_kind == "all":
+                        T.reduce_min(vals, row, dim=1)
+                        acc[0] = T.min(acc[0], row[0])
+                    else:
+                        T.reduce_sum(vals, row, dim=1)
+                        acc[0] = acc[0] + row[0]
+                if op_kind == "count_nonzero":
+                    out[pid_k] = T.cast(acc[0], out_dtype)
+                else:
+                    out[pid_k] = T.cast(acc[0] > 0.5, out_dtype)
+
+        return main
+
+    return _func
+
+
 @functools.lru_cache(maxsize=32)
 def _logical_reduce_kernel(M: int, N: int, op_kind: str, dtype: str, partial: bool = False):
     """Build a TileLang any/all/count_nonzero kernel.
@@ -445,6 +520,12 @@ class LogicalReduceKernel(Kernel):
             tuple(x.shape), k, j, self._elem_bytes, self._smem_budget
         )
         dtype_str = self.dtype_to_str(self._kernel_dtype)
+        if kept >= _FUSE_MIN_KEPT and not planner.needs_tiling:
+            fused = _logical_reduce_edge_fused(lead, kept, trail, self.op_kind, dtype_str)
+            counted = fused(cfg["threads"])(x.reshape(lead, kept, trail))
+            if self.op_kind == "count_nonzero":
+                return counted
+            return counted.view(torch.bool)
         if planner.needs_tiling:
             stage = _logical_reduce_kernel_tiled(
                 lead * kept, trail, self.op_kind, dtype_str, cfg["tile_n"], partial=True

--- a/src/tileops/kernels/reduction/logical_reduce.py
+++ b/src/tileops/kernels/reduction/logical_reduce.py
@@ -36,8 +36,18 @@ from tileops.kernels.reduction._primitives import (
     rows_for_axes,
     tune_by_forward,
 )
+from tileops.kernels.reduction.call_spec import (
+    LogicalReduceCall,
+    logical_edge_fused_region,
+    logical_reduce_region,
+)
 
-__all__ = ["LogicalReduceKernel", "storage_dtype_for", "to_logical_storage"]
+__all__ = [
+    "LogicalReduceEdgeFusedKernel",
+    "LogicalReduceKernel",
+    "storage_dtype_for",
+    "to_logical_storage",
+]
 
 _LOGICAL_REDUCE_KINDS = {"any", "all", "count_nonzero"}
 
@@ -100,12 +110,6 @@ def _logical_out_dtype(op_kind: str, partial: bool) -> str:
     if op_kind != "count_nonzero":
         return "int8"
     return "float32" if partial else "int64"
-
-
-# The fused pass runs one block per kept column and has no other parallelism, so
-# it takes over only where that alone is enough. Measured on an H200 (lead 4,
-# trail 4096, bool): fused wins from kept 32 up and ties below it.
-_FUSE_MIN_KEPT = 32
 
 
 @functools.lru_cache(maxsize=32)
@@ -407,6 +411,11 @@ class LogicalReduceKernel(Kernel):
     """
 
     supported_archs: list[int] = [80, 86, 89, 90]
+    general: bool = True
+
+    @classmethod
+    def applies(cls, call: LogicalReduceCall) -> bool:
+        return logical_reduce_region(call)
 
     def __init__(
         self,
@@ -520,12 +529,6 @@ class LogicalReduceKernel(Kernel):
             tuple(x.shape), k, j, self._elem_bytes, self._smem_budget
         )
         dtype_str = self.dtype_to_str(self._kernel_dtype)
-        if kept >= _FUSE_MIN_KEPT and not planner.needs_tiling:
-            fused = _logical_reduce_edge_fused(lead, kept, trail, self.op_kind, dtype_str)
-            counted = fused(cfg["threads"])(x.reshape(lead, kept, trail))
-            if self.op_kind == "count_nonzero":
-                return counted
-            return counted.view(torch.bool)
         if planner.needs_tiling:
             stage = _logical_reduce_kernel_tiled(
                 lead * kept, trail, self.op_kind, dtype_str, cfg["tile_n"], partial=True
@@ -561,3 +564,70 @@ class LogicalReduceKernel(Kernel):
             return counted.to(torch.int64)
         # 0 or 1 in int8 is bool's own representation, so this is a reinterpretation.
         return counted.view(torch.bool)
+
+
+class LogicalReduceEdgeFusedKernel(Kernel):
+    """Fused H200 logical reduction for a prefix and suffix axis set.
+
+    One block reduces one kept column, walking the leading axis serially while
+    reducing each contiguous trailing row. The general logical reducer remains
+    responsible for non-edge layouts and for rows that require N-tiling.
+    """
+
+    supported_archs: list[int] = [90]
+
+    @classmethod
+    def applies(cls, call: LogicalReduceCall) -> bool:
+        return logical_edge_fused_region(call)
+
+    def __init__(
+        self,
+        M: int,
+        N: int,
+        op_kind: str,
+        dtype: torch.dtype,
+        reduce_axes: "tuple[int, ...]",
+        keepdim: bool = False,
+        config: Optional[dict] = None,
+        tune: bool = False,
+        device_index: "int | None" = None,
+    ):
+        super().__init__(device_index=device_index)
+        if op_kind not in _LOGICAL_REDUCE_KINDS:
+            raise ValueError(
+                f"Unsupported op_kind '{op_kind}'. Expected one of {sorted(_LOGICAL_REDUCE_KINDS)}."
+            )
+        self.M = M
+        self.N = N
+        self.op_kind = op_kind
+        self.dtype = dtype
+        self.reduce_axes = tuple(reduce_axes)
+        self.keepdim = keepdim
+        self._kernel_dtype = storage_dtype_for(dtype)
+        self._elem_bytes = torch.tensor([], dtype=self._kernel_dtype).element_size()
+        self._smem_budget = device_smem_budget(device_index)
+        self.init_config(config, tune)
+
+    @property
+    def default_config(self) -> dict:
+        return {"threads": DEFAULT_THREADS}
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        self._require_cuda(x=x)
+        in_shape = tuple(x.shape)
+        if x.dtype in _UNSUPPORTED_STORAGE_DTYPES:
+            x = to_logical_storage(x)
+        k, j = edge_axis_split(x.ndim, self.reduce_axes)
+        if not k:
+            raise ValueError("LogicalReduceEdgeFusedKernel requires edge reduction axes")
+        lead, kept, trail, planner, cfg = edge_axis_plan(
+            tuple(x.shape), k, j, self._elem_bytes, self._smem_budget
+        )
+        if planner.needs_tiling:
+            raise ValueError("LogicalReduceEdgeFusedKernel requires an untiled trailing pass")
+        threads = self.config.get("threads", cfg["threads"])
+        dtype_str = self.dtype_to_str(self._kernel_dtype)
+        fused = _logical_reduce_edge_fused(lead, kept, trail, self.op_kind, dtype_str)
+        counted = fused(threads)(x.reshape(lead, kept, trail))
+        y = counted if self.op_kind == "count_nonzero" else counted.view(torch.bool)
+        return restore_reduced(y, in_shape, self.reduce_axes, self.keepdim)

--- a/src/tileops/manifest/reduction.yaml
+++ b/src/tileops/manifest/reduction.yaml
@@ -674,6 +674,7 @@ AllFwdOp:
   source:
     kernel: tileops/kernels/reduction/logical_reduce.py
     kernel_map:
+      logical_reduce_edge_fused: LogicalReduceEdgeFusedKernel
       logical_reduce: LogicalReduceKernel
     op: tileops/ops/reduction/logical_reduce.py
     test: tests/ops/test_logical_reduce.py
@@ -720,6 +721,7 @@ AnyFwdOp:
   source:
     kernel: tileops/kernels/reduction/logical_reduce.py
     kernel_map:
+      logical_reduce_edge_fused: LogicalReduceEdgeFusedKernel
       logical_reduce: LogicalReduceKernel
     op: tileops/ops/reduction/logical_reduce.py
     test: tests/ops/test_logical_reduce.py
@@ -763,6 +765,7 @@ CountNonzeroFwdOp:
   source:
     kernel: tileops/kernels/reduction/logical_reduce.py
     kernel_map:
+      logical_reduce_edge_fused: LogicalReduceEdgeFusedKernel
       logical_reduce: LogicalReduceKernel
     op: tileops/ops/reduction/logical_reduce.py
     test: tests/ops/test_logical_reduce.py

--- a/src/tileops/ops/reduction/logical_reduce.py
+++ b/src/tileops/ops/reduction/logical_reduce.py
@@ -6,8 +6,19 @@ import torch
 
 from tileops.backend import Target
 from tileops.kernels.kernel_base import Kernel
-from tileops.kernels.reduction.logical_reduce import LogicalReduceKernel
+from tileops.kernels.reduction._primitives import (
+    device_smem_budget,
+    edge_axis_plan,
+    edge_axis_split,
+)
+from tileops.kernels.reduction.call_spec import LogicalReduceCall
+from tileops.kernels.reduction.logical_reduce import (
+    LogicalReduceEdgeFusedKernel,
+    LogicalReduceKernel,
+    storage_dtype_for,
+)
 from tileops.manifest.shape_rules import reduced_shape
+from tileops.utils import get_sm_count, get_sm_version, is_h200
 
 from ._boundary import register_reduction_op
 from ._multidim import EmptyDimPolicy
@@ -16,7 +27,58 @@ from .reduce import _ReduceOpBase
 __all__ = ["AllFwdOp", "AnyFwdOp", "CountNonzeroFwdOp"]
 
 
-class AllFwdOp(_ReduceOpBase):
+_LOGICAL_REDUCE_KEYS = ("logical_reduce_edge_fused", "logical_reduce")
+
+
+class _LogicalReduceOpBase(_ReduceOpBase):
+    """Shared dispatch for logical reductions."""
+
+    _kernel_key = "logical_reduce"
+    _kernel_cls = LogicalReduceKernel
+
+    @property
+    def default_kernel_map(self) -> Dict[str, Kernel]:
+        return {
+            "logical_reduce_edge_fused": LogicalReduceEdgeFusedKernel,
+            "logical_reduce": LogicalReduceKernel,
+        }
+
+    def _select_kernel_key(
+        self,
+        x: torch.Tensor,
+        axes: "tuple[int, ...]",
+        m: int,
+        n: int,
+    ) -> str:
+        device_index = x.device.index
+        k, j = edge_axis_split(x.ndim, axes)
+        kept = 0
+        trail_needs_tiling = False
+        if k:
+            kernel_dtype = storage_dtype_for(x.dtype)
+            elem_bytes = torch.tensor([], dtype=kernel_dtype).element_size()
+            smem_budget = device_smem_budget(device_index)
+            _, kept, _, planner, _ = edge_axis_plan(tuple(x.shape), k, j, elem_bytes, smem_budget)
+            trail_needs_tiling = planner.needs_tiling
+        call = LogicalReduceCall(
+            arch=get_sm_version(device_index),
+            h200=is_h200(device_index),
+            sm_count=get_sm_count(device_index),
+            shape=tuple(x.shape),
+            axes=axes,
+            op_kind=self._op_kind,
+            dtype=x.dtype,
+            keepdim=self.keepdim,
+            edge_axes=bool(k),
+            kept=kept,
+            trail_needs_tiling=trail_needs_tiling,
+            reduced_count=n,
+            tune=self.tune,
+        )
+        return self.select_kernel_key(_LOGICAL_REDUCE_KEYS, call)
+
+
+class AllFwdOp(_LogicalReduceOpBase):
     """All reduction along ``dim``, returning bool.
 
     Construction: ``AllFwdOp(dim=None, keepdim=False)``.
@@ -81,7 +143,7 @@ class AllFwdOp(_ReduceOpBase):
         return torch.bool
 
 
-class AnyFwdOp(_ReduceOpBase):
+class AnyFwdOp(_LogicalReduceOpBase):
     """Any reduction along ``dim``, returning bool.
 
     Construction: ``AnyFwdOp(dim=None, keepdim=False)``.
@@ -146,7 +208,7 @@ class AnyFwdOp(_ReduceOpBase):
         return torch.bool
 
 
-class CountNonzeroFwdOp(_ReduceOpBase):
+class CountNonzeroFwdOp(_LogicalReduceOpBase):
     """Count nonzero reduction along ``dim``, returning int64.
 
     Construction: ``CountNonzeroFwdOp(dim=None)``.

--- a/src/tileops/ops/reduction/reduce.py
+++ b/src/tileops/ops/reduction/reduce.py
@@ -389,6 +389,17 @@ class _ReduceOpBase(Op):
         """
         return {"device_index": x.device.index}
 
+    def _select_kernel_key(
+        self,
+        x: torch.Tensor,
+        axes: "tuple[int, ...]",
+        m: int,
+        n: int,
+    ) -> str:
+        """Choose the implementation key for this reduce call."""
+
+        return self._kernel_key
+
     def _reduce_axes(self, x: torch.Tensor) -> "tuple[int, ...]":
         """The axes this call reduces, ascending and non-negative.
 
@@ -419,14 +430,15 @@ class _ReduceOpBase(Op):
         m = prod(d for i, d in enumerate(x.shape) if i not in axes)
         self._last_roofline_mn = (m, n)
         extra = self._build_kernel_kwargs(x, axes)
+        selected_key = self._select_kernel_key(x, axes, m, n)
         kernel = self.get_or_build_kernel(
-            self._kernel_key,
+            selected_key,
             (x,),
             # The kernel now owns the permute, so the whole shape decides what it is,
             # not just the row count and width it reduces. The device is in the key
             # because the kernel plans against that device's shared memory.
-            key=(tuple(x.shape), axes, self.keepdim, x.dtype, x.device.index),
-            build=lambda: self.kernel_map[self._kernel_key](
+            key=(selected_key, tuple(x.shape), axes, self.keepdim, x.dtype, x.device.index),
+            build=lambda: self.kernel_map[selected_key](
                 m,
                 n,
                 self._op_kind,

--- a/tests/ops/test_logical_reduce.py
+++ b/tests/ops/test_logical_reduce.py
@@ -747,3 +747,37 @@ def test_logical_reduce_edge_axes_in_own_layout(op_kind: str, dtype: torch.dtype
         "count_nonzero": lambda: torch.count_nonzero(x, (0, 2)),
     }[op_kind]()
     assert torch.equal(op(x), ref)
+
+
+@pytest.mark.smoke
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize(
+    "op_kind, dtype",
+    [
+        ("any", torch.bool),
+        ("all", torch.bool),
+        ("count_nonzero", torch.float16),
+    ],
+)
+def test_logical_reduce_edge_axes_fused_dispatch(op_kind: str, dtype: torch.dtype) -> None:
+    from tileops.ops.reduction.logical_reduce import AllFwdOp, AnyFwdOp, CountNonzeroFwdOp
+    from tileops.utils import is_h200
+
+    if not is_h200():
+        pytest.skip("fused edge logical reduce is selected only for the measured H200 region")
+
+    op_map = {"any": AnyFwdOp, "all": AllFwdOp, "count_nonzero": CountNonzeroFwdOp}
+    op = op_map[op_kind](dim=[0, 2])
+    if dtype == torch.bool:
+        x = torch.rand(4, 128, 4096, device="cuda") > 0.999
+        if op_kind == "all":
+            x = ~x
+    else:
+        x = torch.randn(4, 128, 4096, dtype=dtype, device="cuda")
+    ref = {
+        "any": lambda: x.any(0).any(-1),
+        "all": lambda: x.all(0).all(-1),
+        "count_nonzero": lambda: torch.count_nonzero(x, (0, 2)),
+    }[op_kind]()
+    assert torch.equal(op(x), ref)
+    assert "logical_reduce_edge_fused" in op._kernel_roles


### PR DESCRIPTION
## Summary

- Add a fused H200 edge-axis path for logical reductions over a leading and trailing axis.
- Dispatch it as `LogicalReduceEdgeFusedKernel`, leaving `LogicalReduceKernel` as the general fallback.
- Cover the fused dispatch path for any/all/count_nonzero.