### PR TITLE
[Perf][foundry][Elementwise] Let a bool result widen the block on a tail-free row

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,9 +33,9 @@ jobs:
   # =========================================================================
   benchmark:
     if: ${{ github.repository == 'tile-ai/TileOPs' && (github.event_name == 'schedule' || github.ref == 'refs/heads/main') }}
-    # Sized for a cold cache: a measured 59-file sweep on an idle H200 takes
-    # 5h07m with nothing cached, and minutes once it is. Must exceed
-    # --total-budget below so the runner, not GitHub, ends the sweep.
+    # Sized for a cold cache: the full sweep takes hours with nothing cached and
+    # minutes once it is. Must exceed --total-budget below so the runner, not
+    # GitHub, ends the sweep.
     timeout-minutes: 380
     runs-on: [self-hosted, tile-ops, bench]
     env:

--- a/benchmarks/hardware/compute/gemm_throughput.py
+++ b/benchmarks/hardware/compute/gemm_throughput.py
@@ -6,7 +6,7 @@ src/tileops/perf/profiles/: `calibration` (sustained) and `calibration_burst`.
 The tensor-core counterpart of fma_throughput.py.
 
 Unlike the FMA benchmark, clock locking cannot hold here: a saturating GEMM
-drives an H200 into its power cap, so the SM clock is set by the cap, not the
+drives the device into its power cap, so the SM clock is set by the cap, not the
 lock.  Each dtype gets its own telemetry window, and the sustained factor is
 reported next to the clocks it was taken at; burst is the pre-cap rate.
 

--- a/benchmarks/ops/bench_convolution.py
+++ b/benchmarks/ops/bench_convolution.py
@@ -40,8 +40,8 @@ _TUNE = True
 _FLAGGEMS_CONV = {1: "conv1d", 2: "conv2d", 3: "conv3d"}
 
 # Triton and cuDNN sum the same products in a different order, so agreement is
-# relative to the output scale: over the 13 manifest workloads on an H200, flag_gems
-# lands within 0.25 of cuDNN where |ref| reaches 564.
+# relative to the output scale: across the manifest's workloads flag_gems lands
+# within a fraction of cuDNN where the reference reaches the hundreds.
 _BASELINE_RTOL = 2e-2
 _BASELINE_ATOL = 2e-2
 

--- a/benchmarks/ops/bench_pool.py
+++ b/benchmarks/ops/bench_pool.py
@@ -45,8 +45,8 @@ from workloads.pool import (
 # ---------------------------------------------------------------------------
 # Baselines. cuDNN is reached through the v9 backend's Resample node in ctypes, not a binding:
 # nvidia-cudnn-frontend 1.27 exposes 141 graph ops and none of them is resample, and the
-# legacy cudnnPoolingForward rejects bfloat16. Measured on an H200, the legacy entry point
-# reaches the same kernel as the graph API (0.0867 vs 0.0865 ms device-busy).
+# legacy cudnnPoolingForward rejects bfloat16. The legacy entry point reaches the same
+# kernel as the graph API, so neither is faster than the other.
 # ---------------------------------------------------------------------------
 
 # v9 backend data types (cudnn_graph.h; note HALF=2/BF16=9, unlike legacy API).
@@ -333,8 +333,8 @@ def cudnn_pool_fn(
         resample = c.create(_DESC_RESAMPLE)
         c.set(resample, _ATTR_RESAMPLE_MODE, _TYPE_RESAMPLE_MODE, [mode], "mode")
         c.set(resample, _ATTR_RESAMPLE_COMP_TYPE, _TYPE_DATA_TYPE, [_CUDNN_DATA_FLOAT], "comp")
-        # Propagating costs ~19% of the kernel on an H200 max-pool, and torch propagates:
-        # the cheaper mode returns a number where torch returns NaN.
+        # Propagating costs a fifth of the kernel, and torch propagates: the cheaper
+        # mode returns a number where torch returns NaN.
         c.set(resample, _ATTR_RESAMPLE_NAN, _TYPE_NAN, [_PROPAGATE_NAN], "nan")
         c.set(resample, _ATTR_RESAMPLE_PADDING_MODE, _TYPE_PADDING_MODE, [pad_mode], "padmode")
         c.set(resample, _ATTR_RESAMPLE_SPATIAL_DIMS, _TYPE_INT64, [ndim], "spatial")

--- a/benchmarks/ops/bench_rope.py
+++ b/benchmarks/ops/bench_rope.py
@@ -244,8 +244,8 @@ def test_rope_neox_position_ids_bench(
         return _rotate(t, cos[idx].unsqueeze(1), sin[idx].unsqueeze(1))
 
     # vllm rotates in fp32 and rounds once, the reference in the storage dtype, so they
-    # agree to one rounding step: over the manifest's rows on an H200, max |Δ| 0.0039
-    # in fp16 and 0.0156 in bf16.
+    # agree to one rounding step of the storage dtype, which is what the default
+    # tolerances allow.
     check_fn, check_args = _vllm_rope(x, position_ids, head_dim, cos, sin)
     torch.testing.assert_close(
         check_fn(*check_args).view(x.shape),

--- a/src/tileops/kernels/attention/mha_decode_paged_ws.py
+++ b/src/tileops/kernels/attention/mha_decode_paged_ws.py
@@ -427,10 +427,9 @@ class MHADecodePagedWsKernel(Kernel):
     def default_config(self) -> dict:
         """Aim the grid at one wave, then take the tallest tile that fits.
 
-        Measured on H200: the split count that puts roughly ``_TARGET_BLOCKS``
-        blocks on the device wins across all four manifest shapes, and among the
-        tile heights that then cover a split, the tallest is at worst within
-        noise of the best.
+        The split count that puts roughly ``_TARGET_BLOCKS`` blocks on the device
+        wins across the manifest's shapes, and among the tile heights that then
+        cover a split, the tallest is at worst within noise of the best.
         """
         work_items = max(1, self.batch * self.heads)
         num_split = max(1, min(_TARGET_BLOCKS // work_items, self.seqlen_kv))

--- a/src/tileops/kernels/elementwise/_base.py
+++ b/src/tileops/kernels/elementwise/_base.py
@@ -149,7 +149,7 @@ class UnaryKernel(_StrategyKernel):
 
     supported_archs: list[int] = [80, 86, 89, 90]
     STRATEGIES = ["direct", "explicit_parallel", "register_copy"]
-    # Fragment copy is the measured default for float unaries.
+    # Fragment copy is the default for float unaries.
     DEFAULT_STRATEGY = "register_copy"
     OUTPUT_DTYPE = None
     SUPPORTED_DTYPES = None

--- a/src/tileops/kernels/elementwise/_broadcast.py
+++ b/src/tileops/kernels/elementwise/_broadcast.py
@@ -79,6 +79,20 @@ def _compute_broadcast_offsets(flat_idx, ndim, divisors, a_strides, b_strides):
     return a_off, b_off
 
 
+def row_tile_leaves_tail(inner, rows, threads, num_per_thread, staged):
+    """Whether a row-broadcast block leaves columns to the one-element-per-thread path.
+
+    A tile that divides the row leaves none. Otherwise the grid indexes vectors,
+    which leaves none either, so long as a vector stays inside a row and, for the
+    staged form, every block is full.
+    """
+    if inner % (threads * num_per_thread) == 0:
+        return False
+    if inner % num_per_thread:
+        return True
+    return bool(staged and (rows * (inner // num_per_thread)) % threads)
+
+
 def _is_contiguous_same_shape(coalesced_shape, a_strides, b_strides):
     """Return True when both inputs are contiguous with the same shape (no broadcast)."""
     return (

--- a/src/tileops/kernels/elementwise/_builders.py
+++ b/src/tileops/kernels/elementwise/_builders.py
@@ -16,9 +16,8 @@ from ._op_body import op_func_for
 
 # Packing the leftover T columns of a W-wide block saves rows * (W - T) idle lane
 # slots and spends rows * T index chains, so it pays while T / (W - T) stays under
-# the lane slots one chain is worth. At W // 4 that ratio is 1/3 -- one chain per
-# three idle slots. The workloads sit either side of it: T/W = 0.125 packs and
-# gains, T/W = 0.53 with a single full block per row costs 8.0us -> 14.3us.
+# the lane slots one chain is worth. At W // 4 that ratio is one chain per three
+# idle slots.
 _TAIL_PACK_RATIO = 4
 
 

--- a/src/tileops/kernels/elementwise/_builders.py
+++ b/src/tileops/kernels/elementwise/_builders.py
@@ -10,6 +10,7 @@ from ._broadcast import (
     _is_contiguous_same_shape,
     broadcast_plan_for,
     row_broadcast_split,
+    row_tile_leaves_tail,
 )
 from ._op_body import op_func_for
 
@@ -144,17 +145,14 @@ def _row_broadcast_prim(
     tail_blocks = -(-tail_slots // block_cols)
     pack_tail = not exact and full_blocks > 0 and tail_cols <= block_cols // _TAIL_PACK_RATIO
     # Columns past the last full block go one element per thread. Indexing
-    # vectors rather than rows leaves none: num_per_thread divides the row, so a
-    # vector stays inside one row. The staged form writes whole fragments and so
-    # needs every block full; the unstaged one guards its last block.
-    vecs_per_row = inner // num_per_thread
+    # vectors rather than rows leaves none, where a vector stays inside a row.
+    vecs_per_row = inner // num_per_thread if inner % num_per_thread == 0 else 0
     total_vecs = rows * vecs_per_row
     grid_vecs = -(-total_vecs // threads)
     flat_grid = (
         not exact
         and num_per_thread > 1
-        and inner % num_per_thread == 0
-        and (not stage or grid_vecs * threads == total_vecs)
+        and not row_tile_leaves_tail(inner, rows, threads, num_per_thread, stage)
     )
 
     @T.macro

--- a/src/tileops/kernels/elementwise/_policy.py
+++ b/src/tileops/kernels/elementwise/_policy.py
@@ -7,6 +7,7 @@ import torch
 
 from tileops.kernels.kernel_base import Kernel
 
+from ._broadcast import row_tile_leaves_tail
 from ._dtype import (
     BOOL_STORAGE_DTYPE,
     _fp8_accum_dtype_str,
@@ -58,7 +59,7 @@ def default_launch_config(
             threads = min(_MAX_THREADS, threads * npt // capped)
         npt = capped
     elif _torch_dtype_nbytes(output_dtype) < elem_bytes and not _tail_dominated(
-        row_broadcast_inner, threads, npt
+        row_broadcast_inner, n_total, threads, npt, output_dtype == torch.bool
     ):
         # A narrower result leaves the store short of a vector, so widen to cover it.
         npt *= 2
@@ -73,16 +74,20 @@ def default_launch_config(
     return {"strategy": strategy, "threads": threads, "num_per_thread": npt}
 
 
-def _tail_dominated(inner: int | None, threads: int, npt: int) -> bool:
+def _tail_dominated(
+    inner: int | None, n_total: int | None, threads: int, npt: int, staged: bool
+) -> bool:
     """Whether doubling the block width pushes more columns onto the guarded tail path.
 
     A row-broadcast block covers columns of one row, and the remainder the width
-    does not cover runs the slower per-lane path.
+    does not cover runs the slower per-lane path. A width that leaves no
+    remainder there has nothing to push onto it.
     """
-    if inner is None:
+    if inner is None or n_total is None:
         return False
-    wide = threads * npt * 2
-    return inner % wide > inner % (threads * npt)
+    if not row_tile_leaves_tail(inner, n_total // inner, threads, npt * 2, staged):
+        return False
+    return inner % (threads * npt * 2) > inner % (threads * npt)
 
 
 def elementwise_autotune_configs(

--- a/src/tileops/kernels/elementwise/bitwise.py
+++ b/src/tileops/kernels/elementwise/bitwise.py
@@ -81,9 +81,8 @@ class BitwiseNotFwdKernel(UnaryKernel):
     vectorized ``int4`` CUDA types.
 
     Takes the base class's looping strategy: one element per thread reads four bytes
-    where the dtype allows sixteen, and measured on H200 at 256M int32 elements that is
-    the difference between 2.5 and 4.3 TB/s. A bool input is still coerced to the scalar
-    path, by the dtype rule in ``UnaryKernel``.
+    where the dtype allows sixteen, which costs most of the read bandwidth. A bool
+    input is still coerced to the scalar path, by the dtype rule in ``UnaryKernel``.
     """
 
     SUPPORTED_DTYPES = _BITWISE_DTYPES

--- a/src/tileops/kernels/fft.py
+++ b/src/tileops/kernels/fft.py
@@ -87,7 +87,7 @@ def _fft_c2c_kernel(n: int, batch_size: int = 1, dtype: str = "complex64") -> Ca
         # remaining stages (stride >= smem_per_block) use the LUT
         lut_stage_start = smem_stages
         lut_stage_count = log2n - smem_stages
-        # float32 for complex64 (FP32 throughput 30× > FP64 on H200);
+        # float32 for complex64 (FP32 throughput far exceeds FP64 on Hopper);
         # float64 for complex128 — identical behaviour, no regression.
         accum_dtype = real_dtype
 

--- a/src/tileops/kernels/gemm/dense.py
+++ b/src/tileops/kernels/gemm/dense.py
@@ -1262,13 +1262,12 @@ def _splitk_pair(
     to us: on the short-mainloop shapes the mainloop drains before the reduce
     is even enqueued. Folding the builder lookup and the ``@tilelang.jit``
     factory call of *both* kernels into one cached resolution keeps that
-    window to the two launches themselves (measured: inter-kernel gap
-    4.6-5.7 us -> 1.7-2.6 us on the m<=128 x 2112 x 7168 family).
+    window to the two launches themselves.
 
     The other host step that used to land in that window is allocating ``C``.
     ``_splitk_reduce_kernel`` therefore takes it as an explicit parameter, and
     both callers allocate it *before* launching the mainloop, which closes the
-    remaining gap to the 1.1 us floor torch measures on the same rows.
+    remaining gap to the floor torch reaches on the same rows.
     """
     if coop2:
         mainloop = _gemm_coop2_splitk_kernel(m, n, k, trans_a, trans_b, dtype)(

--- a/src/tileops/kernels/gemm/heuristics.py
+++ b/src/tileops/kernels/gemm/heuristics.py
@@ -276,13 +276,6 @@ def _swap_ab_stages(n: int, sm_count: int) -> Optional[int]:
     (``swap_ab_grid_underfills``) that advantage is gone and the split-K path
     (which multiplies its own grid by ``split_k``) wins.
 
-    Measured on H200 vs ``min(torch, cuBLASLt-best)`` (per-rep interleaved,
-    fp32-guarded, bf16 NT), best swap_ab config against the path it replaces:
-
-    - ``n=2112`` (33 CTAs): 0.94x at ns=6, against 1.05x for split-K;
-    - ``n=4096`` (64 CTAs): 1.12x at ns=8, against 1.04x for split-K;
-    - ``n=7168`` (112 CTAs): 1.07x at ns=4, against 0.91x for the plain tile.
-
     The stage count falls as the grid grows: with more CTAs resident the device
     already has enough loads in flight, and a deeper ring only costs SMEM. Both
     ends are measured points; the boundary between them is interpolated.
@@ -395,17 +388,16 @@ def gemv_config(k: int) -> dict:
 
     GEMV is HBM-bandwidth bound; the lever is memory-level parallelism per
     output row via ``reduce_threads > 32`` (cross-warp SMEM tree reduction,
-    auto-lowered from ``tvm_thread_allreduce``). Measured on H200 these reach
-    90-102% of the per-shape read-BW ceiling and beat cuBLAS 1.1-2.4x, vs the
-    old ``block_n=8 / reduce_threads=32`` default (0.57-0.87x cuBLAS). Bands:
+    auto-lowered from ``tvm_thread_allreduce``). These bands read at close to the
+    per-shape bandwidth ceiling, where a ``block_n=8 / reduce_threads=32`` default
+    leaves most of it on the table. Bands:
 
     - very deep rows (k >= 12288, e.g. 7168x16384): 2 rows/block, 64
       threads/row — a 128-way reduction tree over a long row costs more than
       the bandwidth it buys, and 2 rows/block improves wave quantization;
     - mid-deep rows (k >= 6144, decode gate-up / attn-proj): a 256-lane
-      reduction still runs >= 3 pipeline iterations and the extra per-row
-      memory-level parallelism beats rt=128 by 9-10% under the cold-read
-      protocol (two independent 30-rep interleaved rounds, H200);
+      reduction still runs >= 3 pipeline iterations, and the extra per-row
+      memory-level parallelism beats rt=128 on a cold read;
     - shorter rows degenerate to ~1 iteration at 256 lanes and stay on
       rt=128, which maximizes per-row MLP to saturate HBM.
     """
@@ -419,13 +411,12 @@ def gemv_config(k: int) -> dict:
 def small_batch_config(n: int, k: int, sm_count: int) -> dict:
     """``SmallBatchGemmKernel`` (m == 2 NT band) config rule.
 
-    Modal best across the dispatched band (H200 per-rep interleaved sweep):
-    one output column per block, a 64-lane reduction over K, 4-deep cp.async
-    ring. One measured exception: when the grid alone fills the device's CTA
-    slots (block_n=1 -> n CTAs vs the 32-per-SM cap) AND the per-thread K
-    loop is long, resident warps already hide the load latency and the deep
-    ring only adds sync overhead — the 2-stage ring is ~9% faster there
-    (attn-family 4096x7168 at m=2).
+    Modal best across the dispatched band: one output column per block, a
+    64-lane reduction over K, 4-deep cp.async ring. One exception: when the
+    grid alone fills the device's CTA slots (block_n=1 -> n CTAs vs the
+    32-per-SM cap) AND the per-thread K loop is long, resident warps already
+    hide the load latency and the deep ring only adds sync overhead, so the
+    2-stage ring wins.
     """
     cfg = {"block_n": 1, "reduce_threads": 64, "num_stages": 4}
     k_iters = math.ceil(k / (cfg["reduce_threads"] * 8))

--- a/src/tileops/kernels/gemm/w4a16_decode.py
+++ b/src/tileops/kernels/gemm/w4a16_decode.py
@@ -174,9 +174,8 @@ class GemmW4A16DecodeKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
-        # Tuned on H200 over the manifest's four M=1 workloads: 32 rows of N per
-        # CTA still leaves 224 CTAs at the smallest N, and 128 threads keeps the
-        # carried accumulator in registers.
+        # 32 rows of N per CTA still leaves 224 CTAs at the manifest's smallest
+        # N, and 128 threads keeps the carried accumulator in registers.
         return {"block_n": 32, "block_k": 512, "threads": 128, "num_stages": 4}
 
     @property

--- a/src/tileops/kernels/grouped_gemm/regimes.py
+++ b/src/tileops/kernels/grouped_gemm/regimes.py
@@ -4,8 +4,8 @@ A grouped GEMM whose groups are shorter than a tile leaves most of that tile idl
 and a schedule with a shorter block wins. Kernels of this family ask which regime
 their shape is in and pick a schedule from the answer.
 
-The boundaries are measured, not derived: on H200 with bf16, a short-group schedule
-gains 4-7% inside them and costs 34-39% above them.
+The boundaries are measured, not derived. A short-group schedule gains inside them
+and loses several times that much above them, so they are set where it stops paying.
 """
 
 __all__ = ["rows_per_group_regime"]

--- a/src/tileops/kernels/moe/moe_grouped_gemm_nopad.py
+++ b/src/tileops/kernels/moe/moe_grouped_gemm_nopad.py
@@ -30,9 +30,9 @@ Parameters (all Python ints, baked in at compile time via lru_cache):
   N, K          = output/input feature dimensions
   dtype         = activation dtype string
 
-Performance (E=256, T=4096, block_m=64, H200):
-  old persistent (132×8=1056 CTA): SM util 42%, warp active 12%
-  new (768×8=6144 CTA, ~33% dead): larger grid → better warp occupancy
+The grid is deliberately larger than the device's CTA slots: a persistent grid
+sized to the SM count leaves the warps idle for most of their residency, and the
+occupancy a wider grid buys outweighs the tiles it leaves dead.
 """
 
 import functools

--- a/src/tileops/kernels/moe/moe_grouped_gemm_persistent_3wg_fused_act.py
+++ b/src/tileops/kernels/moe/moe_grouped_gemm_persistent_3wg_fused_act.py
@@ -131,9 +131,9 @@ class MoeGroupedGemmPersistent3WGFusedActKernel(Kernel):
         """Shapes where fusing the activation into this GEMM is the faster pipeline.
 
         The short-group schedules, where the tiling divides the shape; ``call.n`` is
-        the ffn width. Measured on H200 with bf16, fusing wins 5-35% inside this
-        region and loses 6-10% outside it, and the answer is extrapolated to the
-        other SM90 parts and dtypes that classify the same way.
+        the ffn width. Fusing wins inside this region and loses outside it, and the
+        answer is extrapolated to the other SM90 parts and dtypes that classify the
+        same way.
         """
         if call.activation not in cls.SUPPORTED_ACTIVATIONS:
             return False

--- a/src/tileops/kernels/reduction/_primitives.py
+++ b/src/tileops/kernels/reduction/_primitives.py
@@ -968,13 +968,11 @@ class RowTiledAutotuneMixin:
 class _LeadingAxisReducePolicy:
     """Launch heuristics for reductions down contiguous leading axes.
 
-    Measured on an H200 over ``(A, B)`` from ``(4, 128)`` to ``(2048, 4096)``,
-    in bf16 and fp32. The column tile ``threads * cols_per_thread`` is what a
-    block reads from one row, and 512 columns is flat across the sweep; how
-    that tile is divided is not. Sixty-four lanes reading eight columns each
-    leaves a block too narrow to cover the read's latency -- on ``(128, 1024)``
-    bf16 it costs 2.88x against 256 lanes reading two, at the same tile, the
-    same split count and the same grid.
+    The column tile ``threads * cols_per_thread`` is what a block reads from
+    one row, and 512 columns is flat across the shapes this serves; how that
+    tile is divided is not. Sixty-four lanes reading eight columns each leaves
+    a block too narrow to cover the read's latency, and costs several times
+    what 256 lanes reading two costs at the same tile, split count and grid.
     """
 
     cols_per_thread: int = 2
@@ -1109,8 +1107,8 @@ def _down_rows_kernel(
     the buffer is read once in the layout it already has.
 
     The grid is ``(column blocks, splits)``: a leading-axis reduction has only as many
-    output columns as the axes it keeps, and one block per column tile would leave an
-    H200 running four of them.
+    output columns as the axes it keeps, and one block per column tile would leave
+    the device running a handful of them.
 
     Args:
         A: Elements the reduction consumes per output column.

--- a/src/tileops/kernels/reduction/argreduce.py
+++ b/src/tileops/kernels/reduction/argreduce.py
@@ -36,7 +36,6 @@ _KEY_NAN = 0x7FFFFFFF
 
 # Below every float's key, so it loses to any candidate: -inf keys to -0x7F800000.
 _KEY_IDENTITY = -(2**31)
-# Row-splitting thresholds are measured defaults.
 # A row shorter than this is a handful of passes; splitting cannot save more
 # than the second pass costs.
 _SPLIT_MIN_N = 32768
@@ -298,8 +297,7 @@ def _argreduce_output_kernel(
     both the store and the walk. Where the whole span is one contiguous run of each
     axis position, it is staged in shared memory first and the walk reads from
     there, which is what lets the global read widen from one element per thread to a
-    vector: measured on the manifest's 3d workload, 2.36 TB/s against 2.09 for
-    walking the axis in global memory.
+    vector.
     """
     elem_bytes = torch_dtype_nbytes(dtype)
 
@@ -374,10 +372,8 @@ def _argreduce_cta_kernel(M: int, N: int, op_kind: str, dtype: str):
 
     A row the block can hold in registers is read once into a fragment, and the column
     index each key belongs to is the loop variable over that fragment, so nothing has to
-    carry it. That reads the row a vector at a time and keeps it there: measured on H200
-    at 2048x4096 fp16, 2.21 TB/s against 2.02 for walking it in global, where reading the
-    row alone is bounded at 2.35. The gain widens with the row -- at 256x32768, 2.12
-    against 1.65.
+    carry it. That reads the row a vector at a time and keeps it there, where walking it
+    in global reads one element per thread. The wider the row, the more that is worth.
 
     A row too wide for that is walked in global instead, one element per thread per
     access.
@@ -455,7 +451,7 @@ def _argreduce_multicta_partial_kernel(
     ``ctas_per_row`` is a tuning parameter: the trade between the block's serial
     scan and a wider final pass moves with the shape. The tuner measures this
     stage alone; the final pass grows slowly with the split, so its ranking can
-    differ from the pair's at the margin (measured once, by 0.3%).
+    differ from the pair's at the margin.
     """
 
     @tilelang.jit(out_idx=[1, 2])

--- a/src/tileops/kernels/reduction/call_spec.py
+++ b/src/tileops/kernels/reduction/call_spec.py
@@ -38,9 +38,8 @@ def logical_reduce_region(call: LogicalReduceCall) -> bool:
 
 
 # The fused pass runs one block per kept column and has no other parallelism, so
-# it takes over only where that alone is enough. Measured on an H200 with
-# lead=4, trail=4096. Other devices use the general implementation until they
-# have their own measured region.
+# it takes over only where that alone is enough. Other devices use the general
+# implementation until they have a region of their own.
 _EDGE_FUSED_MIN_KEPT_H200 = 32
 
 

--- a/src/tileops/kernels/reduction/logical_reduce.py
+++ b/src/tileops/kernels/reduction/logical_reduce.py
@@ -115,8 +115,8 @@ def _logical_out_dtype(op_kind: str, partial: bool) -> str:
 
 # Elements a lane folds in the edge-fused pass. One block holds a `trail`-wide
 # fp32 fragment, so this is what fixes its register footprint per lane rather
-# than letting it grow with the row. Measured on an H200 over `lead` 2 to 16 and
-# `trail` 256 to 8192: eight is the flat optimum at every width.
+# than letting it grow with the row. Eight is the flat optimum at every width
+# the manifest asks for.
 _FUSED_EDGE_ELEMS_PER_LANE = 8
 _FUSED_EDGE_MIN_THREADS = 64
 _FUSED_EDGE_MAX_THREADS = 1024

--- a/src/tileops/kernels/reduction/logsumexp.py
+++ b/src/tileops/kernels/reduction/logsumexp.py
@@ -60,10 +60,8 @@ _DEFAULT_TUNE_THREADS = 256
 class StreamingLogSumExpPolicy:
     """Launch shape and eligibility gate of the streaming kernel.
 
-    The launch pair is fixed rather than tuned: measured best at
-    [1024, 32768] bf16 on H200 with the L2 flushed per iteration (the
-    benchmark's metric), and ``eligible`` keeps the kernel on shapes
-    where that pair was measured.
+    The launch pair is fixed rather than tuned, and ``eligible`` keeps the
+    kernel on the shapes that pair suits.
     """
 
     threads: int = 128

--- a/src/tileops/kernels/reduction/softmax.py
+++ b/src/tileops/kernels/reduction/softmax.py
@@ -64,9 +64,9 @@ def _softmax_kernel_single(M: int, N: int, op_kind: str, dtype: str):
     path is used.
 
     softmax never reads the row again once it has exponentiated, so it goes global to
-    fragment and back with nothing staged in between: measured on H200 at 1024x4096,
-    dropping the shared round trip takes it from 1.76 to 2.27 TB/s in fp16 and 2.75 to
-    3.34 in fp32. log_softmax needs the row a second time, for ``(x - max) - log(sum)``,
+    fragment and back with nothing staged in between, dropping the shared round trip
+    it would otherwise pay. log_softmax needs the row a second time, for
+    ``(x - max) - log(sum)``,
     and shared memory is the cheaper of the two places to keep it -- the alternative is
     a second fragment of row width, which is what pushes a thread's slice into local
     memory.
@@ -746,10 +746,9 @@ class SoftmaxKernel(RowTiledAutotuneMixin, Kernel):
         """Select default block_m based on shared memory budget.
 
         For the single-tile path (tile_n == 0), prefer the *smallest* block_m.
-        Measured on H200 at 1024x4096 fp16, bandwidth falls monotonically as rows are
-        added to a block, from 1.76 TB/s at one row to 0.19 at sixteen: each extra row
-        hands every thread another ``N_padded / threads`` registers until the fragment
-        spills, and the kernel then re-reads its own row through L2 on every pass.
+        Bandwidth falls as rows are added to a block: each extra row hands every
+        thread another ``N_padded / threads`` registers until the fragment spills,
+        and the kernel then re-reads its own row through L2 on every pass.
 
         For the tiled path, prefer the block_m that **minimises the
         number of N-tiles** (i.e. maximises tile_n).  Fewer tiles means


### PR DESCRIPTION
## problems

- The six comparison ops read a half operand and write bool. On `cnn-feat-broadcast` the store moved 8 bytes per thread against a 16-byte read: half a transaction on the side that carries a third of the traffic.
- `default_launch_config` already doubles `num_per_thread` when the result is narrower than the input, for exactly this reason. `_tail_dominated` held it back here: the doubled width does not divide the 3136-column row, and before #2041 the columns it did not cover ran one element per thread.
- #2041 removed those columns. The guard kept firing on a premise that no longer held, and the six ops stayed 0.3% behind their baseline where every other row-broadcast op crossed.

## changes

- `row_tile_leaves_tail` in `_broadcast.py` answers whether any column falls outside a block: none when the tile divides the row, none when the grid indexes vectors, and some when a vector would straddle a row or the staged form is left a partial block.
- `_row_broadcast_prim` and `_tail_dominated` both call it. The builder's gate is unchanged in behaviour -- it is the same three conditions -- and the policy can no longer drift from what the builder emits.
- `_tail_dominated` takes `n_total` and whether the body stages, which is what the staged case needs to know a block is full.
- Test node delta: 0.

### cnn-feat-broadcast, H200 at 1500MHz, CUPTI device-busy median, us

| op | dtype | before | after | best baseline |
| --- | --- | --- | --- | --- |
| Eq | float16 | 12.128 | 11.872 | 12.096 |
| Eq | bfloat16 | 12.128 | 11.664 | 12.080 |
| Ne | float16 | 12.128 | 11.680 | 12.096 |
| Ne | bfloat16 | 12.160 | 11.648 | 11.968 |
| Ge | float16 | 11.999 | 11.776 | 11.968 |
| Ge | bfloat16 | 12.159 | 11.936 | 12.128 |
| Gt | float16 | 12.160 | 11.968 | 12.159 |
| Gt | bfloat16 | 12.160 | 11.968 | 12.128 |
| Le | float16 | 12.160 | 11.968 | 12.128 |
| Le | bfloat16 | 12.160 | 11.968 | 12.144 |
| Lt | float16 | 12.160 | 11.968 | 12.144 |
| Lt | bfloat16 | 12.160 | 11.968 | 12.128 |

A compiled unary predicate over the same bytes -- read half, write bool, no second operand -- runs at 12.064us. All twelve now sit below it.

float32 is unchanged: `num_per_thread` was already 8 there, because 3136 leaves the same remainder at both widths and the guard never fired.

### other shapes

| case | before | after |
| --- | --- | --- |
| Eq float16, 8192 x 1536, row broadcast | 12.256 | 11.648 |
| Eq float16, 4096 x 3000, row broadcast | 13.456 | 13.408 |
| Eq float16, 65536 x 56, row broadcast | 6.624 | 6.624 |
| Eq float16, 1024 x 4096 by 1 x 4096 | 5.024 | 5.024 |
| Eq float16, hidden-state-prefill | 13.088 | 13.087 |
| Maximum, Div, float16 and float32, cnn-feat-broadcast | unchanged |

3000 is not a multiple of the doubled width, so a vector would straddle a row and the guard correctly still fires.

### verification

- `tests/ops/test_elementwise_binary_broadcast.py`, `test_elementwise_compile.py`, `test_elementwise_config_dtype.py`, `test_elementwise_caching_autotune.py`: 210 passed.

## second commit: drop the measurement records from kernel comments

Separate from the change above, and behaviour-free. Comments across the kernels recorded what a run produced -- bandwidths, microseconds, percentages, and the machine they were taken on. A reader deciding whether a heuristic still applies cannot use a number from a run they cannot reproduce, and the number goes stale the first time anything under it changes. Each comment keeps its reason and loses its record; the runs stay where they are reproducible, in the pull requests that made the changes.

`H200` stays wherever it names something the code dispatches on: `is_h200`, the call spec's flag, `_H200_SMS`, the calibration table's key, the perf profile, the kernels whose region is gated on it, and the runner pool.

22 files, comments and docstrings only. Verified by parsing each file before and after, stripping every docstring, and comparing the syntax trees: no statement differs.
