### PR TITLE
[Doc][README] Replace the static API-reference badge with a TileFoundry count

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <p>
     <a href="https://tile-ai.github.io/TileOPs.github.io/manifest/"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftile-ai%2FTileOPs%2Fstats%2Fmanifest-implemented.json" alt="Spec coverage"></a>
     <a href="https://tile-ai.github.io/TileOPs.github.io/benchmarks/"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftile-ai%2FTileOPs%2Fstats%2Fmanifest-benchmark.json" alt="Bench coverage"></a>
-    <a href="https://tile-ai.github.io/TileOPs.github.io/api/"><img src="https://img.shields.io/badge/docs-API%20reference-1E90FF" alt="API reference"></a>
+    <a href="https://github.com/tile-ai/TileFoundry"><img src="https://img.shields.io/github/issues-search/tile-ai/TileOPs?query=is%3Apr%20is%3Amerged%20label%3Afoundry&label=Forged%20by%20TileFoundry&color=0891b2&logo=github" alt="Kernels forged by TileFoundry"></a>
     <!-- <a href="https://pypi.org/project/src/tileops/"><img src="https://img.shields.io/badge/PyPI-tileops-1E90FF" alt="PyPI version"></a> -->
   </p>
 


### PR DESCRIPTION
## problems

- `docs | API reference` is a static badge: no version, no status, no count. The nav row directly below it already links **Docs**, from which API Reference is a top-level section.
- TileFoundry's README carries `Shipped to TileOPs`, a count of the merged PRs labelled `foundry` here. TileOPs had no badge pointing back.

## changes

- The API-reference badge is replaced by `Forged by TileFoundry`, the same `github/issues-search` count read from this end, linking to tile-ai/TileFoundry. Renders `Forged by TileFoundry: 14` today.
- Colour `0891b2`: the hue of this repository's own `foundry` label (`#67E8F9`), darkened so white text stays readable.
- Badge count is unchanged at three, so the row does not grow.
- Test node delta: 0.