### PR TITLE
[CI][Runner] Bake setuptools-scm so the tileops install skips build isolation

### DIFF
--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -39,9 +39,10 @@ ENV UV_INDEX_URL=https://download.pytorch.org/whl/cu132 \
 # minor refuses to load beside this torch, so vllm's pin is met by the extension-free CPU wheel.
 RUN uv pip install "torch==2.13.0+cu132" "torchvision==0.28.0+cu132"
 # tilelang's build backend and runtime deps, so its stage can use --no-build-isolation. The wheel
-# cmake meets tilelang's >=3.26.1 floor; jammy apt cmake is 3.22.
+# cmake meets tilelang's >=3.26.1 floor; jammy apt cmake is 3.22. setuptools-scm is tileops'
+# backend, baked in for the same reason.
 RUN uv pip install \
-        setuptools wheel ninja scikit-build-core patchelf cmake \
+        setuptools setuptools-scm wheel ninja scikit-build-core patchelf cmake \
         triton apache-tvm-ffi cloudpickle ml_dtypes numpy psutil tqdm \
         typing_extensions Cython z3-solver torch_c_dlpack_ext einops "PyYAML>=6.0"
 ARG MAX_JOBS=64

--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -77,17 +77,11 @@ RUN set -e; \
 # Own layer: no wheel for this torch/py, so it builds from source and changes to the bench loop
 # below must not recompile it.
 FROM post-fa3 AS fa2
-# Retried like DeepGEMM below: setup.py takes a prebuilt wheel from GitHub releases, and
-# a dropped download fails a step that would have worked. FLASH_ATTENTION_FORCE_BUILD
-# compiles instead -- slower, and the way out where that download keeps failing.
+# setup.py takes a prebuilt wheel from GitHub releases. FLASH_ATTENTION_FORCE_BUILD compiles
+# instead -- slower, and the way out where that download is unavailable.
 ARG FLASH_ATTENTION_FORCE_BUILD=
-RUN for attempt in 1 2 3 4 5; do \
-        FLASH_ATTENTION_FORCE_BUILD="${FLASH_ATTENTION_FORCE_BUILD}" \
-            uv pip install --no-build-isolation "flash-attn==2.8.3.post1" && break; \
-        echo "WARNING: flash-attn (FA2) install failed (attempt ${attempt}/5)"; \
-        [ "${attempt}" = 5 ] && exit 1; \
-        sleep "$((attempt * 10))"; \
-    done
+RUN FLASH_ATTENTION_FORCE_BUILD="${FLASH_ATTENTION_FORCE_BUILD}" \
+        uv pip install --no-build-isolation "flash-attn==2.8.3.post1"
 
 # This vllm and no other: its apache-tvm-ffi pin (0.1.11) is the one the tilelang commit needs.
 # Versions come from constraints.txt via UV_CONSTRAINT. sgl-kernel is not installed.
@@ -113,23 +107,10 @@ RUN { mkdir -p /tmp/DeepGEMM \
         && cd /tmp/DeepGEMM \
         && git init -q \
         && git remote add origin https://github.com/deepseek-ai/DeepGEMM.git \
-        && for attempt in 1 2 3 4 5; do \
-            git -c http.version=HTTP/1.1 fetch --depth 1 origin "${DEEPGEMM_GIT_SHA}" && break; \
-            status="$?"; \
-            echo "WARNING: DeepGEMM fetch failed (attempt ${attempt}/5, status ${status})"; \
-            if [ "${attempt}" = 5 ]; then exit "${status}"; fi; \
-            sleep "$((attempt * 10))"; \
-        done \
+        && git fetch --depth 1 origin "${DEEPGEMM_GIT_SHA}" \
         && git checkout -q FETCH_HEAD \
-        && for attempt in 1 2 3 4 5; do \
-            git -c http.version=HTTP/1.1 submodule update --init --depth 1 --jobs 1 \
-                third-party/cutlass third-party/fmt && break; \
-            status="$?"; \
-            echo "WARNING: DeepGEMM submodule fetch failed (attempt ${attempt}/5, status ${status})"; \
-            rm -rf third-party/cutlass third-party/fmt .git/modules/third-party/cutlass .git/modules/third-party/fmt; \
-            if [ "${attempt}" = 5 ]; then exit "${status}"; fi; \
-            sleep "$((attempt * 10))"; \
-        done \
+        && git submodule update --init --depth 1 --jobs 1 \
+            third-party/cutlass third-party/fmt \
         && DG_FORCE_BUILD=1 uv pip install --no-build-isolation --no-deps .; } \
     || echo "WARNING: DeepGEMM v2.1.1.post3 install failed (non-fatal)"; \
     rm -rf /tmp/DeepGEMM
@@ -142,22 +123,15 @@ ARG TILELANG_GIT_SHA
 ARG TILELANG_VERSION
 # --no-deps: never re-resolve the cu132 stack. --reinstall: a same-version PyPI tilelang must not
 # read as already satisfied. `pip wheel` stays on pip — uv has no equivalent subcommand.
+# cutlass and tvm only: composable_kernel is the ROCm backend's, and this image builds CUDA.
 RUN if [ -n "${TILELANG_GIT_SHA}" ]; then \
         mkdir -p /tmp/tilelang && cd /tmp/tilelang \
         && git init -q \
         && git remote add origin https://github.com/tile-ai/tilelang.git \
-        && for attempt in 1 2 3 4 5; do \
-            git -c http.version=HTTP/1.1 fetch --depth 1 origin "${TILELANG_GIT_SHA}" && break; \
-            echo "WARNING: tilelang fetch failed (attempt ${attempt}/5)"; \
-            [ "${attempt}" = 5 ] && exit 1; sleep "$((attempt * 10))"; \
-        done \
+        && git fetch --depth 1 origin "${TILELANG_GIT_SHA}" \
         && git checkout -q FETCH_HEAD \
-        && for attempt in 1 2 3 4 5; do \
-            git -c http.version=HTTP/1.1 submodule update --init --depth 1 --recursive --jobs 1 \
-                3rdparty/composable_kernel 3rdparty/cutlass 3rdparty/tvm && break; \
-            echo "WARNING: tilelang submodule fetch failed (attempt ${attempt}/5)"; \
-            [ "${attempt}" = 5 ] && exit 1; sleep "$((attempt * 10))"; \
-        done \
+        && git submodule update --init --depth 1 --recursive --jobs 1 \
+            3rdparty/cutlass 3rdparty/tvm \
         && mkdir -p /opt/tilelang-wheels \
         && CMAKE_BUILD_PARALLEL_LEVEL="${MAX_JOBS}" \
             python -m pip wheel . --no-deps --no-build-isolation -w /opt/tilelang-wheels \

--- a/.github/runner/requirements.in
+++ b/.github/runner/requirements.in
@@ -12,6 +12,8 @@ torchvision==0.28.0+cu132
 # carries no such extension.
 torchaudio==2.11.0+cpu
 setuptools
+# tileops' build backend, so its editable install can skip build isolation.
+setuptools-scm
 wheel
 ninja
 scikit-build-core

--- a/constraints-runner-lock.txt
+++ b/constraints-runner-lock.txt
@@ -182,6 +182,7 @@ sentencepiece==0.2.2
 sentry-sdk==2.67.1
 setproctitle==1.3.7
 setuptools==80.10.2
+setuptools-scm==10.2.1
 shellingham==1.5.4
 six==1.17.0
 sniffio==1.3.1
@@ -210,6 +211,7 @@ typing-inspection==0.4.3
 urllib3==2.7.0
 uvicorn==0.52.1
 uvloop==0.22.1
+vcs-versioning==2.3.1
 vllm==0.27.1
 watchfiles==1.2.0
 websockets==17.0.1

--- a/scripts/ci/install_tileops.sh
+++ b/scripts/ci/install_tileops.sh
@@ -16,7 +16,16 @@ if ! python3 -c "import tilelang" >/dev/null 2>&1; then
   exit 1
 fi
 
-# tileops only; its runtime deps come from the runner image.
-python3 -m pip install -e "${REPO_ROOT}" --no-deps -c "${CONSTRAINTS}"
+if ! python3 -c "import setuptools_scm" >/dev/null 2>&1; then
+  {
+    echo "::error::setuptools-scm is missing; the install below skips build isolation."
+    echo "  The runner image bakes it. Repoint the runner at a newer tag."
+  } >&2
+  exit 1
+fi
+
+# tileops only; its runtime deps come from the runner image. --no-build-isolation: the image bakes
+# the build backend, and an isolated build fetches it from PyPI per run.
+python3 -m pip install -e "${REPO_ROOT}" --no-deps --no-build-isolation -c "${CONSTRAINTS}"
 
 python3 -c "import tileops, tilelang; print('install_tileops: tileops + tilelang import OK')"

--- a/scripts/ci/verify_runtime_stack.py
+++ b/scripts/ci/verify_runtime_stack.py
@@ -66,6 +66,13 @@ if bindings_pin is not None and not bindings_pin.specifier.contains(
         f"{bindings_pin.specifier}. Install cupti-python with --no-deps."
     )
 
+# install_tileops.sh builds tileops with --no-build-isolation, which resolves no backend itself.
+for dist in ("setuptools", "setuptools-scm", "wheel"):
+    try:
+        md.version(dist)
+    except md.PackageNotFoundError:
+        sys.exit(f"FAIL: {dist} is missing; tileops cannot build with --no-build-isolation.")
+
 # A missing baseline costs the column, not the run, so nothing else notices. FA3 is
 # imported because a returned 0 has meant an installed wrapper with no extension behind
 # it; the rest are checked for presence, since flag_gems and flashinfer want a device.


### PR DESCRIPTION
## Problems

- `install_tileops.sh` resolves a build backend from PyPI on every run, across four CI entry points.
- The runner image bakes no `setuptools-scm`, so that install cannot skip build isolation.
- A missing build backend fails nothing until CI installs; the image build itself does not check.
- The tilelang stage clones `3rdparty/composable_kernel`, the ROCm backend's submodule, into a CUDA-only image.
- Five-attempt loops and an HTTP/1.1 pin work around one network's faults, in a file every contributor builds.

## Changes

- `requirements.in` adds `setuptools-scm`; the lock gains it and `vcs-versioning`, no other version moves.
- The image installs `setuptools-scm` beside `setuptools` and `wheel`.
- `install_tileops.sh` passes `--no-build-isolation`, and refuses an image built before this change.
- `verify_runtime_stack.py` fails the image build when a build backend is missing.
- The tilelang stage clones `3rdparty/cutlass` and `3rdparty/tvm` only.
- The retry loops and the HTTP/1.1 pin are gone.

Needs a rebuilt runner image and a runner rollout before it lands.
