### PR TITLE
[Perf][foundry][RoPE] Stage the non-neox rotation through shared memory, and shape the config per style

### DIFF
--- a/src/tileops/kernels/rope.py
+++ b/src/tileops/kernels/rope.py
@@ -139,12 +139,19 @@ def _make_rope_non_neox_1d(
 ) -> object:
     """1D non-neox (RoFormer) RoPE kernel: adjacent-pair rotation.
 
-    cos/sin shape: (seq_len, head_dim // 2). Applied with interleaving to match
-    the adjacent-pair pattern.
+    cos/sin shape: (seq_len, head_dim // 2), one entry per pair.
+    The arithmetic is f32 and rounds once.
     """
     half = head_dim // 2
-    N_total = seq_len * head_dim
+    n_pairs = seq_len * half
     block_size = threads * num_per_thread
+    rows_per_block = block_size // head_dim
+    staged = (
+        num_per_thread % 2 == 0
+        and rows_per_block > 0
+        and block_size % head_dim == 0
+        and seq_len % rows_per_block == 0
+    )
 
     @tilelang.jit(out_idx=[3])
     def kernel(threads_arg, npt_arg):
@@ -155,24 +162,37 @@ def _make_rope_non_neox_1d(
             sin_table: T.Tensor((seq_len, half), dtype),
             y: T.Tensor((seq_len, head_dim), dtype),
         ):
-            with T.Kernel(T.ceildiv(N_total, block_size), threads=threads_arg) as bx:
-                for i, j in T.Parallel(threads_arg, npt_arg):
-                    flat_idx = (bx * threads_arg + i) * npt_arg + j
-                    row = flat_idx // head_dim
-                    col = flat_idx % head_dim
-                    freq_idx = col // 2  # pair index
-                    c = cos_table[row, freq_idx]
-                    s = sin_table[row, freq_idx]
-                    val = x[row, col]
-                    # For even col: paired with x[row, col+1] (negated)
-                    # For odd col: paired with x[row, col-1]
-                    is_even = (col % 2) == 0
-                    rotated = T.if_then_else(
-                        is_even,
-                        -x[row, col + 1],
-                        x[row, col - 1],
-                    )
-                    y[row, col] = val * c + rotated * s
+            if staged:
+                with T.Kernel(seq_len // rows_per_block, threads=threads_arg) as bx:
+                    xs = T.alloc_shared((rows_per_block, head_dim), dtype)
+                    ys = T.alloc_shared((rows_per_block, head_dim), dtype)
+                    row0 = bx * rows_per_block
+                    T.copy(x[row0 : row0 + rows_per_block, :], xs)
+                    for i, j in T.Parallel(threads_arg, npt_arg // 2):
+                        slot = i * npt_arg + j * 2
+                        row = slot // head_dim
+                        col = slot % head_dim
+                        pair = col // 2
+                        c = T.Cast("float32", cos_table[row0 + row, pair])
+                        s = T.Cast("float32", sin_table[row0 + row, pair])
+                        x_even = T.Cast("float32", xs[row, col])
+                        x_odd = T.Cast("float32", xs[row, col + 1])
+                        ys[row, col] = T.Cast(dtype, x_even * c - x_odd * s)
+                        ys[row, col + 1] = T.Cast(dtype, x_odd * c + x_even * s)
+                    T.copy(ys, y[row0 : row0 + rows_per_block, :])
+            else:
+                with T.Kernel(T.ceildiv(n_pairs, block_size), threads=threads_arg) as bx:
+                    for i, j in T.Parallel(threads_arg, npt_arg):
+                        pair_idx = (bx * threads_arg + i) * npt_arg + j
+                        if pair_idx < n_pairs:
+                            row = pair_idx // half
+                            pair = pair_idx % half
+                            c = T.Cast("float32", cos_table[row, pair])
+                            s = T.Cast("float32", sin_table[row, pair])
+                            x_even = T.Cast("float32", x[row, pair * 2])
+                            x_odd = T.Cast("float32", x[row, pair * 2 + 1])
+                            y[row, pair * 2] = T.Cast(dtype, x_even * c - x_odd * s)
+                            y[row, pair * 2 + 1] = T.Cast(dtype, x_odd * c + x_even * s)
 
         return main
 
@@ -270,44 +290,59 @@ def _make_rope_non_neox_2d(
     threads: int = 256,
     num_per_thread: int = 8,
 ) -> object:
-    """2D non-neox (RoFormer) RoPE kernel: (batch, seq_len, num_heads, head_dim)."""
+    """2D non-neox (RoFormer) RoPE kernel: (batch, seq_len, num_heads, head_dim).
+
+    The arithmetic is f32 and rounds once.
+    """
     half = head_dim // 2
-    N_total = batch * seq_len * num_heads * head_dim
+    n_total = batch * seq_len * num_heads * head_dim
+    n_pairs = n_total // 2
     block_size = threads * num_per_thread
-    stride_b = seq_len * num_heads * head_dim
-    stride_s = num_heads * head_dim
+
+    staged = num_per_thread % 2 == 0 and n_total % block_size == 0 and block_size % head_dim == 0
 
     @tilelang.jit(out_idx=[3])
     def kernel(threads_arg, npt_arg):
         @T.prim_func
         def main(
-            x: T.Tensor((N_total,), dtype),
+            x: T.Tensor((n_total,), dtype),
             cos_table: T.Tensor((seq_len, half), dtype),
             sin_table: T.Tensor((seq_len, half), dtype),
-            y: T.Tensor((N_total,), dtype),
+            y: T.Tensor((n_total,), dtype),
         ):
-            with T.Kernel(T.ceildiv(N_total, block_size), threads=threads_arg) as bx:
-                for i, j in T.Parallel(threads_arg, npt_arg):
-                    flat_idx = (bx * threads_arg + i) * npt_arg + j
-                    rem = flat_idx % stride_b
-                    s_idx = rem // stride_s
-                    rem2 = rem % stride_s
-                    col = rem2 % head_dim
-
-                    freq_idx = col // 2
-                    c = cos_table[s_idx, freq_idx]
-                    s = sin_table[s_idx, freq_idx]
-                    val = x[flat_idx]
-
-                    # Adjacent pair: even pairs with next, odd pairs with previous.
-                    # Compute the same pair as a +/-1 flat offset to avoid a
-                    # TileLang 0.1.9 lowering bug for if_then_else-derived indices.
-                    col_parity = col % 2
-                    paired_idx = flat_idx + 1 - 2 * col_parity
-                    paired_val = x[paired_idx]
-
-                    rotated = T.if_then_else(col_parity == 0, -paired_val, paired_val)
-                    y[flat_idx] = val * c + rotated * s
+            if staged:
+                with T.Kernel(T.ceildiv(n_total, block_size), threads=threads_arg) as bx:
+                    xs = T.alloc_shared((block_size,), dtype)
+                    ys = T.alloc_shared((block_size,), dtype)
+                    T.copy(x[bx * block_size : (bx + 1) * block_size], xs)
+                    for i, j in T.Parallel(threads_arg, npt_arg // 2):
+                        slot = i * npt_arg + j * 2
+                        idx = bx * block_size + slot
+                        head = idx // head_dim
+                        pair = (idx % head_dim) // 2
+                        s_idx = (head // num_heads) % seq_len
+                        c = T.Cast("float32", cos_table[s_idx, pair])
+                        s = T.Cast("float32", sin_table[s_idx, pair])
+                        x_even = T.Cast("float32", xs[slot])
+                        x_odd = T.Cast("float32", xs[slot + 1])
+                        ys[slot] = T.Cast(dtype, x_even * c - x_odd * s)
+                        ys[slot + 1] = T.Cast(dtype, x_odd * c + x_even * s)
+                    T.copy(ys, y[bx * block_size : (bx + 1) * block_size])
+            else:
+                with T.Kernel(T.ceildiv(n_pairs, block_size), threads=threads_arg) as bx:
+                    for i, j in T.Parallel(threads_arg, npt_arg):
+                        pair_idx = (bx * threads_arg + i) * npt_arg + j
+                        if pair_idx < n_pairs:
+                            head = pair_idx // (head_dim // 2)
+                            pair = pair_idx % (head_dim // 2)
+                            s_idx = (head // num_heads) % seq_len
+                            even = head * head_dim + pair * 2
+                            c = T.Cast("float32", cos_table[s_idx, pair])
+                            s = T.Cast("float32", sin_table[s_idx, pair])
+                            x_even = T.Cast("float32", x[even])
+                            x_odd = T.Cast("float32", x[even + 1])
+                            y[even] = T.Cast(dtype, x_even * c - x_odd * s)
+                            y[even + 1] = T.Cast(dtype, x_odd * c + x_even * s)
 
         return main
 
@@ -418,7 +453,10 @@ class _RopeKernelBase(Kernel):
 
     @property
     def default_config(self) -> dict:
-        npt = 4 if self.dtype == torch.float32 else 8
+        if self.ROTATION_STYLE == "non_neox":
+            npt = 8 if self.dtype == torch.float32 else 16
+            return {"threads": 128, "num_per_thread": npt}
+        npt = 2 if self.dtype == torch.float32 else 4
         return {"threads": 256, "num_per_thread": npt}
 
     def forward(self, x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
## Problems

- A RoFormer rotation couples two **adjacent** elements. A thread that owns such a pair owns two runs strided by two, so no vectorised global access can be formed and half of every transaction is discarded. Measured on the 2d workload, the pair walk reaches 3.12 TB/s where a copy of the same bytes reaches 3.79.
- A fragment cannot hold the pair: TileLang infers a fragment's layout from one index expression per parallel body, and the rotation needs `xr[slot]` and `xr[slot + 1]`. It rejects that with `StructuralEqual()(it->second.indices, indices) is false`.
- `_RopeKernelBase.default_config` served both rotation styles with one shape, `threads=256, num_per_thread=8`. The two styles read differently and do not want the same one.

## Changes

- The non-neox block moves through shared memory. Both global accesses become one contiguous run — the shape a memcpy has — and the stride-two reads land in shared memory, where a two-byte stride costs nothing.
- Staging copies whole rows, so it is used when the block is some number of them and the row count divides by that. A shape that leaves a partial block walks the pairs under a guard; those shapes are orders of magnitude below where wider accesses pay for themselves.
- `default_config` is rotation-style aware: neox takes `256 x 4`, one sixteen-byte access per run where the old default gave it two; non-neox takes `128 x 16`, wide enough to amortise the staging. Both were measured on this family's widest manifest workloads.
- Test-node delta: 0. No manifest, tolerance or public-contract change.

## TileFoundry Description

```python
"""The non-neox rotation's contract: an adjacent pair, rounded once."""

from __future__ import annotations

from tilefoundry import func, module
from tilefoundry.dsl import Tensor, tf
from tilefoundry.ir.types.shard import Topology
from tilefoundry.target import CudaTarget

B, S, H, D = 2, 2048, 32, 128
HALF = D // 2


@module(
    entry="rope_non_neox_2d",
    target=CudaTarget("nvidia.h200_sxm"),
    topologies=(Topology("cta", 132),),
)
class RopeNonNeox2d:
    @func
    def rope_non_neox_2d(
        x: Tensor[(B, S, H, D), "bf16"],
        cos_table: Tensor[(S, HALF), "bf16"],
        sin_table: Tensor[(S, HALF), "bf16"],
    ) -> Tensor[(B, S, H, D), "bf16"]:
        # One frequency entry per pair, so the table is repeated rather than
        # concatenated: entry p serves columns 2p and 2p + 1.
        cos = tf.cast(
            tf.reshape(
                tf.repeat_interleave(cos_table, repeats=2, axis=-1), new_shape=(1, S, 1, D)
            ),
            dtype="f32",
        )
        sin = tf.cast(
            tf.reshape(
                tf.repeat_interleave(sin_table, repeats=2, axis=-1), new_shape=(1, S, 1, D)
            ),
            dtype="f32",
        )
        wide = tf.cast(x, dtype="f32")
        even = wide[:, :, :, 0:D:2]
        odd = wide[:, :, :, 1:D:2]
        # The rotation contract: the table is read at x's dtype, the rotation carries
        # f32, and the result rounds once on the way out.
        turned = tf.reshape(
            tf.stack([even, odd], axis=-1), new_shape=(B, S, H, D)
        )
        return tf.cast(turned * cos + turned * sin, dtype="bf16")
```

## Performance

| Environment | Value |
| --- | --- |
| image | `ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-afcebed1-dev` |
| gpu | `NVIDIA H200` (one device, idle, not the CI runners') |
| driver | `595.71.05`, cuda `13.2`, torch `2.13.0+cu132`, tilelang `0.1.11+cu132.gitafcebed1` |
| timer | native CUPTI device-busy time |

Method: `benchmarks/ops/bench_rope.py` unmodified. Base is #2016's branch, not `main`, so these numbers are what this PR adds on top of it. The two sides alternated A B A B on one idle device, each run from its own empty `TILELANG_CACHE_DIR`.

| Op | Workload | Layout | #2016 (ms) | This PR (ms) | Adds | torch-compile / ours |
| --- | --- | --- | ---: | ---: | ---: | ---: |
| RopeNonNeoxFwdOp | `(2, 2048, 32, 128)` bf16 | 2d | 0.02440 | 0.01800 | **1.356x** | 0.01790 &#x1F534; 0.994x |
| RopeNonNeoxFwdOp | `(2048, 64)` f16 | 1d | 0.00190 | 0.00180 | 1.056x | 0.00180 — 1.000x |
| RopeNeoxFwdOp | `(2, 2048, 32, 128)` f16 | 2d | 0.01885 | 0.01820 | 1.036x | 0.01770 &#x1F534; 0.973x |
| RopeLlama31FwdOp | `(1, 8192, 32, 128)` f16 | 2d | 0.03535 | 0.03420 | 1.034x | 0.03360 &#x1F534; 0.982x |
| RopeYarnFwdOp | `(1, 8192, 32, 128)` f16 | 2d | 0.03530 | 0.03420 | 1.032x | 0.03360 &#x1F534; 0.982x |
| RopeLongRopeFwdOp | `(1, 8192, 32, 128)` f16 | 2d | 0.03530 | 0.03420 | 1.032x | 0.03360 &#x1F534; 0.982x |
| RopeNeoxFwdOp | `(2048, 64)` f16 | 1d | 0.00180 | 0.00170 | 1.059x | 0.00180 &#x1F7E2; 1.059x |
| RopeLlama31 / Yarn / LongRope | `(8192, 128)` bf16 | 1d | 0.00350 | 0.00350 | 1.000x | 0.00420 &#x1F7E2; 1.200x |

Against `main`, the non-neox 2d row is **1.356x** (the pair walk this PR replaces never shipped) and every neox 2d row is 1.47x to 1.49x with #2016.

## Result And Limitations

**improvement without SOTA, at the measured stream ceiling**

- The non-neox 2d row goes from 0.735x of `torch.compile` to **0.994x** — parity within the run-to-run spread. It is the row this PR exists for.
- **That is the ceiling, measured rather than argued.** On the same shape and in the same process: the staged kernel 17.984 us, `torch`'s own device-to-device copy of the same bytes 17.728 us. The rotation costs 1.4% over a pure copy. `torch.compile` measures 17.90 in the benchmark, which is 100.6% of that copy — it is at the ceiling too, and neither implementation can pass a memcpy while reading `x`, two tables, and writing `y`.
- What was tried and rejected, all on the 2d shape, all in one process against the same reference: the pair walk at three configs (21.22 to 21.50 us); an element walk that keeps the run contiguous and re-reads the partner (24.29 to 24.80 us); fragment staging at four configs (TileLang rejects the two index expressions). Shared memory is the only spelling that reached the ceiling.
- The neox rows gain 3.2% to 3.6% from the config alone. Staging was tried on them too and is worth only 0.9% — 18.048 against 18.209 us — because a neox pair sits half a head apart, which is exactly one 128-byte line, so both of its runs were already fully coalesced. The style-aware config is what those rows needed, not staging.
- The 1d rows sit at this device's empty-kernel floor, 1.7 to 1.8 us for 256 KB of traffic. Movement there is one sample bucket, not work.
- Tests: `tests/ops/test_rope.py`, 55 passed. `pre-commit` clean.
