### PR TITLE
[Perf][foundry][GQA] Round the fused rope rotation once, and stop the register spill it caused

### DIFF
--- a/src/tileops/kernels/attention/gqa_fwd.py
+++ b/src/tileops/kernels/attention/gqa_fwd.py
@@ -1526,13 +1526,15 @@ def _gqa_prefill_paged_with_kv_cache_rope_append_kernel(
                             paired_d = T.if_then_else(
                                 d < half, d + half, T.if_then_else(d < rotary_dim, d - half, d)
                             )
-                            c = cos_table[logical_pos, freq_idx]
-                            s = sin_table[logical_pos, freq_idx]
+                            c = T.Cast("float32", cos_table[logical_pos, freq_idx])
+                            s = T.Cast("float32", sin_table[logical_pos, freq_idx])
                             val = k_new[q_start + new_pos, by, d]
-                            paired_val = k_new[q_start + new_pos, by, paired_d]
+                            paired_val = T.Cast("float32", k_new[q_start + new_pos, by, paired_d])
                             rotated = T.if_then_else(d < half, -paired_val, paired_val)
                             k_pages[physical_start + i, by, d] = T.if_then_else(
-                                d < rotary_dim, val * c + rotated * s, val
+                                d < rotary_dim,
+                                T.Cast(dtype, T.Cast("float32", val) * c + rotated * s),
+                                val,
                             )
                             v_pages[physical_start + i, by, d] = v_new[q_start + new_pos, by, d]
                     else:
@@ -1546,13 +1548,15 @@ def _gqa_prefill_paged_with_kv_cache_rope_append_kernel(
                             paired_d = T.if_then_else(
                                 d < half, d + half, T.if_then_else(d < rotary_dim, d - half, d)
                             )
-                            c = cos_table[logical_pos, freq_idx]
-                            s = sin_table[logical_pos, freq_idx]
+                            c = T.Cast("float32", cos_table[logical_pos, freq_idx])
+                            s = T.Cast("float32", sin_table[logical_pos, freq_idx])
                             val = k_new[q_start + new_pos, by, d]
-                            paired_val = k_new[q_start + new_pos, by, paired_d]
+                            paired_val = T.Cast("float32", k_new[q_start + new_pos, by, paired_d])
                             rotated = T.if_then_else(d < half, -paired_val, paired_val)
                             k_pages[physical_pos, by, d] = T.if_then_else(
-                                d < rotary_dim, val * c + rotated * s, val
+                                d < rotary_dim,
+                                T.Cast(dtype, T.Cast("float32", val) * c + rotated * s),
+                                val,
                             )
                             v_pages[physical_pos, by, d] = v_new[q_start + new_pos, by, d]
                 else:
@@ -1568,13 +1572,15 @@ def _gqa_prefill_paged_with_kv_cache_rope_append_kernel(
                             paired_d = T.if_then_else(
                                 d < half, d + half, T.if_then_else(d < rotary_dim, d - half, d)
                             )
-                            c = cos_table[logical_pos, freq_idx]
-                            s = sin_table[logical_pos, freq_idx]
+                            c = T.Cast("float32", cos_table[logical_pos, freq_idx])
+                            s = T.Cast("float32", sin_table[logical_pos, freq_idx])
                             val = k_new[q_start + new_pos, by, d]
-                            paired_val = k_new[q_start + new_pos, by, paired_d]
+                            paired_val = T.Cast("float32", k_new[q_start + new_pos, by, paired_d])
                             rotated = T.if_then_else(d < half, -paired_val, paired_val)
                             k_pages[physical_pos, by, d] = T.if_then_else(
-                                d < rotary_dim, val * c + rotated * s, val
+                                d < rotary_dim,
+                                T.Cast(dtype, T.Cast("float32", val) * c + rotated * s),
+                                val,
                             )
                             v_pages[physical_pos, by, d] = v_new[q_start + new_pos, by, d]
 
@@ -1761,12 +1767,16 @@ def _gqa_prefill_paged_with_kv_cache_rope_fwd_kernel(
                         d < half, d + half, T.if_then_else(d < rotary_dim, d - half, d)
                     )
                     if new_pos < q_len:
-                        c = cos_table[abs_pos, freq_idx]
-                        s = sin_table[abs_pos, freq_idx]
+                        c = T.Cast("float32", cos_table[abs_pos, freq_idx])
+                        s = T.Cast("float32", sin_table[abs_pos, freq_idx])
                         val = q[q_start + new_pos, by, d]
-                        paired_val = q[q_start + new_pos, by, paired_d]
+                        paired_val = T.Cast("float32", q[q_start + new_pos, by, paired_d])
                         rotated = T.if_then_else(d < half, -paired_val, paired_val)
-                        q_shared[i, d] = T.if_then_else(d < rotary_dim, val * c + rotated * s, val)
+                        q_shared[i, d] = T.if_then_else(
+                            d < rotary_dim,
+                            T.Cast(dtype, T.Cast("float32", val) * c + rotated * s),
+                            val,
+                        )
                     else:
                         q_shared[i, d] = T.cast(0, dtype)
 
@@ -1822,13 +1832,17 @@ def _gqa_prefill_paged_with_kv_cache_rope_fwd_kernel(
                             paired_d = T.if_then_else(
                                 d < half, d + half, T.if_then_else(d < rotary_dim, d - half, d)
                             )
-                            c = cos_table[logical_pos, freq_idx]
-                            s = sin_table[logical_pos, freq_idx]
+                            c = T.Cast("float32", cos_table[logical_pos, freq_idx])
+                            s = T.Cast("float32", sin_table[logical_pos, freq_idx])
                             val = k_new[q_start + new_pos, cur_kv_head, d]
-                            paired_val = k_new[q_start + new_pos, cur_kv_head, paired_d]
+                            paired_val = T.Cast(
+                                "float32", k_new[q_start + new_pos, cur_kv_head, paired_d]
+                            )
                             rotated = T.if_then_else(d < half, -paired_val, paired_val)
                             k_shared[j, d] = T.if_then_else(
-                                d < rotary_dim, val * c + rotated * s, val
+                                d < rotary_dim,
+                                T.Cast(dtype, T.Cast("float32", val) * c + rotated * s),
+                                val,
                             )
                             v_shared[j, d] = v_new[q_start + new_pos, cur_kv_head, d]
                     else:
@@ -1847,13 +1861,17 @@ def _gqa_prefill_paged_with_kv_cache_rope_fwd_kernel(
                                 paired_d = T.if_then_else(
                                     d < half, d + half, T.if_then_else(d < rotary_dim, d - half, d)
                                 )
-                                c = cos_table[kv_pos, freq_idx]
-                                s = sin_table[kv_pos, freq_idx]
+                                c = T.Cast("float32", cos_table[kv_pos, freq_idx])
+                                s = T.Cast("float32", sin_table[kv_pos, freq_idx])
                                 val = k_new[q_start + new_pos, cur_kv_head, d]
-                                paired_val = k_new[q_start + new_pos, cur_kv_head, paired_d]
+                                paired_val = T.Cast(
+                                    "float32", k_new[q_start + new_pos, cur_kv_head, paired_d]
+                                )
                                 rotated = T.if_then_else(d < half, -paired_val, paired_val)
                                 k_shared[j, d] = T.if_then_else(
-                                    d < rotary_dim, val * c + rotated * s, val
+                                    d < rotary_dim,
+                                    T.Cast(dtype, T.Cast("float32", val) * c + rotated * s),
+                                    val,
                                 )
                                 v_shared[j, d] = v_new[q_start + new_pos, cur_kv_head, d]
                             else:


### PR DESCRIPTION
## Problems

- The fused rope path rotates in the storage dtype at six sites across two kernels, rounding `x * cos` and `rotate(x) * sin` and their sum separately where the operator's contract rounds once. `.claude/rules/code-style.md` asks for the opposite: promote overflow-prone fp16/bf16 math to fp32, cast back at the boundary.
- Two of those sites are inside the pipelined KV loop of the attend kernel, and in the storage dtype the register allocator spills. `ptxas -v` reports **320 bytes of stack frame and 168 bytes each of spill stores and loads**; both forms use the same 255 registers, so what changed is not the budget but whether it fits.
- `RopeNeoxPositionIdsFwdOp` already rounds once after #2010, so the two implementations of the same neox rotation disagreed on where it rounds.

## Changes

- All six neox rotation sites carry f32 and round once at the store: three in `_gqa_prefill_paged_with_kv_cache_rope_append_kernel`, the query rotation in `_gqa_prefill_paged_with_kv_cache_rope_fwd_kernel`, and that kernel's two key rotations. The columns past `rotary_dim` are still passed through uncast, so they are bit-identical to before.
- No public contract, manifest, tolerance, test or benchmark changes. Test-node delta: 0.

## TileFoundry Description

The rotation the change touches, on the manifest's mixed-batch row. This is the contract at issue, not the whole operator — the attention, the paging and the online softmax are not here.

```python
"""The fused rope-append's rotation contract, as authored HIR."""

from __future__ import annotations

from tilefoundry import func, module
from tilefoundry.dsl import Tensor, tf
from tilefoundry.ir.types.shard import Topology
from tilefoundry.target import CudaTarget

TOKENS, HEADS_KV, DIM = 4608, 8, 256
MAX_POS = 33792
ROTARY = 64
HALF = ROTARY // 2


@module(
    entry="rope_new_keys",
    target=CudaTarget("nvidia.h200_sxm"),
    topologies=(Topology("cta", 132),),
)
class FusedRopeAppendRotation:
    @func
    def rope_new_keys(
        k_new: Tensor[(TOKENS, HEADS_KV, DIM), "f16"],
        cos_table: Tensor[(MAX_POS, HALF), "f16"],
        sin_table: Tensor[(MAX_POS, HALF), "f16"],
        position_ids: Tensor[(TOKENS,), "i32"],
    ) -> Tensor[(TOKENS, HEADS_KV, DIM), "f16"]:
        cos_rows = tf.index_select(cos_table, position_ids, dim=0)
        sin_rows = tf.index_select(sin_table, position_ids, dim=0)
        cos = tf.cast(
            tf.reshape(tf.concat([cos_rows, cos_rows], axis=-1), new_shape=(TOKENS, 1, ROTARY)),
            dtype="f32",
        )
        sin = tf.cast(
            tf.reshape(tf.concat([sin_rows, sin_rows], axis=-1), new_shape=(TOKENS, 1, ROTARY)),
            dtype="f32",
        )
        # The rounding contract, stated: the table is read at k_new's dtype, the
        # rotation carries f32, and the result rounds once on the way out. The
        # columns past rotary_dim are passed through untouched, not re-rounded.
        wide = tf.cast(k_new[:, :, 0:ROTARY], dtype="f32")
        low = wide[:, :, 0:HALF]
        high = wide[:, :, HALF:ROTARY]
        rotated = tf.concat([tf.neg(high), low], axis=-1)
        turned = tf.cast(wide * cos + rotated * sin, dtype="f16")
        return tf.concat([turned, k_new[:, :, ROTARY:DIM]], axis=-1)
```

`analyze` is what ruled out the obvious explanation. It reports `bound-by=memory`, `ideal-ns=36176` for this rotation — **0.18% of the 19.73 ms the operator measures on that row**. A change to arithmetic that accounts for a fifth of a percent of the work cannot be worth 1.42x, which is what sent this at the generated code instead of at the math.

## Performance

Operator: `GroupedQueryAttentionPrefillPagedWithKVCacheFwdOp` with `fuse_rope=True`

| Environment | Value |
| --- | --- |
| image | `ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-afcebed1-dev` |
| digest | `sha256:8b0bc9414d6f3d22e984d988f85766bd044b6ff23c0e8e1c42e4f3a61d163db6` |
| gpu | `NVIDIA H200` (one device, idle, not the CI runners') |
| driver | `595.71.05` |
| cuda | `13.2` |
| torch | `2.13.0+cu132` |
| tilelang | `0.1.11+cu132.gitafcebed1` |
| timer | native CUPTI device-busy time |

Method: `benchmarks/ops/attention/bench_gqa.py -k 'paged and rope'` unmodified, all three `fuse_rope` manifest rows. The two sides alternated A B A B A B in one sitting on one idle device, each run starting from its own empty `TILELANG_CACHE_DIR` so neither inherits the other's compile state. Both sides select the same `run_config`; these rows carry `tune=False`, so no autotuning separates them.

| Workload | tokens | cache | rotary_dim | Before (ms) | After (ms) | p10 / p90 | Speedup | After TFLOP/s |
| --- | ---: | ---: | ---: | ---: | ---: | :--- | ---: | ---: |
| qwen35-9b-...-b8-prefix32k-chunk1k-p64-partial-rope64 | 8192 | 32768 x8 | 64 | 55.0250 | 36.7259 | 36.566 / 36.809 | **1.4983x** | 243.25 |
| qwen35-9b-...-mixed-b8-p64-partial-rope64 | 4608 | 4k-32k | 64 | 28.0330 | 19.7328 | 19.703 / 19.774 | **1.4206x** | 168.20 |
| llama-8b-...-b8-prefix4k-chunk512-p64-full-rope | 4096 | 4096 x8 | 128 | 1.7100 | 1.4526 | 1.447 / 1.458 | **1.1772x** | 201.08 |
| geometric mean |  |  |  |  |  |  | **1.3582x** |  |

Run-to-run spread within each side is under 0.2% of the median, an order of magnitude below every win.

## Result And Limitations

- **Where the win is.** Converting the sites in subsets localises it exactly. The three append-kernel sites are worth 0.999x, 1.001x and 0.999x; the query rotation is worth 0.999x, 1.001x and 1.000x; the attend kernel's two key rotations alone are worth 1.507x, 1.422x and 1.178x — the whole effect. Converting all six measures the same as converting those two.
- **Why.** `ptxas -v` on the generated `device_kernel.cu` for the attend kernel: before, `320 bytes stack frame, 168 bytes spill stores, 168 bytes spill loads`; after, `0 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads`. Registers are 255 on both sides.
- **Why the win does not scale with how often the rotation runs.** On the largest row the rotating branch is taken on about 32 of 1056 loop iterations. A spill slot is not per-branch: the local-memory traffic lands wherever the spilled values are live, which is the whole loop. That is also why the smallest row gains least — its cache is short, so the loop it pays for is short.
- **Numerics.** Checked on the mixed-batch benchmark shape rather than only the unit-test shape, which is 96 tokens and does not reach these branches. Against the previous kernel: appended `k_pages` differs by at most 3.906e-03, exactly one float16 ulp at that magnitude, on 528729 of 553648128 elements; the attention output differs by at most 1.22e-04 with a mean absolute difference of 2.9e-06 against a mean magnitude of 0.0104. The two agree to one rounding step, and this side is the one that rounds once.
- **This rests on a codegen outcome, not on the arithmetic.** The change is justified on its own terms — it is the rounding contract the code-style rule states and the one #2010 already ships for the same rotation — but the 1.4x is ptxas fitting the loop into registers, and a future tilelang or CUDA release could reach the same allocation from either spelling. The correctness argument is the durable one.
- Tests: `tests/ops/attention/test_gqa_prefill_paged.py` and `tests/ops/attention/test_gqa.py`, 82 passed. `pre-commit` clean.
