### PR TITLE
[Fix][Bench] Loop the NSA references over sequences, not tokens

### DIFF
--- a/workloads/attention/deepseek.py
+++ b/workloads/attention/deepseek.py
@@ -73,73 +73,51 @@ class NsaFwdWorkload(WorkloadBase):
     def gen_inputs(self) -> tuple[torch.Tensor, ...]:
         offsets = _packed_offsets(self.seq_lens, self.batch, self.c_seq_len, 16)
 
-        perm_q = torch.randperm(self.c_seq_len, device="cuda")
-        perm_k = torch.randperm(self.c_seq_len, device="cuda")
-        perm_v = torch.randperm(self.c_seq_len, device="cuda")
-        q = (
-            torch.linspace(0, 1, steps=self.c_seq_len, dtype=self.dtype, device="cuda")[perm_q]
-            .view(1, self.c_seq_len, 1, 1)
-            .expand(1, self.c_seq_len, self.heads, self.dim)
-            .clone()
-            .requires_grad_(True)
-        )
-        k = (
-            torch.linspace(0, 1, steps=self.c_seq_len, dtype=self.dtype, device="cuda")[perm_k]
-            .view(1, self.c_seq_len, 1, 1)
-            .expand(1, self.c_seq_len, self.head_kv, self.dim)
-            .clone()
-            .requires_grad_(True)
-        )
-        v = (
-            torch.linspace(0, 1, steps=self.c_seq_len, dtype=self.dtype, device="cuda")[perm_v]
-            .view(1, self.c_seq_len, 1, 1)
-            .expand(1, self.c_seq_len, self.head_kv, self.dim)
-            .clone()
-            .requires_grad_(True)
-        )
-        self.o_slc = torch.empty(
-            (self.batch, self.c_seq_len, self.heads, self.dim), dtype=self.dtype, device="cuda"
-        )
-        self.lse_slc = torch.empty(
-            (self.batch, self.c_seq_len, self.heads, self.dim), dtype=torch.float, device="cuda"
-        )
+        def _shuffled(n_head: int) -> torch.Tensor:
+            perm = torch.randperm(self.c_seq_len, device="cuda")
+            return (
+                torch.linspace(0, 1, steps=self.c_seq_len, dtype=self.dtype, device="cuda")[perm]
+                .view(self.c_seq_len, 1, 1)
+                .expand(self.c_seq_len, n_head, self.dim)
+                .clone()
+                .requires_grad_(True)
+            )
 
+        q, k, v = _shuffled(self.heads), _shuffled(self.head_kv), _shuffled(self.head_kv)
         self.g_slc = torch.ones(
-            (self.batch, self.c_seq_len, self.heads), dtype=self.dtype, device="cuda"
-        ).requires_grad_(True)
-        self.g_swa = torch.ones(
             (self.batch, self.c_seq_len, self.heads), dtype=self.dtype, device="cuda"
         ).requires_grad_(True)
 
         token_indices = prepare_token_indices(offsets)
-        token_indices_list = token_indices.tolist()
-        block_indices = torch.full(
-            (1, self.c_seq_len, self.head_kv, self.selected_blocks),
-            self.c_seq_len,
-            dtype=torch.int32,
-            device="cuda",
+        # How many blocks each token may attend to: the one it sits in, and those before.
+        chunks = ((token_indices[:, 1] + self.block_size - 1) // self.block_size).clamp(min=1)
+        n_cand = max(int(chunks.max().item()), self.selected_blocks)
+        # Each token picks selected_blocks distinct blocks out of its candidates. Sorting
+        # one random key per candidate is a batched randperm; the ineligible tail sorts
+        # last under +inf, and a pick that reaches there becomes a c_seq_len slot, which
+        # the kernel and the reference both read as "attends to nothing".
+        keys = torch.rand((self.c_seq_len, self.head_kv, n_cand), device="cuda").masked_fill(
+            torch.arange(n_cand, device="cuda") >= chunks[:, None, None], float("inf")
         )
-
-        for i in range(self.c_seq_len):
-            _, t = token_indices_list[i]
-            chunks = max(1, (t + self.block_size - 1) // self.block_size)
-            for h in range(self.head_kv):
-                i_i = torch.randperm(chunks)[: self.selected_blocks]
-                block_indices[0, i, h, : len(i_i)] = i_i
-        block_indices = block_indices.sort(-1)[0]
+        picked = keys.argsort(-1)[..., : self.selected_blocks]
+        block_indices = (
+            torch.where(picked < chunks[:, None, None], picked, self.c_seq_len)
+            .to(torch.int32)
+            .sort(-1)[0]
+        )
         block_counts = torch.randint(
             1,
             self.selected_blocks + 1,
-            (1, self.c_seq_len, self.head_kv),
+            (self.c_seq_len, self.head_kv),
             dtype=torch.int32,
             device="cuda",
         )
         return (
-            q.squeeze(0),
-            k.squeeze(0),
-            v.squeeze(0),
-            block_indices.squeeze(0),
-            block_counts.squeeze(0),
+            q,
+            k,
+            v,
+            block_indices,
+            block_counts,
             offsets.to(torch.int32),
             token_indices.to(torch.int32),
         )
@@ -155,126 +133,48 @@ class NsaFwdWorkload(WorkloadBase):
         token_indices: torch.Tensor,
     ) -> torch.Tensor:
         _ = token_indices
-        q = q.unsqueeze(0)
-        k = k.unsqueeze(0)
-        v = v.unsqueeze(0)
-        block_indices = block_indices.unsqueeze(0)
-        block_counts = block_counts.unsqueeze(0)
-        g_slc = self.g_slc
-        g_swa = self.g_swa
-        block_size = self.block_size
-        window_size = 0
-        scale = self.scale
-        cu_seqlens = offsets
-        head_first = False
-        if scale is None:
-            scale = k.shape[-1] ** -0.5
-        if cu_seqlens is not None:
-            assert q.shape[0] == 1, "batch size must be 1 when cu_seqlens are provided"
-            if head_first:
-                raise RuntimeError(
-                    "Sequences with variable lengths are not supported for head-first mode"
-                )
-        if head_first:
-            q, k, v, block_indices = (
-                rearrange(x, "b h t d -> b t h d") for x in (q, k, v, block_indices)
-            )
-            g_slc, g_swa = (rearrange(x, "b h t -> b t h") for x in (g_slc, g_swa))
-            if isinstance(block_counts, torch.Tensor):
-                block_counts = rearrange(block_counts, "b h t -> b t h")
+        dtype, device = q.dtype, q.device
+        bs = self.block_size
+        scale = self.scale if self.scale is not None else k.shape[-1] ** -0.5
+        group = q.shape[1] // k.shape[1]
+        n_slot = block_indices.shape[-1] * bs
 
-        dtype = q.dtype
-        g = q.shape[2] // k.shape[2]
-        bs = block_size
-        s = block_indices.shape[-1]
         k, v, block_indices = (
-            repeat(x, "b t h d -> b t (h g) d", g=g) for x in (k, v, block_indices)
+            repeat(x, "t h d -> t (h g) d", g=group) for x in (k, v, block_indices)
         )
-        if isinstance(block_counts, torch.Tensor):
-            block_counts = repeat(block_counts, "b t h -> b t (h g)", g=g)
-        c = torch.arange(s).repeat_interleave(bs).unsqueeze(1).expand(-1, q.shape[2]).to(q.device)
+        block_counts = repeat(block_counts, "t h -> t (h g)", g=group)
         q, k, v = (x.float() for x in (q, k, v))
+        heads = q.shape[1]
+        # Which selected block each gathered position came from, for the count mask.
+        slot_block = (torch.arange(n_slot, device=device) // bs).view(1, n_slot, 1)
+        head = torch.arange(heads, device=device)
 
         o_slc = torch.zeros_like(v)
-        o_swa = torch.zeros_like(v) if window_size > 0 else None
-        varlen = True
-        if cu_seqlens is None:
-            varlen = False
-            b, t = q.shape[:2]
-            cu_seqlens = torch.cat(
-                [block_indices.new_tensor(range(0, b * t, t)), block_indices.new_tensor([b * t])]
+        for i in range(len(offsets) - 1):
+            bos, eos = offsets[i].item(), offsets[i + 1].item()
+            n_token = eos - bos
+            q_b, k_b, v_b = q[bos:eos], k[bos:eos], v[bos:eos]
+
+            # [t, s*bs, hq]: the token each selected block contributes, per head.
+            pos = block_indices[bos:eos].unsqueeze(-1) * bs + torch.arange(bs, device=device)
+            pos = pos.view(n_token, heads, n_slot).transpose(1, 2)
+            # Out-of-range positions are masked below; clamping only keeps the gather legal.
+            k_slc, v_slc = (x[pos.clamp(0, n_token - 1), head] for x in (k_b, v_b))
+
+            i_q = torch.arange(n_token, device=device).view(n_token, 1, 1)
+            attn = (
+                einsum(q_b * scale, k_slc, "t h d, t n h d -> t n h")
+                .masked_fill(
+                    (pos < 0) | (pos > i_q) | (slot_block >= block_counts[bos:eos].unsqueeze(1)),
+                    float("-inf"),
+                )
+                .softmax(1)
             )
+            o_slc[bos:eos] = einsum(attn, v_slc, "t n h, t n h v -> t h v") * self.g_slc[
+                0, bos:eos
+            ].unsqueeze(-1)
 
-        for i in range(len(cu_seqlens) - 1):
-            if not varlen:
-                q_b, k_b, v_b = q[i], k[i], v[i]
-                g_slc_b, g_swa_b, i_b = g_slc[i], g_swa[i], block_indices[i]
-                s_b = block_counts[i] if isinstance(block_counts, torch.Tensor) else block_counts
-            else:
-                t = cu_seqlens[i + 1] - cu_seqlens[i]
-                q_b, k_b, v_b, g_slc_b, g_swa_b, i_b = (
-                    x[0][cu_seqlens[i] : cu_seqlens[i + 1]]
-                    for x in (q, k, v, g_slc, g_swa, block_indices)
-                )
-                s_b = (
-                    block_counts[0][cu_seqlens[i] : cu_seqlens[i + 1]]
-                    if isinstance(block_counts, torch.Tensor)
-                    else block_counts
-                )
-
-            i_b = i_b.unsqueeze(-1) * bs + i_b.new_tensor(range(bs))
-            # [t, s*bs, hq]
-            i_b = i_b.view(t, block_indices.shape[2], -1).transpose(1, 2)
-            for i_q in range(t):
-                # [hq, d]
-                q_i = q_b[i_q] * scale
-                # [hq]
-                g_slc_i = g_slc_b[i_q]
-                # [hq]
-                g_swa_i = g_swa_b[i_q]
-                i_i = i_b[i_q]
-                s_i = s_b[i_q] if isinstance(block_counts, torch.Tensor) else s_b
-                k_i_slc, v_i_slc = (
-                    x.gather(0, i_i.clamp(0, t - 1).unsqueeze(-1).expand(*i_i.shape, x.shape[-1]))
-                    for x in (k_b, v_b)
-                )
-                # [s*bs, hq]
-                attn_slc = (
-                    torch.einsum("h d, n h d -> n h", q_i, k_i_slc)
-                    .masked_fill(
-                        torch.logical_or(i_i < 0, i_i > i_q)
-                        | (c >= s_i if block_counts is not None else False),
-                        float("-inf"),
-                    )
-                    .softmax(0)
-                )
-                if not varlen:
-                    o_slc[i, i_q] = torch.einsum(
-                        "n h, n h v -> h v", attn_slc, v_i_slc
-                    ) * g_slc_i.unsqueeze(-1)
-                else:
-                    o_slc[0][cu_seqlens[i] + i_q] = torch.einsum(
-                        "n h, n h v -> h v", attn_slc, v_i_slc
-                    ) * g_slc_i.unsqueeze(-1)
-                if window_size > 0:
-                    k_i_swa, v_i_swa = (
-                        x[max(0, i_q - window_size + 1) : i_q + 1] for x in (k_b, v_b)
-                    )
-                    attn_swa = torch.einsum("h d, n h d -> n h", q_i, k_i_swa).softmax(0)
-                    if not varlen:
-                        o_swa[i, i_q] = torch.einsum(
-                            "n h, n h v -> h v", attn_swa, v_i_swa
-                        ) * g_swa_i.unsqueeze(-1)
-                    else:
-                        o_swa[0][cu_seqlens[i] + i_q] = torch.einsum(
-                            "n h, n h v -> h v", attn_swa, v_i_swa
-                        ) * g_swa_i.unsqueeze(-1)
-
-        if head_first:
-            o_slc = rearrange(o_slc, "b t h d -> b h t d")
-            o_swa = rearrange(o_swa, "b t h d -> b h t d")
-
-        return o_slc.to(dtype) + o_swa.to(dtype) if o_swa is not None else o_slc.to(dtype)
+        return o_slc.to(dtype)
 
 
 class NsaCmpFwdWorkload(WorkloadBase):
@@ -646,39 +546,43 @@ def _parallel_nsa_compression_fwd_pytorch(test, q, k_cmp, v_cmp, block_size, sca
     device = q.device
     num_seq = len(offsets) - 1
 
+    # A token before the first block closed attends to nothing; both outputs stay zero.
     o = torch.zeros((seq_len, heads, dim_v), dtype=torch.float32, device=device)
-    lse = torch.full((seq_len, heads), float("-inf"), dtype=torch.float32, device=device)
+    lse = torch.zeros((seq_len, heads), dtype=torch.float32, device=device)
 
     chunk_offsets_local = prepare_chunk_offsets(offsets, block_size)
 
     for i_n in range(num_seq):
         bos, eos = offsets[i_n].item(), offsets[i_n + 1].item()
         boc = chunk_offsets_local[i_n].item()
+        n_token = eos - bos
+        # Blocks the last token attends to; every earlier token attends to a prefix.
+        n_chunk = n_token // block_size
+        if n_chunk == 0:
+            continue
 
-        for i_t in range(eos - bos):
-            nc = (i_t + 1) // block_size
-            if nc == 0:
-                lse[bos + i_t] = 0.0
-                continue
+        nc = (torch.arange(n_token, device=device) + 1) // block_size
+        q_seq = q[bos:eos].float().view(n_token, head_kv, group, dim_k)
+        k_seq = k_cmp[boc : boc + n_chunk].float()
+        v_seq = v_cmp[boc : boc + n_chunk].float()
 
-            q_curr = q[bos + i_t].float()
-            k_curr = k_cmp[boc : boc + nc].transpose(0, 1).float()
-            v_curr = v_cmp[boc : boc + nc].transpose(0, 1).float()
+        scores = einsum(q_seq, k_seq, "t h g d, n h d -> t h g n") * scale
+        scores = scores.masked_fill(
+            torch.arange(n_chunk, device=device) >= nc[:, None, None, None], float("-inf")
+        )
+        m = scores.max(dim=-1, keepdim=True)[0]
+        reached = scores > float("-inf")
+        exp_scores = torch.where(reached, torch.exp(torch.where(reached, scores - m, 0.0)), 0.0)
+        sum_exp = exp_scores.sum(dim=-1, keepdim=True)
+        out = einsum(exp_scores / sum_exp, v_seq, "t h g n, n h v -> t h g v")
 
-            k_curr = k_curr.unsqueeze(1).expand(-1, group, -1, -1).reshape(heads, nc, dim_k)
-            v_curr = v_curr.unsqueeze(1).expand(-1, group, -1, -1).reshape(heads, nc, dim_v)
-
-            scores = torch.matmul(q_curr.unsqueeze(1), k_curr.transpose(-1, -2)).squeeze(1) * scale
-
-            m = torch.max(scores, dim=-1, keepdim=True)[0]
-            exp_scores = torch.exp(scores - m)
-            sum_exp = torch.sum(exp_scores, dim=-1, keepdim=True)
-
-            probs = exp_scores / sum_exp
-            out = torch.matmul(probs.unsqueeze(1), v_curr).squeeze(1)
-
-            o[bos + i_t] = out
-            lse[bos + i_t] = (m + torch.log(sum_exp)).squeeze(-1)
+        # A token whose blocks have not closed divides 0 by 0 above; where() writes the
+        # zeros the kernel writes rather than that quotient.
+        attends = (nc > 0).view(n_token, 1, 1)
+        o[bos:eos] = torch.where(attends.unsqueeze(-1), out, 0.0).reshape(n_token, heads, dim_v)
+        lse[bos:eos] = torch.where(attends, (m + torch.log(sum_exp)).squeeze(-1), 0.0).reshape(
+            n_token, heads
+        )
 
     return o.to(test.dtype), lse.to(test.dtype)
 
@@ -687,7 +591,7 @@ def _nsa_topk_torch(
     test, q, k_cmp, lse, block_counts, block_size, scale, offsets, token_indices, chunk_offsets
 ):
     """PyTorch reference for NSA top-k block selection."""
-    _ = lse
+    _ = lse, token_indices
     q = q.squeeze(0) if q.dim() == 4 else q
     k_cmp = k_cmp.squeeze(0) if k_cmp.dim() == 4 else k_cmp
     c_seq_len, heads, dim = q.shape
@@ -703,127 +607,61 @@ def _nsa_topk_torch(
     device = q.device
     accum_dtype = torch.float32
 
-    lse_out = torch.zeros((c_seq_len, heads), dtype=accum_dtype, device=device)
-    block_indices = torch.zeros(
-        (c_seq_len, head_kv, selected_block_num), dtype=torch.int32, device=device
+    # The kernel ranks bs candidates at a time against a pool that retains the best bs
+    # seen so far, so its first bs slots are the ranking over every candidate and the
+    # rest are whichever batch it read last. Only the first bs are a defined answer.
+    if selected_block_num > bs:
+        raise ValueError("selected_block_num must be no larger than block_size")
+
+    # A slot no candidate block reaches reads as -1.
+    block_indices = torch.full(
+        (c_seq_len, head_kv, selected_block_num), -1, dtype=torch.int32, device=device
     )
 
-    for i_c in range(c_seq_len):
-        i_n, i_t = token_indices[i_c, 0].item(), token_indices[i_c, 1].item()
-        bos = offsets[i_n].item()
+    for i_n in range(len(offsets) - 1):
+        bos, eos = offsets[i_n].item(), offsets[i_n + 1].item()
         boc = chunk_offsets[i_n].item()
-        nc = (i_t + 1) // bs
-        q_curr = q[bos + i_t]
+        n_token = eos - bos
+        # Blocks the last token ranks; every earlier token ranks a prefix of them.
+        n_chunk = (n_token - 1) // bs + 1
 
-        for i_h in range(head_kv):
-            q_h = q_curr[i_h * group : (i_h + 1) * group]
-            scores_max = torch.full((group,), float("-inf"), dtype=accum_dtype, device=device)
-            logsum = torch.zeros((group,), dtype=accum_dtype, device=device)
+        i_t = torch.arange(n_token, device=device)
+        nc = ((i_t + 1) // bs)[:, None, None, None]  # blocks closed before the token
+        curr = (i_t // bs)[:, None, None, None]  # the block the token sits in
+        o_c = torch.arange(n_chunk, device=device)
 
-            for i_loop in range(0, nc, bs):
-                start_idx = i_loop
-                end_idx = min(start_idx + bs, nc)
-                curr_bc = end_idx - start_idx
-                k_blocks = k_cmp[boc + start_idx : boc + end_idx, i_h]
-                acc_s = torch.matmul(q_h, k_blocks.t()).to(accum_dtype)
-                if curr_bc < bs:
-                    padding = torch.full(
-                        (group, bs - curr_bc), float("-inf"), dtype=accum_dtype, device=device
-                    )
-                    acc_s = torch.cat([acc_s, padding], dim=1)
-                o_c = torch.arange(start_idx, start_idx + bs, dtype=torch.int32, device=device)
-                valid_mask = o_c < nc
-                acc_s = torch.where(
-                    valid_mask.unsqueeze(0), acc_s, torch.full_like(acc_s, float("-inf"))
-                )
-                scores_max_prev = scores_max.clone()
-                scores_max_curr = acc_s.max(dim=1)[0]
-                scores_max = torch.maximum(scores_max, scores_max_curr)
-                scores_scale = torch.exp2((scores_max_prev - scores_max) * scale_log2)
-                acc_s_exp = torch.exp2((acc_s - scores_max.unsqueeze(1)) * scale_log2)
-                acc_s_exp = torch.where(
-                    acc_s > float("-inf"), acc_s_exp, torch.zeros_like(acc_s_exp)
-                )
-                logsum = logsum * scores_scale + acc_s_exp.sum(dim=1)
+        q_seq = q[bos:eos].view(n_token, head_kv, group, dim)
+        k_seq = k_cmp[boc : boc + n_chunk]
+        acc_s = einsum(q_seq, k_seq, "t h g d, n h d -> t h g n").to(accum_dtype)
 
-            if nc == 0:
-                b_lse = torch.zeros((group,), dtype=accum_dtype, device=device)
-            else:
-                logsum_log2 = torch.where(
-                    logsum > 0,
-                    torch.log2(logsum),
-                    torch.full((group,), float("-inf"), dtype=accum_dtype, device=device),
-                )
-                b_lse = (scores_max * scale_log2 + logsum_log2) / LOG2_E
-                b_lse = torch.where(logsum <= 0, torch.zeros_like(b_lse), b_lse)
-            lse_out[bos + i_t, i_h * group : (i_h + 1) * group] = b_lse
+        # The log-sum-exp over the closed blocks, which the kernel's running softmax
+        # arrives at the same way. A token with none of them attends to nothing, and
+        # taking exp2 only where a block is attended keeps that row out of NaN.
+        attended = acc_s.masked_fill(o_c >= nc, float("-inf"))
+        scores_max = attended.max(dim=-1, keepdim=True)[0]
+        reached = attended > float("-inf")
+        shifted = torch.where(reached, (attended - scores_max) * scale_log2, 0.0)
+        logsum = torch.where(reached, torch.exp2(shifted), 0.0).sum(dim=-1, keepdim=True)
+        b_lse = torch.where(nc > 0, (scores_max * scale_log2 + torch.log2(logsum)) / LOG2_E, 0.0)
 
-            nc_topk = i_t // bs + 1
-            pool_scores = torch.full((bs * 2,), float("-inf"), dtype=accum_dtype, device=device)
-            pool_indices = torch.zeros((bs * 2,), dtype=torch.int32, device=device)
+        # A closed block ranks by the share of the token's attention it holds. The block
+        # the token sits in scores group, which no closed block can reach.
+        importance = torch.where(
+            o_c == curr,
+            1.0,
+            torch.where(o_c < curr, torch.exp2((acc_s * scale - b_lse) * LOG2_E), 0.0),
+        ).sum(dim=2)
 
-            for i_tk in range(0, nc_topk, bs):
-                start_idx = i_tk
-                end_idx = min(start_idx + bs, nc_topk)
-                curr_bc_tk = end_idx - start_idx
-                k_blocks = k_cmp[boc + start_idx : boc + end_idx, i_h]
-                acc_s = torch.matmul(q_h, k_blocks.t()).to(accum_dtype)
-                if curr_bc_tk < bs:
-                    padding = torch.full(
-                        (group, bs - curr_bc_tk), float("-inf"), dtype=accum_dtype, device=device
-                    )
-                    acc_s = torch.cat([acc_s, padding], dim=1)
-                o_c = torch.arange(start_idx, start_idx + bs, dtype=torch.int32, device=device)
-                is_curr = o_c == i_t // bs
-                is_hist = o_c < i_t // bs
-                importance = torch.where(
-                    is_curr.unsqueeze(0),
-                    torch.ones((group, bs), dtype=accum_dtype, device=device),
-                    torch.where(
-                        is_hist.unsqueeze(0),
-                        torch.exp2((acc_s * scale - b_lse.unsqueeze(1)) * LOG2_E),
-                        torch.zeros((group, bs), dtype=accum_dtype, device=device),
-                    ),
-                )
-                b_i_current = importance.sum(dim=0)
-                pool_scores[bs : bs + bs] = b_i_current
-                pool_indices[bs : bs + bs] = (
-                    torch.arange(start_idx, start_idx + bs, dtype=torch.int32, device=device) + 1
-                )
-                o_c_valid = (
-                    torch.arange(start_idx, start_idx + bs, dtype=torch.int32, device=device)
-                    < nc_topk
-                )
-                pool_scores[bs : bs + bs] = torch.where(
-                    o_c_valid,
-                    pool_scores[bs : bs + bs],
-                    torch.full_like(pool_scores[bs : bs + bs], float("-inf")),
-                )
-                pool_indices[bs : bs + bs] = torch.where(
-                    o_c_valid,
-                    pool_indices[bs : bs + bs],
-                    torch.zeros_like(pool_indices[bs : bs + bs]),
-                )
-                eps_val, score_scale = 1e-5, 1e12
-                scores_quantized = (pool_scores / eps_val).round() * eps_val
-                sort_key = scores_quantized.to(torch.float64) * score_scale + pool_indices.to(
-                    torch.float64
-                )
-                sort_key = torch.where(
-                    pool_indices > 0,
-                    sort_key,
-                    torch.full_like(sort_key, float("-inf"), dtype=torch.float64),
-                )
-                sorted_indices = torch.argsort(sort_key, descending=True)
-                pool_scores = pool_scores[sorted_indices]
-                pool_indices = pool_indices[sorted_indices]
+        # Quantizing the score and adding the block ordinal makes the ranking total, so
+        # equal scores break the same way here and in the kernel.
+        eps, score_scale = 1e-5, 1e12
+        sort_key = (importance / eps).round().to(torch.float64) * eps * score_scale + o_c
+        sort_key = sort_key.masked_fill(o_c > curr.squeeze(-1), float("-inf"))
 
-            final_indices = pool_indices[:selected_block_num] - 1
-            final_indices = torch.where(
-                final_indices >= 0,
-                final_indices,
-                torch.tensor(-1, dtype=torch.int32, device=device),
-            )
-            block_indices[i_c, i_h, :selected_block_num] = final_indices.to(torch.int32)
+        n_pick = min(selected_block_num, n_chunk)
+        top = sort_key.topk(n_pick, dim=-1)
+        block_indices[bos:eos, :, :n_pick] = torch.where(
+            top.values > float("-inf"), top.indices.to(torch.int32), -1
+        )
 
     return block_indices


### PR DESCRIPTION
## problems

- Nightly run 33664549328 killed `benchmarks/ops/attention/bench_deepseek_nsa.py` at 901s. The runner's `--stall-timeout 900` fired on the first case and the py-spy stack sat in `cuptiActivityFlushAll` under `benchmarks/timing.py:_flush`. All three NSA ops came back NO VERDICT.
- The three torch references walked one token at a time. `nsa-cmp-s8k-r8-h32-d128` launched 119420 kernels per `torch-ref` iteration against 1 for the op, and the benchmark records every launch as a CUPTI activity.
- The file is new in #2034, so that was its first nightly. It is the only file the sweep gained since the previous run.

## changes

- Each reference computes a sequence's scores over its whole block range and masks per token, so the Python loop is over sequences.
- `NsaFwdWorkload.ref_program` drops the head-first, sliding-window, non-varlen and integer-`block_counts` branches, none of which this workload reaches, and returns `(c_seq_len, heads, dim)` rather than that shape under a leading 1.
- `NsaFwdWorkload.gen_inputs` builds `block_indices` with one batched argsort instead of `c_seq_len * head_kv` calls to `randperm`, and drops `o_slc`, `lse_slc` and `g_swa`, which nothing reads.
- `_nsa_topk_torch` ranks with one `topk` instead of the kernel's incremental pool, and drops `lse_out`, which it computed and never returned. The two agree while the pool retains at least as many slots as the caller asks for; past that the kernel returns whichever batch it read last, so the reference refuses `selected_block_num` above `block_size`.
- Top-k block indices are unchanged over every case below; the float outputs move by at most one fp16 ulp.
- Test node delta: 0.

### one reference call per bench row, H200 at 1500MHz, seconds

| row | before | after |
| --- | --- | --- |
| `nsa-cmp-s8k-r8-h32-d128` | 1.35 | 0.095 |
| `nsa-cmp-s4k-r4-h32-d128` | 0.61 | 0.002 |
| `nsa-topk-s8k-r8-h32-d128` | 12.19 | 0.017 |
| `nsa-topk-s4k-r4-h32-d128` | 6.03 | 0.003 |
| `nsa-slc-s8k-r4-h16-d64-b1` | 2.02 | 0.008 |
| `nsa-slc-s8k-r2-h16-d64-b4` | 1.97 | 0.025 |

### what the benchmark records for `torch-ref`

| row | kernels before | kernels after | latency before | latency after |
| --- | --- | --- | --- | --- |
| `nsa-cmp-s8k-r8-h32-d128` | 119420 | 236 | 5158.98 ms | 13.40 ms |
| `nsa-cmp-s4k-r4-h32-d128` | 59716 | 124 | 2574.86 ms | 6.87 ms |

The whole bench file ran 8.8s against a local run of the previous references that a 3000s timeout killed.

### old against new, per sequence layout

| layout | cmp max abs | top-k mismatches | slc max abs |
| --- | --- | --- | --- |
| `[32]` | 0 | 0 | 0 |
| `[33]` | 0 | 0 | 0 |
| `[64]` | 2.4e-4 | 0 | 0 |
| `[1024]` | 9.8e-4 | 0 | 0 |
| `[4096]` | - | 0 | 0 |
| `[31, 33, 64]` | 1.2e-4 | 0 | 0 |
| `[2048, 2048]` | - | - | 4.9e-4 |

Every difference is one fp16 ulp at that magnitude. `selected_block_num == block_size` is the one case where top-k moves, by 2 slots in 131072 (0.0015%), from the reduction order of the fp16 matmul; the test threshold is 0.1%.