### PR TITLE
[Perf][foundry][Elementwise] Index a row broadcast by vector, not by row

### DIFF
--- a/src/tileops/kernels/elementwise/_builders.py
+++ b/src/tileops/kernels/elementwise/_builders.py
@@ -120,12 +120,14 @@ def _row_broadcast_prim(
     runs once per block, and the inner loop indexes affinely, so it vectorizes.
     The generic path pays that chain per element and every access is a gather.
     A ragged inner extent splits at trace time. Full blocks always run unguarded.
-    The columns past them go one of two ways: packed end to end across rows into
-    blocks of their own, or left in place as one guarded block per row.
+    Where *num_per_thread* divides the row, the grid indexes vectors instead and
+    there are no leftover columns at all. Otherwise the columns past the full
+    blocks go one of two ways: packed end to end across rows into blocks of their
+    own, or left in place as one guarded block per row -- scalar either way.
 
     *stage* moves the full blocks through fragments, which keeps the copies wide
     when the body cannot vectorize. It is opt-in because a body that does
-    vectorize is slower for the round trip. Leftover columns stay scalar either way.
+    vectorize is slower for the round trip.
     """
     op_func = op_func_for(op_name)
     ndim, divisors, a_strides, b_strides = _broadcast_index_terms(plan_name)
@@ -142,6 +144,24 @@ def _row_broadcast_prim(
     body_blocks = full_blocks * rows
     tail_blocks = -(-tail_slots // block_cols)
     pack_tail = not exact and full_blocks > 0 and tail_cols <= block_cols // _TAIL_PACK_RATIO
+    # A per-row tile is exact only when threads * num_per_thread divides the row.
+    # When it does not, the columns past the last full block go one element per
+    # thread whichever way the tail is placed, and the widest access the body
+    # could have used is lost on them. Indexing vectors rather than rows removes
+    # the boundary they come from: num_per_thread divides the row, so a vector
+    # stays inside one row and the operand offsets remain a property of the row,
+    # computed per thread instead of per block.
+    vecs_per_row = inner // num_per_thread
+    total_vecs = rows * vecs_per_row
+    grid_vecs = -(-total_vecs // threads)
+    # The staged form writes whole fragments, so it needs every block full; the
+    # unstaged one guards its last block instead.
+    flat_grid = (
+        not exact
+        and num_per_thread > 1
+        and inner % num_per_thread == 0
+        and (not stage or grid_vecs * threads == total_vecs)
+    )
 
     @T.macro
     def write_col(a, b, y, a_base, b_base, by, col):
@@ -207,6 +227,94 @@ def _row_broadcast_prim(
                 write_col(a, b, y, a_base, b_base, by, (bxc * threads + i) * num_per_thread + j)
         else:
             write_held_block(a, b, y, a_base, b_base, by, bxc)
+
+    if flat_grid:
+        exact_grid = grid_vecs * threads == total_vecs
+
+        @T.macro
+        def write_flat_vec(a, b, y, v, j):
+            """The *j*-th column of vector *v*, wherever in the grid that lands."""
+            row = v // vecs_per_row
+            col = (v % vecs_per_row) * num_per_thread + j
+            a_base, b_base = _compute_broadcast_offsets(
+                row * inner, ndim, divisors, a_strides, b_strides
+            )
+            write_col(a, b, y, a_base, b_base, row, col)
+
+        @T.macro
+        def write_flat_staged(a, b, y, bx):
+            """One block of vectors, read and written a fragment at a time.
+
+            Staging and the flat grid answer different halves of the same block.
+            The copy loops carry no body, so they take the width the row allows
+            even where the body would have scalarised them; the flat grid leaves
+            no column outside a vector for either loop to fall back on. A block
+            spans rows here, so the operand a row broadcasts is one register per
+            thread rather than one per block.
+            """
+            y_reg = T.alloc_fragment((block_cols,), out_dtype)
+            if a_inner:
+                a_reg = T.alloc_fragment((block_cols,), dtype)
+            else:
+                a_held = T.alloc_fragment((threads,), dtype)
+            if b_inner:
+                b_reg = T.alloc_fragment((block_cols,), dtype)
+            else:
+                b_held = T.alloc_fragment((threads,), dtype)
+            for i, j in T.Parallel(threads, num_per_thread):
+                v = bx * threads + i
+                col = (v % vecs_per_row) * num_per_thread + j
+                a_base, b_base = _compute_broadcast_offsets(
+                    (v // vecs_per_row) * inner, ndim, divisors, a_strides, b_strides
+                )
+                if a_inner:
+                    a_reg[i * num_per_thread + j] = a[a_base + col * a_inner]
+                if b_inner:
+                    b_reg[i * num_per_thread + j] = b[b_base + col * b_inner]
+            for i in T.Parallel(threads):
+                a_base, b_base = _compute_broadcast_offsets(
+                    ((bx * threads + i) // vecs_per_row) * inner,
+                    ndim,
+                    divisors,
+                    a_strides,
+                    b_strides,
+                )
+                if not a_inner:
+                    a_held[i] = a[a_base]
+                if not b_inner:
+                    b_held[i] = b[b_base]
+            for i, j in T.Parallel(threads, num_per_thread):
+                k = i * num_per_thread + j
+                y_reg[k] = op_func(
+                    a_reg[k] if a_inner else a_held[i],
+                    b_reg[k] if b_inner else b_held[i],
+                )
+            for i, j in T.Parallel(threads, num_per_thread):
+                v = bx * threads + i
+                y[(v // vecs_per_row) * inner + (v % vecs_per_row) * num_per_thread + j] = y_reg[
+                    i * num_per_thread + j
+                ]
+
+        @T.prim_func
+        def flat_main(
+            a: T.Tensor((a_numel,), dtype),
+            b: T.Tensor((b_numel,), dtype),
+            y: T.Tensor((N_total,), out_dtype),
+        ):
+            with T.Kernel(grid_vecs, threads=threads) as bx:
+                if stage:
+                    write_flat_staged(a, b, y, bx)
+                else:
+                    for i, j in T.Parallel(threads, num_per_thread):
+                        v = bx * threads + i
+                        if exact_grid:
+                            write_flat_vec(a, b, y, v, j)
+                        else:
+                            with T.If(v < total_vecs):  # noqa: SIM117
+                                with T.Then():
+                                    write_flat_vec(a, b, y, v, j)
+
+        return flat_main
 
     if pack_tail:
 

--- a/src/tileops/kernels/elementwise/_builders.py
+++ b/src/tileops/kernels/elementwise/_builders.py
@@ -120,10 +120,9 @@ def _row_broadcast_prim(
     runs once per block, and the inner loop indexes affinely, so it vectorizes.
     The generic path pays that chain per element and every access is a gather.
     A ragged inner extent splits at trace time. Full blocks always run unguarded.
-    Where *num_per_thread* divides the row, the grid indexes vectors instead and
-    there are no leftover columns at all. Otherwise the columns past the full
-    blocks go one of two ways: packed end to end across rows into blocks of their
-    own, or left in place as one guarded block per row -- scalar either way.
+    Where *num_per_thread* divides the row, the grid indexes vectors and leaves no
+    columns over. Otherwise they go one of two ways, scalar either way: packed end
+    to end across rows into blocks of their own, or left as one guarded block per row.
 
     *stage* moves the full blocks through fragments, which keeps the copies wide
     when the body cannot vectorize. It is opt-in because a body that does
@@ -144,18 +143,13 @@ def _row_broadcast_prim(
     body_blocks = full_blocks * rows
     tail_blocks = -(-tail_slots // block_cols)
     pack_tail = not exact and full_blocks > 0 and tail_cols <= block_cols // _TAIL_PACK_RATIO
-    # A per-row tile is exact only when threads * num_per_thread divides the row.
-    # When it does not, the columns past the last full block go one element per
-    # thread whichever way the tail is placed, and the widest access the body
-    # could have used is lost on them. Indexing vectors rather than rows removes
-    # the boundary they come from: num_per_thread divides the row, so a vector
-    # stays inside one row and the operand offsets remain a property of the row,
-    # computed per thread instead of per block.
+    # Columns past the last full block go one element per thread. Indexing
+    # vectors rather than rows leaves none: num_per_thread divides the row, so a
+    # vector stays inside one row. The staged form writes whole fragments and so
+    # needs every block full; the unstaged one guards its last block.
     vecs_per_row = inner // num_per_thread
     total_vecs = rows * vecs_per_row
     grid_vecs = -(-total_vecs // threads)
-    # The staged form writes whole fragments, so it needs every block full; the
-    # unstaged one guards its last block instead.
     flat_grid = (
         not exact
         and num_per_thread > 1
@@ -245,12 +239,9 @@ def _row_broadcast_prim(
         def write_flat_staged(a, b, y, bx):
             """One block of vectors, read and written a fragment at a time.
 
-            Staging and the flat grid answer different halves of the same block.
-            The copy loops carry no body, so they take the width the row allows
-            even where the body would have scalarised them; the flat grid leaves
-            no column outside a vector for either loop to fall back on. A block
-            spans rows here, so the operand a row broadcasts is one register per
-            thread rather than one per block.
+            The copy loops carry no body, so they keep the full width where the
+            body would have scalarised them. A block spans rows, so the operand
+            a row broadcasts is one register per thread, not one per block.
             """
             y_reg = T.alloc_fragment((block_cols,), out_dtype)
             if a_inner:


### PR DESCRIPTION
## problems

- `cnn-feat-broadcast` (`[16,256,56,56]` op `[256,1,1]`) is the worst case of every binary elementwise op in the nightly: Maximum, Minimum, Le, Ge, Lt, Ne, Eq, Gt, Div all sit 1.05-1.08x above their best baseline on float16/bfloat16.
- The row is 3136 = 8 * 392 and 392 is not a warp multiple, so no 8-wide per-row tile divides it. At the shipped 128 x 8 the last 64 columns of every row fall to the scalar path: 2 bytes per lane where the rest of the row moves 16.
- The tail is 2% of the data and no per-row launch config removes it. Sweeping every `threads * num_per_thread == 3136` split reaches 14.496us at best, against 14.912us shipped and a 14.336us copy floor.

## changes

- `_row_broadcast_prim` indexes vectors instead of rows when `num_per_thread` divides the inner extent. A vector then never straddles a row, so the operand offsets stay a property of the row and move from the block to the thread. No leftover columns remain.
- Staging composes with it. The copy loops carry no body, so they keep the full width even where the body would scalarise them, and the operand a row broadcasts becomes one register per thread rather than one per block. This is what brings the NaN-builtin (Maximum, Minimum) and bool-predicate (the six comparisons) bodies along.
- Shapes whose inner extent the current tile already divides keep the per-row tile, as does an inner extent `num_per_thread` does not divide. The staged form additionally requires a full last block; the unstaged form guards it.
- Test node delta: 0.

### cnn-feat-broadcast, H200 at 1500MHz, CUPTI device-busy median, us

| op | dtype | before | after | best baseline | copy floor |
| --- | --- | --- | --- | --- | --- |
| Maximum | float16 | 14.656 | 14.336 | 14.368 | 14.336 |
| Maximum | bfloat16 | 14.656 | 14.336 | 14.368 | 14.304 |
| Maximum | float32 | 26.400 | 26.016 | 26.304 | 26.208 |
| Minimum | float16 | 14.656 | 14.336 | 14.368 | 14.336 |
| Minimum | bfloat16 | 14.656 | 14.336 | 14.399 | 14.304 |
| Minimum | float32 | 26.368 | 25.952 | 26.304 | 26.208 |
| Eq | float16 | 12.640 | 12.128 | 12.096 | - |
| Eq | bfloat16 | 12.640 | 12.128 | 12.080 | - |
| Eq | float32 | 18.816 | 18.528 | 18.464 | - |
| Div | float16 | 15.648 | 15.136 | 14.368 | 14.336 |
| Div | bfloat16 | 15.617 | 15.104 | 14.368 | 14.304 |
| Div | float32 | 26.656 | 26.272 | 26.368 | 26.208 |

Maximum and Minimum land on the copy floor in all three dtypes, and 14.336us repeated 5 times without variation. The copy floor is a compiled one-input elementwise kernel over the same bytes; `copy_` lowers to a memcpy and launches no kernel.

### other inner extents, Div, float16

| shape | before | after |
| --- | --- | --- |
| 4096 x 3000, tail 952 | 16.032 | 15.264 |
| 8192 x 1536, tail 512 | 15.968 | 15.216 |
| 65536 x 56, no full block | 5.792 | 5.823 |
| 1024 x 4096, tile divides the row | 6.400 | 6.432 |
| hidden-state-prefill, contiguous | 15.104 | 15.104 |

### verification

- `tests/ops/test_elementwise_binary_broadcast.py`, `test_elementwise_compile.py`, `test_elementwise_config_dtype.py`, `test_elementwise_caching_autotune.py`: 210 passed.
- A shape sweep over 8 layouts x 2 dtypes x 6 ops, covering the guarded last block, a single row, an inner extent below one block, and the broadcast on either operand: all match torch.

### what this does not close

Div stays 5.3% above its baseline on float16 and bfloat16. The division costs 0.77us over the copy floor and does not move: a hoisted reciprocal is slower, a native half division measures the same as the float32 one, wider vectors are slower in the builder, and staging is within noise. The baseline reaches the copy floor with a division present.
