### PR TITLE
[Perf][foundry][RoPE] Rotate a neox pair per thread in both layouts

### DIFF
--- a/src/tileops/kernels/rope.py
+++ b/src/tileops/kernels/rope.py
@@ -50,11 +50,11 @@ def _make_rope_neox_1d(
 ) -> object:
     """1D neox RoPE kernel: (seq_len, head_dim) x cos(seq_len, half) x sin(seq_len, half).
 
-    cos/sin are of shape (seq_len, head_dim // 2).
-    The kernel internally constructs full-dim cos/sin by duplication.
+    cos/sin are of shape (seq_len, head_dim // 2), one entry per rotated pair.
+    One thread per pair ``(c, c + half)``; the arithmetic is f32 and rounds once.
     """
     half = head_dim // 2
-    N_total = seq_len * head_dim
+    n_pairs = seq_len * half
     block_size = threads * num_per_thread
 
     @tilelang.jit(out_idx=[3])
@@ -66,24 +66,18 @@ def _make_rope_neox_1d(
             sin_table: T.Tensor((seq_len, half), dtype),
             y: T.Tensor((seq_len, head_dim), dtype),
         ):
-            with T.Kernel(T.ceildiv(N_total, block_size), threads=threads_arg) as bx:
+            with T.Kernel(T.ceildiv(n_pairs, block_size), threads=threads_arg) as bx:
                 for i, j in T.Parallel(threads_arg, npt_arg):
-                    flat_idx = (bx * threads_arg + i) * npt_arg + j
-                    row = flat_idx // head_dim
-                    col = flat_idx % head_dim
-                    # Neox: first half uses cos[col], second half uses cos[col - half]
-                    freq_idx = col % half
-                    c = cos_table[row, freq_idx]
-                    s = sin_table[row, freq_idx]
-                    val = x[row, col]
-                    # rotate_half: if col < half -> paired with x[row, col + half] (negated)
-                    # if col >= half -> paired with x[row, col - half]
-                    rotated = T.if_then_else(
-                        col < half,
-                        -x[row, col + half],
-                        x[row, col - half],
-                    )
-                    y[row, col] = val * c + rotated * s
+                    pair_idx = (bx * threads_arg + i) * npt_arg + j
+                    if pair_idx < n_pairs:
+                        row = pair_idx // half
+                        col = pair_idx % half
+                        c = T.Cast("float32", cos_table[row, col])
+                        s = T.Cast("float32", sin_table[row, col])
+                        x_low = T.Cast("float32", x[row, col])
+                        x_high = T.Cast("float32", x[row, col + half])
+                        y[row, col] = T.Cast(dtype, x_low * c - x_high * s)
+                        y[row, col + half] = T.Cast(dtype, x_high * c + x_low * s)
 
         return main
 
@@ -103,43 +97,36 @@ def _make_rope_neox_2d(
     """2D neox RoPE kernel: (batch, seq_len, num_heads, head_dim).
 
     cos/sin are of shape (seq_len, head_dim // 2), broadcast over batch and heads.
+    One thread per pair ``(c, c + half)``; the arithmetic is f32 and rounds once.
     """
     half = head_dim // 2
-    N_total = batch * seq_len * num_heads * head_dim
+    n_total = batch * seq_len * num_heads * head_dim
+    n_pairs = batch * seq_len * num_heads * half
     block_size = threads * num_per_thread
-    stride_b = seq_len * num_heads * head_dim
-    stride_s = num_heads * head_dim
 
     @tilelang.jit(out_idx=[3])
     def kernel(threads_arg, npt_arg):
         @T.prim_func
         def main(
-            x: T.Tensor((N_total,), dtype),
+            x: T.Tensor((n_total,), dtype),
             cos_table: T.Tensor((seq_len, half), dtype),
             sin_table: T.Tensor((seq_len, half), dtype),
-            y: T.Tensor((N_total,), dtype),
+            y: T.Tensor((n_total,), dtype),
         ):
-            with T.Kernel(T.ceildiv(N_total, block_size), threads=threads_arg) as bx:
+            with T.Kernel(T.ceildiv(n_pairs, block_size), threads=threads_arg) as bx:
                 for i, j in T.Parallel(threads_arg, npt_arg):
-                    flat_idx = (bx * threads_arg + i) * npt_arg + j
-                    rem = flat_idx % stride_b
-                    s_idx = rem // stride_s
-                    rem2 = rem % stride_s
-                    col = rem2 % head_dim
-
-                    freq_idx = col % half
-                    c = cos_table[s_idx, freq_idx]
-                    s = sin_table[s_idx, freq_idx]
-                    val = x[flat_idx]
-
-                    # Compute the paired index for rotate_half
-                    paired_col = T.if_then_else(col < half, col + half, col - half)
-                    head_base = flat_idx - col
-                    paired_idx = head_base + paired_col
-                    paired_val = x[paired_idx]
-
-                    rotated = T.if_then_else(col < half, -paired_val, paired_val)
-                    y[flat_idx] = val * c + rotated * s
+                    pair_idx = (bx * threads_arg + i) * npt_arg + j
+                    if pair_idx < n_pairs:
+                        head = pair_idx // half
+                        col = pair_idx % half
+                        s_idx = (head // num_heads) % seq_len
+                        low = head * head_dim + col
+                        c = T.Cast("float32", cos_table[s_idx, col])
+                        s = T.Cast("float32", sin_table[s_idx, col])
+                        x_low = T.Cast("float32", x[low])
+                        x_high = T.Cast("float32", x[low + half])
+                        y[low] = T.Cast(dtype, x_low * c - x_high * s)
+                        y[low + half] = T.Cast(dtype, x_high * c + x_low * s)
 
         return main
 


### PR DESCRIPTION
## Problems

- Both neox builders walked one output element per thread, so every thread loaded its own value and then its rotation partner's, and the partner load was a scalar behind an `if_then_else` rather than a vector. A memory-bound rotation was moving three units of traffic — two reads and a write — where two suffice.
- The 2d builder located each element by taking the flat index modulo the batch stride and dividing by the sequence stride, four integer divisions per output element.
- The rotation ran in the storage dtype, rounding the product and the sum separately, where `.claude/rules/code-style.md` asks for f32 with one rounding at the boundary and where `RopeNeoxPositionIdsFwdOp` already rounds once after #2010.

## Changes

- A thread owns the pair `(c, c + half)`, in both layouts: `x` is read once, both outputs leave in the same step, and the frequency entry is read once per pair rather than once per element.
- The 2d position arithmetic drops to the head a pair sits in. The batch stride never enters it.
- The rotation carries f32 and rounds once at the store.
- Test-node delta: 0. No manifest, tolerance or public-contract change.

Four ops share these two builders — `RopeNeoxFwdOp`, `RopeLlama31FwdOp`, `RopeYarnFwdOp`, `RopeLongRopeFwdOp` — differing only in how the op layer fills the frequency table. All four are measured below.

## TileFoundry Description

Placed over CTAs with the intermediates in registers, so the traffic reported is the fused kernel's rather than a chain of materialised temporaries. `analyze` gives `bound-by=memory`, `ideal-ns=14637` for the 2d float16 row.

```python
"""The 2d neox rotation placed on CTAs, its intermediates in registers: the fused floor."""

from __future__ import annotations

from tilefoundry import func, module
from tilefoundry.dsl import Mesh, Tensor, tf
from tilefoundry.ir.types.shard import Topology
from tilefoundry.target import CudaTarget

B, S, H, D = 2, 2048, 32, 128
HALF = D // 2
CTAS = 1024


@module(
    entry="rope_neox_2d",
    target=CudaTarget("nvidia.h200_sxm"),
    topologies=(Topology("cta", CTAS),),
)
class RopeNeox2dPlaced:
    @func
    def rope_neox_2d(
        x: Tensor[(B, S, H, D), "f16"],
        cos_table: Tensor[(S, HALF), "f16"],
        sin_table: Tensor[(S, HALF), "f16"],
    ) -> Tensor[(B, S, H, D), "f16"]:
        with Mesh(("cta",), layout=(CTAS,), names=("tile",)) as cta:
            cos_full = tf.reshape(
                tf.concat([cos_table, cos_table], axis=-1), new_shape=(1, S, 1, D)
            )
            sin_full = tf.reshape(
                tf.concat([sin_table, sin_table], axis=-1), new_shape=(1, S, 1, D)
            )
            x_reg = tf.reshard(x, (B, S @ cta.tile, H, D), "rmem")
            cos = tf.reshard(cos_full, (1, S @ cta.tile, 1, D), "rmem")
            sin = tf.reshard(sin_full, (1, S @ cta.tile, 1, D), "rmem")
            low = x_reg[:, :, :, 0:HALF]
            high = x_reg[:, :, :, HALF:D]
            rotated = tf.concat([tf.neg(high), low], axis=-1)
            return tf.reshard(x_reg * cos + rotated * sin, (B, S @ cta.tile, H, D), "gmem")
```

A second pair of modules states the rounding contract for each layout — the table read at `x`'s dtype, the rotation in f32, one rounding on the way out — and `check` runs the shipped kernels against them as runtime twins, on the manifest's own shapes with a real frequency table:

| Layout | Predicate | This branch | The kernel it replaces |
| --- | --- | --- | --- |
| 1d `(2048, 64)` f16 | `equal` | 0 of 131072 differ, **PASS** | 27574 differ, `max_abs` 1.95e-03, FAIL |
| 2d `(2, 2048, 32, 128)` f16 | `equal` | 0 of 16777216 differ, **PASS** | 3506980 differ, `max_abs` 3.91e-03, FAIL |

The control failing at one float16 ulp is what makes `equal` a claim rather than a formality.

## Performance

| Environment | Value |
| --- | --- |
| image | `ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-afcebed1-dev` |
| gpu | `NVIDIA H200` (one device, idle, not the CI runners') |
| driver | `595.71.05`, cuda `13.2`, torch `2.13.0+cu132`, tilelang `0.1.11+cu132.gitafcebed1` |
| timer | native CUPTI device-busy time |

Method: `benchmarks/ops/bench_rope.py` unmodified. The two sides alternated A B A B in one sitting on one idle device, each run from its own empty `TILELANG_CACHE_DIR`.

| Op | Workload | Layout | Before (ms) | After (ms) | Speedup | torch-compile (ms) / ours |
| --- | --- | --- | ---: | ---: | ---: | ---: |
| RopeNeoxFwdOp | `(2, 2048, 32, 128)` f16 | 2d | 0.02680 | 0.01890 | **1.418x** | 0.01790 &#x1F534; 0.947x |
| RopeLlama31FwdOp | `(1, 8192, 32, 128)` f16 | 2d | 0.05095 | 0.03540 | **1.439x** | 0.03390 &#x1F534; 0.958x |
| RopeYarnFwdOp | `(1, 8192, 32, 128)` f16 | 2d | 0.05095 | 0.03535 | **1.441x** | 0.03390 &#x1F534; 0.959x |
| RopeLongRopeFwdOp | `(1, 8192, 32, 128)` f16 | 2d | 0.05105 | 0.03535 | **1.444x** | 0.03390 &#x1F534; 0.959x |
| RopeNeoxFwdOp | `(4096, 128)` bf16 | 1d | 0.00260 | 0.00250 | 1.040x | 0.00290 &#x1F7E2; 1.160x |
| RopeNeoxFwdOp | `(2048, 64)` f16 | 1d | 0.00170 | 0.00180 | 0.944x | 0.00190 &#x1F7E2; 1.056x |
| RopeLlama31FwdOp | `(8192, 128)` bf16 | 1d | 0.00350 | 0.00350 | 1.000x | 0.00415 &#x1F7E2; 1.186x |
| RopeYarnFwdOp | `(8192, 128)` bf16 | 1d | 0.00350 | 0.00350 | 1.000x | 0.00415 &#x1F7E2; 1.186x |
| RopeLongRopeFwdOp | `(8192, 128)` bf16 | 1d | 0.00350 | 0.00350 | 1.000x | 0.00415 &#x1F7E2; 1.186x |

Against `torch-ref` the 2d rows are 12.2x to 12.4x and the 1d rows 4.1x to 4.7x, before and after.

## Result And Limitations

**improvement without SOTA**

- Every 2d row improves by 1.418x to 1.444x. That is the traffic: three units become two, and the measured ratio lands where a 3:2 reduction predicts.
- The 1d rows do not move because they are not bandwidth-bound. `(2048, 64)` is 128 K elements — 256 KB of traffic — and runs in 1.7 to 1.8 us, which is this device's empty-kernel floor. Nothing about the kernel body is reachable there, and the 0.944x on that row is one sample bucket at the floor, not a regression in the work.
- Against the fused floor the 2d float16 row sits at 1.244x of `ideal-ns=14637`. That gap is nominal bandwidth: `analyze` divides traffic by the device's 4.8 TB/s, and a copy of the same bytes reaches 3.8. Measured on this shape, a twin with the same grid and walk but no rotation runs in 18.399 us and `torch`'s own device copy in 17.792, against the shipped kernel's 18.208 at its best config — the rotation costs about 1% over a pure copy of its own access pattern.
- **A 4% config win is left for the follow-up.** The shared `_RopeKernelBase.default_config` picks `threads=256, num_per_thread=8`. On the 2d float16 shape that measures 18.944 us, where `256x4` measures 18.208 and `128x8` 18.241 — both faster than the copy twin at the default config. The default is shared with the non-neox builders, which are being reworked separately; changing it there lets one measurement cover all five ops rather than splitting the decision across two PRs. The numbers in the table above are the default config, so this PR under-reports itself by about 4% on the 2d rows.
- The 2d rows remain 4.1% to 5.3% behind `torch.compile`, which is itself at the copy ceiling on this shape. The config change above closes most of that.
- Tests: `tests/ops/test_rope.py`, 55 passed. `pre-commit` clean.
