### PR TITLE
[Feat][MoE] Implement staged pre and post permute APIs

### DIFF
--- a/benchmarks/ops/bench_moe_staged.py
+++ b/benchmarks/ops/bench_moe_staged.py
@@ -1,0 +1,113 @@
+"""Benchmarks for the staged rank-grouped MoE preparation boundaries."""
+
+import pytest
+import torch
+
+try:
+    from vllm.model_executor.layers.fused_moe.moe_permute_unpermute import (
+        moe_permute,
+        moe_unpermute,
+    )
+
+    _VLLM_AVAILABLE = True
+except ImportError:
+    _VLLM_AVAILABLE = False
+
+from benchmarks.benchmark_base import ManifestBenchmark, workload_params
+from tileops.manifest import load_workloads
+from tileops.ops.moe import ContiguousLayoutSpec, MoePostPermuteFwdOp, MoePrePermuteFwdOp
+from workloads.moe import MoePermuteWorkload, MoeUnpermuteWorkload
+
+
+def _pre_args(workload: dict, _dtype: torch.dtype) -> tuple[int, int, int, int]:
+    tokens, hidden = workload["hidden_states_shape"]
+    _, top_k = workload["local_expert_ids_shape"]
+    return tokens, top_k, workload["num_local_experts"], hidden
+
+
+@pytest.mark.parametrize(
+    "tokens,top_k,num_local_experts,hidden",
+    workload_params(load_workloads(MoePrePermuteFwdOp), _pre_args),
+)
+def test_moe_pre_permute_bench(
+    tokens: int, top_k: int, num_local_experts: int, hidden: int
+) -> None:
+    layout = ContiguousLayoutSpec.tight_physical_psum()
+    op = MoePrePermuteFwdOp(layout, num_local_experts)
+    workload = MoePermuteWorkload(tokens, top_k, num_local_experts, hidden, torch.bfloat16)
+    hidden_states, local_ids = workload.gen_inputs()
+    benchmark = ManifestBenchmark(op, workload)
+    token_rows = torch.arange(tokens, device=hidden_states.device).repeat_interleave(top_k)
+    tight_slots = torch.arange(tokens * top_k, dtype=torch.int32, device=hidden_states.device)
+
+    def _torch_reference(hidden: torch.Tensor, expert_ids: torch.Tensor):
+        flat_ids = expert_ids.flatten().to(torch.int64)
+        sorted_flat_indices = torch.argsort(flat_ids, stable=True)
+        expert_input = hidden[token_rows[sorted_flat_indices]]
+        counts = torch.bincount(flat_ids, minlength=num_local_experts)
+        physical_ends = torch.cumsum(counts, dim=0).to(torch.int32)
+        inverse = torch.empty_like(sorted_flat_indices, dtype=torch.int32)
+        inverse[sorted_flat_indices] = tight_slots
+        return expert_input, physical_ends, inverse
+
+    functors = {"tileops": op, "torch-ref": _torch_reference}
+    if _VLLM_AVAILABLE:
+
+        def _vllm_reference(hidden: torch.Tensor, expert_ids: torch.Tensor):
+            return moe_permute(hidden, None, expert_ids, num_local_experts)
+
+        functors["vllm"] = _vllm_reference
+
+    benchmark.compare(functors, hidden_states, local_ids)
+
+
+def _post_args(workload: dict, _dtype: torch.dtype) -> tuple[int, int, int]:
+    rows, hidden = workload["expert_output_shape"]
+    tokens, top_k = workload["topk_weights_shape"]
+    assert rows == tokens * top_k
+    return tokens, top_k, hidden
+
+
+@pytest.mark.parametrize(
+    "tokens,top_k,hidden",
+    workload_params(load_workloads(MoePostPermuteFwdOp), _post_args),
+)
+def test_moe_post_permute_bench(tokens: int, top_k: int, hidden: int) -> None:
+    layout = ContiguousLayoutSpec.tight_physical_psum()
+    op = MoePostPermuteFwdOp(layout)
+    workload = MoeUnpermuteWorkload(tokens, top_k, hidden, torch.bfloat16)
+    expert_output, inverse, weights = workload.gen_inputs()
+    benchmark = ManifestBenchmark(op, workload)
+
+    def _torch_reference(
+        output: torch.Tensor,
+        routing_weights: torch.Tensor,
+        inverse_indices: torch.Tensor,
+    ) -> torch.Tensor:
+        inverse_long = inverse_indices.to(torch.int64)
+        gathered = output[inverse_long].float()
+        weighted = gathered.view(tokens, top_k, hidden) * routing_weights.unsqueeze(-1)
+        return weighted.sum(dim=1).to(output.dtype)
+
+    functors = {"tileops": op, "torch-ref": _torch_reference}
+    if _VLLM_AVAILABLE:
+        numel = tokens * top_k
+        inverse_permuted_idx = torch.empty(numel, dtype=torch.int32, device=inverse.device)
+        inverse_permuted_idx[inverse.long()] = torch.arange(
+            numel, dtype=torch.int32, device=inverse.device
+        )
+        out_vllm = torch.empty(
+            tokens, hidden, dtype=expert_output.dtype, device=expert_output.device
+        )
+
+        def _vllm_reference(
+            output: torch.Tensor,
+            routing_weights: torch.Tensor,
+            _inverse_indices: torch.Tensor,
+        ) -> torch.Tensor:
+            moe_unpermute(out_vllm, output, routing_weights, inverse_permuted_idx)
+            return out_vllm
+
+        functors["vllm"] = _vllm_reference
+
+    benchmark.compare(functors, expert_output, weights, inverse)

--- a/src/tileops/manifest/moe.yaml
+++ b/src/tileops/manifest/moe.yaml
@@ -421,29 +421,38 @@ FusedMoeFwdOp:
 MoePrePermuteFwdOp:
   ref_api: "none"
   family: moe
-  status: spec-only
+  status: implemented
+  torch_compile_fullgraph: true
   signature:
     inputs:
       hidden_states: {dtype: "bfloat16"}
-      topk_ids: {dtype: "int32"}
+      local_expert_ids: {dtype: "int32"}
     outputs:
       expert_input: {dtype: "same_as(hidden_states)"}
+      layout_metadata: {dtype: "int32"}
+      inverse_indices: {dtype: "int32"}
     params:
       layout: {type: MGroupedLayoutSpec}
-      num_experts: {type: int}
-      out: {type: "tensor | None", default: null}
+      num_local_experts: {type: int}
     shape_rules:
     - "hidden_states.ndim == 2"
-    - "topk_ids.ndim == 2"
-    - "topk_ids.shape[0] == hidden_states.shape[0]"
-    - "num_experts > 0"
-  workloads: []
-  roofline: {flops: "0", bytes: "hidden_states.numel() * elem_bytes + topk_ids.numel() * 4"}
+    - "local_expert_ids.ndim == 2"
+    - "local_expert_ids.shape[0] == hidden_states.shape[0]"
+    - "num_local_experts > 0"
+  workloads:
+  - {hidden_states_shape: [32, 128], local_expert_ids_shape: [32, 2], num_local_experts: 4, layout: tight_physical_psum, dtypes: [bfloat16], label: "small"}
+  - {hidden_states_shape: [512, 128], local_expert_ids_shape: [512, 2], num_local_experts: 4, layout: tight_physical_psum, dtypes: [bfloat16], label: "prefill"}
+  roofline:
+    flops: "0"
+    bytes: "(hidden_states.numel() + expert_input.numel()) * elem_bytes + (local_expert_ids.numel() + layout_metadata.numel() + inverse_indices.numel()) * 4"
   source:
     kernel: tileops/ops/moe/staged.py
     op: tileops/ops/moe/staged.py
     test: tests/ops/test_moe_staged_contracts.py
     bench: benchmarks/ops/bench_moe_staged.py
+    bench_manifest_driven: true
+    kernel_map:
+      tight_physical_psum: _TightPhysicalPsumPrePermuteKernel
 
 MoeGroupedGemmFwdOp:
   ref_api: "none"
@@ -509,25 +518,34 @@ MoeExpertMLPFwdOp:
 MoePostPermuteFwdOp:
   ref_api: "none"
   family: moe
-  status: spec-only
+  status: implemented
+  torch_compile_fullgraph: true
   signature:
     inputs:
       expert_output: {dtype: "bfloat16"}
       topk_weights: {dtype: "float32"}
+      inverse_indices: {dtype: "int32"}
     outputs:
       output: {dtype: "bfloat16"}
     params:
+      layout: {type: MGroupedLayoutSpec}
       epilogue: {type: "RoutingEpilogueSpec | None", default: null}
-      inverse_permute_context: {type: InversePermuteContext}
       out: {type: "tensor | None", default: null}
     shape_rules:
     - "expert_output.ndim == 2 or expert_output.ndim == 3"
     - "topk_weights.ndim == 2"
     - "output.shape == (topk_weights.shape[0], expert_output.shape[-1])"
-  workloads: []
-  roofline: {flops: "2 * topk_weights.numel() * expert_output.shape[-1]", bytes: "0"}
+  workloads:
+  - {expert_output_shape: [64, 128], topk_weights_shape: [32, 2], inverse_indices_shape: [64], layout: tight_physical_psum, dtypes: [bfloat16], label: "small"}
+  - {expert_output_shape: [1024, 128], topk_weights_shape: [512, 2], inverse_indices_shape: [1024], layout: tight_physical_psum, dtypes: [bfloat16], label: "prefill"}
+  roofline:
+    flops: "2 * topk_weights.numel() * expert_output.shape[-1]"
+    bytes: "(expert_output.numel() + output.numel()) * elem_bytes + (topk_weights.numel() + inverse_indices.numel()) * 4"
   source:
     kernel: tileops/ops/moe/staged.py
     op: tileops/ops/moe/staged.py
     test: tests/ops/test_moe_staged_contracts.py
     bench: benchmarks/ops/bench_moe_staged.py
+    bench_manifest_driven: true
+    kernel_map:
+      tight_physical_psum: _TightPhysicalPsumPostPermuteKernel

--- a/src/tileops/ops/moe/staged.py
+++ b/src/tileops/ops/moe/staged.py
@@ -2,23 +2,23 @@
 
 from __future__ import annotations
 
-from typing import Mapping
+from typing import ClassVar, Mapping
 
 import torch
 
 from tileops.kernels.kernel_base import Kernel
+from tileops.kernels.moe import MoePermuteNopadKernel, MoeUnpermuteKernel
 from tileops.kernels.moe.call_spec import MGroupedGemmCall, PostPermuteCall, PrePermuteCall
+from tileops.ops.compile_boundary import get_instance
 from tileops.ops.op_base import Op
 from tileops.utils import get_sm_version
 
 from ..elementwise import SiluAndMulFwdOp
 from .contracts import (
-    InversePermuteContext,
     MaskedLayoutSpec,
     MaterializedExpertLayout,
     MGroupedLayoutSpec,
     NoScaleComputeSpec,
-    PrePermuteOutput,
     RoutingEpilogueSpec,
 )
 
@@ -38,7 +38,72 @@ def _same_device(named_tensors: Mapping[str, torch.Tensor]) -> torch.device:
     return next(iter(devices))
 
 
-class _SpecOnlyStagedOp(Op):
+class _TightPhysicalPsumPrePermuteKernel(Kernel):
+    """Adapt the staged tensor contract to the shipped no-pad kernel."""
+
+    supported_archs = [80, 86, 89, 90]
+
+    @classmethod
+    def applies(cls, call: PrePermuteCall) -> bool:
+        return call.layout.selection_key == "tight_physical_psum"
+
+    def __init__(self, call: PrePermuteCall) -> None:
+        """Build the no-pad specialization selected by ``call``."""
+        super().__init__()
+        self.inner = MoePermuteNopadKernel(
+            call.num_tokens,
+            call.top_k,
+            call.num_experts,
+            call.hidden_size,
+            call.input_dtype,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        local_expert_ids: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Return staged expert rows, physical ends, and inverse indices."""
+        perm_h, true_offsets, true_sizes, _, inverse_indices = self.inner(
+            hidden_states, local_expert_ids
+        )
+        return perm_h, true_offsets + true_sizes, inverse_indices
+
+
+class _TightPhysicalPsumPostPermuteKernel(Kernel):
+    """Adapt staged inverse indices to the shipped weighted unpermute kernel."""
+
+    supported_archs = [80, 86, 89, 90]
+
+    @classmethod
+    def applies(cls, call: PostPermuteCall) -> bool:
+        return call.layout_key == "tight_physical_psum" and call.output_dtype == call.input_dtype
+
+    def __init__(self, call: PostPermuteCall) -> None:
+        """Build the weighted no-pad inverse specialization selected by ``call``."""
+        super().__init__()
+        self.inner = MoeUnpermuteKernel(
+            call.num_tokens,
+            call.top_k,
+            call.hidden_size,
+            call.materialized_rows,
+            scaling=call.epilogue.routed_scaling_factor,
+            dtype=call.input_dtype,
+        )
+
+    def forward(
+        self,
+        expert_output: torch.Tensor,
+        inverse_indices: torch.Tensor,
+        topk_weights: torch.Tensor,
+        *,
+        out: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Restore token order and apply the configured routing epilogue."""
+        return self.inner(expert_output, inverse_indices, topk_weights, out=out)
+
+
+class _StagedOpBase(Op):
     """Common behavior for a staged boundary with no shipped implementation yet."""
 
     @property
@@ -55,40 +120,93 @@ class _SpecOnlyStagedOp(Op):
         raise NotImplementedError("staged roofline evaluation requires materialized runtime data")
 
 
-class MoePrePermuteFwdOp(_SpecOnlyStagedOp):
-    """Materialize token-order activations into an expert-compute layout."""
+class MoePrePermuteFwdOp(_StagedOpBase):
+    """Materialize rank-grouped activations into a local expert layout.
+
+    ``local_expert_ids`` must already be in ``[0, num_local_experts)``.
+    Global placement and communication belong to EPDispatch.
+    """
+
+    compile_op_names: ClassVar[tuple[str, ...]] = ("tileops::moe_pre_permute_fwd",)
 
     def __init__(
         self,
         layout: MGroupedLayoutSpec,
-        num_experts: int,
+        num_local_experts: int,
         *,
         kernel_map: dict[str, Kernel] | None = None,
         target: object = None,
     ) -> None:
         """Configure a pre-permute boundary for one layout and expert domain."""
-        if num_experts <= 0:
-            raise ValueError("num_experts must be positive")
+        if num_local_experts <= 0:
+            raise ValueError("num_local_experts must be positive")
         self.layout = layout
-        self.num_experts = num_experts
+        self.num_local_experts = num_local_experts
         self.target = target
         self.dispatch_kernel(kernel_map)
 
-    def make_call(self, hidden_states: torch.Tensor, topk_ids: torch.Tensor) -> PrePermuteCall:
+    @property
+    def default_kernel_map(self) -> dict[str, Kernel]:
+        return {"tight_physical_psum": _TightPhysicalPsumPrePermuteKernel}
+
+    def _infer_output_shapes(
+        self,
+        hidden_states_shape: tuple[int, ...],
+        local_expert_ids_shape: tuple[int, ...],
+    ) -> dict[str, tuple[int, ...]]:
+        rows = hidden_states_shape[0] * local_expert_ids_shape[1]
+        if isinstance(self.layout, MaskedLayoutSpec):
+            expert_input = (
+                self.num_local_experts,
+                self.layout.max_m,
+                hidden_states_shape[1],
+            )
+        else:
+            expert_input = (rows, hidden_states_shape[1])
+        layout_key = getattr(self.layout, "selection_key", self.layout)
+        metadata_rows = rows if layout_key == "tight_per_row" else self.num_local_experts
+        return {
+            "expert_input": expert_input,
+            "layout_metadata": (metadata_rows,),
+            "inverse_indices": (rows,),
+        }
+
+    def eval_roofline(self) -> tuple[int, int]:
+        if self.input_shapes is None or self.dtype is None:
+            raise RuntimeError("eval_roofline requires a prior forward call")
+        hidden_shape, ids_shape = self.input_shapes
+        tokens, hidden = hidden_shape
+        rows = tokens * ids_shape[1]
+        output_shapes = self._infer_output_shapes(hidden_shape, ids_shape)
+        expert_numel = 1
+        for dim in output_shapes["expert_input"]:
+            expert_numel *= dim
+        metadata_numel = output_shapes["layout_metadata"][0]
+        nbytes = (tokens * hidden + expert_numel) * self.dtype.itemsize
+        nbytes += (ids_shape[0] * ids_shape[1] + rows + metadata_numel) * 4
+        return 0, int(nbytes)
+
+    def make_call(
+        self,
+        hidden_states: torch.Tensor,
+        local_expert_ids: torch.Tensor,
+    ) -> PrePermuteCall:
         """Validate inputs and construct the immutable selection record."""
-        device = _same_device({"hidden_states": hidden_states, "topk_ids": topk_ids})
+        device = _same_device(
+            {"hidden_states": hidden_states, "local_expert_ids": local_expert_ids}
+        )
         if device.type != "cuda":
             raise ValueError("staged pre-permute currently requires CUDA tensors")
         if hidden_states.ndim != 2:
             raise ValueError("hidden_states must have shape [tokens, hidden_size]")
-        if topk_ids.ndim != 2 or topk_ids.shape[0] != hidden_states.shape[0]:
-            raise ValueError("topk_ids must have shape [tokens, top_k]")
-        if topk_ids.shape[1] <= 0:
+        if local_expert_ids.ndim != 2 or local_expert_ids.shape[0] != hidden_states.shape[0]:
+            raise ValueError("local_expert_ids must have shape [tokens, top_k]")
+        if local_expert_ids.shape[1] <= 0:
             raise ValueError("top_k must be positive")
-        if topk_ids.dtype is not torch.int32:
-            raise TypeError("topk_ids must have dtype torch.int32")
-        if not hidden_states.is_contiguous() or not topk_ids.is_contiguous():
-            raise ValueError("hidden_states and topk_ids must be contiguous")
+        if local_expert_ids.dtype is not torch.int32:
+            raise TypeError("local_expert_ids must have dtype torch.int32")
+        if not hidden_states.is_contiguous() or not local_expert_ids.is_contiguous():
+            raise ValueError("hidden_states and local_expert_ids must be contiguous")
         if hidden_states.dtype is not torch.bfloat16:
             raise TypeError("the current staged pre-permute contract accepts BF16 only")
         return PrePermuteCall(
@@ -96,31 +214,40 @@ class MoePrePermuteFwdOp(_SpecOnlyStagedOp):
             layout=self.layout,
             device_type=hidden_states.device.type,
             input_dtype=hidden_states.dtype,
-            num_experts=self.num_experts,
+            num_experts=self.num_local_experts,
             num_tokens=hidden_states.shape[0],
             hidden_size=hidden_states.shape[1],
-            top_k=topk_ids.shape[1],
+            top_k=local_expert_ids.shape[1],
+            routing_input_kind="local_expert_ids",
         )
 
     def forward(
         self,
         hidden_states: torch.Tensor,
-        topk_ids: torch.Tensor,
-        out: torch.Tensor | None = None,
-    ) -> PrePermuteOutput:
-        """Materialize token rows and return expert layout plus inverse state."""
-        call = self.make_call(hidden_states, topk_ids)
+        local_expert_ids: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Return ``(expert_input, layout_metadata, inverse_indices)``."""
+        return _moe_pre_permute_fwd(hidden_states, local_expert_ids, self._instance_key)
+
+    def _eager_forward(
+        self,
+        hidden_states: torch.Tensor,
+        local_expert_ids: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        call = self.make_call(hidden_states, local_expert_ids)
+        self.dtype = hidden_states.dtype
+        self.input_shapes = [tuple(hidden_states.shape), tuple(local_expert_ids.shape)]
         name = self.select_kernel_key(tuple((self.kernel_map or {}).keys()), call)
         kernel = self.get_or_build_kernel(
             name,
-            inputs=(hidden_states, topk_ids),
+            inputs=(hidden_states, local_expert_ids),
             key=call,
             build=lambda: self.kernel_map[name](call),
         )
-        return kernel(hidden_states, topk_ids, out=out)
+        return kernel(hidden_states, local_expert_ids)
 
 
-class MoeGroupedGemmFwdOp(_SpecOnlyStagedOp):
+class MoeGroupedGemmFwdOp(_StagedOpBase):
     """Independently callable typed M-grouped GEMM boundary."""
 
     def __init__(
@@ -206,7 +333,7 @@ class MoeGroupedGemmFwdOp(_SpecOnlyStagedOp):
         return kernel(a, b, expert_layout, scales=scales, out=out)
 
 
-class MoeExpertMLPFwdOp(_SpecOnlyStagedOp):
+class MoeExpertMLPFwdOp(_StagedOpBase):
     """Compose two typed grouped GEMMs around a gated activation."""
 
     def __init__(
@@ -276,11 +403,17 @@ class MoeExpertMLPFwdOp(_SpecOnlyStagedOp):
         return self.down(activated, w_down, expert_layout, out=out)
 
 
-class MoePostPermuteFwdOp(_SpecOnlyStagedOp):
+class MoePostPermuteFwdOp(_StagedOpBase):
     """Restore token order and apply the declared local routing epilogue."""
+
+    compile_op_names: ClassVar[tuple[str, ...]] = (
+        "tileops::moe_post_permute_fwd",
+        "tileops::moe_post_permute_fwd_inplace",
+    )
 
     def __init__(
         self,
+        layout: MGroupedLayoutSpec,
         epilogue: RoutingEpilogueSpec | None = None,
         *,
         kernel_map: dict[str, Kernel] | None = None,
@@ -290,21 +423,48 @@ class MoePostPermuteFwdOp(_SpecOnlyStagedOp):
         epilogue = RoutingEpilogueSpec() if epilogue is None else epilogue
         if not isinstance(epilogue, RoutingEpilogueSpec):
             raise TypeError("epilogue must be RoutingEpilogueSpec")
+        self.layout = layout
         self.epilogue = epilogue
         self.target = target
         self.dispatch_kernel(kernel_map)
 
+    @property
+    def default_kernel_map(self) -> dict[str, Kernel]:
+        return {"tight_physical_psum": _TightPhysicalPsumPostPermuteKernel}
+
+    def _infer_output_shapes(
+        self,
+        expert_output_shape: tuple[int, ...],
+        topk_weights_shape: tuple[int, ...],
+        inverse_indices_shape: tuple[int, ...],
+    ) -> dict[str, tuple[int, ...]]:
+        return {"output": (topk_weights_shape[0], expert_output_shape[-1])}
+
+    def eval_roofline(self) -> tuple[int, int]:
+        if self.input_shapes is None or self.dtype is None:
+            raise RuntimeError("eval_roofline requires a prior forward call")
+        expert_shape, weights_shape, inverse_shape = self.input_shapes
+        rows = 1
+        for dim in expert_shape[:-1]:
+            rows *= dim
+        hidden = expert_shape[-1]
+        tokens, top_k = weights_shape
+        flops = 2 * tokens * top_k * hidden
+        nbytes = (rows * hidden + tokens * hidden) * self.dtype.itemsize
+        nbytes += (weights_shape[0] * weights_shape[1] + inverse_shape[0]) * 4
+        return int(flops), int(nbytes)
+
     def make_call(
         self,
         expert_output: torch.Tensor,
-        inverse_permute_context: InversePermuteContext,
         topk_weights: torch.Tensor,
+        inverse_indices: torch.Tensor,
         out: torch.Tensor | None = None,
     ) -> PostPermuteCall:
-        """Validate invocation-bound state and construct the selection record."""
+        """Validate tensor-only state and construct the selection record."""
         tensors = {
             "expert_output": expert_output,
-            "inverse_indices": inverse_permute_context.inverse_indices,
+            "inverse_indices": inverse_indices,
             "topk_weights": topk_weights,
         }
         if out is not None:
@@ -312,25 +472,27 @@ class MoePostPermuteFwdOp(_SpecOnlyStagedOp):
         device = _same_device(tensors)
         if device.type != "cuda":
             raise ValueError("staged post-permute currently requires CUDA tensors")
-        context = inverse_permute_context
         if not expert_output.is_contiguous():
             raise ValueError("expert_output must be contiguous")
         if expert_output.ndim not in (2, 3):
             raise ValueError("expert_output must be contiguous rank 2 or masked rank 3")
-        if isinstance(context.layout, MaskedLayoutSpec):
-            expected = (context.num_experts, context.layout.max_m)
-            if expert_output.ndim != 3 or tuple(expert_output.shape[:2]) != expected:
-                raise ValueError("masked expert_output leading dimensions do not match context")
+        if isinstance(self.layout, MaskedLayoutSpec):
+            if expert_output.ndim != 3 or expert_output.shape[1] != self.layout.max_m:
+                raise ValueError("masked expert_output must have shape [experts, max_m, hidden]")
         elif expert_output.ndim != 2:
             raise ValueError("contiguous expert_output must be rank 2")
         physical_rows = expert_output.numel() // expert_output.shape[-1]
-        if physical_rows != context.materialized_rows:
-            raise ValueError("expert_output row count does not match inverse context")
-        if tuple(topk_weights.shape) != (context.num_tokens, context.top_k):
-            raise ValueError("topk_weights shape does not match inverse context")
+        if topk_weights.ndim != 2:
+            raise ValueError("topk_weights must have shape [tokens, top_k]")
+        if inverse_indices.ndim != 1 or inverse_indices.numel() != topk_weights.numel():
+            raise ValueError("inverse_indices must have one entry per routing weight")
         if topk_weights.dtype is not torch.float32:
             raise TypeError("topk_weights must have dtype torch.float32")
-        output_shape = (context.num_tokens, expert_output.shape[-1])
+        if inverse_indices.dtype is not torch.int32:
+            raise TypeError("inverse_indices must have dtype torch.int32")
+        if expert_output.dtype is not torch.bfloat16:
+            raise TypeError("the current staged post-permute contract accepts BF16 only")
+        output_shape = (topk_weights.shape[0], expert_output.shape[-1])
         if out is not None and not out.is_contiguous():
             raise ValueError("out must be contiguous")
         if out is not None and (
@@ -339,40 +501,116 @@ class MoePostPermuteFwdOp(_SpecOnlyStagedOp):
             raise ValueError("out shape and dtype must match the routing epilogue output")
         return PostPermuteCall(
             arch=get_sm_version(device.index),
-            layout_key=context.selection_key,
-            max_m=context.layout.max_m,
+            layout_key=self.layout.selection_key,
+            max_m=self.layout.max_m,
             epilogue=self.epilogue,
             device_type=expert_output.device.type,
             input_dtype=expert_output.dtype,
             routing_weight_dtype=topk_weights.dtype,
             output_dtype=self.epilogue.output_dtype,
-            num_experts=context.num_experts,
-            materialized_rows=context.materialized_rows,
-            num_tokens=context.num_tokens,
+            num_experts=expert_output.shape[0] if isinstance(self.layout, MaskedLayoutSpec) else 0,
+            materialized_rows=physical_rows,
+            num_tokens=topk_weights.shape[0],
             hidden_size=expert_output.shape[-1],
-            top_k=context.top_k,
+            top_k=topk_weights.shape[1],
         )
 
     def forward(
         self,
         expert_output: torch.Tensor,
         topk_weights: torch.Tensor,
-        inverse_permute_context: InversePermuteContext,
+        inverse_indices: torch.Tensor,
         out: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Restore token order, apply routing weights, reduce top-k, and cast."""
-        call = self.make_call(expert_output, inverse_permute_context, topk_weights, out)
+        if out is None:
+            return _moe_post_permute_fwd(
+                expert_output, inverse_indices, topk_weights, self._instance_key
+            )
+        _moe_post_permute_fwd_inplace(
+            expert_output, inverse_indices, topk_weights, out, self._instance_key
+        )
+        return out
+
+    def _eager_forward(
+        self,
+        expert_output: torch.Tensor,
+        inverse_indices: torch.Tensor,
+        topk_weights: torch.Tensor,
+        out: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        call = self.make_call(expert_output, topk_weights, inverse_indices, out)
+        self.dtype = expert_output.dtype
+        self.input_shapes = [
+            tuple(expert_output.shape),
+            tuple(topk_weights.shape),
+            tuple(inverse_indices.shape),
+        ]
         name = self.select_kernel_key(tuple((self.kernel_map or {}).keys()), call)
         kernel = self.get_or_build_kernel(
             name,
-            inputs=(expert_output, topk_weights),
+            inputs=(expert_output, topk_weights, inverse_indices),
             key=call,
             build=lambda: self.kernel_map[name](call),
         )
         return kernel(
             expert_output,
-            inverse_permute_context,
+            inverse_indices,
             topk_weights,
-            epilogue=self.epilogue,
             out=out,
         )
+
+
+@torch.library.custom_op("tileops::moe_pre_permute_fwd", mutates_args=())
+def _moe_pre_permute_fwd(
+    hidden_states: torch.Tensor,
+    local_expert_ids: torch.Tensor,
+    instance_key: str,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    return get_instance(instance_key)._eager_forward(hidden_states, local_expert_ids)
+
+
+@_moe_pre_permute_fwd.register_fake
+def _moe_pre_permute_fwd_fake(
+    hidden_states: torch.Tensor,
+    local_expert_ids: torch.Tensor,
+    instance_key: str,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    op = get_instance(instance_key)
+    shapes = op._infer_output_shapes(tuple(hidden_states.shape), tuple(local_expert_ids.shape))
+    return (
+        hidden_states.new_empty(shapes["expert_input"]),
+        torch.empty(shapes["layout_metadata"], dtype=torch.int32, device=hidden_states.device),
+        torch.empty(shapes["inverse_indices"], dtype=torch.int32, device=hidden_states.device),
+    )
+
+
+@torch.library.custom_op("tileops::moe_post_permute_fwd", mutates_args=())
+def _moe_post_permute_fwd(
+    expert_output: torch.Tensor,
+    inverse_indices: torch.Tensor,
+    topk_weights: torch.Tensor,
+    instance_key: str,
+) -> torch.Tensor:
+    return get_instance(instance_key)._eager_forward(expert_output, inverse_indices, topk_weights)
+
+
+@_moe_post_permute_fwd.register_fake
+def _moe_post_permute_fwd_fake(
+    expert_output: torch.Tensor,
+    inverse_indices: torch.Tensor,
+    topk_weights: torch.Tensor,
+    instance_key: str,
+) -> torch.Tensor:
+    return expert_output.new_empty((topk_weights.shape[0], expert_output.shape[-1]))
+
+
+@torch.library.custom_op("tileops::moe_post_permute_fwd_inplace", mutates_args=("out",))
+def _moe_post_permute_fwd_inplace(
+    expert_output: torch.Tensor,
+    inverse_indices: torch.Tensor,
+    topk_weights: torch.Tensor,
+    out: torch.Tensor,
+    instance_key: str,
+) -> None:
+    get_instance(instance_key)._eager_forward(expert_output, inverse_indices, topk_weights, out=out)

--- a/tests/ops/test_moe_compile.py
+++ b/tests/ops/test_moe_compile.py
@@ -26,7 +26,12 @@ from tests.compile_contract import (
     register_compile_contract,
     traced_call_targets,
 )
-from tileops.ops.moe import MoePermuteAlignFwdOp
+from tileops.ops.moe import (
+    ContiguousLayoutSpec,
+    MoePermuteAlignFwdOp,
+    MoePostPermuteFwdOp,
+    MoePrePermuteFwdOp,
+)
 from tileops.ops.moe.routed_expert import FusedMoEExpertsNopadPersistent3WGFwdOp
 from tileops.ops.moe.routed_expert.gate_up import MoeGateUpFwdOp
 from tileops.ops.moe.routed_expert.moe_grouped_gemm_nopad import MoeGroupedGemmNopadFwdOp
@@ -88,6 +93,21 @@ def _permute_nopad_case(local: int = _NUM_EXPERTS, with_map: bool = False):
     return make, inputs, (1, 2, 3)
 
 
+def _pre_permute_case():
+    def make():
+        return MoePrePermuteFwdOp(
+            ContiguousLayoutSpec.tight_physical_psum(),
+            num_local_experts=_NUM_EXPERTS,
+        )
+
+    hidden_states = torch.randn(_TOKENS, _HIDDEN, dtype=torch.bfloat16, device="cuda")
+    local_expert_ids = torch.randint(
+        0, _NUM_EXPERTS, (_TOKENS, _TOP_K), dtype=torch.int32, device="cuda"
+    )
+    # Atomic slot assignment makes expert_input and inverse_indices non-deterministic.
+    return make, (hidden_states, local_expert_ids), (1,)
+
+
 def _gate_up_case():
     numel, ffn, k = 64, 128, 128
 
@@ -109,6 +129,7 @@ def _grouped_gemm_nopad_case():
 _LEAF_CASES = {
     "permute_align": _permute_align_case,
     "permute_nopad": _permute_nopad_case,
+    "pre_permute": _pre_permute_case,
     # Supplying the map keeps the graph inside the same operator: the fake sizes the
     # four per-expert outputs from ``num_experts_local``, a constructor parameter, so
     # the map's contents never reach a traced region.
@@ -164,6 +185,31 @@ def test_unpermute_owns_its_graph_nodes() -> None:
 
 @pytest.mark.smoke
 @pytest.mark.usefixtures("isolated_dynamo")
+def test_post_permute_owns_its_graph_nodes() -> None:
+    """The staged allocating and in-place registrations own their graph nodes."""
+    numel = _TOKENS * _TOP_K
+    expert_output = torch.randn(numel, _HIDDEN, dtype=torch.bfloat16, device="cuda")
+    inverse_indices = torch.arange(numel, dtype=torch.int32, device="cuda")
+    topk_weights = torch.rand(_TOKENS, _TOP_K, dtype=torch.float32, device="cuda")
+    out = torch.empty(_TOKENS, _HIDDEN, dtype=torch.bfloat16, device="cuda")
+
+    def make():
+        return MoePostPermuteFwdOp(ContiguousLayoutSpec.tight_physical_psum())
+
+    assert_op_owns_graph_nodes(make(), expert_output, topk_weights, inverse_indices)
+    assert_op_owns_graph_nodes(make(), expert_output, topk_weights, inverse_indices, out)
+    compiled = _compile_cold(make(), expert_output, topk_weights, inverse_indices)
+    eager = (make()(expert_output, topk_weights, inverse_indices),)
+    _assert_same_layout(compiled, eager)
+    torch.testing.assert_close(compiled[0], eager[0])
+
+    out.zero_()
+    torch.compile(make(), fullgraph=True)(expert_output, topk_weights, inverse_indices, out)
+    torch.testing.assert_close(out, eager[0])
+
+
+@pytest.mark.smoke
+@pytest.mark.usefixtures("isolated_dynamo")
 def test_the_experts_composite_shows_only_its_leaf_ops() -> None:
     """A composite is not the unit of replacement, so it registers nothing.
 
@@ -211,6 +257,8 @@ for _op_cls in (
     MoePermuteAlignFwdOp,
     MoePermuteNopadFwdOp,
     MoeUnpermuteFwdOp,
+    MoePrePermuteFwdOp,
+    MoePostPermuteFwdOp,
     MoeGateUpFwdOp,
     MoeGroupedGemmNopadFwdOp,
 ):

--- a/tests/ops/test_moe_staged_contracts.py
+++ b/tests/ops/test_moe_staged_contracts.py
@@ -56,8 +56,8 @@ def test_layout_presets_expose_only_supported_semantics() -> None:
     with pytest.raises(ValueError, match="non-negative"):
         MaskedLayoutSpec(max_m=-1)
 
-    with pytest.raises(ValueError, match="num_experts must be positive"):
-        MoePrePermuteFwdOp(physical, num_experts=0)
+    with pytest.raises(ValueError, match="num_local_experts must be positive"):
+        MoePrePermuteFwdOp(physical, num_local_experts=0)
 
 
 def test_default_public_surface_hides_kernel_author_and_metadata_types() -> None:
@@ -239,7 +239,7 @@ def test_compute_and_epilogue_specs_are_minimal_and_frozen() -> None:
     with pytest.raises(TypeError, match="NoScaleComputeSpec"):
         MoeGroupedGemmFwdOp(compute=0)  # type: ignore[arg-type]
     with pytest.raises(TypeError, match="RoutingEpilogueSpec"):
-        MoePostPermuteFwdOp(epilogue=0)  # type: ignore[arg-type]
+        MoePostPermuteFwdOp(ContiguousLayoutSpec.tight_physical_psum(), epilogue=0)  # type: ignore[arg-type]
 
 
 def test_family_call_specs_are_frozen_and_keep_selection_axes_separate() -> None:
@@ -376,7 +376,7 @@ def test_public_ops_build_complete_calls_before_selection() -> None:
     hidden = torch.empty(2, 8, dtype=torch.bfloat16, device="cuda")
     topk_ids = torch.tensor([[0], [1]], dtype=torch.int32, device="cuda")
     pre_call = MoePrePermuteFwdOp(
-        ContiguousLayoutSpec.tight_physical_psum(), num_experts=2
+        ContiguousLayoutSpec.tight_physical_psum(), num_local_experts=2
     ).make_call(hidden, topk_ids)
     assert (
         pre_call.num_experts,
@@ -445,13 +445,13 @@ def test_staged_wiring_builds_all_family_calls_without_an_executable_candidate()
         num_tokens=2,
         top_k=1,
     )
-    post_call = MoePostPermuteFwdOp(RoutingEpilogueSpec()).make_call(
+    post_call = MoePostPermuteFwdOp(layout.layout, RoutingEpilogueSpec()).make_call(
         torch.empty(2, 8, dtype=torch.bfloat16, device=device),
-        context,
         torch.ones(2, 1, dtype=torch.float32, device=device),
+        context.inverse_indices,
     )
     assert post_call.layout_key == "tight_physical_psum"
-    assert (post_call.num_experts, post_call.materialized_rows) == (2, 2)
+    assert post_call.materialized_rows == 2
     assert (post_call.num_tokens, post_call.top_k, post_call.hidden_size) == (2, 1, 8)
 
 
@@ -469,11 +469,11 @@ def test_post_permute_rejects_wrong_masked_geometry_with_same_row_count() -> Non
     )
     wrong_geometry = torch.empty(1, 8, 4, dtype=torch.bfloat16, device=device)
 
-    with pytest.raises(ValueError, match="leading dimensions"):
-        MoePostPermuteFwdOp().make_call(
+    with pytest.raises(ValueError, match="masked expert_output"):
+        MoePostPermuteFwdOp(layout.layout).make_call(
             wrong_geometry,
-            context,
             torch.ones(1, 1, dtype=torch.float32, device=device),
+            context.inverse_indices,
         )
 
 
@@ -509,9 +509,36 @@ def test_expert_mlp_forwards_only_caller_replacements_to_matching_delegates() ->
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="candidate test uses CUDA calls")
-def test_public_op_without_candidates_fails_explicitly() -> None:
+def test_pre_permute_ships_the_tight_physical_candidate() -> None:
     hidden = torch.empty(1, 4, dtype=torch.bfloat16, device="cuda")
     topk_ids = torch.zeros(1, 1, dtype=torch.int32, device="cuda")
-    op = MoePrePermuteFwdOp(ContiguousLayoutSpec.tight_physical_psum(), num_experts=1)
-    with pytest.raises(ValueError, match="no implementation serves this call"):
-        op(hidden, topk_ids)
+    op = MoePrePermuteFwdOp(ContiguousLayoutSpec.tight_physical_psum(), num_local_experts=1)
+    call = op.make_call(hidden, topk_ids)
+    assert op.select_kernel_key(tuple(op.kernel_map), call) == "tight_physical_psum"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="staged kernels require CUDA")
+def test_staged_tight_pre_post_round_trip() -> None:
+    """The tensor-only staged boundary preserves every routed contribution."""
+    tokens, top_k, experts, hidden = 4, 2, 4, 64
+    x = torch.randn(tokens, hidden, dtype=torch.bfloat16, device="cuda")
+    local_ids = torch.tensor([[0, 1], [2, 3], [0, 2], [1, 3]], dtype=torch.int32, device="cuda")
+    weights = torch.rand(tokens, top_k, dtype=torch.float32, device="cuda")
+    layout = ContiguousLayoutSpec.tight_physical_psum()
+
+    pre = MoePrePermuteFwdOp(layout, num_local_experts=experts)
+    expert_input, metadata, inverse = pre(x, local_ids)
+    assert expert_input.shape == (tokens * top_k, hidden)
+    assert metadata.shape == (experts,)
+    assert inverse.shape == (tokens * top_k,)
+
+    token_rows = torch.arange(tokens * top_k, device="cuda") // top_k
+    torch.testing.assert_close(expert_input[inverse.long()], x[token_rows])
+
+    post = MoePostPermuteFwdOp(layout)
+    output = post(expert_input, weights, inverse)
+    expected = x.float() * weights.sum(dim=1, keepdim=True)
+    torch.testing.assert_close(output.float(), expected, rtol=2e-2, atol=2e-2)
+    assert pre.eval_roofline() == (0, 1616)
+
+    assert post.eval_roofline() == (1024, 1600)

--- a/tests/test_roofline_oracle.py
+++ b/tests/test_roofline_oracle.py
@@ -119,6 +119,40 @@ class TestBytesOracle:
         )
         assert op.eval_roofline()[1] == oracle
 
+    def test_moe_pre_permute_counts_inputs_and_three_outputs(self):
+        from tileops.ops.moe import ContiguousLayoutSpec, MoePrePermuteFwdOp
+
+        tokens, top_k, experts, hidden = 512, 2, 4, 128
+        op = MoePrePermuteFwdOp.__new__(MoePrePermuteFwdOp)
+        op.layout = ContiguousLayoutSpec.tight_physical_psum()
+        op.num_local_experts = experts
+        op.input_shapes = [(tokens, hidden), (tokens, top_k)]
+        op.dtype = torch.bfloat16
+        oracle = _nbytes(
+            ((tokens, hidden), torch.bfloat16),
+            ((tokens, top_k), torch.int32),
+            ((tokens * top_k, hidden), torch.bfloat16),
+            ((experts,), torch.int32),
+            ((tokens * top_k,), torch.int32),
+        )
+        assert op.eval_roofline()[1] == oracle
+
+    def test_moe_post_permute_counts_inputs_and_output(self):
+        from tileops.ops.moe import MoePostPermuteFwdOp
+
+        tokens, top_k, hidden = 512, 2, 128
+        rows = tokens * top_k
+        op = MoePostPermuteFwdOp.__new__(MoePostPermuteFwdOp)
+        op.input_shapes = [(rows, hidden), (tokens, top_k), (rows,)]
+        op.dtype = torch.bfloat16
+        oracle = _nbytes(
+            ((rows, hidden), torch.bfloat16),
+            ((tokens, top_k), torch.float32),
+            ((rows,), torch.int32),
+            ((tokens, hidden), torch.bfloat16),
+        )
+        assert op.eval_roofline()[1] == oracle
+
     def test_w4a16_counts_packed_weights_and_group_metadata(self):
         from tileops.ops.gemm.gemm import GemmW4A16FwdOp
 
@@ -198,6 +232,8 @@ AUDITED = frozenset(
         "GemmFp8FwdOp",
         "GemmW4A16FwdOp",
         "GroupedQueryAttentionPrefillFwdOp",
+        "MoePostPermuteFwdOp",
+        "MoePrePermuteFwdOp",
         "RMSNormFwdOp",
         "VarMeanFwdOp",
     }


### PR DESCRIPTION
Closes #2021

## Summary

- implement the existing spec-only MoePrePermuteFwdOp and MoePostPermuteFwdOp as executable tensor-only custom-op boundaries
- add CallSpec-based dispatch adapters that reuse the shipped no-pad permute and weighted unpermute kernels
- keep the legacy Permute, Unpermute, expert-map path, and FusedMoE pipeline unchanged
- add BF16 contract, fullgraph compile, roofline, and manifest-driven benchmark coverage

The first production candidate is materialized BF16 tight/no-pad. Mapping-only preparation remains a separate future mapping-Op plus indirect-GEMM pipeline.

## Benchmark coverage

The TileOps manifest benchmark uses the same vLLM production baselines as the legacy benchmarks:

- PrePermute: vLLM moe_permute
- PostPermute: vLLM moe_unpermute

Both implementations run the same BF16 tight/no-pad workloads:

| Label | Tokens | Local experts | Top-k | Hidden size | Materialized rows |
| --- | ---: | ---: | ---: | ---: | ---: |
| small | 32 | 4 | 2 | 128 | 64 |
| prefill | 512 | 4 | 2 | 128 | 1024 |

## Performance results

Measured by the TileOps manifest benchmark on NVIDIA H200 with Torch 2.13.0+cu132, CUDA 13.2, vLLM 0.27.1, and cupti-python 13.2.0. All rows use CUPTI attribution.

| Op | Tokens | Implementation | Latency | Device busy | Kernel gap | Kernels |
| --- | ---: | --- | ---: | ---: | ---: | ---: |
| PrePermute | 32 | TileOps | 0.0094 ms | 0.0065 ms | 0.0030 ms | 4 |
| PrePermute | 32 | vLLM | 0.0135 ms | 0.0094 ms | 0.0041 ms | 5 |
| PrePermute | 512 | TileOps | 0.0104 ms | 0.0074 ms | 0.0030 ms | 4 |
| PrePermute | 512 | vLLM | 0.0152 ms | 0.0112 ms | 0.0040 ms | 5 |
| PostPermute | 32 | TileOps | 0.0018 ms | 0.0018 ms | 0.0000 ms | 1 |
| PostPermute | 32 | vLLM | 0.0023 ms | 0.0023 ms | 0.0000 ms | 1 |
| PostPermute | 512 | TileOps | 0.0023 ms | 0.0023 ms | 0.0000 ms | 1 |
| PostPermute | 512 | vLLM | 0.0029 ms | 0.0029 ms | 0.0000 ms | 1 |

TileOps PrePermute is 1.44x faster at 32 tokens and 1.46x faster at 512 tokens by end-to-end latency. TileOps PostPermute is 1.28x and 1.26x faster, respectively.

## Validation

- staged MoE contract tests: 28 passed
- MoE compile-boundary tests: 9 passed
- legacy standalone Permute and Unpermute tests: 26 passed
- staged manifest-driven benchmarks with vLLM baselines: 4 passed
- roofline oracle tests: 12 passed
- strict manifest validation for PrePermute and PostPermute: passed
- pre-commit hooks: passed