### PR TITLE
[Feat][MoE] Migrate fused experts to staged permute

### DIFF
--- a/src/tileops/ops/moe/routed_expert/fused_routed_expert.py
+++ b/src/tileops/ops/moe/routed_expert/fused_routed_expert.py
@@ -21,6 +21,8 @@ from ..abc import (
     WeightedReduceNoOp,
     _validate_fused_moe_experts_dtypes,
 )
+from ..contracts import ContiguousLayoutSpec, RoutingEpilogueSpec
+from ..staged import MoePostPermuteFwdOp, MoePrePermuteFwdOp
 from .gate_up import MoeGateUpFwdOp
 from .moe_grouped_gemm_nopad import MoeGroupedGemmNopadFwdOp
 from .permute_nopad import MoePermuteNopadFwdOp
@@ -32,12 +34,13 @@ __all__ = ["FusedMoEExpertsNopadPersistent3WGFwdOp"]
 class FusedMoEExpertsNopadPersistent3WGFwdOp(FusedMoEExpertsModular):
     """Expert GEMM using tight (T*K rows, no-pad) layout with 3WG persistent kernel.
 
-    Internal pipeline: MoePermuteNopadFwdOp -> MoeGateUpFwdOp -> down GEMM ->
-    MoeUnpermuteFwdOp (weighted reduction included). Every stage is built at
-    construction, so ``forward`` resolves nothing and stays traceable.
+    The local non-EP pipeline uses staged PrePermute/PostPermute boundaries
+    around the existing GateUp and down-GEMM stages. The EP compatibility path
+    retains the legacy Permute/Unpermute operators.
 
-    forward() output shape is (T, H): reduction is done internally by
-    MoeUnpermuteFwdOp, so make_weighted_reduce() returns WeightedReduceNoOp.
+    forward() output shape is (T, H): reduction is done internally by the
+    PostPermute/Unpermute stage, so make_weighted_reduce() returns
+    WeightedReduceNoOp.
 
     Example:
         ```python linenums="1"
@@ -105,6 +108,19 @@ class FusedMoEExpertsNopadPersistent3WGFwdOp(FusedMoEExpertsModular):
             k=ffn_size,
             kernel_map=kernel_map,
         )
+        layout = ContiguousLayoutSpec.tight_physical_psum()
+        self._pre_permute = MoePrePermuteFwdOp(
+            layout=layout,
+            num_local_experts=num_experts_local,
+            kernel_map=kernel_map,
+        )
+        self._post_permute = MoePostPermuteFwdOp(
+            layout=layout,
+            epilogue=RoutingEpilogueSpec(
+                routed_scaling_factor=routed_scaling_factor,
+            ),
+            kernel_map=kernel_map,
+        )
         self._unpermute = MoeUnpermuteFwdOp(
             total_tokens=num_tokens,
             top_k=top_k,
@@ -120,7 +136,14 @@ class FusedMoEExpertsNopadPersistent3WGFwdOp(FusedMoEExpertsModular):
         )
 
     def kernel_delegates(self) -> tuple[Op, ...]:
-        return (self._permute, self._gate_up, self._gemm_down, self._unpermute)
+        return (
+            self._pre_permute,
+            self._gate_up,
+            self._gemm_down,
+            self._post_permute,
+            self._permute,
+            self._unpermute,
+        )
 
     def eval_roofline(self) -> tuple[int, int]:
         """Manifest ``roofline``: three F x H weight planes per local expert."""
@@ -249,14 +272,34 @@ class FusedMoEExpertsNopadPersistent3WGFwdOp(FusedMoEExpertsModular):
             workspace2,
             expert_map=expert_map,
         )
+        if expert_map is None and hidden_states.dtype is torch.bfloat16:
+            expert_input, physical_ends, inverse_indices = self._pre_permute(
+                hidden_states, topk_ids
+            )
+            # Temporary layout bridge to the legacy grouped-GEMM ABI. Keep this
+            # conversion localized so the later ExpertMLP/GroupedGemm migration
+            # can remove it as one block.
+            true_offsets = torch.cat((physical_ends.new_zeros(1), physical_ends[:-1]))
+            true_sizes = physical_ends - true_offsets
+            act = self._gate_up(expert_input, w_gate_up, true_sizes, true_offsets)
+            expert_output = self._gemm_down(act, w_down, true_sizes, true_offsets)
+            self._post_permute(
+                expert_output,
+                topk_weights,
+                inverse_indices,
+                out=output,
+            )
+            return
+
+        # FP16 has no staged production candidate yet, and EP dispatch still
+        # supplies global IDs plus a global-to-local map. Keep both compatibility
+        # cases on the legacy path until their respective staged migrations.
         perm_h, true_offsets, true_sizes, _, fwd_idx = self._permute(
             hidden_states, topk_ids, expert_map
         )
         act = self._gate_up(perm_h, w_gate_up, true_sizes, true_offsets)
-        mm2 = self._gemm_down(act, w_down, true_sizes, true_offsets)
-        # Unpermute reduces into ``output`` directly and folds
-        # ``routed_scaling_factor`` into its prim_func — no separate copy/scale.
-        self._unpermute(mm2, fwd_idx, topk_weights, out=output)
+        expert_output = self._gemm_down(act, w_down, true_sizes, true_offsets)
+        self._unpermute(expert_output, fwd_idx, topk_weights, out=output)
 
     def compute_roof(self) -> str:
         """FLOPs are matmul contractions; priced on tensor cores."""

--- a/tests/ops/test_moe_compile.py
+++ b/tests/ops/test_moe_compile.py
@@ -17,6 +17,8 @@ operators and nothing else. ``FusedMoeFwdOp`` is absent because the routing op i
 builds has no boundary yet.
 """
 
+import operator
+
 import pytest
 import torch
 
@@ -239,17 +241,27 @@ def test_the_experts_composite_shows_only_its_leaf_ops() -> None:
         hidden_states.new_empty(0),
     )
     kwargs = {"num_experts": num_experts}
+    local_pipeline_leaves = (
+        experts._pre_permute,
+        experts._gate_up,
+        experts._gemm_down,
+        experts._post_permute,
+    )
     owned_by_leaves = {
         operator_overload(name)
-        for leaf in (experts._permute, experts._gate_up, experts._gemm_down, experts._unpermute)
+        for leaf in local_pipeline_leaves
         for name in type(leaf).compile_op_names
     }
 
     calls = traced_call_targets(experts, *args, **kwargs)
 
     assert calls, "the traced graph called nothing"
-    assert calls <= owned_by_leaves, (
-        f"graph holds nodes no leaf op owns: {sorted(str(c) for c in calls - owned_by_leaves)}"
+    # Temporary bridge from staged physical ends to the existing grouped-GEMM
+    # sizes/offsets ABI. These are the only tensor operations allowed outside a leaf.
+    layout_bridge = {torch.cat, operator.sub}
+    assert calls <= owned_by_leaves | layout_bridge, (
+        "graph holds unexpected nodes: "
+        f"{sorted(str(c) for c in calls - owned_by_leaves - layout_bridge)}"
     )
 
 


### PR DESCRIPTION
Closes #2023

## Problem

#2022 introduced executable tensor-only `MoePrePermuteFwdOp` and
`MoePostPermuteFwdOp` boundaries, but
`FusedMoEExpertsNopadPersistent3WGFwdOp` still used the legacy
`MoePermuteNopadFwdOp` and `MoeUnpermuteFwdOp` pipeline.

The staged boundary therefore had no production composite consumer, and its
compatibility with the existing GateUp and GroupedGemm pipeline was not covered.

## Changes

- Route the BF16 local non-EP `FusedMoEExpertsNopadPersistent3WGFwdOp` path through:
  - `MoePrePermuteFwdOp`
  - the existing GateUp and down GroupedGemm Ops
  - `MoePostPermuteFwdOp`
- Use the BF16 tight/no-pad physical-psum layout.
- Convert staged `physical_ends` into the legacy GroupedGemm ABI in one
  localized compatibility bridge:

  ```python
  true_offsets = torch.cat(
      (physical_ends.new_zeros(1), physical_ends[:-1])
  )
  true_sizes = physical_ends - true_offsets
  ```

- Pass `expert_output`, `topk_weights`, and `inverse_indices` to
  `MoePostPermuteFwdOp`.
- Update the fullgraph boundary test to permit only the staged leaf Ops and the
  explicit `cat`/`sub` layout bridge.

## Data flow

```text
hidden_states + local expert IDs
    ↓
MoePrePermuteFwdOp
    ↓
expert_input + physical_ends + inverse_indices
    ↓
temporary physical_ends → offsets/sizes bridge
    ↓
existing GateUp / GroupedGemm
    ↓
MoePostPermuteFwdOp
    ↓
token output
```

## Compatibility

FP16 has no staged production candidate yet, so FP16 local calls remain on the
legacy Permute/Unpermute pipeline. The `expert_map` pseudo-EP path also remains
on that compatibility pipeline. Removing the pseudo-EP path and the legacy Ops
is intentionally left to the follow-up cleanup issue.

This keeps the staged integration independently reviewable and preserves the
existing EP compatibility behavior while the local non-EP path migrates.

This PR does not change the PrePermute/PostPermute kernels or the GroupedGemm
ABI.

## Performance

Measured on two otherwise idle NVIDIA H200 GPUs with Torch 2.13.0+cu132 and
CUDA 13.2. The base and candidate used separate TileLang caches.

- Base: `origin/main@79f39a28`
- Candidate: `45c3f117`
- Workloads: the four BF16 non-EP FusedMoEExperts manifest cases

| Workload | Device-busy change | End-to-end latency change | Kernels |
| --- | ---: | ---: | ---: |
| Qwen3 decode, T=512, E=128 | +0.16% to +0.22% | +7.3% to +8.9% | 6 → 10 |
| Qwen3 prefill, T=4096, E=128 | -0.44% to +0.62% | +3.2% to +4.7% | 7 → 11 |
| DeepSeek decode, T=512, E=256 | +0.01% to +0.07% | +4.3% to +4.7% | 6 → 10 |
| DeepSeek prefill, T=4096, E=256 | -0.76% to +1.20% | +1.8% to +2.7% | 7 → 11 |

The main compute kernels remain effectively unchanged: device-busy time stays
within approximately ±1.2% of main.

The temporary metadata round trip adds four kernels and increases end-to-end
latency by 1.8%–8.9%, with the largest effect on decode. This is the temporary
cost of adapting the legacy five-output Permute kernel to staged
`physical_ends`, then converting that metadata back to the current GroupedGemm
offsets/sizes ABI.

The extra metadata work will be removed incrementally when the legacy Permute
kernel is changed to emit `physical_ends` directly and when GroupedGemm moves
to the staged metadata ABI.