### PR TITLE
[Perf][foundry][Softmax] Read a few long rows once, and scale each row once

### DIFF
--- a/src/tileops/kernels/reduction/_split_softmax.py
+++ b/src/tileops/kernels/reduction/_split_softmax.py
@@ -24,6 +24,7 @@ from tileops.kernels.reduction._primitives import (
 __all__ = [
     "edge_split_partials_kernel",
     "edge_split_view",
+    "make_block_split_fold",
     "make_split_fold",
     "softmax_split_partials_kernel",
     "split_seg_n",
@@ -149,6 +150,62 @@ def make_split_fold(num_segs: int):
                 T.cast(0.0, "float32"),
                 seg_sum[base + s] * T.exp(held[0] - row_max[0]),
             )
+
+    return fold
+
+
+def make_block_split_fold(num_segs: int, threads: int):
+    """Create the macro folding one row's segment statistics across a whole block.
+
+    Every lane folds a strided share of the ``num_segs`` pairs into a
+    ``(1, threads)`` fragment, and two block reductions close it. Use it where
+    the block goes on to walk the row afterwards: a per-thread serial fold
+    there costs ``num_segs`` dependent exponentials in every lane, and that
+    cost is the block's rather than the data's. :func:`make_split_fold` stays
+    the form for a fold that is a kernel's only work.
+
+    The statistics are read from global at *base*. A few hundred fp32 pairs
+    that every block of one row reads sit in L2, and staging them through
+    shared memory pays a barrier to restate that. The caller allocates
+    *part_max* and *part_sum* as ``(1, threads)`` fp32 fragments and *row_max*
+    and *row_sum* as ``(1,)`` fp32 fragments. Segment semantics match
+    :func:`make_split_fold`: an all--inf segment contributes nothing, and an
+    all--inf row leaves ``(-inf, 0)``.
+    """
+    rounds = ceildiv_int(num_segs, threads)
+    last = num_segs - 1
+
+    def owned(r, t):
+        """The segment lane *t* folds in round *r*, and whether it has one.
+
+        A lane past the last segment reads the last one instead of running off
+        the array; the flag is what keeps its value out of both reductions.
+        """
+        return T.min(r * threads + t, last), r * threads + t <= last
+
+    @T.macro
+    def fold(seg_max, seg_sum, base, part_max, part_sum, row_max, row_sum):
+        for _, t in T.Parallel(1, threads):
+            part_max[0, t] = -T.infinity("float32")
+            for r in T.serial(rounds):
+                s, mine = owned(r, t)
+                part_max[0, t] = T.max(
+                    part_max[0, t],
+                    T.if_then_else(mine, seg_max[base + s], -T.infinity("float32")),
+                )
+        T.fill(row_max, -T.infinity("float32"))
+        T.reduce_max(part_max, row_max, dim=1, clear=False)
+
+        for _, t in T.Parallel(1, threads):
+            part_sum[0, t] = 0.0
+            for r in T.serial(rounds):
+                s, mine = owned(r, t)
+                part_sum[0, t] = part_sum[0, t] + T.if_then_else(
+                    T.And(mine, seg_max[base + s] != -T.infinity("float32")),
+                    seg_sum[base + s] * T.exp(seg_max[base + s] - row_max[0]),
+                    T.cast(0.0, "float32"),
+                )
+        T.reduce_sum(part_sum, row_sum, dim=1)
 
     return fold
 

--- a/src/tileops/kernels/reduction/_split_softmax.py
+++ b/src/tileops/kernels/reduction/_split_softmax.py
@@ -20,10 +20,12 @@ from tileops.kernels.reduction._primitives import (
     align_up,
     ceildiv_int,
 )
+from tileops.utils import WARP_LANES
 
 __all__ = [
     "edge_split_partials_kernel",
     "edge_split_view",
+    "fused_split_plan",
     "make_block_split_fold",
     "make_split_fold",
     "softmax_split_partials_kernel",
@@ -208,6 +210,29 @@ def make_block_split_fold(num_segs: int, threads: int):
         T.reduce_sum(part_sum, row_sum, dim=1)
 
     return fold
+
+
+def fused_split_plan(M: int, N: int, seg_n: int) -> "int | None":
+    """The thread width a one-kernel split runs at, or None when it cannot.
+
+    A fused split keeps its segment in registers across a grid barrier, so it
+    reads the row once where the two-kernel pair reads it twice. Two conditions
+    bound it. The grid must be co-resident, since a cooperative launch wider
+    than the device holds is refused outright; ``split_seg_n`` already aims at
+    ``split_target_blocks``, and this rejects the shapes where the segment cap
+    pushed it past that. The two fp32 fragments must also fit the same
+    per-thread budget one fragment gets elsewhere, which is what picks the
+    width: the narrowest power of two from ``WARP_LANES`` up that holds them.
+    """
+    num_segs = ceildiv_int(N, seg_n)
+    if num_segs * M > split_target_blocks():
+        return None
+    threads = WARP_LANES
+    while threads <= DEFAULT_THREADS:
+        if 2 * seg_n <= FRAGMENT_ELEMS_PER_THREAD * threads:
+            return threads
+        threads *= 2
+    return None
 
 
 def edge_split_view(

--- a/src/tileops/kernels/reduction/softmax.py
+++ b/src/tileops/kernels/reduction/softmax.py
@@ -35,6 +35,7 @@ from tileops.kernels.reduction._primitives import (
     rows_for_axes,
 )
 from tileops.kernels.reduction._split_softmax import (
+    fused_split_plan,
     make_block_split_fold,
     softmax_split_partials_kernel,
     split_seg_n,
@@ -507,6 +508,93 @@ def _softmax_split_finalize_kernel(
     return _func
 
 
+@functools.lru_cache(maxsize=64)
+def _softmax_fused_split_kernel(M: int, N: int, op_kind: str, dtype: str, seg_n: int, threads: int):
+    """Normalize a few long rows in one kernel, reading each row once.
+
+    The split pair reads the row twice: once for the segment statistics, once
+    to normalize. Here a block keeps its segment in registers across a grid
+    barrier and rescales it in place, so the row moves one read and one write
+    and the launch that separated the two passes goes away. A grid barrier is
+    what makes that legal, and :func:`fused_split_plan` is what says the grid
+    can take one.
+
+    The rescale is the flash-attention identity, ``exp(x - row_max) =
+    exp(x - seg_max) * exp(seg_max - row_max)``, which is why the segment's
+    exponentials survive the fold. A segment of only ``-inf`` holds zeros
+    rather than the NaN ``exp(-inf - -inf)`` would leave, so it contributes
+    nothing; an all--inf row still reads NaN for softmax and -inf for
+    log_softmax, as torch does.
+    """
+    num_segs = ceildiv_int(N, seg_n)
+    fold = make_block_split_fold(num_segs, threads)
+
+    @tilelang.jit(out_idx=[3])
+    def _func():
+        @T.prim_func
+        def main(
+            x: T.Tensor[(M, N), dtype],
+            seg_max: T.Tensor[(M * num_segs,), "float32"],  # noqa: F821
+            seg_sum: T.Tensor[(M * num_segs,), "float32"],  # noqa: F821
+            y: T.Tensor[(M, N), dtype],
+        ):
+            with T.Kernel(num_segs, M, threads=threads) as (pid_s, pid_m):
+                held = T.alloc_fragment((1, seg_n), "float32")
+                shifted = T.alloc_fragment((1, seg_n), "float32")
+                seg_m = T.alloc_fragment((1,), "float32")
+                seg_s = T.alloc_fragment((1,), "float32")
+                part_max = T.alloc_fragment((1, threads), "float32")
+                part_sum = T.alloc_fragment((1, threads), "float32")
+                row_max = T.alloc_fragment((1,), "float32")
+                row_sum = T.alloc_fragment((1,), "float32")
+                row_scale = T.alloc_local((1,), "float32")
+                shift = T.alloc_local((1,), "float32")
+
+                for _, j in T.Parallel(1, seg_n):
+                    held[0, j] = T.if_then_else(
+                        pid_s * seg_n + j < N,
+                        T.cast(x[pid_m, pid_s * seg_n + j], "float32"),
+                        -T.infinity("float32"),
+                    )
+                T.fill(seg_m, -T.infinity("float32"))
+                T.reduce_max(held, seg_m, dim=1, clear=False)
+                # A segment of only -inf shifts by zero instead of by its own
+                # -inf, which would leave every lane the NaN of exp(-inf - -inf).
+                # Shifting by zero leaves exp(-inf) = 0, so the segment sums to
+                # zero and contributes nothing; the test is the row's, so it is
+                # taken once here rather than at every element.
+                shift[0] = T.if_then_else(
+                    seg_m[0] == -T.infinity("float32"), T.cast(0.0, "float32"), seg_m[0]
+                )
+                for _, j in T.Parallel(1, seg_n):
+                    shifted[0, j] = T.exp(held[0, j] - shift[0])
+                T.reduce_sum(shifted, seg_s, dim=1)
+                seg_max[pid_m * num_segs + pid_s] = seg_m[0]
+                seg_sum[pid_m * num_segs + pid_s] = seg_s[0]
+
+                T.sync_grid()
+
+                fold(seg_max, seg_sum, pid_m * num_segs, part_max, part_sum, row_max, row_sum)
+
+                if op_kind == "softmax":
+                    row_scale[0] = T.exp(seg_m[0] - row_max[0]) / row_sum[0]
+                else:
+                    row_scale[0] = row_max[0] + T.log(row_sum[0])
+
+                for _, j in T.Parallel(1, seg_n):
+                    col = pid_s * seg_n + j
+                    with T.If(col < N):  # noqa: SIM117
+                        with T.Then():
+                            if op_kind == "softmax":
+                                y[pid_m, col] = T.cast(shifted[0, j] * row_scale[0], dtype)
+                            else:
+                                y[pid_m, col] = T.cast(held[0, j] - row_scale[0], dtype)
+
+        return main
+
+    return _func
+
+
 def _compute_padded_cols(N: int, tile_n: int) -> int:
     """Compute the total column count (may exceed N_padded for tiled path)."""
     N_padded = align_up(N, DEFAULT_ALIGNMENT)
@@ -808,9 +896,10 @@ class SoftmaxKernel(RowTiledAutotuneMixin, Kernel):
     def _normalize_rows(self, x: torch.Tensor) -> torch.Tensor:
         """Normalize the trailing axis of an ``(M, N)`` buffer.
 
-        The prim_func writes an alignment-padded row; the surplus columns are trimmed
-        here. A handful of long rows goes to the split-row pair instead, which
-        writes exact columns.
+        The prim_func writes an alignment-padded row; the surplus columns are
+        trimmed here. A handful of long rows goes to a split instead, which
+        writes exact columns: one fused kernel where the grid can hold a
+        barrier, and the two-kernel pair where it cannot.
         """
         seg_n = (
             split_seg_n(self.M, self.N, self.config["block_m"], self._split_target)
@@ -818,6 +907,13 @@ class SoftmaxKernel(RowTiledAutotuneMixin, Kernel):
             else 0
         )
         if seg_n:
+            fused_threads = fused_split_plan(self.M, self.N, seg_n)
+            if fused_threads is not None:
+                num_segs = ceildiv_int(self.N, seg_n)
+                stats = torch.empty(2, self.M * num_segs, dtype=torch.float32, device=x.device)
+                return _softmax_fused_split_kernel(
+                    self.M, self.N, self.op_kind, self.dtype_str, seg_n, fused_threads
+                )()(x, stats[0], stats[1])
             # split_seg_n's fragment cap assumes the default width.
             threads = _DEFAULT_TUNE_THREADS
             seg_max, seg_sum = softmax_split_partials_kernel(

--- a/src/tileops/kernels/reduction/softmax.py
+++ b/src/tileops/kernels/reduction/softmax.py
@@ -35,7 +35,7 @@ from tileops.kernels.reduction._primitives import (
     rows_for_axes,
 )
 from tileops.kernels.reduction._split_softmax import (
-    make_split_fold,
+    make_block_split_fold,
     softmax_split_partials_kernel,
     split_seg_n,
     split_target_blocks,
@@ -453,12 +453,15 @@ def _softmax_split_finalize_kernel(
 ):
     """Fold per-segment ``(max, sum)`` and write one normalized segment per block.
 
-    The fold reads ``num_segs`` fp32 pairs; staged through shared memory
-    once, every thread then folds redundantly from there rather than each
-    walking global memory.
+    The statistics are folded across the block, and the row's scale -- a
+    reciprocal for softmax, a log for log_softmax -- is taken once before the
+    block walks its segment. Both are what ``_softmax_kernel_single`` already
+    does: a per-thread serial fold costs ``num_segs`` dependent exponentials
+    in every lane, and a divide or a log left inside the element loop is paid
+    once per element.
     """
     num_segs = ceildiv_int(N, seg_n)
-    fold = make_split_fold(num_segs)
+    fold = make_block_split_fold(num_segs, threads)
 
     @tilelang.jit(out_idx=[3])
     def _func():
@@ -470,18 +473,18 @@ def _softmax_split_finalize_kernel(
             y: T.Tensor[(M, N), dtype],
         ):
             with T.Kernel(num_segs, M, threads=threads) as (pid_s, pid_m):
-                stat_max = T.alloc_shared((num_segs,), "float32")
-                stat_sum = T.alloc_shared((num_segs,), "float32")
-                row_max = T.alloc_local((1,), "float32")
-                row_sum = T.alloc_local((1,), "float32")
-                held = T.alloc_local((1,), "float32")
+                part_max = T.alloc_fragment((1, threads), "float32")
+                part_sum = T.alloc_fragment((1, threads), "float32")
+                row_max = T.alloc_fragment((1,), "float32")
+                row_sum = T.alloc_fragment((1,), "float32")
+                row_scale = T.alloc_local((1,), "float32")
 
-                for s in T.Parallel(num_segs):
-                    stat_max[s] = seg_max[pid_m * num_segs + s]
-                    stat_sum[s] = seg_sum[pid_m * num_segs + s]
-                T.sync_threads()
+                fold(seg_max, seg_sum, pid_m * num_segs, part_max, part_sum, row_max, row_sum)
 
-                fold(stat_max, stat_sum, 0, row_max, row_sum, held)
+                if op_kind == "softmax":
+                    row_scale[0] = 1.0 / row_sum[0]
+                else:
+                    row_scale[0] = T.log(row_sum[0])
 
                 for _, j in T.Parallel(1, seg_n):
                     col = pid_s * seg_n + j
@@ -490,14 +493,12 @@ def _softmax_split_finalize_kernel(
                             if op_kind == "softmax":
                                 y[pid_m, col] = T.cast(
                                     T.exp(T.cast(x[pid_m, col], "float32") - row_max[0])
-                                    / row_sum[0],
+                                    * row_scale[0],
                                     dtype,
                                 )
                             else:
                                 y[pid_m, col] = T.cast(
-                                    T.cast(x[pid_m, col], "float32")
-                                    - row_max[0]
-                                    - T.log(row_sum[0]),
+                                    T.cast(x[pid_m, col], "float32") - row_max[0] - row_scale[0],
                                     dtype,
                                 )
 

--- a/src/tileops/kernels/reduction/softmax.py
+++ b/src/tileops/kernels/reduction/softmax.py
@@ -581,14 +581,20 @@ def _softmax_fused_split_kernel(M: int, N: int, op_kind: str, dtype: str, seg_n:
                 else:
                     row_scale[0] = row_max[0] + T.log(row_sum[0])
 
+                # Indexed with the expression rather than a name bound to it:
+                # TileLang's parallel-loop verifier does not substitute the
+                # binding, and reads the store as j-independent.
                 for _, j in T.Parallel(1, seg_n):
-                    col = pid_s * seg_n + j
-                    with T.If(col < N):  # noqa: SIM117
+                    with T.If(pid_s * seg_n + j < N):  # noqa: SIM117
                         with T.Then():
                             if op_kind == "softmax":
-                                y[pid_m, col] = T.cast(shifted[0, j] * row_scale[0], dtype)
+                                y[pid_m, pid_s * seg_n + j] = T.cast(
+                                    shifted[0, j] * row_scale[0], dtype
+                                )
                             else:
-                                y[pid_m, col] = T.cast(held[0, j] - row_scale[0], dtype)
+                                y[pid_m, pid_s * seg_n + j] = T.cast(
+                                    held[0, j] - row_scale[0], dtype
+                                )
 
         return main
 

--- a/tests/ops/test_softmax.py
+++ b/tests/ops/test_softmax.py
@@ -18,6 +18,11 @@ import torch
 import torch.nn.functional as F
 
 from tests.test_base import FixtureBase, TestBase
+from tileops.kernels.reduction._split_softmax import (
+    fused_split_plan,
+    split_seg_n,
+    split_target_blocks,
+)
 from tileops.ops.reduction.softmax import LogSoftmaxFwdOp, LogSumExpFwdOp, SoftmaxFwdOp
 from workloads.reduction import LogSoftmaxWorkload, LogSumExpWorkload, SoftmaxWorkload
 
@@ -750,6 +755,27 @@ def test_split_rows_survive_fully_masked_segments() -> None:
     torch.testing.assert_close(SoftmaxFwdOp(dim=-1)(x), F.softmax(x, dim=-1))
     torch.testing.assert_close(LogSumExpFwdOp(dim=-1)(x), torch.logsumexp(x, dim=-1))
 
+    torch.testing.assert_close(
+        LogSoftmaxFwdOp(dim=-1)(x), F.log_softmax(x, dim=-1), atol=5e-3, rtol=5e-3
+    )
+
     x[0, :] = float("-inf")
     torch.testing.assert_close(SoftmaxFwdOp(dim=-1)(x), F.softmax(x, dim=-1), equal_nan=True)
     torch.testing.assert_close(LogSumExpFwdOp(dim=-1)(x), torch.logsumexp(x, dim=-1))
+
+
+@pytest.mark.smoke
+def test_split_shape_runs_as_one_fused_kernel() -> None:
+    """The manifest's split shape reads its row once, under a grid barrier.
+
+    A fused split is what keeps the row in registers across the fold; without
+    it the pair reads the row a second time. The two shapes below are what
+    ``fused_split_plan`` refuses: a grid wider than a cooperative launch holds,
+    and a segment too wide for two fp32 fragments.
+    """
+    seg_n = split_seg_n(4, 102400, 1, split_target_blocks())
+    assert seg_n
+    assert fused_split_plan(4, 102400, seg_n) is not None
+
+    assert fused_split_plan(1, 10_000_000, 16384) is None
+    assert fused_split_plan(1, 100_000, 16384) is None


### PR DESCRIPTION
## Problems

`SoftmaxFwdOp` and `LogSoftmaxFwdOp` were the only rows in their file behind every baseline, and both were behind on the same workload: `lm-head-logits`, `(4, 102400)`. Four rows of one row cannot fill the device one block per row, so the shape takes the split-row path, and that path carried three costs that are the block's rather than the data's.

- The split pair reads the row **twice**. The statistics pass reads every column to find the row's max and its sum of exponentials; the finalize pass reads them all again to normalize. The op moves 2.45 MB where 1.64 MB is the work.
- `_softmax_split_finalize_kernel` folded the segment statistics **serially in every lane**: `num_segs` dependent exponentials, repeated by all 256 threads of all 232 blocks, for a result every lane computes identically.
- The finalize pass divided by the row sum **once per output element**, and `log_softmax` took `T.log(row_sum)` once per output element. Both are row-invariant. `_softmax_kernel_single` already takes one reciprocal per row and multiplies; the split path was the one place that did not.

## Changes

- `_softmax_fused_split_kernel`: one kernel for the whole split. The block keeps its segment in registers across a grid barrier and rescales it in place through `exp(x - row_max) = exp(x - seg_max) * exp(seg_max - row_max)`, so the row is read once and the launch that separated the two passes goes away.
- `fused_split_plan` states when that form applies: the grid must fit a cooperative launch, and the two fp32 fragments must fit the per-thread budget one fragment gets elsewhere. Shapes outside it keep the two-kernel pair, which is also fixed below.
- `make_block_split_fold`: the fold as two block reductions over a `(1, threads)` fragment. `make_split_fold` stays the form for a fold that is a kernel's only work, which is what `logsumexp` uses.
- The row's scale — a reciprocal for softmax, a log for log_softmax — is taken once before the block walks its segment, in both the fused kernel and the pair's finalize.
- A segment of only `-inf` shifts by zero rather than by its own `-inf`, which would leave every lane the NaN of `exp(-inf - -inf)`. The test is the row's, so it is taken once instead of at every element.
- The fused store indexes with `pid_s * seg_n + j` rather than a name bound to it. TileLang's parallel-loop verifier does not substitute the binding and warned about a data race on every compile — the same fix #1843 made for `da_cumsum`. `tests/ops/test_softmax.py` reports no race warnings.
- Test-node delta: +1. No manifest, tolerance or public-contract change.

Only `lm-head-logits` reaches the split path: `attn-weights-4k` and `attn-weights-32k` both have `M = 1024`, which fills the row grid on its own. Every other row in the file is measured below and unchanged.

## TileFoundry Description

The authored HIR is the fused softmax — one read of `x`, one write of `y`, rather than the chain of materialised temporaries an unfused form leaves.

```python
"""The lm-head-logits softmax as one fused kernel: the traffic a row must move."""

from __future__ import annotations

from tilefoundry import func, module
from tilefoundry.dsl import Tensor, tf
from tilefoundry.target import CudaTarget

M, N = 4, 102400


@module(entry="softmax_rows", target=CudaTarget("nvidia.h200_sxm"))
class SoftmaxRows:
    @func
    def softmax_rows(x: Tensor[(M, N), "f16"]) -> Tensor[(M, N), "f16"]:
        return tf.softmax(x, axis=-1)
```

`analyze` gives `traffic=gmem:r819200/w819200`, `ideal-ns=342`, `bound-by=memory`.

That bound is nominal bandwidth, and this shape does not reach it: 1.64 MB is too little to fill the device, so the row is launch-bound rather than bandwidth-bound. The reachable floor was measured instead, as a copy twin with the same grid and the same walk — **1.92 us** — and a grid barrier on top of it costs **1.09 us**. The structural floor for this design is therefore about 3.0 us, against the 4.06 us the kernel now takes.

A second pair of modules states the rounding contract — the statistics and the normalization in f32, one rounding on the way out — and `check` runs the shipped `SoftmaxKernel` against them as runtime twins, on the manifest's own shape:

| Row | Predicate | Result |
| --- | --- | --- |
| `(4, 102400)` f16 | `allclose(atol=1e-3, rtol=1e-3)`, `max_abs(max=1e-3)` | `max_abs 0`, **PASS** |
| `(4, 102400)` f32 | `allclose(atol=1e-7, rtol=1e-7)`, `max_abs(max=1e-7)` | `max_abs 8.94e-08`, **PASS** |

The f16 output is bit-identical to the reference. The f32 row's `8.94e-08` is one ulp, and it is the reciprocal: `exp(x - max) * (1 / sum)` rounds once more than `exp(x - max) / sum`. That is the trade `_softmax_kernel_single` already makes.

## Performance

| Environment | Value |
| --- | --- |
| image | `ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-afcebed1-foundry-dev` |
| gpu | `NVIDIA H200` (one device, idle, not the CI runners') |
| driver | `595.71.05`, cuda `13.2`, torch `2.13.0+cu132`, tilelang `0.1.11+cu132.gitafcebed1` |
| timer | native CUPTI device-busy time |

Method: `benchmarks/ops/bench_softmax.py` unmodified. The two sides alternated A B A B in one sitting on one idle device, each run from its own empty `TILELANG_CACHE_DIR`; each tag takes the minimum over its two rounds. The `before` side is a detached checkout of this branch's merge base.

| Op | Workload | Before (us) | After (us) | Speedup | Strongest baseline (us) / ours |
| --- | --- | ---: | ---: | ---: | ---: |
| SoftmaxFwdOp | `lm-head-logits` f16 | 9.184 | 4.224 | **2.174x** | torch-compile 8.032 🟢 1.902x |
| SoftmaxFwdOp | `lm-head-logits` bf16 | 9.184 | 4.224 | **2.174x** | torch-compile 8.000 🟢 1.894x |
| SoftmaxFwdOp | `lm-head-logits` f32 | 9.376 | 4.607 | **2.035x** | torch-compile 8.352 🟢 1.813x |
| LogSoftmaxFwdOp | `lm-head-logits` f16 | 9.152 | 4.192 | **2.183x** | torch-compile 8.418 🟢 2.008x |
| LogSoftmaxFwdOp | `lm-head-logits` bf16 | 9.152 | 4.224 | **2.167x** | torch-compile 7.968 🟢 1.886x |
| LogSoftmaxFwdOp | `lm-head-logits` f32 | 9.312 | 4.577 | **2.035x** | torch-compile 8.768 🟢 1.916x |

The other fourteen rows in the file, none of which reaches the split path:

| Op | Workload | Before (us) | After (us) | Ratio |
| --- | --- | ---: | ---: | ---: |
| SoftmaxFwdOp | `attn-weights-4k` f16 / bf16 / f32 | 7.648 / 7.552 / 10.080 | 7.648 / 7.552 / 10.112 | 1.000 / 1.000 / 0.997 |
| SoftmaxFwdOp | `attn-weights-32k` bf16 | 54.304 | 54.495 | 0.996 |
| LogSoftmaxFwdOp | `attn-weights-4k` f16 / bf16 / f32 | 7.584 / 7.904 / 10.272 | 8.000 / 7.904 / 10.303 | 0.948 / 1.000 / 0.997 |
| LogSoftmaxFwdOp | `attn-weights-32k` bf16 | 49.920 | 50.080 | 0.997 |
| LogSumExpFwdOp | all six rows | — | — | 0.995 to 1.000 |

## Result And Limitations

**improvement without SOTA**

- Every `lm-head-logits` row improves by 2.03x to 2.18x, and every one of them now leads its strongest baseline by 1.81x to 2.01x. Before this branch all six were behind.
- The gain decomposes, measured one change at a time on the f16 row: the shipped kernel is 10.58 us on the nightly's runner and 9.18 us on this idle device; folding across the block and hoisting the row's scale takes it to 5.95 us; reading the row once under a grid barrier to 4.42 us; hoisting the masked-segment test to 4.22 us; and indexing the store with its expression to 4.06 us.
- **This design has about 1.1 us left in it, and no way to reach it that TileLang can express.** The floor is 1.92 us of copy plus 1.09 us of grid barrier, both measured. Of the 1.1 us above that, the fold is 0.51 us and the two block reductions in the statistics pass are the rest. Removing either needs a reduction TileLang does not offer: `T.reduce` takes no custom combiner, so an associative `(max, sum)` fold has to go through shared memory, and allocating shared memory in this kernel costs more in occupancy (5.41 us) than the fold costs. A per-row barrier over 50 blocks instead of a grid barrier over 232 would need a spin loop, and TileLang rejects device-side `while`.
- **One rewrite was measured and rejected on numerics.** Referencing the fold's sum to the block's own `seg_max` instead of the row's max removes the fold's max reduction entirely: softmax reaches 3.94 us and stays correct even when the row spans 1200 in magnitude, because the `exp` overflow that produces `inf` gives exactly the `0` the true answer rounds to. `log_softmax` does not survive it — `log(inf)` writes `-inf` where the true value is a large finite negative — and softmax has its own edge, a fully masked segment in a row whose live values are all below -88, where `1/S` gives NaN instead of 0. 7% is not worth an edge case I cannot close.
- The `LogSoftmaxFwdOp` `attn-weights-4k` f16 row reads 0.948. It does not reach any changed code — `M = 1024` fills the row grid, so the split gate is off and the shipped kernel is byte-identical — and the two sibling rows on the same shape read 1.000 and 0.997. It is one sample bucket, not a regression in the work.
- Tests: `tests/ops/test_softmax.py`, 143 passed, no data-race warnings. `pre-commit` clean.
