### PR TITLE
[Refactor][attention] Migrate dense GQA sliding-window kernel

### DIFF
--- a/src/tileops/kernels/attention/gqa_sliding_window_fwd.py
+++ b/src/tileops/kernels/attention/gqa_sliding_window_fwd.py
@@ -8,7 +8,7 @@ import torch
 
 from tileops.kernels.kernel_base import Kernel
 
-from .online_softmax import make_log2e_scale
+from .online_softmax import LOG2E, make_apply_softcap
 
 __all__ = [
     "GQASlidingWindowFwdWgmmaPipelinedKernel",
@@ -25,11 +25,13 @@ def _gqa_sw_fwd_wgmma_pipelined_kernel(
     is_causal: bool,
     window_size_left: int,
     window_size_right: int,
+    sm_scale: Optional[float] = None,
+    softcap: float = 0.0,
     dtype: str = "float16",
 ) -> Callable:
-    scale = make_log2e_scale(dim)
-    if heads % heads_kv != 0:
-        raise ValueError("heads must be divisible by heads_kv")
+    score_scale = dim**-0.5 if sm_scale is None else sm_scale
+    use_softcap = softcap > 0.0
+    scale = LOG2E if use_softcap else score_scale * LOG2E
     groups = heads // heads_kv
     accum_dtype = "float"
     has_window = window_size_left >= 0 or window_size_right >= 0
@@ -42,6 +44,11 @@ def _gqa_sw_fwd_wgmma_pipelined_kernel(
     def _gqa_sw_fwd_wgmma_pipelined_func(block_m, block_n, num_stages, threads):
         q_shape = (batch, seq_len, heads, dim)
         kv_shape = (batch, seq_len, heads_kv, dim)
+        apply_softcap = (
+            make_apply_softcap(score_scale, softcap, accum_dtype, block_m, block_n)
+            if use_softcap
+            else None
+        )
 
         @T.macro
         def mma0(
@@ -148,6 +155,8 @@ def _gqa_sw_fwd_wgmma_pipelined_kernel(
                 for k_offset in T.Pipelined(loop_count, num_stages=num_stages):
                     k_idx = k_start + k_offset
                     mma0(k, q_shared, k_shared, acc_s, k_idx, bx, by, bz)
+                    if use_softcap:
+                        apply_softcap(acc_s)
                     # Online softmax with scores_max clamping.
                     # Clamping prevents exp2(+inf) when all block scores are -inf.
                     T.copy(scores_max, scores_max_prev)
@@ -200,6 +209,8 @@ def _gqa_sw_fwd_wgmma_pipelined_wrapped_kernel(
     is_causal: bool,
     window_size_left: int,
     window_size_right: int,
+    sm_scale: float,
+    softcap: float,
     dtype: str,
     block_m: int,
     block_n: int,
@@ -210,7 +221,17 @@ def _gqa_sw_fwd_wgmma_pipelined_wrapped_kernel(
     v: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     return _gqa_sw_fwd_wgmma_pipelined_kernel(
-        batch, heads, heads_kv, seq_len, dim, is_causal, window_size_left, window_size_right, dtype
+        batch,
+        heads,
+        heads_kv,
+        seq_len,
+        dim,
+        is_causal,
+        window_size_left,
+        window_size_right,
+        sm_scale,
+        softcap,
+        dtype,
     )(block_m, block_n, num_stages, threads)(q, k, v)
 
 
@@ -224,6 +245,8 @@ def _(
     is_causal,
     window_size_left,
     window_size_right,
+    sm_scale,
+    softcap,
     dtype,
     block_m,
     block_n,
@@ -237,6 +260,8 @@ def _(
 
 
 class GQASlidingWindowFwdWgmmaPipelinedKernel(Kernel):
+    """SM90 Dense sliding-window kernel with a native BSHD ABI."""
+
     supported_archs: list[int] = [90]
 
     def __init__(
@@ -250,14 +275,16 @@ class GQASlidingWindowFwdWgmmaPipelinedKernel(Kernel):
         window_size_left: int,
         window_size_right: int,
         dtype: torch.dtype,
+        sm_scale: Optional[float] = None,
+        softcap: float = 0.0,
         config: Optional[dict] = None,
         tune: bool = False,
+        *,
+        device_index: Optional[int] = None,
     ) -> None:
-        super().__init__()
+        super().__init__(device_index=device_index)
         self.batch = batch
         self.heads = heads
-        if heads % heads_kv != 0:
-            raise ValueError("heads must be divisible by heads_kv")
         self.heads_kv = heads_kv
         self.seq_len = seq_len
         self.dim = dim
@@ -265,6 +292,8 @@ class GQASlidingWindowFwdWgmmaPipelinedKernel(Kernel):
         self.window_size_left = window_size_left
         self.window_size_right = window_size_right
         self.dtype = dtype
+        self.sm_scale = dim**-0.5 if sm_scale is None else sm_scale
+        self.softcap = softcap
 
         self.kernel = _gqa_sw_fwd_wgmma_pipelined_kernel(
             self.batch,
@@ -275,6 +304,8 @@ class GQASlidingWindowFwdWgmmaPipelinedKernel(Kernel):
             self.is_causal,
             self.window_size_left,
             self.window_size_right,
+            self.sm_scale,
+            self.softcap,
             self.dtype_str,
         )
 
@@ -296,7 +327,18 @@ class GQASlidingWindowFwdWgmmaPipelinedKernel(Kernel):
             {"block_m": c[0], "block_n": c[1], "num_stages": c[2], "threads": c[3]} for c in configs
         ]
 
-    def forward(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        q_scale: Optional[torch.Tensor] = None,
+        k_scale: Optional[torch.Tensor] = None,
+        v_scale: Optional[torch.Tensor] = None,
+        rope_cos: Optional[torch.Tensor] = None,
+        rope_sin: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        self._require_cuda(q=q, k=k, v=v)
         output, _ = _gqa_sw_fwd_wgmma_pipelined_wrapped_kernel(
             self.batch,
             self.heads,
@@ -306,6 +348,8 @@ class GQASlidingWindowFwdWgmmaPipelinedKernel(Kernel):
             self.is_causal,
             self.window_size_left,
             self.window_size_right,
+            self.sm_scale,
+            self.softcap,
             self.dtype_str,
             self.config["block_m"],
             self.config["block_n"],

--- a/src/tileops/manifest/attention.yaml
+++ b/src/tileops/manifest/attention.yaml
@@ -119,9 +119,12 @@ GroupedQueryAttentionDenseFwdOp:
     func: "tileops.perf.formulas.gqa_fwd_roofline"
 
   source:
-    kernel: tileops/kernels/attention/gqa_prefill_fwd_ws.py
+    kernel:
+      - tileops/kernels/attention/gqa_prefill_fwd_ws.py
+      - tileops/kernels/attention/gqa_sliding_window_fwd.py
     kernel_map:
       gqa_dense: GQADensePrefillCausalWsKernel
+      gqa_dense_sliding_window: GQASlidingWindowFwdWgmmaPipelinedKernel
     op: tileops/ops/attention/gqa.py
     test: tests/ops/attention/test_gqa.py
     bench: benchmarks/ops/attention/bench_gqa.py

--- a/src/tileops/ops/attention/gqa.py
+++ b/src/tileops/ops/attention/gqa.py
@@ -18,6 +18,7 @@ from tileops.kernels.attention import (
     GQAPrefillPagedWithKVCacheFwdKernel,
     GQAPrefillPagedWithKVCacheRopeFwdKernel,
     GQAPrefillVarlenFwdKernel,
+    GQASlidingWindowFwdWgmmaPipelinedKernel,
     GQASlidingWindowVarlenFwdWgmmaPipelinedKernel,
 )
 from tileops.kernels.kernel_base import Kernel
@@ -328,7 +329,10 @@ class GroupedQueryAttentionDenseFwdOp(Op):
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
-        return {"gqa_dense": GQADensePrefillCausalWsKernel}
+        return {
+            "gqa_dense": GQADensePrefillCausalWsKernel,
+            "gqa_dense_sliding_window": GQASlidingWindowFwdWgmmaPipelinedKernel,
+        }
 
     def _infer_output_shapes(
         self,
@@ -454,18 +458,19 @@ class GroupedQueryAttentionDenseFwdOp(Op):
         if rope_cos.shape != rope_sin.shape:
             raise ValueError("rope_cos and rope_sin must have the same shape")
 
-    def _validate_builtin_call(self, q: torch.Tensor) -> None:
-        """Reject features not implemented by the in-tree Dense kernel."""
+    def _validate_builtin_call(self, q: torch.Tensor, k: torch.Tensor) -> None:
+        """Reject features not implemented by the in-tree Dense kernels."""
         if not self.is_causal:
             raise ValueError("Dense GQA currently supports causal attention only")
         if q.shape[-1] != 128:
             raise ValueError("Dense GQA currently requires head dimension 128")
         if q.dtype not in (torch.float16, torch.bfloat16):
             raise ValueError("Dense GQA currently supports float16 and bfloat16 inputs only")
-        if self.window_size_left != -1 or self.window_size_right != -1:
-            raise ValueError("Dense GQA does not yet support sliding windows")
         if self.pos_encoding_mode != "none":
             raise ValueError("Dense GQA does not yet support fused RoPE")
+        uses_window = self.window_size_left != -1 or self.window_size_right != -1
+        if uses_window and q.shape[1] != k.shape[1]:
+            raise ValueError("Dense sliding-window GQA currently requires equal Q and KV lengths")
 
     @staticmethod
     def _canonicalize_inputs(
@@ -492,10 +497,26 @@ class GroupedQueryAttentionDenseFwdOp(Op):
         assert q is not None and k is not None
         batch, seq_len_q, heads, dim = q.shape
         _, seq_len_kv, heads_kv, _ = k.shape
-        role = "gqa_dense"
+        uses_window = self.window_size_left != -1 or self.window_size_right != -1
+        role = "gqa_dense_sliding_window" if uses_window else "gqa_dense"
 
         def build() -> Kernel:
-            self._validate_builtin_call(q)
+            self._validate_builtin_call(q, k)
+            if uses_window:
+                return self.kernel_map[role](
+                    batch=batch,
+                    heads=heads,
+                    heads_kv=heads_kv,
+                    seq_len=seq_len_q,
+                    dim=dim,
+                    is_causal=self.is_causal,
+                    window_size_left=self.window_size_left,
+                    window_size_right=self.window_size_right,
+                    dtype=q.dtype,
+                    sm_scale=self.sm_scale,
+                    softcap=self.softcap,
+                    device_index=q.device.index,
+                )
             return self.kernel_map[role](
                 batch=batch,
                 heads=heads,

--- a/tests/ops/attention/test_gqa.py
+++ b/tests/ops/attention/test_gqa.py
@@ -11,6 +11,7 @@ from tileops.kernels.attention import (
     GQADensePrefillCausalWsKernel,
     GQAFwdWsPersistentCausalKernel,
     GQAPrefillFwdWsPersistentCausalKernel,
+    GQASlidingWindowFwdWgmmaPipelinedKernel,
 )
 from tileops.ops import (
     GroupedQueryAttentionBwdOp,
@@ -101,6 +102,8 @@ def _gqa_prefill_ref(
     is_causal: bool,
     sm_scale: Optional[float] = None,
     softcap: Optional[float] = None,
+    window_size_left: int = -1,
+    window_size_right: int = -1,
 ) -> torch.Tensor:
     batch, seq_len_q, _, dim = q.shape
     seq_len_kv = k.shape[1]
@@ -112,11 +115,17 @@ def _gqa_prefill_ref(
     scores = torch.matmul(q_bhsd, k_bhsd.transpose(-2, -1)) * scale
     if softcap is not None and softcap > 0:
         scores = softcap * torch.tanh(scores / softcap)
+    offset = seq_len_kv - seq_len_q
+    q_pos = torch.arange(seq_len_q, device=q.device)[:, None] + offset
+    k_pos = torch.arange(seq_len_kv, device=q.device)[None, :]
+    mask = torch.ones((seq_len_q, seq_len_kv), device=q.device, dtype=torch.bool)
     if is_causal:
-        offset = seq_len_kv - seq_len_q
-        q_pos = torch.arange(seq_len_q, device=q.device)[:, None] + offset
-        k_pos = torch.arange(seq_len_kv, device=q.device)[None, :]
-        mask = k_pos <= q_pos
+        mask &= k_pos <= q_pos
+    if window_size_left >= 0:
+        mask &= k_pos >= q_pos - window_size_left
+    if window_size_right >= 0:
+        mask &= k_pos <= q_pos + window_size_right
+    if is_causal or window_size_left >= 0 or window_size_right >= 0:
         scores = scores.masked_fill(~mask.view(1, 1, seq_len_q, seq_len_kv), float("-inf"))
     probs = torch.softmax(scores, dim=-1)
     output = torch.matmul(probs, v_bhsd)
@@ -153,6 +162,46 @@ def test_gqa_dense_h200_main_kernel_matches_reference() -> None:
         rtol=1e-5,
     )
     assert isinstance(next(iter(op.iter_kernels())), GQADensePrefillCausalWsKernel)
+
+
+@pytest.mark.smoke
+def test_gqa_dense_h200_sliding_window_kernel_matches_reference() -> None:
+    if not is_h200():
+        pytest.skip("Dense sliding-window prefill is currently supported on H200")
+    batch, seq_len, heads, heads_kv, dim = 1, 256, 8, 2, 128
+    window_size_left = 64
+    sm_scale = 0.125
+    softcap = 2.0
+    q = torch.randn(batch, seq_len, heads, dim, device="cuda", dtype=torch.float16)
+    k = torch.randn(batch, seq_len, heads_kv, dim, device="cuda", dtype=torch.float16)
+    v = torch.randn_like(k)
+
+    op = GroupedQueryAttentionDenseFwdOp(
+        window_size_left=window_size_left,
+        window_size_right=0,
+        sm_scale=sm_scale,
+        softcap=softcap,
+    )
+    output = op(q, k, v)
+
+    torch.testing.assert_close(
+        output,
+        _gqa_prefill_ref(
+            q,
+            k,
+            v,
+            heads=heads,
+            heads_kv=heads_kv,
+            is_causal=True,
+            sm_scale=sm_scale,
+            softcap=softcap,
+            window_size_left=window_size_left,
+            window_size_right=0,
+        ),
+        atol=5e-3,
+        rtol=1e-5,
+    )
+    assert isinstance(next(iter(op.iter_kernels())), GQASlidingWindowFwdWgmmaPipelinedKernel)
 
 
 def _gqa_prefill_varlen_ref(


### PR DESCRIPTION
## Summary

- Route windowed calls from `GroupedQueryAttentionDenseFwdOp` to the existing SM90 BSHD sliding-window kernel.
- Align that kernel with the Dense Op ABI and support its `sm_scale` and `softcap` semantics.
- Keep the existing non-window Dense path unchanged; rectangular sliding attention, RoPE, and FP8 remain out of scope.

This is the sliding-window follow-up to #2035.

## Validation

- `ruff check` and `ruff format --check` on the changed Python files.
- Manifest validation for `GroupedQueryAttentionDenseFwdOp`.
- H200 GPU smoke: `2 passed, 42 deselected` (main Dense path and sliding-window path).