### PR TITLE
[Perf][foundry][Elementwise] Read a broadcast row's constant operand once, and fix ne against NaN

### DIFF
--- a/src/tileops/kernels/elementwise/_builders.py
+++ b/src/tileops/kernels/elementwise/_builders.py
@@ -152,31 +152,61 @@ def _row_broadcast_prim(
         """One full block, read and written a fragment at a time.
 
         An operand at stride 0 is one value for the whole row, so it is read
-        where it is used and never staged.
+        into a register rather than staged across a fragment it would fill with
+        copies of itself. Reading it at the use site instead leaves the load in
+        the element loop, and with it whatever the body wraps around it -- for
+        maximum and minimum that is a NaN test, which is the row's property and
+        not the element's.
         """
         y_reg = T.alloc_fragment((block_cols,), out_dtype)
         col0 = bx * block_cols
         if a_inner:
             a_reg = T.alloc_fragment((block_cols,), dtype)
             T.copy(a[a_base + col0 : a_base + col0 + block_cols], a_reg)
+        else:
+            a_held = T.alloc_local((1,), dtype)
+            a_held[0] = a[a_base]
         if b_inner:
             b_reg = T.alloc_fragment((block_cols,), dtype)
             T.copy(b[b_base + col0 : b_base + col0 + block_cols], b_reg)
+        else:
+            b_held = T.alloc_local((1,), dtype)
+            b_held[0] = b[b_base]
         for i, j in T.Parallel(threads, num_per_thread):
             idx = i * num_per_thread + j
             y_reg[idx] = op_func(
-                a_reg[idx] if a_inner else a[a_base],
-                b_reg[idx] if b_inner else b[b_base],
+                a_reg[idx] if a_inner else a_held[0],
+                b_reg[idx] if b_inner else b_held[0],
             )
         T.copy(y_reg, y[by * inner + col0 : by * inner + col0 + block_cols])
+
+    @T.macro
+    def write_held_block(a, b, y, a_base, b_base, by, bxc):
+        """One full block with the row's stride-0 operand read into a register.
+
+        An operand at stride 0 is one value for the whole row. Left as a
+        subscript it is read again at every element, and so is the arithmetic
+        the body wraps around it -- for maximum and minimum that is a NaN test,
+        which is the row's and not the element's.
+        """
+        held = T.alloc_local((1,), dtype)
+        held[0] = a[a_base] if not a_inner else b[b_base]
+        for i, j in T.Parallel(threads, num_per_thread):
+            col = (bxc * threads + i) * num_per_thread + j
+            if a_inner:
+                y[by * inner + col] = op_func(a[a_base + col * a_inner], held[0])
+            else:
+                y[by * inner + col] = op_func(held[0], b[b_base + col * b_inner])
 
     @T.macro
     def write_full_block(a, b, y, a_base, b_base, by, bxc):
         if stage:
             write_block_staged(a, b, y, a_base, b_base, by, bxc)
-        else:
+        elif a_inner and b_inner:
             for i, j in T.Parallel(threads, num_per_thread):
                 write_col(a, b, y, a_base, b_base, by, (bxc * threads + i) * num_per_thread + j)
+        else:
+            write_held_block(a, b, y, a_base, b_base, by, bxc)
 
     if pack_tail:
 

--- a/src/tileops/kernels/elementwise/comparison.py
+++ b/src/tileops/kernels/elementwise/comparison.py
@@ -49,13 +49,29 @@ class EqBoolStorageFwdKernel(_Uint8StorageBinaryKernel):
 
 
 class NeFwdKernel(BinaryKernel):
-    """Element-wise not-equal: y = (a != b)."""
+    """Element-wise not-equal: y = (a != b).
+
+    A half operand is compared in float32, which is where ``!=`` means what
+    IEEE 754 says. CUDA's ``__hne`` is an *ordered* comparison and answers
+    false when either operand is NaN; ``!=`` is the unordered one and answers
+    true, since NaN is unequal to everything, itself included. Widening is
+    exact for float16 and bfloat16, and float32's own ``!=`` already carries
+    the case, so only the half formats pay it.
+
+    The other five comparisons want the ordered answer -- IEEE reads ``<``,
+    ``<=``, ``>``, ``>=`` and ``==`` as false against a NaN -- and take the
+    operator directly. Negating equality does not work here: the simplifier
+    folds ``not (a == b)`` back to ``a != b``, which is the comparison being
+    avoided.
+    """
 
     SUPPORTED_DTYPES = _BINARY_FULL_DTYPES
     OUTPUT_DTYPE = torch.bool
 
     @staticmethod
     def op_func(a, b):
+        if str(a.dtype) in ("float16", "bfloat16"):
+            return T.Cast("float32", a) != T.Cast("float32", b)
         return a != b
 
 

--- a/tests/ops/test_comparison.py
+++ b/tests/ops/test_comparison.py
@@ -410,3 +410,27 @@ def test_comparison_bool_result_per_strategy(strategy: str) -> None:
     out = GtFwdKernel(shape, shape, torch.float16, config={"strategy": strategy}).forward(a, b)
     assert out.dtype == torch.bool
     assert torch.equal(out, torch.gt(a, b))
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_comparison_nan_ordering(dtype: torch.dtype) -> None:
+    """``ne`` is the one comparison IEEE 754 reads as true against a NaN.
+
+    ``<``, ``<=``, ``>``, ``>=`` and ``==`` are ordered and answer false when
+    either operand is NaN; ``!=`` is unordered and answers true, NaN against
+    itself included. CUDA's half comparison intrinsics are all ordered, so the
+    half formats are where the two can disagree.
+    """
+    nan = float("nan")
+    a = torch.tensor([nan, nan, 1.0, 1.0, 2.0], device="cuda", dtype=dtype)
+    b = torch.tensor([nan, 1.0, nan, 1.0, 3.0], device="cuda", dtype=dtype)
+    for op_cls, ref_fn in (
+        (EqFwdOp, torch.eq),
+        (NeFwdOp, torch.ne),
+        (LtFwdOp, torch.lt),
+        (LeFwdOp, torch.le),
+        (GtFwdOp, torch.gt),
+        (GeFwdOp, torch.ge),
+    ):
+        assert torch.equal(op_cls()(a, b), ref_fn(a, b)), op_cls.__name__


### PR DESCRIPTION
## Problems

- **A broadcast row's constant operand was read at every element.** An operand at stride 0 is one value for the whole row. The staged broadcast block read it at the use site, so the load sat in the element loop — and so did whatever the body wrapped around it. For `maximum` and `minimum` that is a NaN test on both operands, and one of the two is the row's property, not the element's. The generated CUDA read the same scalar three times per element and re-evaluated `b != b` eight times per lane.
- **`NeFwdOp` read `ne(NaN, NaN)` as False in float16 and bfloat16.** torch reads True. CUDA's `__hne` is an *ordered* comparison and answers false when either operand is NaN; IEEE 754's `!=` is the unordered one, and NaN is unequal to everything, itself included. float32 lowers to the native `!=` and was already right. Independent of shape and of the broadcast layout — the same answer on `(16, 1024)` against `(16, 1024)`, which takes no broadcast path at all.

## Changes

- `write_block_staged` reads a stride-0 operand into a register before the element loop, rather than at the use site. The two operands take separate registers, so a plan where both are stride 0 cannot alias.
- `write_held_block`: the same for the unstaged path, which is what the bodies that do vectorize take.
- `NeFwdKernel.op_func` widens a half operand to float32 before comparing, which is exact and is where `!=` means what IEEE says. Negating equality does not work: the simplifier folds `not (a == b)` back to `a != b`, which is the comparison being avoided. The other five comparisons want the ordered answer — IEEE reads `<`, `<=`, `>`, `>=` and `==` as false against a NaN — and take the operator directly.
- Test-node delta: +3. One test, `test_comparison_nan_ordering`, over the three float dtypes; it covers all six comparisons against NaN on both sides and on one side.

Closes #2030.

## Performance

| Environment | Value |
| --- | --- |
| image | `ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-afcebed1-foundry-dev` |
| gpu | `NVIDIA H200` (one device, idle, not the CI runners') |
| driver | `595.71.05`, cuda `13.2`, torch `2.13.0+cu132`, tilelang `0.1.11+cu132.gitafcebed1` |
| timer | native CUPTI device-busy time |

Method: `benchmarks/ops/bench_elementwise_manifest.py` and `benchmarks/ops/bench_binary_elementwise.py` unmodified, 278 rows. The two sides alternated A B A B in one sitting on one idle device, each run from its own empty `TILELANG_CACHE_DIR`; each tag takes the minimum over its two rounds. The `before` side is a detached checkout of this branch's merge base.

**The noise floor first.** Comparing the two `before` rounds against each other — same code, same device, same sitting — the 261 rows that take 5 us or more have a median of 1.000 and a 5th-to-95th percentile of 0.987 to 1.017, with the 99th at 1.032. The rows below 5 us are launch-bound and spread 0.945 to 1.077; nothing is read off them.

| Op | Workload | Before (us) | After (us) | Speedup | Strongest baseline (us) / ours |
| --- | --- | ---: | ---: | ---: | ---: |
| MinimumFwdOp | `cnn-feat-broadcast` f16 | 15.488 | 14.720 | **1.052x** | torch-compile 14.176 🔴 0.963x |
| MaximumFwdOp | `cnn-feat-broadcast` f16 | 15.424 | 14.785 | **1.043x** | torch-compile 14.193 🔴 0.960x |
| MaximumFwdOp | `cnn-feat-broadcast` bf16 | 15.745 | 15.231 | **1.034x** | torch-compile 14.240 🔴 0.935x |
| MinimumFwdOp | `cnn-feat-broadcast` bf16 | 15.520 | 15.200 | 1.021x | torch-compile 14.240 🔴 0.937x |
| MaximumFwdOp | `cnn-feat-broadcast` f32 | 26.944 | 26.400 | 1.021x | torch-compile 26.224 🔴 0.993x |
| MinimumFwdOp | `cnn-feat-broadcast` f32 | 27.073 | 26.528 | 1.021x | torch-compile 26.304 🔴 0.992x |

All six are above the 95th percentile of the same-code distribution and four are above the 99th, and all six move the same way. The other 272 rows land inside it. `NeFwdOp` on the same workload reads 0.997x, 0.997x and 1.002x, which is what the bugfix costing nothing looks like.

The seven other ops on this workload — `div`, `eq`, `ne`, `lt`, `le`, `gt`, `ge` — are unchanged, and that is the expected result: their bodies read the constant without wrapping it, so the repeated subscript was already folded to one load. Only `maximum` and `minimum` re-evaluated arithmetic with it.

## Result And Limitations

**improvement without SOTA**

- `maximum` and `minimum` were the worst rows in the elementwise family. This branch takes them from 0.867x and 0.855x against torch-compile on the nightly's runner to 0.935x to 0.963x on an idle device, and closes the whole gap between them and `div`, which does the same traffic: before this branch `maximum` was 15.42 us against `div`'s 14.66, and after it they are within 0.13 us of each other.
- **They are still behind torch-compile by about 4%, and that 4% is the memory floor, not the op.** A flat copy of the row's 51.4 MB measures **14.016 us** on this device, at 3.67 TB/s, and it is flat: 2048-element blocks at 256 lanes and 1024-element blocks at 128 lanes both land there. torch-compile takes 14.143 us, which is 1.009x of that copy. Nothing on this workload can lead it by more than a percent.
- Two ways to close the remaining gap were measured and rejected:
  - **The tail is not it.** `inner` is 3136 and the block covers 1024 columns, so 64 columns a row take the packed tail — 2% of the elements. Forcing an exact tiling instead, 3136 columns on 224 lanes, gives 14.656 us against the tailed form's 14.688: no tail, and no gain.
  - **Rewriting the tail so each lane owns a contiguous run made it worse**, 14.66 us to 17.54 us for `div`. Spelling it as a 1-D parallel over the lanes with the run serial inside costs the coalescing the current 2-D form gets across lanes.
- What is left is about 2.7% between the kernel and a copy at the same geometry, which is the op's own arithmetic: eight f32 divides a lane for `div`, a NaN select for `maximum`. I did not find a way to take it.
- Tests: `tests/ops/test_binary_arith.py`, `test_comparison.py`, `test_elementwise_binary_broadcast.py`, `test_elementwise_config_dtype.py`, `test_special_elementwise.py`, 358 passed. A separate harness over 9 ops x 5 broadcast layouts x 3 dtypes with NaN on both sides matches torch on every case, where before the `ne` fix ten of them differed. `pre-commit` clean.
