### PR TITLE
[Perf][foundry][Reduction] Give a small-output reduction the lanes and the folds it asks for

### DIFF
--- a/src/tileops/kernels/reduction/_primitives.py
+++ b/src/tileops/kernels/reduction/_primitives.py
@@ -966,13 +966,22 @@ class RowTiledAutotuneMixin:
 
 @dataclass(frozen=True)
 class _LeadingAxisReducePolicy:
-    """Launch heuristics for reductions down contiguous leading axes."""
+    """Launch heuristics for reductions down contiguous leading axes.
 
-    cols_per_thread: int = 8
+    Measured on an H200 over ``(A, B)`` from ``(4, 128)`` to ``(2048, 4096)``,
+    in bf16 and fp32. The column tile ``threads * cols_per_thread`` is what a
+    block reads from one row, and 512 columns is flat across the sweep; how
+    that tile is divided is not. Sixty-four lanes reading eight columns each
+    leaves a block too narrow to cover the read's latency -- on ``(128, 1024)``
+    bf16 it costs 2.88x against 256 lanes reading two, at the same tile, the
+    same split count and the same grid.
+    """
 
-    threads: int = 64
+    cols_per_thread: int = 2
 
-    target_blocks: int = 512
+    threads: int = 256
+
+    target_blocks: int = 256
 
 
 _LEADING_POLICY = _LeadingAxisReducePolicy()

--- a/src/tileops/kernels/reduction/logical_reduce.py
+++ b/src/tileops/kernels/reduction/logical_reduce.py
@@ -28,6 +28,7 @@ from tileops.kernels.reduction._primitives import (
     FP32_EXACT_INT_LIMIT,
     BlockConfigPlanner,
     align_up,
+    ceildiv_int,
     device_smem_budget,
     edge_axis_plan,
     edge_axis_split,
@@ -112,6 +113,22 @@ def _logical_out_dtype(op_kind: str, partial: bool) -> str:
     return "float32" if partial else "int64"
 
 
+# Elements a lane folds in the edge-fused pass. One block holds a `trail`-wide
+# fp32 fragment, so this is what fixes its register footprint per lane rather
+# than letting it grow with the row. Measured on an H200 over `lead` 2 to 16 and
+# `trail` 256 to 8192: eight is the flat optimum at every width.
+_FUSED_EDGE_ELEMS_PER_LANE = 8
+_FUSED_EDGE_MIN_THREADS = 64
+_FUSED_EDGE_MAX_THREADS = 1024
+
+
+def fused_edge_threads(trail: int) -> int:
+    """The thread width the edge-fused pass runs a ``trail``-wide row at."""
+    lanes = ceildiv_int(trail, _FUSED_EDGE_ELEMS_PER_LANE)
+    lanes = 1 << max(lanes - 1, 0).bit_length()
+    return max(_FUSED_EDGE_MIN_THREADS, min(lanes, _FUSED_EDGE_MAX_THREADS))
+
+
 @functools.lru_cache(maxsize=32)
 def _logical_reduce_edge_fused(lead: int, kept: int, trail: int, op_kind: str, dtype: str):
     """Build an any/all/count_nonzero kernel reducing a leading and a trailing axis.
@@ -136,7 +153,8 @@ def _logical_reduce_edge_fused(lead: int, kept: int, trail: int, op_kind: str, d
     pad_val = _pad_value_for_op(op_kind)
     out_dtype = _logical_out_dtype(op_kind, partial=False)
     # any is a max and all is a min over 0/1, so each starts from its identity;
-    # a count sums from zero.
+    # a count sums from zero. The column-wise fold starts from the same value a
+    # padding column carries, since both are that op's identity.
     init_val = {"any": 0.0, "all": 1.0, "count_nonzero": 0.0}[op_kind]
 
     @tilelang.jit(out_idx=[1])
@@ -148,9 +166,14 @@ def _logical_reduce_edge_fused(lead: int, kept: int, trail: int, op_kind: str, d
         ):
             with T.Kernel(kept, threads=threads) as pid_k:
                 vals = T.alloc_fragment((1, trail_padded), "float32")
-                row = T.alloc_fragment((1,), "float32")
                 acc = T.alloc_fragment((1,), "float32")
-                acc[0] = init_val
+
+                # The leading axis folds into the fragment column by column, so
+                # the block reduces once at the end rather than once per leading
+                # index: the reduction is a barrier and a tree, and `lead` of
+                # them cost more than the column-wise fold they replace.
+                for j in T.Parallel(trail_padded):
+                    vals[0, j] = init_val
                 for lead_idx in T.serial(lead):
                     for j in T.Parallel(trail_padded):
                         if needs_pad:
@@ -161,16 +184,20 @@ def _logical_reduce_edge_fused(lead: int, kept: int, trail: int, op_kind: str, d
                             )
                         else:
                             val = T.cast(x[lead_idx, pid_k, j], "float32")
-                        vals[0, j] = T.if_then_else(val != 0.0, 1.0, 0.0)
-                    if op_kind == "any":
-                        T.reduce_max(vals, row, dim=1)
-                        acc[0] = T.max(acc[0], row[0])
-                    elif op_kind == "all":
-                        T.reduce_min(vals, row, dim=1)
-                        acc[0] = T.min(acc[0], row[0])
-                    else:
-                        T.reduce_sum(vals, row, dim=1)
-                        acc[0] = acc[0] + row[0]
+                        one = T.if_then_else(val != 0.0, 1.0, 0.0)
+                        if op_kind == "any":
+                            vals[0, j] = T.max(vals[0, j], one)
+                        elif op_kind == "all":
+                            vals[0, j] = T.min(vals[0, j], one)
+                        else:
+                            vals[0, j] = vals[0, j] + one
+                if op_kind == "any":
+                    T.reduce_max(vals, acc, dim=1)
+                elif op_kind == "all":
+                    T.reduce_min(vals, acc, dim=1)
+                else:
+                    T.reduce_sum(vals, acc, dim=1)
+
                 if op_kind == "count_nonzero":
                     out[pid_k] = T.cast(acc[0], out_dtype)
                 else:
@@ -610,7 +637,14 @@ class LogicalReduceEdgeFusedKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
-        return {"threads": DEFAULT_THREADS}
+        """No width: it follows ``trail``, which only the call's shape carries.
+
+        One block holds a ``trail``-wide fp32 fragment, so a fixed width hands
+        every lane ``trail / threads`` registers and the occupancy falls as the
+        row grows. ``forward`` reads the row and fills the width in; a caller
+        that states one keeps it.
+        """
+        return {"threads": None}
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         self._require_cuda(x=x)
@@ -625,7 +659,7 @@ class LogicalReduceEdgeFusedKernel(Kernel):
         )
         if planner.needs_tiling:
             raise ValueError("LogicalReduceEdgeFusedKernel requires an untiled trailing pass")
-        threads = self.config.get("threads", cfg["threads"])
+        threads = self.config.get("threads") or fused_edge_threads(trail)
         dtype_str = self.dtype_to_str(self._kernel_dtype)
         fused = _logical_reduce_edge_fused(lead, kept, trail, self.op_kind, dtype_str)
         counted = fused(threads)(x.reshape(lead, kept, trail))


### PR DESCRIPTION
## Problems

Two reduction rows were behind every baseline, and for the same reason: the grid was sized by something other than the work.

- **The edge-fused logical pass reduced once per leading index.** One block owns one kept column and walks the leading axis, and each step ran its own `T.reduce_*` — a barrier and a tree — for a fold it could do column by column and reduce once at the end. On `3d-multidim-reduce` that is four reductions where one would do.
- **It ran at a fixed 256 lanes whatever row it held.** A block holds a `trail`-wide fp32 fragment, so the width is what fixes the fragment per lane; leaving it fixed hands every lane more of the fragment as the row grows. At `trail = 4096` the kernel was slower than the general two-pass reducer it exists to replace, which is the wrong way round for a form whose whole argument is that it saves a launch.
- **The leading-axis policy read eight columns on each of sixty-four lanes.** Sixty-four lanes are too few to cover the read's latency. The 512-column tile that `threads * cols_per_thread` makes is right — it is flat across the sweep — but its division is not.

## Changes

- `_logical_reduce_edge_fused` folds the leading axis into the fragment column by column and reduces once. `any` is a max and `all` a min over 0/1 and a count is a sum, so each folds with its own identity, which is the value a padding column already carries.
- `fused_edge_threads` gives the pass a width from the row it holds: eight elements a lane, from `WARP_LANES * 2` up to the block limit. `default_config` no longer states a width, because `trail` is a fact only the call's shape carries; `forward` fills it in and a caller that states one keeps it.
- `_LeadingAxisReducePolicy` reads two columns on each of 256 lanes against a 256-block target, keeping the 512-column tile it already had.
- Test-node delta: 0. No manifest, tolerance or public-contract change.

The fused pass is now faster than the general two-pass reducer everywhere it applies, which is what its region already claims; no region needed narrowing. Measured over `lead` 2 to 16, `kept` 8 to 1024 and `trail` 256 to 8192, it leads at all 16 grid points once the width follows the row — before this branch it trailed at five of them, including the manifest's own.

## TileFoundry Description

Both rows authored as one fused kernel — one read of the input, one write of the kept axis:

```python
@module(entry="any_edge", target=CudaTarget("nvidia.h200_sxm"))
class AnyEdgeFused:
    @func
    def any_edge(x: Tensor[(4, 128, 4096), "bool"]) -> Tensor[(128,), "bool"]:
        return tf.reduce(x, kind="max", axes=(0, 2), keepdim=False)


@module(entry="sum_lead", target=CudaTarget("nvidia.h200_sxm"))
class SumLeadFused:
    @func
    def sum_lead(x: Tensor[(2048, 4096), "bf16"]) -> Tensor[(4096,), "bf16"]:
        return tf.reduce(x, kind="sum", axes=(0,), keepdim=False)
```

`analyze` gives `traffic=gmem:r16777216/w8192`, `ideal-ns=3497`, `bound-by=memory` for the leading-axis sum. That bound is nominal bandwidth and this device does not reach it at 16.8 MB: a flat read of the same bytes measures **7.10 us**, against the 8.83 us the row now takes. For the logical row `analyze` models `bool` as one bit, so its traffic is eight times below what torch's byte-per-bool actually moves; the measured read floor for 2.10 MB is **2.53 us**, against 2.98 us.

A second pair of modules states the accumulation contract — the reduction carried in f32, one rounding at the store — and `check` runs the shipped kernels against them as runtime twins, on the manifest's own shapes:

| Row | Predicate | Result |
| --- | --- | --- |
| `any` over `(4, 128, 4096)` bool, axes `(0, 2)` | `equal` | 0 of 128 differ, **PASS** |
| `sum` over `(2048, 4096)` bf16, axis 0 | `allclose(atol=2e-2, rtol=2e-2)`, `max_rel(max=2e-2)` | `max_rel 0`, **PASS** |

Neither change moves a bit: both are about which lanes do the work, not what the arithmetic is.

## Performance

| Environment | Value |
| --- | --- |
| image | `ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-afcebed1-foundry-dev` |
| gpu | `NVIDIA H200` (one device, idle, not the CI runners') |
| driver | `595.71.05`, cuda `13.2`, torch `2.13.0+cu132`, tilelang `0.1.11+cu132.gitafcebed1` |
| timer | native CUPTI device-busy time |

Method: `benchmarks/ops/bench_reduce.py` and `benchmarks/ops/bench_logical_reduce.py` unmodified, 43 rows. The two sides alternated A B A B in one sitting on one idle device, each run from its own empty `TILELANG_CACHE_DIR`; each tag takes the minimum over its two rounds. The `before` side is a detached checkout of this branch's merge base.

**The noise floor is stated first, because most of the table is inside it.** Comparing the two `before` rounds against each other — same code, same device, same sitting — the 43 rows spread over `0.965x` to `1.037x`. Only moves outside that band are read as changes.

| Op | Workload | Before (us) | After (us) | Speedup | Strongest baseline (us) / ours |
| --- | --- | ---: | ---: | ---: | ---: |
| AllFwdOp | `3d-multidim-reduce` bool | 5.152 | 3.136 | **1.643x** | torch-compile 3.680 🟢 1.173x |
| AnyFwdOp | `3d-multidim-reduce` bool | 5.153 | 3.136 | **1.643x** | torch-compile 3.488 🟢 1.112x |
| SumFwdOp | `hidden-state-reduce-dim0` bf16 | 11.519 | 8.832 | **1.304x** | torch-compile 10.017 🟢 1.134x |
| CountNonzeroFwdOp | `3d-multidim-reduce` f16 | 3.871 | 3.488 | **1.110x** | torch-compile 4.352 🟢 1.248x |

The other 39 rows all land inside the noise band. Nothing regressed outside it.

The policy change is not fitted to the one manifest row it was found on. `reduce_down_rows` on its own, old policy against new, over the shapes it is asked for:

| `(A, B)` | dtype | Before (us) | After (us) | Speedup |
| --- | --- | ---: | ---: | ---: |
| `(128, 1024)` | bf16 | 16.960 | 5.888 | **2.880x** |
| `(4096, 1024)` | bf16 | 12.384 | 7.136 | **1.735x** |
| `(2048, 4096)` | bf16 | 11.361 | 8.768 | **1.296x** |
| `(64, 4096)` | f32 | 4.064 | 3.296 | **1.233x** |
| `(512, 8192)` | bf16 | 6.368 | 5.792 | 1.099x |
| `(2048, 4096)` | f32 | 15.168 | 14.144 | 1.072x |
| `(4, 128)` | f32 | 0.960 | 0.928 | 1.034x |

## Result And Limitations

**improvement without SOTA**

- The two rows that were behind every baseline now lead their strongest one, by 1.11x to 1.17x, and `count_nonzero` on the same layout comes with them at 1.25x.
- The logical pass reaches 2.98 us against a 2.53 us measured read floor, and the leading-axis sum 8.83 us against 7.10 us. Both are within 1.24x of what a flat read of the same bytes costs on this device.
- **Four rows are still behind, and I could not close them.** `mask-validation-4k` and `mask-validation-32k` for `any` and `all` read 0.905x to 0.944x against torch-compile. They are row reductions with 32 rows, so the grid is 32 blocks whatever else is true, and the levers do not reach:
  - Width: sweeping 128 to 1024 lanes moves `(32, 32768)` from 3.23 us to 3.04 us at best, and the optimum is not a rule — `(32, 4096)` wants 128 lanes, `(32, 32768)` wants 512, and `(2048, 4096)` wants 256 and loses 21% at 512. Four points, no form that fits them and nothing that crosses the baseline.
  - Splitting the row: a second launch costs about 1.5 us and a grid barrier about 1.09 us, both measured. Against a 2.11 us read floor for 1.05 MB, either lands at 3.2 to 3.7 us — no better than the 3.36 us the row takes now, and torch-compile's 3.10 us is at the same wall.
- **`MeanFwdOp` and `SumFwdOp` on `long-seq-reduce` read 0.957x and 0.983x against flag_gems.** Same shape of problem: 64 rows, 64 blocks. The A/A comparison puts both inside the noise band, so what these rows say is that we are at parity there, not that this branch moved them.
- Tests: `tests/ops/test_reduce.py`, `test_logical_reduce.py`, `test_reduce_multidim.py`, 389 passed. `pre-commit` clean.
