### PR TITLE
[Chore] Strip narrative and tuning-run records from Python comments

### DIFF
--- a/benchmarks/hardware/compute/fma_throughput.py
+++ b/benchmarks/hardware/compute/fma_throughput.py
@@ -220,7 +220,6 @@ def main():
         print("Running benchmark (5 runs x 50 reps per ILP, this takes a few minutes) ...\n")
         lines, sampler = _run(binary, args.iters, theo_peak_tflops, args.gpu_index)
 
-    # Print raw output
     for line in lines:
         print(line)
 

--- a/benchmarks/hardware/memory/hbm_bandwidth.py
+++ b/benchmarks/hardware/memory/hbm_bandwidth.py
@@ -105,7 +105,6 @@ def main():
         print("Running benchmark (5 runs x 200 reps, this may take a few minutes) ...\n")
         lines = _run(binary, args.size_mb, theo_peak_gbs)
 
-    # Print raw output
     for line in lines:
         print(line)
 

--- a/benchmarks/ops/attention/bench_gqa_sliding_window_varlen.py
+++ b/benchmarks/ops/attention/bench_gqa_sliding_window_varlen.py
@@ -182,7 +182,6 @@ def test_gqa_sliding_window_varlen_fwd_bench(
     op.max_seqlen_k = max(seqlens_k)
     bm = ManifestBenchmark(op, test)
 
-    # Warmup: trigger JIT compilation before timed profiling
     op(*inputs)
     torch.cuda.synchronize()
 

--- a/benchmarks/ops/bench_argreduce.py
+++ b/benchmarks/ops/bench_argreduce.py
@@ -43,9 +43,6 @@ def _functors(op, baseline_fn, flaggems_name: str, dim: int, inputs) -> dict:
     }
 
 
-# Argmax benchmarks
-
-
 @pytest.mark.parametrize(
     "shape, dtype, extra", workloads_to_params(ArgmaxFwdOp, include_extra=True)
 )
@@ -62,9 +59,6 @@ def test_argmax_bench(shape: tuple, dtype: torch.dtype, extra: dict) -> None:
         return x.argmax(dim=dim)
 
     bm.compare(_functors(op, baseline_fn, "argmax", dim, inputs), *inputs)
-
-
-# Argmin benchmarks
 
 
 @pytest.mark.parametrize(

--- a/benchmarks/ops/bench_batch_norm.py
+++ b/benchmarks/ops/bench_batch_norm.py
@@ -23,11 +23,6 @@ from tileops.manifest import load_workloads
 from tileops.ops.norm.batch_norm import BatchNormBwdOp, BatchNormFwdOp
 from workloads.normalization import BatchNormBwdWorkload, BatchNormFwdWorkload
 
-# Benchmark classes
-
-
-# Benchmark helpers
-
 
 def _make_inputs(N, C, spatial, dtype, device="cuda"):
     shape = (N, C, *spatial)
@@ -109,9 +104,6 @@ def _aten_bn_bwd(grad_out, x, weight, mean, rstd):
     )
 
 
-# Manifest-driven params
-
-
 def _fwd_args(w: dict, dtype: torch.dtype) -> tuple:
     n, c, *spatial = w["x_shape"]
     return (n, c, tuple(spatial), dtype, True, False)
@@ -120,9 +112,6 @@ def _fwd_args(w: dict, dtype: torch.dtype) -> tuple:
 def _bwd_args(w: dict, dtype: torch.dtype) -> tuple:
     n, c, *spatial = w["x_shape"]
     return (n, c, tuple(spatial), dtype)
-
-
-# Benchmark tests
 
 
 @pytest.mark.parametrize(

--- a/benchmarks/ops/bench_binary_elementwise.py
+++ b/benchmarks/ops/bench_binary_elementwise.py
@@ -695,8 +695,7 @@ class FusedGatedStrategyBenchFixture(FixtureBase):
 
 
 # How far behind the fastest strategy the default may sit before the choice is
-# stale. Measured at 1024x4096 fp16, the two are 8.4us and 16.2us apart, so this
-# margin flags a flip without firing on run-to-run spread.
+# stale. Wide enough to clear run-to-run spread, narrow enough to flag a flip.
 _STRATEGY_MARGIN = 1.25
 
 

--- a/benchmarks/ops/bench_binary_elementwise.py
+++ b/benchmarks/ops/bench_binary_elementwise.py
@@ -95,7 +95,6 @@ class BinaryArithBenchFixture(FixtureBase):
         (
             "op_name, shape, dtype, output_dtype, op_cls, baseline_fn, gen_inputs",
             [
-                # sub
                 pytest.param(
                     "sub",
                     _SHAPES[0],
@@ -126,7 +125,6 @@ class BinaryArithBenchFixture(FixtureBase):
                     "normal",
                     marks=pytest.mark.full,
                 ),
-                # mul
                 pytest.param(
                     "mul",
                     _SHAPES[0],
@@ -157,7 +155,6 @@ class BinaryArithBenchFixture(FixtureBase):
                     "normal",
                     marks=pytest.mark.full,
                 ),
-                # div
                 pytest.param(
                     "div",
                     _SHAPES[0],
@@ -188,7 +185,6 @@ class BinaryArithBenchFixture(FixtureBase):
                     "positive",
                     marks=pytest.mark.full,
                 ),
-                # remainder
                 pytest.param(
                     "remainder",
                     _SHAPES[0],
@@ -209,7 +205,6 @@ class BinaryArithBenchFixture(FixtureBase):
                     "positive",
                     marks=pytest.mark.full,
                 ),
-                # pow
                 pytest.param(
                     "pow",
                     _SHAPES[0],
@@ -230,7 +225,6 @@ class BinaryArithBenchFixture(FixtureBase):
                     "positive",
                     marks=pytest.mark.full,
                 ),
-                # floor_divide
                 pytest.param(
                     "floor_divide",
                     _SHAPES[0],
@@ -272,7 +266,6 @@ class BinaryArithBenchFixture(FixtureBase):
                     "normal",
                     marks=pytest.mark.full,
                 ),
-                # maximum
                 pytest.param(
                     "maximum",
                     _SHAPES[0],
@@ -303,7 +296,6 @@ class BinaryArithBenchFixture(FixtureBase):
                     "normal",
                     marks=pytest.mark.full,
                 ),
-                # minimum
                 pytest.param(
                     "minimum",
                     _SHAPES[0],
@@ -747,7 +739,6 @@ class BroadcastBenchFixture(FixtureBase):
         (
             "op_name, a_shape, b_shape, dtype, op_cls, baseline_fn, gen_inputs",
             [
-                # sub — bias-add pattern
                 pytest.param(
                     "sub",
                     *_BROADCAST_SHAPES[0],
@@ -775,7 +766,6 @@ class BroadcastBenchFixture(FixtureBase):
                     "normal",
                     marks=pytest.mark.full,
                 ),
-                # mul — bias-add pattern
                 pytest.param(
                     "mul",
                     *_BROADCAST_SHAPES[0],
@@ -803,7 +793,6 @@ class BroadcastBenchFixture(FixtureBase):
                     "normal",
                     marks=pytest.mark.full,
                 ),
-                # div — bias-add pattern
                 pytest.param(
                     "div",
                     *_BROADCAST_SHAPES[0],

--- a/benchmarks/ops/bench_convolution.py
+++ b/benchmarks/ops/bench_convolution.py
@@ -267,8 +267,6 @@ def _profile_conv(
     bm.compare({"tileops": op, **baselines}, *inputs)
 
 
-# Conv1d
-
 _CONV1D_KERNEL_KEYS = ("kW",)
 
 
@@ -292,8 +290,6 @@ def test_conv1d_bench(case: ConvCase) -> None:
     _run_conv(op, bm, F.conv1d, case, rank=1, with_bias=case.with_bias, static_weight=True)
 
 
-# Conv2d
-
 _CONV2D_KERNEL_KEYS = ("kH", "kW")
 
 
@@ -316,8 +312,6 @@ def test_conv2d_bench(case: ConvCase) -> None:
     bm = ManifestBenchmark(op, case)
     _run_conv(op, bm, F.conv2d, case, rank=2, with_bias=case.with_bias)
 
-
-# Conv3d
 
 _CONV3D_KERNEL_KEYS = ("kD", "kH", "kW")
 

--- a/benchmarks/ops/bench_deltanet.py
+++ b/benchmarks/ops/bench_deltanet.py
@@ -37,9 +37,6 @@ def _to_fla_layout(q, k, v, beta):
     )
 
 
-# Forward benchmark
-
-
 def _deltanet_args(workload: dict) -> tuple[int, int, int, int, int, int]:
     """Constructor arguments for one manifest workload row."""
     batch, heads, seq_len, dim_k = workload["q_shape"]
@@ -80,9 +77,6 @@ def test_deltanet_vs_fla_fwd(
     functors["fla"] = (fla_fwd, ())
 
     bm.compare(functors, *inputs)
-
-
-# Backward benchmark
 
 
 @pytest.mark.parametrize(

--- a/benchmarks/ops/bench_fft.py
+++ b/benchmarks/ops/bench_fft.py
@@ -19,7 +19,6 @@ def test_fft_bench(shape: tuple, dtype: torch.dtype) -> None:
 
     op = FFTC2CFwdOp(tune=True)
 
-    # Warmup: trigger JIT compilation before timed profiling
     op(*inputs)
     torch.cuda.synchronize()
 

--- a/benchmarks/ops/bench_fused_moe_experts.py
+++ b/benchmarks/ops/bench_fused_moe_experts.py
@@ -64,15 +64,6 @@ from workloads.moe import MoeExpertsWorkload
 # Workload
 
 
-# Benchmark class
-
-
-# Manifest-driven parametrize
-
-
-# Benchmark test
-
-
 @pytest.mark.parametrize(
     "num_tokens, num_experts, top_k, hidden_size, ffn_size, dtype",
     workload_params(

--- a/benchmarks/ops/bench_gated_deltanet.py
+++ b/benchmarks/ops/bench_gated_deltanet.py
@@ -43,9 +43,6 @@ def _to_fla_layout(q, k, v, g, beta):
     )
 
 
-# Forward benchmark
-
-
 def _gdn_bhtd_args(workload: dict) -> tuple[int, int, int, int, int, int]:
     """Constructor arguments for one manifest workload row, head-major."""
     batch, heads, seq_len, dim_k = workload["q_shape"]
@@ -115,9 +112,6 @@ def test_gated_deltanet_bhtd_vs_fla_fwd(
         return chunk_gated_delta_rule(*bthd, scale=1.0)
 
     bm.compare({"tileops": (op, inputs), "fla": (fla_fwd, ())})
-
-
-# Backward benchmark
 
 
 @pytest.mark.parametrize(

--- a/benchmarks/ops/bench_gla_chunkwise.py
+++ b/benchmarks/ops/bench_gla_chunkwise.py
@@ -49,9 +49,6 @@ def _gla_bwd_args(workload: dict) -> tuple[int, int, int, int, int, int]:
     return batch, seq_len, heads, dim_k, workload["v_shape"][3], workload.get("chunk_size", 64)
 
 
-# Forward benchmark
-
-
 @pytest.mark.parametrize(
     "batch, seq_len, heads, dim_k, dim_v, chunk_size, has_initial_state, dtype, tune",
     workload_params(load_workloads(GLAFwdOp), then_dtype(_gla_args, tune=False)),
@@ -87,9 +84,6 @@ def test_gla_fwd_bench(
     functors["fla"] = (fla_fwd, ())
 
     bm.compare(functors, *inputs)
-
-
-# Backward benchmark
 
 
 @pytest.mark.xfail(
@@ -150,6 +144,3 @@ def test_gla_bwd_bench(
     functors["fla"] = (fla_bwd, ())
 
     bm.compare(functors)
-
-
-# Combined fwd+bwd benchmark

--- a/benchmarks/ops/bench_gla_recurrence.py
+++ b/benchmarks/ops/bench_gla_recurrence.py
@@ -84,7 +84,6 @@ def test_gla_decode_bench(
     test = GLADecodeWorkload(batch, heads, dim_k, dim_v, dtype, scale=scale)
     inputs = test.gen_inputs()
 
-    # --- TileOPs ---
     op = GLADecodeFwdOp(scale=scale, tune=tune)
     bm = ManifestBenchmark(op, test)
     functors = {"tileops": op}

--- a/benchmarks/ops/bench_grouped_gemm.py
+++ b/benchmarks/ops/bench_grouped_gemm.py
@@ -32,8 +32,6 @@ from workloads.grouped_gemm import (
 _TUNE = True
 
 
-# Test functions
-
 _GROUPED_GEMM_PARAMS = workload_params(
     load_workloads(GroupedGemmFwdOp),
     fields("batch_sum", "batch_count", "n", "k", "dtype", "transpose_a", "transpose_b"),

--- a/benchmarks/ops/bench_logical_reduce.py
+++ b/benchmarks/ops/bench_logical_reduce.py
@@ -22,8 +22,6 @@ from benchmarks.benchmark_base import ManifestBenchmark, workloads_to_params
 from tileops.ops.reduction.logical_reduce import AllFwdOp, AnyFwdOp, CountNonzeroFwdOp
 from workloads.reduction import AllWorkload, AnyWorkload, CountNonzeroWorkload
 
-# Op name constants
-
 
 def _functors(op, baseline_fn, inputs, flaggems_name=None, dim=None, keepdim=False) -> dict:
     """The op, flag_gems where it has a kernel, and torch eager and compiled.
@@ -43,9 +41,6 @@ def _functors(op, baseline_fn, inputs, flaggems_name=None, dim=None, keepdim=Fal
     functors["torch"] = baseline_fn
     functors[TORCH_COMPILE_TAG] = compiled_reference(baseline_fn)
     return functors
-
-
-# Any benchmarks
 
 
 @pytest.mark.parametrize(
@@ -73,9 +68,6 @@ def test_any_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> None:
         raise
 
 
-# All benchmarks
-
-
 @pytest.mark.parametrize(
     "shape, dtype, op_params",
     workloads_to_params(AllFwdOp, include_extra=True),
@@ -99,9 +91,6 @@ def test_all_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> None:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
         raise
-
-
-# CountNonzero benchmarks
 
 
 @pytest.mark.parametrize(

--- a/benchmarks/ops/bench_mamba2_e2e.py
+++ b/benchmarks/ops/bench_mamba2_e2e.py
@@ -132,8 +132,6 @@ def mamba2_fwd_ref(
 
 # FLOPS / memory calculators
 
-# Benchmark test
-
 
 def _mamba2_args(workload: dict) -> tuple:
     """Constructor arguments for one manifest workload row."""

--- a/benchmarks/ops/bench_moe_fused_topk.py
+++ b/benchmarks/ops/bench_moe_fused_topk.py
@@ -22,8 +22,6 @@ from tileops.manifest import load_workloads
 from tileops.ops.moe import FusedTopKOp
 from workloads.moe import FusedTopKWorkload
 
-# Benchmark test
-
 
 @pytest.mark.parametrize(
     "num_tokens, num_experts, top_k, scoring_func, renormalize, with_correction_bias, dtype",
@@ -61,7 +59,6 @@ def test_fused_topk_bench(
     inputs = test.gen_inputs()
     gating_output = inputs[0]
 
-    # TileOPs
     op = FusedTopKOp(
         top_k=top_k,
         scoring_func=scoring_func,

--- a/benchmarks/ops/bench_moe_gate_up.py
+++ b/benchmarks/ops/bench_moe_gate_up.py
@@ -49,7 +49,6 @@ def test_moe_gate_up_bench(
     op = MoeGateUpFwdOp(numel, num_experts, ffn, k)
     bm = ManifestBenchmark(op, workload)
 
-    # Warmup: trigger JIT compilation before timed profiling.
     op(a, b, true_sizes, true_offsets)
     torch.cuda.synchronize()
 

--- a/benchmarks/ops/bench_moe_grouped_gemm_nopad.py
+++ b/benchmarks/ops/bench_moe_grouped_gemm_nopad.py
@@ -38,7 +38,6 @@ def test_moe_grouped_gemm_nopad_bench(
     op = MoeGroupedGemmNopadFwdOp(numel, num_experts, n, k)
     bm = ManifestBenchmark(op, workload)
 
-    # Warmup: trigger JIT compilation before timed profiling.
     op(a, b, true_sizes, true_offsets)
     torch.cuda.synchronize()
 

--- a/benchmarks/ops/bench_moe_permute_align.py
+++ b/benchmarks/ops/bench_moe_permute_align.py
@@ -139,12 +139,6 @@ def _triton_permute_align(
     )
 
 
-# Benchmark class
-
-
-# Manifest-driven parametrize
-
-
 @pytest.mark.parametrize(
     "total_tokens, top_k, num_experts, block_size",
     workload_params(
@@ -159,11 +153,9 @@ def test_permute_align_bench(
     test = MoePermuteAlignWorkload(total_tokens, top_k, num_experts, block_size)
     inputs = test.gen_inputs()
 
-    # TileOPs
     op = MoePermuteAlignFwdOp(total_tokens, top_k, num_experts, block_size)
     bm = ManifestBenchmark(op, test)
 
-    # Warmup: trigger JIT compilation before timed profiling
     op(*inputs)
     torch.cuda.synchronize()
 
@@ -185,7 +177,6 @@ def test_permute_align_bench(
         )
         return sorted_ids, expert_ids, num_post_pad
 
-    # Warmup Triton baseline
     _triton_fn(*inputs)
     torch.cuda.synchronize()
 
@@ -211,7 +202,6 @@ def test_permute_align_bench(
             )
             return sorted_ids_sgl, expert_ids_sgl, num_post_pad_sgl
 
-        # Warmup sgl-kernel baseline
         _sgl_fn(*inputs)
         torch.cuda.synchronize()
 

--- a/benchmarks/ops/bench_moe_shared_fused_moe.py
+++ b/benchmarks/ops/bench_moe_shared_fused_moe.py
@@ -125,9 +125,6 @@ class SharedFusedMoEBenchFixture(FixtureBase):
     ]
 
 
-# Benchmark class
-
-
 class SharedFusedMoEBenchmark(OpBenchmark[SharedFusedMoeWorkload]):
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -158,9 +155,6 @@ class SharedFusedMoEBenchmark(OpBenchmark[SharedFusedMoeWorkload]):
         shared_w = 3 * t.shared_ffn_size * t.hidden_size * elem
         act = t.num_tokens * t.hidden_size * elem * 2
         return routed_w + shared_w + act
-
-
-# Benchmark test
 
 
 @SharedFusedMoEBenchFixture

--- a/benchmarks/ops/bench_moe_shared_fused_moe.py
+++ b/benchmarks/ops/bench_moe_shared_fused_moe.py
@@ -278,9 +278,9 @@ def test_shared_fused_moe_bench(
             ),
         )
     else:
-        # No baseline rather than a misleading one. The per-expert Python loop this used
-        # to time is a correctness reference: it upcasts to fp32 and index_add_s one
-        # expert at a time, so "TileOPs is 30x faster" said nothing about either.
+        # No baseline rather than a misleading one: the per-expert Python loop is a
+        # correctness reference, upcasting to fp32 and index_add_ing one expert at a
+        # time, so timing against it measures neither implementation.
         warnings.warn(
             "vLLM is not installed; recording no baseline for SharedFusedMoE. "
             "Install vllm to compare against fused_topk + fused_experts.",

--- a/benchmarks/ops/bench_reduce.py
+++ b/benchmarks/ops/bench_reduce.py
@@ -45,8 +45,6 @@ from workloads.reduction import (
     VarWorkload,
 )
 
-# Op name constants
-
 
 def _functors(op, baseline_fn, inputs, dtype: torch.dtype, flaggems_fn=None) -> dict:
     """The op, flag_gems where it has a kernel, and torch eager and compiled."""
@@ -57,9 +55,6 @@ def _functors(op, baseline_fn, inputs, dtype: torch.dtype, flaggems_fn=None) -> 
     functors["torch"] = baseline_fn
     functors[TORCH_COMPILE_TAG] = compiled_reference(baseline_fn)
     return functors
-
-
-# Sum benchmarks
 
 
 @pytest.mark.parametrize(
@@ -92,9 +87,6 @@ def test_sum_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> None:
         raise
 
 
-# Mean benchmarks
-
-
 @pytest.mark.parametrize(
     "shape, dtype, op_params",
     workloads_to_params(MeanFwdOp, include_extra=True),
@@ -123,9 +115,6 @@ def test_mean_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> None:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
         raise
-
-
-# Amax benchmarks
 
 
 @pytest.mark.parametrize(
@@ -158,9 +147,6 @@ def test_amax_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> None:
         raise
 
 
-# Amin benchmarks
-
-
 @pytest.mark.parametrize(
     "shape, dtype, op_params",
     workloads_to_params(AminFwdOp, include_extra=True),
@@ -186,9 +172,6 @@ def test_amin_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> None:
         raise
 
 
-# Prod benchmarks
-
-
 @pytest.mark.parametrize("shape, dtype", workloads_to_params(ProdFwdOp))
 def test_prod_bench(shape: tuple, dtype: torch.dtype) -> None:
     test = ProdWorkload(shape, dtype)
@@ -211,9 +194,6 @@ def test_prod_bench(shape: tuple, dtype: torch.dtype) -> None:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
         raise
-
-
-# Std benchmarks
 
 
 @pytest.mark.parametrize(
@@ -246,9 +226,6 @@ def test_std_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> None:
         raise
 
 
-# Var benchmarks
-
-
 @pytest.mark.parametrize(
     "shape, dtype, op_params",
     workloads_to_params(VarFwdOp, include_extra=True),
@@ -277,9 +254,6 @@ def test_var_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> None:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
         raise
-
-
-# VarMean benchmarks
 
 
 @pytest.mark.parametrize(

--- a/benchmarks/ops/bench_softmax.py
+++ b/benchmarks/ops/bench_softmax.py
@@ -27,8 +27,6 @@ from workloads.reduction import (
     SoftmaxWorkload,
 )
 
-# Op name constants
-
 
 def _flaggems_softmax(name: str, dim: int):
     """Bind a flag_gems softmax entry point to *dim*."""
@@ -38,9 +36,6 @@ def _flaggems_softmax(name: str, dim: int):
         return fn(x, dim)
 
     return baseline_fn
-
-
-# Softmax benchmarks
 
 
 @pytest.mark.parametrize("shape, dtype", workloads_to_params(SoftmaxFwdOp))
@@ -73,9 +68,6 @@ def test_softmax_bench(shape: tuple, dtype: torch.dtype) -> None:
         raise
 
 
-# LogSoftmax benchmarks
-
-
 @pytest.mark.parametrize("shape, dtype", workloads_to_params(LogSoftmaxFwdOp))
 def test_log_softmax_bench(shape: tuple, dtype: torch.dtype) -> None:
     test = LogSoftmaxWorkload(shape, dtype)
@@ -104,9 +96,6 @@ def test_log_softmax_bench(shape: tuple, dtype: torch.dtype) -> None:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
         raise
-
-
-# LogSumExp benchmarks
 
 
 @pytest.mark.parametrize(

--- a/benchmarks/ops/bench_vector_norm.py
+++ b/benchmarks/ops/bench_vector_norm.py
@@ -23,8 +23,6 @@ from benchmarks.benchmark_base import ManifestBenchmark, workloads_to_params
 from tileops.ops.reduction.vector_norm import InfNormFwdOp, L1NormFwdOp, L2NormFwdOp
 from workloads.reduction import InfNormWorkload, L1NormWorkload, L2NormWorkload
 
-# Op name constants
-
 
 def _flaggems_vector_norm(ord_value, dim, keepdim: bool):
     """flag_gems' ``vector_norm``, which accumulates in fp32 as the reference does."""
@@ -45,9 +43,6 @@ def _functors(op, baseline_fn, flaggems_fn, inputs, dtype: torch.dtype) -> dict:
         "torch": baseline_fn,
         TORCH_COMPILE_TAG: compiled_reference(baseline_fn),
     }
-
-
-# L1 Norm benchmarks
 
 
 @pytest.mark.parametrize(
@@ -82,9 +77,6 @@ def test_l1_norm_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> Non
         raise
 
 
-# L2 Norm benchmarks
-
-
 @pytest.mark.parametrize(
     "shape, dtype, op_params",
     workloads_to_params(L2NormFwdOp, include_extra=True),
@@ -115,9 +107,6 @@ def test_l2_norm_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> Non
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
         raise
-
-
-# Inf Norm benchmarks
 
 
 @pytest.mark.parametrize(

--- a/benchmarks/report.py
+++ b/benchmarks/report.py
@@ -201,7 +201,6 @@ class BenchmarkReport:
             lines.append(f"## {name}")
             lines.append("")
 
-            # Group by tag
             tag_entries = {}
             for entry in entries:
                 tag_entries.setdefault(entry["tag"], []).append(entry)

--- a/benchmarks/studies/bench_grouped_gemm_3wg.py
+++ b/benchmarks/studies/bench_grouped_gemm_3wg.py
@@ -161,9 +161,9 @@ def _grouped_matmul_kernel(
         last_problem_end = last_problem_end + num_tiles
 
 
-# Trimmed from the full BLOCK_M×BLOCK_N×BLOCK_K×stages×warps grid to a handful of
-# representative Hopper configs: the full sweep added minutes of cold-start
-# autotune JIT with no measurable win on these grouped-GEMM shapes.
+# A handful of representative Hopper configs rather than the full
+# BLOCK_M×BLOCK_N×BLOCK_K×stages×warps grid, which costs minutes of cold-start
+# autotune JIT on these grouped-GEMM shapes without finding a faster config.
 _TMA_CONFIGS = [
     triton.Config(
         {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": bn, "BLOCK_SIZE_K": 64}, num_stages=s, num_warps=8
@@ -326,8 +326,8 @@ def _deepgemm_launch(A, B, D, m_indices, tries=8):
 # output before its timing is recorded — a layout bug or a future torch/Triton
 # behavior change would otherwise produce plausible TFLOPS for a wrong result.
 # The comparison is row-blocked in fp32: a single ``.float()`` on the largest
-# cases (numel up to ~2M x N) would itself OOM, which is why correctness was
-# dropped before; blocking keeps the peak to one chunk.
+# cases (numel up to ~2M x N) would itself OOM, and blocking keeps the peak to
+# one chunk.
 _RTOL, _ATOL = 2e-2, 2e-2
 
 

--- a/benchmarks/timing.py
+++ b/benchmarks/timing.py
@@ -47,9 +47,9 @@ _CUPTI = None
 _COLLECTOR_ACTIVE = False
 _CALLBACKS_REGISTERED = False
 # Whatever CUPTI does with a buffer between handing it back and asking for the next one
-# scales with its size and runs on this thread, inside a timed call. On a three-kernel
-# call whose kernels occupy 19.1 us: 8 MB stalls 23 of 60 iterations past 200 us, 32 MB
-# 30 of 60, 256 KB none. Only latency_ms picks it up; the records are the same.
+# scales with its size and runs on this thread, inside a timed call, so a buffer of a
+# few megabytes stalls iterations of a short call. Only latency_ms picks the stall up;
+# the records are the same either way.
 _BUFFER_BYTES = 256 * 1024
 _BUFFER_ALIGN = 8
 # What the next buffer request answers with. A phase that lost records raises it for

--- a/scripts/test_node_delta.py
+++ b/scripts/test_node_delta.py
@@ -67,7 +67,6 @@ def _collect_node_count(test_file: str, *, ref: str | None = None) -> int | None
             timeout=120,
         )
     finally:
-        # Clean up temp file regardless of success/failure
         if ref is not None:
             Path(target).unlink(missing_ok=True)
 

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -4232,9 +4232,8 @@ def validate_manifest(
             out.append(item)
         return out
 
-    # Route strict-parity (C1-C7) failures: in strict mode they are
-    # blocking errors; in advisory mode they downgrade to warnings so
-    # the gate can land before all current main violations are fixed.
+    # Route strict-parity (C1-C7) failures: in strict mode they are blocking
+    # errors; in advisory mode they downgrade to warnings.
     if strict_parity:
         all_errors.extend(strict_errors)
     else:

--- a/src/tileops/kernels/attention/deepseek_dsa_decode.py
+++ b/src/tileops/kernels/attention/deepseek_dsa_decode.py
@@ -239,7 +239,6 @@ def _sparse_mla_kernel(
                     T.fill(acc_o_l, 0)
 
                     for i_i in T.serial(T.ceildiv(n_i, 2)):
-                        # Buffer 0
                         T.barrier_wait(bar_k_0_ready[0], (i_i & 1))
 
                         for h_i, bi_i in T.Parallel(h_per_block, i_block):
@@ -277,7 +276,6 @@ def _sparse_mla_kernel(
                         T.barrier_arrive(bar_s_scale_and_s_ready)
                         T.barrier_arrive(bar_k_0_free[0])
 
-                        # Buffer 1
                         T.barrier_wait(bar_k_1_ready[0], (i_i & 1))
 
                         for h_i, bi_i in T.Parallel(h_per_block, i_block):
@@ -314,7 +312,6 @@ def _sparse_mla_kernel(
                         T.barrier_arrive(bar_s_scale_and_s_ready)
                         T.barrier_arrive(bar_k_1_free[0])
 
-                    # Rescale
                     for h_i in T.Parallel(h_per_block):
                         sum_exp_shared[h_i] = sumexp[h_i]
                     for h_i, d_i in T.Parallel(h_per_block, d // 2):
@@ -328,7 +325,6 @@ def _sparse_mla_kernel(
                     T.set_max_nreg(168, 1)
                     T.fill(acc_o_r, 0)
                     for i_i in T.serial(T.ceildiv(n_i, 2)):
-                        # Buffer 0
                         T.barrier_arrive(bar_s_scale_and_s_ready)
                         T.barrier_wait(bar_s_scale_and_s_ready, ((i_i * 2) & 1))
                         for h_i, d_i in T.Parallel(h_per_block, d // 2):
@@ -337,7 +333,6 @@ def _sparse_mla_kernel(
                         T.barrier_arrive(bar_k_0_free[0])
                         T.barrier_arrive(bar_s_scale_and_s_free)
 
-                        # Buffer 1
                         T.barrier_arrive(bar_s_scale_and_s_ready)
                         T.barrier_wait(bar_s_scale_and_s_ready, ((i_i * 2 + 1) & 1))
                         for h_i, d_i in T.Parallel(h_per_block, d // 2):
@@ -347,7 +342,6 @@ def _sparse_mla_kernel(
                         if i_i != T.ceildiv(n_i, 2) - 1:
                             T.barrier_arrive(bar_s_scale_and_s_free)
 
-                    # Rescale
                     for h_i, d_i in T.Parallel(h_per_block, d // 2):
                         acc_o_r[h_i, d_i] /= sum_exp_shared[h_i]
 
@@ -355,10 +349,8 @@ def _sparse_mla_kernel(
                     T.copy(o_shared_r, output[b_i, s_i, h0:h1, d // 2 : d])
 
                 elif tx >= 256:
-                    # producer
                     T.set_max_nreg(80, 0)
                     for i_i in T.serial(T.ceildiv(n_i, 2)):
-                        # Buffer 0
                         T.barrier_wait(bar_k_0_free[0], ((i_i & 1) ^ 1))
                         for r in T.serial(4):
                             indices_local[0] = indices[
@@ -396,7 +388,6 @@ def _sparse_mla_kernel(
                                         ]
                         T.cp_async_barrier_noinc(bar_k_0_ready[0])
 
-                        # Buffer 1
                         T.barrier_wait(bar_k_1_free[0], ((i_i & 1) ^ 1))
                         for r in T.serial(4):
                             indices_local[0] = indices[
@@ -705,6 +696,5 @@ class SparseMlaKernel(Kernel):
 
         tuned_kernel = self._call_autotuned_kernel(autotuned_kernel_fn, self.kernel)
 
-        # Extract and store the best config
         self.config = tuned_kernel.config
         print(f"Best config: {self.config}")

--- a/src/tileops/kernels/attention/deepseek_dsa_decode.py
+++ b/src/tileops/kernels/attention/deepseek_dsa_decode.py
@@ -264,7 +264,7 @@ def _sparse_mla_kernel(
                             acc_s[h_i, bi_i] = T.exp2(
                                 acc_s[h_i, bi_i] * sm_scale - m_i[h_i] * sm_scale
                             )
-                        T.reduce_sum(acc_s, sumexp_i, dim=1)  # is this a accumulate operator?
+                        T.reduce_sum(acc_s, sumexp_i, dim=1)
                         for h_i in T.Parallel(h_per_block):
                             sumexp[h_i] = sumexp[h_i] * alpha_local[h_i] + sumexp_i[h_i]
                         for h_i, d_i in T.Parallel(h_per_block, d // 2):
@@ -301,7 +301,7 @@ def _sparse_mla_kernel(
                             acc_s[h_i, bi_i] = T.exp2(
                                 acc_s[h_i, bi_i] * sm_scale - m_i[h_i] * sm_scale
                             )
-                        T.reduce_sum(acc_s, sumexp_i, dim=1)  # is this a accumulate operator?
+                        T.reduce_sum(acc_s, sumexp_i, dim=1)
                         for h_i in T.Parallel(h_per_block):
                             sumexp[h_i] = sumexp[h_i] * alpha_local[h_i] + sumexp_i[h_i]
                         for h_i, d_i in T.Parallel(h_per_block, d // 2):
@@ -632,8 +632,6 @@ class SparseMlaKernel(Kernel):
             indices,
         )
 
-    # @property
-    # params unused
     def supply_prog(self) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """
         Generates synthetic data for the kernel program.
@@ -677,7 +675,7 @@ class SparseMlaKernel(Kernel):
 
         return q, kv, indices
 
-    def autotune(self, warmup: int = 10, rep: int = 10) -> None:  # Removed supply_prog parameter
+    def autotune(self, warmup: int = 10, rep: int = 10) -> None:
         """
         Performs autotuning by evaluating different kernel configurations.
 

--- a/src/tileops/kernels/attention/deepseek_mla_decode.py
+++ b/src/tileops/kernels/attention/deepseek_mla_decode.py
@@ -136,7 +136,7 @@ def _mla_decode_ws_kernel(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, dty
                             acc_s[h_i, bi_i] = T.exp2(
                                 acc_s[h_i, bi_i] * sm_scale - m_i[h_i] * sm_scale
                             )
-                        T.reduce_sum(acc_s, sumexp_i, dim=1)  # is this a accumulate operator?
+                        T.reduce_sum(acc_s, sumexp_i, dim=1)
                         for h_i in T.Parallel(block_H):
                             sumexp[h_i] = sumexp[h_i] * alpha_local[h_i] + sumexp_i[h_i]
                         for h_i, d_i in T.Parallel(block_H, dim // 2):
@@ -170,7 +170,7 @@ def _mla_decode_ws_kernel(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, dty
                             acc_s[h_i, bi_i] = T.exp2(
                                 acc_s[h_i, bi_i] * sm_scale - m_i[h_i] * sm_scale
                             )
-                        T.reduce_sum(acc_s, sumexp_i, dim=1)  # is this a accumulate operator?
+                        T.reduce_sum(acc_s, sumexp_i, dim=1)
                         for h_i in T.Parallel(block_H):
                             sumexp[h_i] = sumexp[h_i] * alpha_local[h_i] + sumexp_i[h_i]
                         for h_i, d_i in T.Parallel(block_H, dim // 2):
@@ -393,7 +393,7 @@ def _mla_decode_ws_kernel(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, dty
                             acc_s[h_i, bi_i] = T.exp2(
                                 acc_s[h_i, bi_i] * sm_scale - m_i[h_i] * sm_scale
                             )
-                        T.reduce_sum(acc_s, sumexp_i, dim=1)  # is this a accumulate operator?
+                        T.reduce_sum(acc_s, sumexp_i, dim=1)
                         for h_i in T.Parallel(block_H):
                             sumexp[h_i] = sumexp[h_i] * alpha_local[h_i] + sumexp_i[h_i]
                         for h_i, d_i in T.Parallel(block_H, dim // 2):
@@ -427,7 +427,7 @@ def _mla_decode_ws_kernel(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, dty
                             acc_s[h_i, bi_i] = T.exp2(
                                 acc_s[h_i, bi_i] * sm_scale - m_i[h_i] * sm_scale
                             )
-                        T.reduce_sum(acc_s, sumexp_i, dim=1)  # is this a accumulate operator?
+                        T.reduce_sum(acc_s, sumexp_i, dim=1)
                         for h_i in T.Parallel(block_H):
                             sumexp[h_i] = sumexp[h_i] * alpha_local[h_i] + sumexp_i[h_i]
                         for h_i, d_i in T.Parallel(block_H, dim // 2):

--- a/src/tileops/kernels/attention/deepseek_mla_decode.py
+++ b/src/tileops/kernels/attention/deepseek_mla_decode.py
@@ -114,7 +114,6 @@ def _mla_decode_ws_kernel(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, dty
                     T.fill(acc_o_l, 0)
 
                     for i_i in T.serial(T.ceildiv(NI, 2)):
-                        # Buffer 0
                         T.barrier_wait(bar_k_0_ready[0], (i_i & 1))
 
                         T.clear(acc_s)
@@ -149,7 +148,6 @@ def _mla_decode_ws_kernel(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, dty
                         T.barrier_arrive(bar_sScale_and_sS_ready)
                         T.barrier_arrive(bar_k_0_free[0])
 
-                        # Buffer 1
                         T.barrier_wait(bar_k_1_ready[0], (i_i & 1))
 
                         T.clear(acc_s)
@@ -183,7 +181,6 @@ def _mla_decode_ws_kernel(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, dty
                         T.barrier_arrive(bar_sScale_and_sS_ready)
                         T.barrier_arrive(bar_k_1_free[0])
 
-                    # Rescale
                     for h_i in T.Parallel(block_H):
                         sum_exp_shared[h_i] = sumexp[h_i]
                     for h_i, d_i in T.Parallel(block_H, dim // 2):
@@ -200,7 +197,6 @@ def _mla_decode_ws_kernel(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, dty
                     T.set_max_nreg(168, 1)
                     T.fill(acc_o_r, 0)
                     for i_i in T.serial(T.ceildiv(NI, 2)):
-                        # Buffer 0
                         T.barrier_arrive(bar_sScale_and_sS_ready)
                         T.barrier_wait(bar_sScale_and_sS_ready, ((i_i * 2) & 1))
                         for h_i, d_i in T.Parallel(block_H, dim // 2):
@@ -209,7 +205,6 @@ def _mla_decode_ws_kernel(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, dty
                         T.barrier_arrive(bar_k_0_free[0])
                         T.barrier_arrive(bar_sScale_and_sS_free)
 
-                        # Buffer 1
                         T.barrier_arrive(bar_sScale_and_sS_ready)
                         T.barrier_wait(bar_sScale_and_sS_ready, ((i_i * 2 + 1) & 1))
                         for h_i, d_i in T.Parallel(block_H, dim // 2):
@@ -219,7 +214,6 @@ def _mla_decode_ws_kernel(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, dty
                         if i_i != T.ceildiv(NI, 2) - 1:
                             T.barrier_arrive(bar_sScale_and_sS_free)
 
-                    # Rescale
                     for h_i, d_i in T.Parallel(block_H, dim // 2):
                         acc_o_r[h_i, d_i] /= sum_exp_shared[h_i]
 
@@ -232,10 +226,8 @@ def _mla_decode_ws_kernel(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, dty
                     )
 
                 elif tx >= 256:
-                    # producer
                     T.set_max_nreg(80, 0)
                     for i_i in T.serial(T.ceildiv(NI, 2)):
-                        # Buffer 0
                         T.barrier_wait(bar_k_0_free[0], ((i_i & 1) ^ 1))
                         for r in T.serial(4):
                             kv_indices = (i_i * 2) * block_N + r * 16 + (tx - 256) // 8
@@ -267,7 +259,6 @@ def _mla_decode_ws_kernel(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, dty
                                     ] = K_pe[bid, kv_indices, cur_kv_head, (tx - 256) % 8 * 8 + v]
                         T.cp_async_barrier_noinc(bar_k_0_ready[0])
 
-                        # Buffer 1
                         T.barrier_wait(bar_k_1_free[0], ((i_i & 1) ^ 1))
                         for r in T.serial(4):
                             kv_indices = (i_i * 2 + 1) * block_N + r * 16 + (tx - 256) // 8
@@ -371,7 +362,6 @@ def _mla_decode_ws_kernel(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, dty
                     T.fill(acc_o_l, 0)
 
                     for i_i in T.serial(T.ceildiv(NI, 2)):
-                        # Buffer 0
                         T.barrier_wait(bar_k_0_ready[0], (i_i & 1))
 
                         T.clear(acc_s)
@@ -406,7 +396,6 @@ def _mla_decode_ws_kernel(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, dty
                         T.barrier_arrive(bar_sScale_and_sS_ready)
                         T.barrier_arrive(bar_k_0_free[0])
 
-                        # Buffer 1
                         T.barrier_wait(bar_k_1_ready[0], (i_i & 1))
 
                         T.clear(acc_s)
@@ -440,7 +429,6 @@ def _mla_decode_ws_kernel(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, dty
                         T.barrier_arrive(bar_sScale_and_sS_ready)
                         T.barrier_arrive(bar_k_1_free[0])
 
-                    # Rescale
                     for h_i in T.Parallel(block_H):
                         sum_exp_shared[h_i] = sumexp[h_i]
                     for h_i, d_i in T.Parallel(block_H, dim // 2):
@@ -460,7 +448,6 @@ def _mla_decode_ws_kernel(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, dty
                     T.set_max_nreg(168, 1)
                     T.fill(acc_o_r, 0)
                     for i_i in T.serial(T.ceildiv(NI, 2)):
-                        # Buffer 0
                         T.barrier_arrive(bar_sScale_and_sS_ready)
                         T.barrier_wait(bar_sScale_and_sS_ready, ((i_i * 2) & 1))
                         for h_i, d_i in T.Parallel(block_H, dim // 2):
@@ -469,7 +456,6 @@ def _mla_decode_ws_kernel(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, dty
                         T.barrier_arrive(bar_k_0_free[0])
                         T.barrier_arrive(bar_sScale_and_sS_free)
 
-                        # Buffer 1
                         T.barrier_arrive(bar_sScale_and_sS_ready)
                         T.barrier_wait(bar_sScale_and_sS_ready, ((i_i * 2 + 1) & 1))
                         for h_i, d_i in T.Parallel(block_H, dim // 2):
@@ -479,7 +465,6 @@ def _mla_decode_ws_kernel(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, dty
                         if i_i != T.ceildiv(NI, 2) - 1:
                             T.barrier_arrive(bar_sScale_and_sS_free)
 
-                    # Rescale
                     for h_i, d_i in T.Parallel(block_H, dim // 2):
                         acc_o_r[h_i, d_i] /= sum_exp_shared[h_i]
 
@@ -492,10 +477,8 @@ def _mla_decode_ws_kernel(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, dty
                     )
 
                 elif tx >= 256:
-                    # producer
                     T.set_max_nreg(80, 0)
                     for i_i in T.serial(T.ceildiv(NI, 2)):
-                        # Buffer 0
                         T.barrier_wait(bar_k_0_free[0], ((i_i & 1) ^ 1))
                         for r in T.serial(4):
                             kv_indices = (
@@ -532,7 +515,6 @@ def _mla_decode_ws_kernel(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, dty
                                     ] = K_pe[bid, kv_indices, cur_kv_head, (tx - 256) % 8 * 8 + v]
                         T.cp_async_barrier_noinc(bar_k_0_ready[0])
 
-                        # Buffer 1
                         T.barrier_wait(bar_k_1_free[0], ((i_i & 1) ^ 1))
                         for r in T.serial(4):
                             kv_indices = (

--- a/src/tileops/kernels/attention/deepseek_nsa_fwd.py
+++ b/src/tileops/kernels/attention/deepseek_nsa_fwd.py
@@ -130,13 +130,11 @@ def _nsa_fwd_varlen_kernel(
                             policy=T.GemmWarpPolicy.FullRow,
                         )
 
-                        # Softmax
                         online_softmax(
                             acc_s, scores_max, scores_max_prev, scores_scale, scores_sum, logsum
                         )
                         T.copy(acc_s, acc_s_cast)
 
-                        # Rescale
                         rescale(acc_o, scores_scale)
 
                         # V * softmax(Q * K)

--- a/src/tileops/kernels/attention/gqa_bwd.py
+++ b/src/tileops/kernels/attention/gqa_bwd.py
@@ -93,9 +93,6 @@ class FlashAttnBwdPreprocessKernel(Kernel):
         return self.kernel(o, do)
 
 
-# GQA
-
-
 @functools.lru_cache(maxsize=32)
 def _gqa_bwd_wgmma_pipelined_kernel(
     batch: int,

--- a/src/tileops/kernels/attention/gqa_decode.py
+++ b/src/tileops/kernels/attention/gqa_decode.py
@@ -409,9 +409,6 @@ def _(
     return torch.empty_like(Q)
 
 
-# Kernel class
-
-
 class GQADecodeKernel(Kernel):
     supported_archs: list[int] = [80, 89, 90]
     # The implementation behind the specialised ones for this key.

--- a/src/tileops/kernels/attention/gqa_decode_paged.py
+++ b/src/tileops/kernels/attention/gqa_decode_paged.py
@@ -492,9 +492,6 @@ def _(
     return torch.empty_like(Q)
 
 
-# Kernel class
-
-
 class GQADecodePagedKernel(Kernel):
     supported_archs: list[int] = [80, 89, 90]
     # The implementation behind the specialised ones for this key.

--- a/src/tileops/kernels/attention/gqa_fwd.py
+++ b/src/tileops/kernels/attention/gqa_fwd.py
@@ -55,9 +55,6 @@ def _make_apply_softcap_no_mask_guard(score_scale, softcap, accum_dtype, block_r
     return apply_softcap
 
 
-# GQA
-
-
 @functools.lru_cache(maxsize=32)
 def _gqa_fwd_wgmma_pipelined_kernel(
     batch: int,

--- a/src/tileops/kernels/attention/mha_decode.py
+++ b/src/tileops/kernels/attention/mha_decode.py
@@ -454,9 +454,6 @@ def _(
     return torch.empty_like(Q)
 
 
-# Kernel class
-
-
 class MHADecodeKernel(Kernel):
     supported_archs: list[int] = [80, 89, 90]
 

--- a/src/tileops/kernels/attention/mha_decode.py
+++ b/src/tileops/kernels/attention/mha_decode.py
@@ -245,7 +245,6 @@ def _mha_decode_split_kernel(batch, heads, seqlen_q, seqlen_kv, dim, is_causal, 
                 T.fill(scores_max, -T.infinity(accum_dtype))
 
                 loop_range = T.ceildiv(split_length_shared[sid], block_N)
-                # move it to input var...
                 for k in T.Pipelined(loop_range, num_stages=2):
                     MMA0(K, Q_shared, K_shared, real_seqlen_kv, acc_s, k, mid, hid, bid, sid)
                     online_softmax(

--- a/src/tileops/kernels/attention/mha_decode_paged.py
+++ b/src/tileops/kernels/attention/mha_decode_paged.py
@@ -545,9 +545,6 @@ def _(
     return torch.empty_like(Q)
 
 
-# Kernel class
-
-
 class MHADecodePagedKernel(Kernel):
     supported_archs: list[int] = [80, 89, 90]
     # The implementation behind the specialised one for this key: it serves any

--- a/src/tileops/kernels/attention/mha_decode_paged_ws.py
+++ b/src/tileops/kernels/attention/mha_decode_paged_ws.py
@@ -354,9 +354,6 @@ def _(
     return torch.empty_like(Q)
 
 
-# Kernel class
-
-
 class MHADecodePagedWsKernel(Kernel):
     """Hopper paged MHA decode: hand-written warp specialization, no MMA."""
 

--- a/src/tileops/kernels/convolution/conv1d.py
+++ b/src/tileops/kernels/convolution/conv1d.py
@@ -84,7 +84,7 @@ def _conv1d_kernel(
                         ol = bx * block_n + j
                         # k runs over (kernel_l, c_in): one k tile then covers a single
                         # tap across every input channel, which is one rectangle of x.
-                        # Laying it out the other way costs 50% on c_in=128, kernel 10.
+                        # The other order splits each tap across k tiles.
                         kw = k_idx // c_in
                         ci = k_idx % c_in
                         il = ol * stride_l + kw * dilation_l - pad_left

--- a/src/tileops/kernels/convolution/conv3d.py
+++ b/src/tileops/kernels/convolution/conv3d.py
@@ -389,7 +389,7 @@ def _conv3d_ndhwc_kernel(
 
     # Unlike the NCDHW kernels above, tl.enable_async_copy stays enabled here:
     # the NDHWC gather vectorises to >=4B accesses, which are cp.async-eligible
-    # inside the pipelined K loop (aspp workload: 0.0413 -> 0.0328 ms).
+    # inside the pipelined K loop.
     @tilelang.jit(
         out_idx=[5],
         compile_flags=["-O3", "-DENABLE_BF16"],

--- a/src/tileops/kernels/engram/engram_bwd.py
+++ b/src/tileops/kernels/engram/engram_bwd.py
@@ -212,7 +212,6 @@ def _engram_gate_conv_bwd_kernel(M, seq_len, d, eps, dtype):
                 dk_local = T.alloc_fragment((d_padded,), accum_dtype)
                 dv_local = T.alloc_fragment((d_padded,), accum_dtype)
 
-                # 2D fragments for reduce_sum
                 dalpha_2d = T.alloc_fragment((1, d_padded), accum_dtype)
                 dalpha_sum = T.alloc_fragment((1,), accum_dtype)
                 dot_h_2d = T.alloc_fragment((1, d_padded), accum_dtype)
@@ -290,7 +289,6 @@ def _engram_gate_conv_bwd_kernel(M, seq_len, d, eps, dtype):
                         ddot_val * h_norm_local[j] * k_local[j] * rrms_k_val,
                     )
 
-                # Write outputs
                 for j in T.Parallel(d_padded):
                     dH[bid, tid, j] = T.cast(dh_local[j], dtype)
                     dk[bid, tid, j] = T.cast(dk_local[j], dtype)

--- a/src/tileops/kernels/engram/engram_decode.py
+++ b/src/tileops/kernels/engram/engram_decode.py
@@ -87,7 +87,6 @@ def _engram_decode_kernel(batch, d_mem, d, max_conv_len, conv_kernel_size, dilat
             new_conv_state: T.Tensor((batch, max_conv_len, d_padded), dtype),
         ):
             with T.Kernel(batch, threads=threads) as (bid,):
-                # --- Registers ---
                 e_local = T.alloc_fragment((d_mem,), accum_dtype)
                 k_local = T.alloc_fragment((d_padded,), accum_dtype)
                 v_local = T.alloc_fragment((d_padded,), accum_dtype)
@@ -95,7 +94,6 @@ def _engram_decode_kernel(batch, d_mem, d, max_conv_len, conv_kernel_size, dilat
                 vhat_local = T.alloc_fragment((d_padded,), accum_dtype)
                 conv_out = T.alloc_fragment((d_padded,), accum_dtype)
 
-                # 2D fragments for T.reduce_sum
                 hsq_2d = T.alloc_fragment((1, d_padded), accum_dtype)
                 ksq_2d = T.alloc_fragment((1, d_padded), accum_dtype)
                 vsq_2d = T.alloc_fragment((1, d_padded), accum_dtype)

--- a/src/tileops/kernels/engram/engram_fwd.py
+++ b/src/tileops/kernels/engram/engram_fwd.py
@@ -61,7 +61,6 @@ def _engram_gate_conv_fwd_kernel(M, seq_len, d, eps, dtype):
         ):
             # ======== Pass 1: RMSNorm + gate -> vhat ========
             with T.Kernel(seq_len, M, threads=threads) as (bx, by):
-                # 2D fragments for reduce_sum compatibility
                 h_2d = T.alloc_fragment((1, d_padded), accum_dtype)
                 k_2d = T.alloc_fragment((1, d_padded), accum_dtype)
                 v_1d = T.alloc_fragment((d_padded,), accum_dtype)
@@ -91,7 +90,6 @@ def _engram_gate_conv_fwd_kernel(M, seq_len, d, eps, dtype):
                     ksq[0, j] = k_2d[0, j] * k_2d[0, j]
                 T.reduce_sum(ksq, sumsq_k, dim=1)
 
-                # rrms values
                 rrms_h_val = T.rsqrt(sumsq_h[0] / float(d) + eps)
                 rrms_k_val = T.rsqrt(sumsq_k[0] / float(d) + eps)
                 rrms_h_buf[bid, tid] = rrms_h_val

--- a/src/tileops/kernels/fft.py
+++ b/src/tileops/kernels/fft.py
@@ -205,7 +205,6 @@ def _fft_c2c_kernel(n: int, batch_size: int = 1, dtype: str = "complex64") -> Ca
 
                     T.sync_threads()
 
-                # ---- store ----
                 for i in T.Parallel(threads):
                     if i < smem_per_block:
                         store_complex(

--- a/src/tileops/kernels/fp8_lightning_indexer.py
+++ b/src/tileops/kernels/fp8_lightning_indexer.py
@@ -153,7 +153,6 @@ def _fp8_lightning_indexer_kernel(
                             logits[bn_i, bq_i, g]
                         )
 
-        # Return the kernel function handle
         return _fp8_lightning_indexer_main
 
     return _fp8_lightning_indexer_func

--- a/src/tileops/kernels/fp8_quant.py
+++ b/src/tileops/kernels/fp8_quant.py
@@ -54,7 +54,6 @@ def _fp8_quant_kernel(batch, seq_len_kv, kv_group, index_dim, in_dtype: str):
                         input_local[i, j] / scale_local[i], fp8_min, fp8_max
                     )
 
-                # Write back scale and output
                 for i in T.Parallel(block_m):
                     scale_tensor[bx, pid_m * block_m + i, g] = scale_local[i]
                 for i, j in T.Parallel(block_m, index_dim):

--- a/src/tileops/kernels/gemm/bmm.py
+++ b/src/tileops/kernels/gemm/bmm.py
@@ -103,9 +103,8 @@ def _bmm_kernel(batch: int, m: int, n: int, k: int, dtype: str = "float16") -> C
                     T.gemm(a_smem, b_smem, c_local, policy=T.GemmWarpPolicy.FullRow)
 
                 # Epilogue: stage fp32 accum through SMEM before GMEM store.
-                # 1-19% faster than direct fragment->GMEM — the M/N
-                # tail guard breaks coalescing off the wgmma fragment layout,
-                # but SMEM->GMEM stores stay coalesced under predication.
+                # The M/N tail guard breaks coalescing off the wgmma fragment
+                # layout; SMEM->GMEM stores stay coalesced under predication.
                 T.copy(c_local, c_smem)
                 for i, j in T.Parallel(block_m, block_n):
                     if m_start + i < m and n_start + j < n:
@@ -652,7 +651,7 @@ class BmmKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
-        # 64x64x64, stages=2, 1 warpgroup. Modal winner on H20-3e manifest
+        # 64x64x64, stages=2, one warpgroup: the tile the manifest shapes share.
         block_k = 64 if self.k % 64 == 0 else (32 if self.k % 32 == 0 else 16)
         return {
             "block_m": 64,

--- a/src/tileops/kernels/grouped_gemm/grouped_gemm.py
+++ b/src/tileops/kernels/grouped_gemm/grouped_gemm.py
@@ -91,14 +91,12 @@ def _grouped_gemm_kernel(batch_sum, batch_count, N, K, transpose_a, transpose_b,
                         T.clear(C_local)
 
                         for k in T.Pipelined(T.ceildiv(K, block_k), num_stages=num_stages):
-                            # Load A block (same for NT and NN)
                             for i, j in T.Parallel(block_m, block_k):
                                 A_shared[i, j] = T.if_then_else(
                                     i < actual_rows and j < K - k * block_k,
                                     A[m_start + i, k * block_k + j],
                                     0,
                                 )
-                            # Load B block
                             if transpose_b:
                                 for i, j in T.Parallel(block_n, block_k):
                                     B_shared[i, j] = T.if_then_else(
@@ -114,7 +112,6 @@ def _grouped_gemm_kernel(batch_sum, batch_count, N, K, transpose_a, transpose_b,
                                         0,
                                     )
                             T.gemm(A_shared, B_shared, C_local, transpose_B=transpose_b)
-                        # Store result
                         for i, j in T.Parallel(block_m, block_n):
                             if i < actual_rows and j < actual_cols:
                                 C[m_start + i, n_start + j] = C_local[i, j]
@@ -161,12 +158,10 @@ def _grouped_gemm_kernel(batch_sum, batch_count, N, K, transpose_a, transpose_b,
                     for m in T.Pipelined(T.ceildiv(batch_size, block_m), num_stages=num_stages):
                         m_start = batch_start + m * block_m
                         actual_rows = T.min(block_m, batch_size - m * block_m)
-                        # Load A block (same for TN and TT)
                         for i, j in T.Parallel(block_m, block_n):
                             A_shared[i, j] = T.if_then_else(
                                 i < actual_rows and j < actual_N, A[m_start + i, n_start + j], 0
                             )
-                        # Load B block
                         if transpose_b:
                             for i, j in T.Parallel(block_k, block_m):
                                 B_shared[i, j] = T.if_then_else(
@@ -180,7 +175,6 @@ def _grouped_gemm_kernel(batch_sum, batch_count, N, K, transpose_a, transpose_b,
                         T.gemm(
                             A_shared, B_shared, C_local, transpose_A=True, transpose_B=transpose_b
                         )
-                    # Store result
                     for i, j in T.Parallel(block_n, block_k):
                         if i < actual_N and j < actual_K:
                             C[bx, n_start + i, k_start + j] = C_local[i, j]

--- a/src/tileops/kernels/grouped_gemm/grouped_gemm_persistent_3wg.py
+++ b/src/tileops/kernels/grouped_gemm/grouped_gemm_persistent_3wg.py
@@ -52,8 +52,8 @@ _DEFAULT_CONFIG = {
     "num_stages": 3,
     "threads": 384,
     # Threadblock swizzle: group this many consecutive m-tiles so concurrent
-    # CTAs in a wave share B[e] columns in L2. 8 is the robust Triton-standard
-    # default (~5% over 1 on compute-bound MoE shapes); autotune sweeps it.
+    # CTAs in a wave share B[e] columns in L2. 8 is the Triton-standard default;
+    # autotune sweeps it.
     "group_size_m": 8,
 }
 

--- a/src/tileops/kernels/linear_attention/deltanet/compute_w_u_bwd.py
+++ b/src/tileops/kernels/linear_attention/deltanet/compute_w_u_bwd.py
@@ -68,7 +68,6 @@ def compute_w_u_bwd_tl(
             dbeta: T.Tensor([batch, head, seq_len], dtype),
         ):
             with T.Kernel(batch, head, num_chunks, threads=threads) as (bid, hid, by):
-                # --- Shared memory ---
                 Aw_s = T.alloc_shared([block_C, block_C], accum_dtype)
                 Au_s = T.alloc_shared([block_C, block_C], accum_dtype)
                 dw_s = T.alloc_shared([block_C, dim_k], accum_dtype)
@@ -84,7 +83,6 @@ def compute_w_u_bwd_tl(
                 dP_s = T.alloc_shared([block_C, block_C], accum_dtype)
                 dk_partial_s = T.alloc_shared([block_C, dim_k], dtype)
                 dk_corr_s = T.alloc_shared([block_C, dim_k], dtype)
-                # --- Fragments ---
                 dAw_frag = T.alloc_fragment([block_C, block_C], accum_dtype)
                 dAu_frag = T.alloc_fragment([block_C, block_C], accum_dtype)
                 d_k_beta_frag = T.alloc_fragment([block_C, dim_k], accum_dtype)
@@ -92,7 +90,6 @@ def compute_w_u_bwd_tl(
                 dk_A_frag = T.alloc_fragment([block_C, dim_k], accum_dtype)
                 dw_corr_frag = T.alloc_fragment([block_C, dim_k], accum_dtype)
 
-                # Load inputs
                 T.copy(Aw[bid, hid, by * block_C : (by + 1) * block_C, :], Aw_s, disable_tma=True)
                 T.copy(Au[bid, hid, by * block_C : (by + 1) * block_C, :], Au_s, disable_tma=True)
                 T.copy(dw[bid, hid, by * block_C : (by + 1) * block_C, :], dw_s, disable_tma=True)

--- a/src/tileops/kernels/linear_attention/deltanet/deltanet_bwd.py
+++ b/src/tileops/kernels/linear_attention/deltanet/deltanet_bwd.py
@@ -78,7 +78,6 @@ def _bwd_parallel_tl(
             dh_local: T.Tensor([batch, head, num_chunks, dim_k, dim_v], accum_dtype),
         ):
             with T.Kernel(num_chunks, batch, head, threads=threads) as (tid, bid, hid):
-                # Shared buffers
                 q_c = T.alloc_shared([block_C, dim_k], dtype)
                 k_c = T.alloc_shared([block_C, dim_k], dtype)
                 w_c = T.alloc_shared([block_C, dim_k], dtype)
@@ -88,15 +87,12 @@ def _bwd_parallel_tl(
                 v_new_c = T.alloc_shared([block_C, dim_v], dtype)
                 o_part = T.alloc_shared([block_C, dim_v], dtype)
                 attn = T.alloc_shared([block_C, block_C], dtype)
-                # Gradients
                 d_q_c = T.alloc_shared([block_C, dim_k], dtype)
                 d_k_c = T.alloc_shared([block_C, dim_k], dtype)
                 d_w_c = T.alloc_shared([block_C, dim_k], dtype)
                 d_v_new_c = T.alloc_shared([block_C, dim_v], dtype)
                 d_attn = T.alloc_shared([block_C, block_C], dtype)
-                # Working
                 dP = T.alloc_shared([block_C, dim_k], dtype)
-                # Fragments
                 ws_frag = T.alloc_fragment([block_C, dim_v], accum_dtype)
                 attn_frag = T.alloc_fragment([block_C, block_C], accum_dtype)
                 d_v_new_frag = T.alloc_fragment([block_C, dim_v], accum_dtype)
@@ -106,7 +102,6 @@ def _bwd_parallel_tl(
                 dP_frag = T.alloc_fragment([block_C, dim_k], accum_dtype)
                 dh_frag = T.alloc_fragment([dim_k, dim_v], accum_dtype)
 
-                # Load chunk data
                 T.copy(q[bid, hid, tid * block_C : (tid + 1) * block_C, :], q_c, disable_tma=True)
                 T.copy(k[bid, hid, tid * block_C : (tid + 1) * block_C, :], k_c, disable_tma=True)
                 T.copy(w[bid, hid, tid * block_C : (tid + 1) * block_C, :], w_c, disable_tma=True)
@@ -179,7 +174,6 @@ def _bwd_parallel_tl(
                 for i, j in T.Parallel(block_C, dim_k):
                     d_w_c[i, j] = dP[i, j]
 
-                # Write outputs
                 T.copy(
                     d_q_c, dq[bid, hid, tid * block_C : (tid + 1) * block_C, :], disable_tma=True
                 )
@@ -255,14 +249,12 @@ def _dh_recurrence_bwd_tl(
             du_corr: T.Tensor([batch, head, seq_len, dim_v], dtype),
         ):
             with T.Kernel(batch, head, threads=threads) as (bid, hid):
-                # Shared buffers
                 k_c = T.alloc_shared([block_C, dim_k], dtype)
                 w_c = T.alloc_shared([block_C, dim_k], dtype)
                 v_new_c = T.alloc_shared([block_C, dim_v], dtype)
                 dh_loc = T.alloc_shared([dim_k, dim_v], accum_dtype)
                 dP = T.alloc_shared([block_C, dim_k], dtype)
                 dh_buf = T.alloc_shared([dim_k, dim_v], dtype)
-                # Fragments
                 dh_fp32 = T.alloc_fragment([dim_k, dim_v], accum_dtype)
                 du_corr_frag = T.alloc_fragment([block_C, dim_v], accum_dtype)
                 dP_frag = T.alloc_fragment([block_C, dim_k], accum_dtype)
@@ -484,7 +476,6 @@ class DeltaNetBwdKernel(Kernel):
         B, H, S, BC = self.batch, self.head, self.seq_len, self.chunk_size
         DK, DV, dt = self.dim_k, self.dim_v, self.dtype_str
 
-        # --- Tune bwd_parallel ---
         parallel_configs = [{"threads": t} for t in [128, 256]]
         print(f"Autotuning bwd_parallel ({len(parallel_configs)} configs)...")
         parallel_jit = _bwd_parallel_tl(B, H, S, BC, DK, DV, dt)
@@ -502,7 +493,6 @@ class DeltaNetBwdKernel(Kernel):
         parallel_best = tuned_parallel.config
         print(f"  Best: {parallel_best}")
 
-        # --- Tune dh_recurrence_bwd ---
         recurrence_configs = [{"num_stages": ns, "threads": t} for ns in [1, 2] for t in [128, 256]]
         print(f"Autotuning dh_recurrence_bwd ({len(recurrence_configs)} configs)...")
         recurrence_jit = _dh_recurrence_bwd_tl(B, H, S, BC, DK, DV, dt)
@@ -520,7 +510,6 @@ class DeltaNetBwdKernel(Kernel):
         recurrence_best = tuned_recurrence.config
         print(f"  Best: {recurrence_best}")
 
-        # --- Tune compute_w_u_bwd ---
         wu_bwd_configs = [{"num_stages": ns, "threads": t} for ns in [1, 2] for t in [128, 256]]
         print(f"Autotuning compute_w_u_bwd ({len(wu_bwd_configs)} configs)...")
         wu_bwd_jit = compute_w_u_bwd_tl(B, H, S, BC, DK, DV, dt)

--- a/src/tileops/kernels/linear_attention/deltanet/fused_prepare_compute_w_u.py
+++ b/src/tileops/kernels/linear_attention/deltanet/fused_prepare_compute_w_u.py
@@ -55,7 +55,6 @@ def fused_prepare_compute_w_u_tl(
             u: T.Tensor([batch, head, seq_len, dim_v], dtype),
         ):
             with T.Kernel(batch, head, seq_len // block_C, threads=threads) as (bid, hid, by):
-                # Shared buffers
                 k_shared = T.alloc_shared([block_C, dim_k], dtype)
                 v_shared = T.alloc_shared([block_C, dim_v], dtype)
                 beta_shared = T.alloc_shared([block_C], dtype)
@@ -63,13 +62,11 @@ def fused_prepare_compute_w_u_tl(
                 v_beta_shared = T.alloc_shared([block_C, dim_v], dtype)
                 S_shared = T.alloc_shared([block_C, block_C], dtype)
                 P_shared = T.alloc_shared([block_C, block_C], dtype)
-                # Fragments (fp32 accumulators)
                 gram_frag = T.alloc_fragment([block_C, block_C], accum_dtype)
                 temp_frag = T.alloc_fragment([block_C, block_C], accum_dtype)
                 w_frag = T.alloc_fragment([block_C, dim_k], accum_dtype)
                 u_frag = T.alloc_fragment([block_C, dim_v], accum_dtype)
 
-                # Load inputs
                 T.copy(
                     k[bid, hid, by * block_C : (by + 1) * block_C, :], k_shared, disable_tma=True
                 )

--- a/src/tileops/kernels/linear_attention/deltanet_recurrence.py
+++ b/src/tileops/kernels/linear_attention/deltanet_recurrence.py
@@ -579,7 +579,6 @@ def _deltanet_decode_fp32_tl(
 
                 beta_val = T.cast(beta[bid, hid], accum_dtype)
 
-                # Zero-init fragment accumulators
                 T.fill(sk_frag, 0.0)
                 T.fill(sq_frag, 0.0)
 
@@ -592,7 +591,6 @@ def _deltanet_decode_fp32_tl(
                         sk_frag[j] = sk_frag[j] + k_val * h_val
                         sq_frag[j] = sq_frag[j] + q_val * h_val
 
-                # q . k dot product
                 qk_dot[0] = 0.0
                 for kk in T.Serial(dim_k):
                     qk_dot[0] += q[bid, hid, kk] * k[bid, hid, kk]

--- a/src/tileops/kernels/linear_attention/gated_deltanet/fused_prepare_compute_w_u.py
+++ b/src/tileops/kernels/linear_attention/gated_deltanet/fused_prepare_compute_w_u.py
@@ -64,7 +64,6 @@ def fused_prepare_compute_w_u_tl(
             u: T.Tensor([batch, head, seq_len, dim_v], dtype),
         ):
             with T.Kernel(batch, head, seq_len // block_C, threads=threads) as (bid, hid, by):
-                # Shared buffers
                 k_shared = T.alloc_shared([block_C, dim_k], dtype)
                 v_shared = T.alloc_shared([block_C, dim_v], dtype)
                 g_shared = T.alloc_shared([block_C], dtype)
@@ -73,13 +72,11 @@ def fused_prepare_compute_w_u_tl(
                 v_beta_shared = T.alloc_shared([block_C, dim_v], dtype)
                 S_shared = T.alloc_shared([block_C, block_C], dtype)
                 P_shared = T.alloc_shared([block_C, block_C], dtype)
-                # Fragments (fp32 accumulators)
                 gram_frag = T.alloc_fragment([block_C, block_C], accum_dtype)
                 temp_frag = T.alloc_fragment([block_C, block_C], accum_dtype)
                 w_frag = T.alloc_fragment([block_C, dim_k], accum_dtype)
                 u_frag = T.alloc_fragment([block_C, dim_v], accum_dtype)
 
-                # Load inputs
                 T.copy(
                     k[bid, hid, by * block_C : (by + 1) * block_C, :], k_shared, disable_tma=True
                 )

--- a/src/tileops/kernels/linear_attention/gated_deltanet/gated_deltanet_bwd.py
+++ b/src/tileops/kernels/linear_attention/gated_deltanet/gated_deltanet_bwd.py
@@ -78,7 +78,6 @@ def _bwd_parallel_tl(
             dh_local: T.Tensor([batch, head, num_chunks, dim_k, dim_v], dtype),
         ):
             with T.Kernel(num_chunks, batch, head, threads=threads) as (tid, bid, hid):
-                # Shared buffers
                 q_c = T.alloc_shared([block_C, dim_k], dtype)
                 k_c = T.alloc_shared([block_C, dim_k], dtype)
                 g_c = T.alloc_shared([block_C], dtype)
@@ -89,18 +88,15 @@ def _bwd_parallel_tl(
                 v_new_c = T.alloc_shared([block_C, dim_v], dtype)
                 o_part = T.alloc_shared([block_C, dim_v], dtype)
                 attn = T.alloc_shared([block_C, block_C], dtype)
-                # Gradients
                 d_q_c = T.alloc_shared([block_C, dim_k], dtype)
                 d_k_c = T.alloc_shared([block_C, dim_k], dtype)
                 dg_c = T.alloc_shared([block_C], dtype)
                 d_w_c = T.alloc_shared([block_C, dim_k], dtype)
                 d_v_new_c = T.alloc_shared([block_C, dim_v], dtype)
                 d_attn = T.alloc_shared([block_C, block_C], dtype)
-                # Working
                 exp_g = T.alloc_shared([block_C], dtype)
                 P = T.alloc_shared([block_C, dim_k], dtype)
                 dP = T.alloc_shared([block_C, dim_k], dtype)
-                # Fragments
                 ws_frag = T.alloc_fragment([block_C, dim_v], accum_dtype)
                 attn_frag = T.alloc_fragment([block_C, block_C], accum_dtype)
                 d_v_new_frag = T.alloc_fragment([block_C, dim_v], accum_dtype)
@@ -110,7 +106,6 @@ def _bwd_parallel_tl(
                 dP_frag = T.alloc_fragment([block_C, dim_k], accum_dtype)
                 dh_frag = T.alloc_fragment([dim_k, dim_v], accum_dtype)
 
-                # Load chunk data
                 T.copy(q[bid, hid, tid * block_C : (tid + 1) * block_C, :], q_c, disable_tma=True)
                 T.copy(k[bid, hid, tid * block_C : (tid + 1) * block_C, :], k_c, disable_tma=True)
                 T.copy(g[bid, hid, tid * block_C : (tid + 1) * block_C], g_c, disable_tma=True)
@@ -207,7 +202,6 @@ def _bwd_parallel_tl(
                 T.gemm(P, d_v_new_c, dh_sub_frag, transpose_A=True)
                 for i, j in T.Parallel(dim_k, dim_v):
                     dh_frag[i, j] -= dh_sub_frag[i, j]
-                # dw
                 for i, j in T.Parallel(block_C, dim_k):
                     d_w_c[i, j] = dP[i, j] * T.exp2((g_c[i] + g_c[block_C - 1]) * LOG2E)
                 # dg from P*dP
@@ -221,7 +215,6 @@ def _bwd_parallel_tl(
                     dg_c[i] += dg_step5_tmp[i]
                 dg_c[block_C - 1] = dg_c[block_C - 1] + dg_step5_total[0]
 
-                # Write outputs
                 T.copy(
                     d_q_c, dq[bid, hid, tid * block_C : (tid + 1) * block_C, :], disable_tma=True
                 )
@@ -400,7 +393,6 @@ def _dh_recurrence_bwd_tl(
             dw_corr_partial: T.Tensor([batch, head, num_v_tiles, seq_len, dim_k], dtype),
         ):
             with T.Kernel(num_v_tiles, batch, head, threads=threads) as (vid, bid, hid):
-                # Shared buffers
                 g_c = T.alloc_shared([block_C], dtype)
                 k_c = T.alloc_shared([block_C, dim_k], dtype)
                 v_new_c = T.alloc_shared([block_C, BV], dtype)
@@ -417,7 +409,6 @@ def _dh_recurrence_bwd_tl(
                 d_g_last_partial = T.alloc_shared([dim_k], dtype)
                 d_g_last_scalar1 = T.alloc_shared([1], accum_dtype)
                 d_g_last_scalar2 = T.alloc_shared([1], accum_dtype)
-                # Fragments
                 dh_frag = T.alloc_fragment([dim_k, BV], accum_dtype)
                 du_corr_frag = T.alloc_fragment([block_C, BV], accum_dtype)
                 dP_frag = T.alloc_fragment([block_C, dim_k], accum_dtype)
@@ -429,7 +420,6 @@ def _dh_recurrence_bwd_tl(
 
                 for t in T.Pipelined(num_chunks, num_stages=num_stages):
                     t_bwd = num_chunks - 1 - t
-                    # Load data
                     T.copy(
                         g[bid, hid, t_bwd * block_C : (t_bwd + 1) * block_C], g_c, disable_tma=True
                     )

--- a/src/tileops/kernels/linear_attention/gated_deltanet/prefill/fused_fwd.py
+++ b/src/tileops/kernels/linear_attention/gated_deltanet/prefill/fused_fwd.py
@@ -178,7 +178,6 @@ def _build_fused_chunk_gdr_fwd_kernel(
             if tx < 128:
                 T.set_max_nreg(CONSUMER_S_NREG, 1)
 
-                # Initialize S
                 if use_initial_state:
                     T.copy(
                         h0[bb, bh, 0:DK, bv * block_DV : (bv + 1) * block_DV],
@@ -187,19 +186,14 @@ def _build_fused_chunk_gdr_fwd_kernel(
                 else:
                     T.clear(h_fragment)
 
-                # Main Loop
                 for i_s in T.serial(num_iters):
-                    # [STAGE 0]
                     T.barrier_wait(data_is_ready[i_s % 2], (i_s // 2 + 0) % 2)
                     T.barrier_arrive(bar_0)
 
-                    # [STAGE 0] 0
                     T.barrier_wait(bar_0, i_s % 2)
-                    # S4[S] S
                     T.copy(h_fragment, h_shared)
                     T.barrier_arrive(bar_1)
 
-                    # [STAGE 0] 2, 3, 4
                     T.barrier_wait(bar_1, i_s % 2)
                     # S = g_last * S
                     g_last_local[0] = g_exp_shared[block_S - 1]
@@ -207,7 +201,6 @@ def _build_fused_chunk_gdr_fwd_kernel(
                         h_fragment[j_k, j_v] *= g_last_local[0]
                     T.barrier_arrive(bar_5)
 
-                    # [STAGE 0] 5
                     T.barrier_wait(bar_5, i_s % 2)
                     # S += K^T @ V'
                     T.gemm_v1(
@@ -220,7 +213,6 @@ def _build_fused_chunk_gdr_fwd_kernel(
 
                     T.barrier_arrive(data_is_free[i_s % 2])
 
-                # Store final S
                 if need_store_final_state:
                     T.copy(
                         h_fragment,
@@ -241,13 +233,10 @@ def _build_fused_chunk_gdr_fwd_kernel(
             elif tx < 256:
                 T.set_max_nreg(CONSUMER_V_NREG, 1)
 
-                # Main Loop
                 for i_s in T.serial(num_iters):
-                    # [STAGE 0]
                     T.barrier_wait(data_is_ready[i_s % 2], (i_s // 2 + 0) % 2)
                     T.barrier_arrive(bar_0)
 
-                    # [STAGE 0] 0
                     T.barrier_wait(bar_0, i_s % 2)
                     # Precompute g, g_last/g
                     for j_s in T.Parallel(block_S):
@@ -262,7 +251,6 @@ def _build_fused_chunk_gdr_fwd_kernel(
                         )
                     T.barrier_arrive(bar_1)
 
-                    # [STAGE 0] 1
                     T.barrier_wait(bar_1, i_s % 2)
                     # U = K @ S
                     T.gemm_v1(k_shared[i_s % 2, :, :], h_shared, u_fragment, clear_accum=True)
@@ -273,11 +261,9 @@ def _build_fused_chunk_gdr_fwd_kernel(
                         u_fragment[j_s, j_v] *= -g_exp_shared[j_s]
                     for j_s, j_v in T.Parallel(block_S, block_DV):
                         u_fragment[j_s, j_v] += v_shared[i_s % 2, j_s, j_v]
-                    # S2[V] W
                     for j_s, j_v in T.Parallel(block_S, block_DV):
                         v_shared[i_s % 2, j_s, j_v] = u_fragment[j_s, j_v]
 
-                    # [STAGE 0] 3
                     T.barrier_wait(bar_3, i_s % 2)
                     # Vd = Ag @ W
                     T.gemm_v1(
@@ -286,7 +272,6 @@ def _build_fused_chunk_gdr_fwd_kernel(
                         v_fragment,
                         clear_accum=True,
                     )
-                    # S2[2] Vd
                     T.copy(v_fragment, vd_shared)
                     T.barrier_arrive(bar_4)
 
@@ -294,7 +279,6 @@ def _build_fused_chunk_gdr_fwd_kernel(
                     # V' = g_last/g Vd
                     for j_s, j_v in T.Parallel(block_S, block_DV):
                         v_fragment[j_s, j_v] *= g_rev_exp_shared[j_s]
-                    # S2[1] V'
                     T.copy(v_fragment, vn_shared)
                     T.barrier_arrive(bar_5)
 
@@ -305,13 +289,10 @@ def _build_fused_chunk_gdr_fwd_kernel(
             elif tx < 384:
                 T.set_max_nreg(CONSUMER_O_NREG, 1)
 
-                # Main Loop
                 for i_s in T.serial(num_iters):
-                    # [STAGE 0]
                     T.barrier_wait(data_is_ready[i_s % 2], (i_s // 2 + 0) % 2)
                     T.barrier_arrive(bar_0)
 
-                    # [STAGE 0] 0
                     T.barrier_wait(bar_0, i_s % 2)
                     # P = Q K^T
                     T.gemm_v1(
@@ -341,7 +322,6 @@ def _build_fused_chunk_gdr_fwd_kernel(
                     for j_s, j_t in T.Parallel(block_S, block_S):
                         a_shared[i_s % 2, j_s, j_t] = a_fragment[j_s, j_t]
 
-                    # [STAGE 0] 2
                     T.barrier_wait(bar_1, i_s % 2)
                     # O = Q @ S
                     T.gemm_v1(q_shared[i_s % 2, :, :], h_shared, o_fragment, clear_accum=True)
@@ -350,22 +330,18 @@ def _build_fused_chunk_gdr_fwd_kernel(
                     # Pg = s * G * P
                     for j_s, j_t in T.Parallel(block_S, block_S):
                         p_fragment[j_s, j_t] *= scale * g_fragment[j_s, j_t]
-                    # S1[1] Pg
                     T.copy(p_fragment, p_shared)
                     T.barrier_arrive(bar_3)
                     # O = s * g * O
                     for j_s, j_k in T.Parallel(block_S, DK):
                         o_fragment[j_s, j_k] *= scale * g_exp_shared[j_s]
 
-                    # [STAGE 0] 4
                     T.barrier_wait(bar_4, i_s % 2)
                     # O += Pg @ Vd
                     T.gemm_v1(p_shared, vd_shared, o_fragment, clear_accum=False)
                     T.barrier_arrive(bar_5)
 
-                    # [STAGE 0] 5
                     T.barrier_wait(bar_5, i_s % 2)
-                    # S2[S] O
                     T.copy(o_fragment, o_shared)
 
                     T.barrier_arrive(data_is_free[i_s % 2])
@@ -381,13 +357,11 @@ def _build_fused_chunk_gdr_fwd_kernel(
                         left = seq_start_idx + i_s * block_S
                         right = left + block_S
 
-                        # Load Q
                         T.tma_copy(
                             q[batch_idx, left:right, bhg, 0:DK],
                             q_shared[i_s % 2, :, :],
                             barrier=data_is_ready[i_s % 2],
                         )
-                        # Load K
                         T.tma_copy(
                             k[batch_idx, left:right, bhg, 0:DK],
                             k_shared[i_s % 2, :, :],
@@ -402,7 +376,6 @@ def _build_fused_chunk_gdr_fwd_kernel(
                         left = seq_start_idx + i_s * block_S
                         right = left + block_S
 
-                        # Load V
                         T.tma_copy(
                             v[
                                 batch_idx,
@@ -413,7 +386,6 @@ def _build_fused_chunk_gdr_fwd_kernel(
                             v_shared[i_s % 2, :, :],
                             barrier=data_is_ready[i_s % 2],
                         )
-                        # Load beta
                         if right <= seq_end_idx:
                             for j_s in T.Parallel(block_S):
                                 b_shared[i_s % 2, j_s] = b[batch_idx, left + j_s, bh]
@@ -432,13 +404,11 @@ def _build_fused_chunk_gdr_fwd_kernel(
                         left = seq_start_idx + i_s * block_S
                         right = left + block_S
 
-                        # Load A
                         T.tma_copy(
                             a[batch_idx, left:right, bh, 0:block_S],
                             a_shared[i_s % 2, :, :],
                             barrier=data_is_ready[i_s % 2],
                         )
-                        # Load gamma
                         if right <= seq_end_idx:
                             for j_s in T.Parallel(block_S):
                                 g_shared[i_s % 2, j_s] = g[batch_idx, left + j_s, bh]
@@ -459,7 +429,6 @@ def _build_fused_chunk_gdr_fwd_kernel(
                         T.barrier_arrive(bar_0)
 
                         T.barrier_wait(bar_0, i_s % 2)
-                        # Store O
                         if i_s > 0 and store_o:
                             T.copy(
                                 o_shared,
@@ -473,7 +442,6 @@ def _build_fused_chunk_gdr_fwd_kernel(
                         T.barrier_arrive(bar_5)
 
                         T.barrier_wait(bar_1, i_s % 2)
-                        # Store S
                         if store_h:
                             if state_head_first:
                                 T.copy(
@@ -505,7 +473,6 @@ def _build_fused_chunk_gdr_fwd_kernel(
                         T.barrier_arrive(bar_0)
 
                         T.barrier_wait(bar_0, num_unmasked_iters % 2)
-                        # Store O
                         if num_unmasked_iters > 0 and store_o:
                             T.copy(
                                 o_shared,
@@ -519,7 +486,6 @@ def _build_fused_chunk_gdr_fwd_kernel(
                         T.barrier_arrive(bar_5)
 
                         T.barrier_wait(bar_1, num_unmasked_iters % 2)
-                        # Store S
                         if store_h:
                             if state_head_first:
                                 T.copy(
@@ -546,7 +512,6 @@ def _build_fused_chunk_gdr_fwd_kernel(
 
                     seq_split_idx = seq_start_idx + (num_iters - 1) * block_S
 
-                    # Store O
                     T.barrier_wait(bar_o, 0)
                     if store_o:
                         for j_s, j_v in T.Parallel(block_S, block_DV):

--- a/src/tileops/kernels/linear_attention/gated_deltanet/prefill/prepare_h.py
+++ b/src/tileops/kernels/linear_attention/gated_deltanet/prefill/prepare_h.py
@@ -153,25 +153,19 @@ def _build_prepare_h_kernel(
             if tx < 128:
                 T.set_max_nreg(CONSUMER_S_NREG, 1)
 
-                # Initialize S
                 if use_initial_state:
                     T.copy(h0[bb, bh, 0:DK, 0:DV], h_fragment)
                 else:
                     T.clear(h_fragment)
 
-                # Main Loop
                 for i_s in T.serial(num_iters):
-                    # [STAGE = i_s % num_stages]
                     T.barrier_wait(data_is_ready[i_s % num_stages], (i_s // num_stages + 0) % 2)
                     T.barrier_arrive(bar_0)
 
-                    # [STAGE = i_s % num_stages] 0
                     T.barrier_wait(bar_0, i_s % 2)
-                    # S4[1] S
                     T.copy(h_fragment, h_shared)
                     T.barrier_arrive(bar_1)
 
-                    # [STAGE = i_s % num_stages] 1
                     T.barrier_wait(bar_1, i_s % 2)
                     # S = g_last * S
                     g_last_local_S[0] = T.exp2(g_shared[i_s % num_stages, block_S - 1] * LOG2E)
@@ -179,7 +173,6 @@ def _build_prepare_h_kernel(
                         h_fragment[j_k, j_v] *= g_last_local_S[0]
                     T.barrier_arrive(bar_2)
 
-                    # [STAGE = i_s % num_stages] 2
                     T.barrier_wait(bar_2, i_s % 2)
                     # S += X^T @ Y
                     T.gemm_v1(
@@ -193,7 +186,6 @@ def _build_prepare_h_kernel(
 
                     T.barrier_arrive(data_is_free[i_s % num_stages])
 
-                # Store final S
                 if store_final_state:
                     T.copy(h_fragment, ht[bb, bh, 0:DK, 0:DV])
 
@@ -208,13 +200,10 @@ def _build_prepare_h_kernel(
                             m_fragment_R[j_k, j_v] = 0
                     g_prod_X[0] = 0
 
-                # Main Loop
                 for i_s in T.serial(num_iters):
-                    # [STAGE = i_s % num_stages]
                     T.barrier_wait(data_is_ready[i_s % num_stages], (i_s // num_stages + 0) % 2)
                     T.barrier_arrive(bar_0)
 
-                    # [STAGE = i_s % num_stages] 0
                     T.barrier_wait(bar_0, i_s % 2)
                     # X = A^T @ K
                     T.gemm_v1(
@@ -229,17 +218,13 @@ def _build_prepare_h_kernel(
                     # X = - b * X
                     for j_s, j_k in T.Parallel(block_S, DK):
                         x_fragment[j_s, j_k] *= -b_shared[i_s % num_stages, j_s]
-                    # S2[1] X
                     T.copy(x_fragment, x_shared)
                     T.barrier_arrive(bar_2)
 
                     if calc_mt:
-                        # [STAGE = i_s % num_stages] 2
                         g_prod_X[0] += g_shared[i_s % num_stages, block_S - 1]
-                        # S4[2] M
                         T.copy(m_fragment_R, m_shared_R)
 
-                        # [STAGE = i_s % num_stages] 3
                         T.barrier_wait(bar_3, i_s % 2)
                         # Z = K @ M
                         T.gemm_v1(
@@ -248,7 +233,6 @@ def _build_prepare_h_kernel(
                             z_fragment_R,
                             clear_accum=True,
                         )
-                        # S4[2] Z
                         T.copy(z_fragment_R, z_shared_R)
                         # M += X^T @ Z
                         T.gemm_v1(
@@ -278,13 +262,10 @@ def _build_prepare_h_kernel(
                             m_fragment_L[j_k, j_v] = 0
                     g_prod_Y[0] = 0
 
-                # Main Loop
                 for i_s in T.serial(num_iters):
-                    # [STAGE = i_s % num_stages]
                     T.barrier_wait(data_is_ready[i_s % num_stages], (i_s // num_stages + 0) % 2)
                     T.barrier_arrive(bar_0)
 
-                    # [STAGE = i_s % num_stages] 0
                     T.barrier_wait(bar_0, i_s % 2)
                     # Precompute g_last/g
                     g_last_local_Y[0] = g_shared[i_s % num_stages, block_S - 1]
@@ -295,7 +276,6 @@ def _build_prepare_h_kernel(
                     g_last_local_Y[0] = T.exp2(g_last_local_Y[0] * LOG2E)
                     T.barrier_arrive(bar_1)
 
-                    # [STAGE = i_s % num_stages] 1
                     T.barrier_wait(bar_1, i_s % 2)
                     # U = K @ S
                     T.gemm_v1(
@@ -311,17 +291,13 @@ def _build_prepare_h_kernel(
                         y_fragment[j_s, j_v] -= (
                             v_shared[i_s % num_stages, j_s, j_v] * g_rev_exp_shared[j_s]
                         )
-                    # S2[2] Y
                     T.copy(y_fragment, y_shared)
                     T.barrier_arrive(bar_2)
 
                     if calc_mt:
-                        # [STAGE = i_s % num_stages] 2
                         g_prod_Y[0] += g_shared[i_s % num_stages, block_S - 1]
-                        # S4[2] M
                         T.copy(m_fragment_L, m_shared_L)
 
-                        # [STAGE = i_s % num_stages] 3
                         T.barrier_wait(bar_3, i_s % 2)
                         # Z = K @ M
                         T.gemm_v1(
@@ -330,7 +306,6 @@ def _build_prepare_h_kernel(
                             z_fragment_L,
                             clear_accum=True,
                         )
-                        # S4[2] Z
                         T.copy(z_fragment_L, z_shared_L)
                         # M += X^T @ Z
                         T.gemm_v1(
@@ -358,7 +333,6 @@ def _build_prepare_h_kernel(
                         left = seq_start_idx + i_s * block_S
                         right = left + block_S
 
-                        # Load K
                         T.tma_copy(
                             k[batch_idx, left:right, bhg, 0:DK],
                             k_shared[i_s % num_stages, :, :],
@@ -373,13 +347,12 @@ def _build_prepare_h_kernel(
                         left = seq_start_idx + i_s * block_S
                         right = left + block_S
 
-                        # Load V
                         T.tma_copy(
                             v[batch_idx, left:right, bh, 0:DV],
                             v_shared[i_s % num_stages, :, :],
                             barrier=data_is_ready[i_s % num_stages],
                         )
-                        # Load A  TODO: Mask A for the last chunk
+                        # TODO: mask A for the last chunk
                         T.tma_copy(
                             a[batch_idx, left:right, bh, 0:block_S],
                             a_shared[i_s % num_stages, :, :],
@@ -394,7 +367,6 @@ def _build_prepare_h_kernel(
                         left = seq_start_idx + i_s * block_S
                         right = left + block_S
 
-                        # Load gamma
                         if right <= seq_end_idx:
                             for j_s in T.Parallel(block_S):
                                 g_shared[i_s % num_stages, j_s] = g[batch_idx, left + j_s, bh]
@@ -406,7 +378,6 @@ def _build_prepare_h_kernel(
                                     g_shared[i_s % num_stages, j_s] = g[
                                         batch_idx, seq_end_idx - 1, bh
                                     ]
-                        # Load beta
                         if right <= seq_end_idx:
                             for j_s in T.Parallel(block_S):
                                 b_shared[i_s % num_stages, j_s] = b[batch_idx, left + j_s, bh]
@@ -425,7 +396,6 @@ def _build_prepare_h_kernel(
 
                         T.barrier_wait(bar_0, i_s % 2)
                         T.barrier_wait(bar_1, i_s % 2)
-                        # Store S
                         if store_h:
                             T.copy(
                                 h_shared,

--- a/src/tileops/kernels/linear_attention/gated_deltanet_recurrence.py
+++ b/src/tileops/kernels/linear_attention/gated_deltanet_recurrence.py
@@ -343,7 +343,6 @@ class GatedDeltaNetDecodeKernel(Kernel):
         best_time = float("inf")
         best_config = self.default_config
 
-        # Generate dummy inputs for profiling
         B, H, DK, DV = self.batch, self.head, self.dim_k, self.dim_v
         torch_dtype = {
             "float32": torch.float32,
@@ -557,7 +556,6 @@ def _gated_deltanet_decode_fp32_tl(
                 alpha = T.exp2(g_val * LOG2E)
                 alpha_beta = alpha * beta_val
 
-                # Zero-init fragment accumulators
                 T.fill(sk_frag, 0.0)
                 T.fill(sq_frag, 0.0)
 
@@ -573,7 +571,6 @@ def _gated_deltanet_decode_fp32_tl(
                         sk_frag[j] = sk_frag[j] + k_val * h_val
                         sq_frag[j] = sq_frag[j] + q_val * h_val
 
-                # q . k dot product
                 qk_dot[0] = 0.0
                 for kk in T.Serial(dim_k):
                     qk_dot[0] += q[bid, hid, kk] * k[bid, hid, kk]

--- a/src/tileops/kernels/linear_attention/gla/gla_bwd.py
+++ b/src/tileops/kernels/linear_attention/gla/gla_bwd.py
@@ -645,7 +645,6 @@ class GLABwdKernel(Kernel):
         NT = T // BT
         dtype_torch = self.dtype
 
-        # Generate representative inputs
         q = torch.randn(B, T, H, K, device="cuda", dtype=dtype_torch) * 0.1
         k = torch.randn(B, T, H, K, device="cuda", dtype=dtype_torch) * 0.1
         v = torch.randn(B, T, H, V, device="cuda", dtype=dtype_torch) * 0.1

--- a/src/tileops/kernels/linear_attention/gla/gla_fwd.py
+++ b/src/tileops/kernels/linear_attention/gla/gla_fwd.py
@@ -280,17 +280,14 @@ def _gla_fwd_o_kernel(
                 # h cast to native dtype for tensor core
                 h_cast_s = T.alloc_shared([dim_k, dim_v], dtype)
 
-                # Input buffers
                 q_s = T.alloc_shared([chunk_size, dim_k], dtype)
                 k_s = T.alloc_shared([chunk_size, dim_k], dtype)
                 v_s = T.alloc_shared([chunk_size, dim_v], dtype)
                 g_cumsum_s = T.alloc_shared([chunk_size, dim_k], accum_dtype)
 
-                # Compute buffers
                 q_gated_s = T.alloc_shared([chunk_size, dim_k], dtype)
                 A_s = T.alloc_shared([chunk_size, chunk_size], dtype)
 
-                # Load inputs via T.copy
                 T.copy(
                     q[i_b, chunk_start : chunk_start + chunk_size, i_h, :], q_s, disable_tma=True
                 )
@@ -527,7 +524,6 @@ class GLAFwdKernel(Kernel):
         B, T, H, K, V = (self.batch, self.seq_len, self.heads, self.dim_k, self.dim_v)
         dtype_torch = getattr(torch, self.dtype_name)
 
-        # Generate representative inputs
         q = torch.randn(B, T, H, K, device="cuda", dtype=dtype_torch) * 0.1
         k = torch.randn(B, T, H, K, device="cuda", dtype=dtype_torch) * 0.1
         v = torch.randn(B, T, H, V, device="cuda", dtype=dtype_torch) * 0.1

--- a/src/tileops/kernels/linear_attention/gla_recurrence.py
+++ b/src/tileops/kernels/linear_attention/gla_recurrence.py
@@ -367,7 +367,6 @@ def _gla_decode_fp32_tl(
                 for i in T.Parallel(dim_v):
                     v_shared[i] = v[bid, hid, i]
 
-                # Zero-init fragment accumulator
                 T.fill(sq_frag, 0.0)
 
                 # === Pass 1: Element-wise matvec (full fp32 precision) ===
@@ -379,7 +378,6 @@ def _gla_decode_fp32_tl(
                     for j in T.Parallel(dim_v):
                         sq_frag[j] = sq_frag[j] + q_gated * state[bid, hid, kk, j]
 
-                # q . k dot product
                 qk_dot[0] = 0.0
                 for kk in T.Serial(dim_k):
                     qk_dot[0] += q_shared[kk] * k_shared[kk]
@@ -487,7 +485,6 @@ class GLADecodeFP32Kernel(Kernel):
         else:
             self.init_config(config, tune=False)
 
-        # Cache the JIT-compiled kernel
         self._kernel_fn = _gla_decode_fp32_tl(
             batch,
             head,

--- a/src/tileops/kernels/mamba/cb_producer.py
+++ b/src/tileops/kernels/mamba/cb_producer.py
@@ -81,7 +81,6 @@ def _cb_producer_kernel(
                 B * C * G,  # batch * chunks * groups
                 threads=threads,
             ) as (bl, bs, bcg):
-                # Decode indices
                 bcg_tmp = bcg
                 bb = bcg_tmp // (C * G)
                 cg = bcg_tmp % (C * G)
@@ -94,7 +93,6 @@ def _cb_producer_kernel(
                 # Check causality: only compute if s0 < l0 + block_l
                 # This prunes upper-triangular tiles
                 if s0 < l0 + block_l:
-                    # Allocate shared memory for C and B tiles
                     C_tile = T.alloc_shared((block_l, block_n), dtype)
                     B_tile = T.alloc_shared((block_s, block_n), dtype)
 
@@ -106,11 +104,9 @@ def _cb_producer_kernel(
                         }
                     )
 
-                    # Accumulator for this tile
                     acc = T.alloc_fragment((block_l, block_s), accum_dtype)
                     T.clear(acc)
 
-                    # Blocked GEMM over N dimension
                     for n_blk in T.serial(T.ceildiv(N, block_n)):
                         n0 = n_blk * block_n
 
@@ -153,7 +149,6 @@ def _cb_producer_kernel(
                         l_abs = l0 + ll
                         s_abs = s0 + ss
                         if l_abs < Q and s_abs < Q:
-                            # Causal mask: only write if s <= l
                             if s_abs <= l_abs:
                                 cb[bb, bc, bg, l_abs, s_abs] = T.cast(acc[ll, ss], dtype)
                             else:
@@ -169,9 +164,6 @@ def _cb_producer_kernel(
         return main
 
     return kernel_func
-
-
-# PyTorch custom op registration
 
 
 @torch.library.custom_op("tileops::cb_producer", mutates_args=())
@@ -217,9 +209,6 @@ def _(
             dtype, torch.float16
         ),
     )
-
-
-# High-level Kernel wrapper
 
 
 class CBProducerKernel(Kernel):
@@ -283,7 +272,6 @@ class CBProducerKernel(Kernel):
             for block_s in [32, 64, 128]:
                 for block_n in [32, 64, 128]:
                     for threads in [128, 256]:
-                        # Reasonable constraints
                         if block_l <= self.chunk_len and block_s <= self.chunk_len:
                             configs.append(
                                 {

--- a/src/tileops/kernels/mamba/da_cumsum.py
+++ b/src/tileops/kernels/mamba/da_cumsum.py
@@ -380,9 +380,8 @@ class DaCumsumFwdKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
-        # Triton autotune selects one head for the small 780M shape and two for
-        # the larger rows. Match that measured choice while keeping the
-        # analysis-derived ownership kernel structural rather than config-only.
+        # One head per tile on the narrowest shape, two elsewhere: a wider tile
+        # spends threads a single-row batch has no work for.
         block_h = 1 if self.batch == 1 and self.n_heads == 48 else 2
         return {"block_h": block_h, "threads": min(block_h * self.chunk_len, 1024)}
 

--- a/src/tileops/kernels/mamba/da_cumsum.py
+++ b/src/tileops/kernels/mamba/da_cumsum.py
@@ -203,10 +203,8 @@ def _da_cumsum_fwd_kernel(
                     safe_bh = T.min(bh, H - 1)
                     safe_seq_idx = T.min(seq_idx, S - 1)
 
-                    # Load dt; zero-pad out-of-bounds positions.
                     val = T.if_then_else(in_b, dt[bb, safe_seq_idx, safe_bh], T.float32(0.0))
 
-                    # Optional bias addition.
                     if has_dt_bias:
                         bias = T.if_then_else(bh < H, dt_bias[safe_bh], T.float32(0.0))
                         val = val + bias
@@ -219,7 +217,6 @@ def _da_cumsum_fwd_kernel(
                             val,
                         )
 
-                    # Clamp to [dt_min, dt_max].
                     val = T.min(T.max(val, T.float32(dt_min)), T.float32(dt_max))
 
                     # Re-apply out-of-bounds zero mask after nonlinearities.
@@ -299,7 +296,6 @@ def _(
     A: torch.Tensor,
     dt_bias: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    # Convert dtype string to torch.dtype
     dtype_map = {"bfloat16": torch.bfloat16, "float16": torch.float16, "float32": torch.float32}
     torch_dtype = dtype_map.get(dtype, torch.float16)
     dt_out = dt.new_empty((batch, n_heads, num_chunks, chunk_len), dtype=torch_dtype)

--- a/src/tileops/kernels/mamba/ssd_chunk_scan.py
+++ b/src/tileops/kernels/mamba/ssd_chunk_scan.py
@@ -135,7 +135,6 @@ def _ssd_chunk_scan_fwd_kernel(
                 l0 = bl * block_l
                 p0 = bp * block_p
 
-                # output accumulator [block_l, block_p]
                 acc = T.alloc_fragment((block_l, block_p), accum_dtype)
                 T.clear(acc)
 

--- a/src/tileops/kernels/mamba/ssd_chunk_scan.py
+++ b/src/tileops/kernels/mamba/ssd_chunk_scan.py
@@ -116,8 +116,8 @@ def _ssd_chunk_scan_fwd_kernel(
             dt: T.Tensor(dt_shape, dtype),  # type: ignore
             out: T.Tensor(out_shape, accum_dtype),  # type: ignore
         ):
-            # Grid redesign: separate H dimension for better load balancing
-            # New layout: (L_tiles × P_tiles, B × C, H)
+            # Grid: (L_tiles × P_tiles, B × C, H). H gets its own axis so the
+            # load balances across heads.
             with T.Kernel(
                 T.ceildiv(Q, block_l) * T.ceildiv(P, block_p),
                 B * C,
@@ -156,7 +156,6 @@ def _ssd_chunk_scan_fwd_kernel(
                     }
                 )
 
-                # trace c_tile loading
                 for n_blk in T.Pipelined(T.ceildiv(N, block_n), num_stages=num_stages):
                     n0 = n_blk * block_n
 
@@ -172,7 +171,6 @@ def _ssd_chunk_scan_fwd_kernel(
                             T.cast(T.float32(0.0), dtype),
                         )
 
-                    # trace state_tile loading
                     # prev_states[b, c, h, p, n]  layout: [B, C, H, P, N]  float32
                     # Iterate (block_p, block_n) so consecutive threads vary nn (the contiguous N
                     # dim), giving coalesced 128-byte loads instead of strided-by-N accesses.
@@ -187,7 +185,6 @@ def _ssd_chunk_scan_fwd_kernel(
                             T.cast(T.float32(0.0), dtype),
                         )
 
-                    # trace gemm
                     # hist_acc += c_tile @ state_tile
                     T.gemm(c_tile, state_tile, hist_acc)
 
@@ -595,7 +592,6 @@ class SSDChunkScanFwdKernel(Kernel):
     def default_config(self) -> dict:
         # threads=128 (4 warps) balances parallelism with register pressure.
         # block_n=64 keeps occupancy high for typical d_state sizes (64-128).
-        # num_stages=3 optimal based on full-kernel benchmarking.
         return {
             "block_l": 64,
             "block_p": 64,
@@ -607,19 +603,11 @@ class SSDChunkScanFwdKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        # Focused search around the known-good default (block_l=64, block_p=64,
-        # block_n=128, block_s=64, threads=128, num_stages=3).
-        #
-        # NCU evidence:
-        #   - block_l=64, block_p=64 anchors GEMM tile efficiency; smaller tiles
-        #     hurt more than they help (tested: shape-aware default was slower).
-        #   - block_n only affects the history-path loop count; vary minimally.
-        #   - block_s and threads are the primary levers: block_s controls causal
-        #     GEMM tile size and s-loop iteration count; threads controls warps/block
-        #     and latency-hiding capacity.
-        #   - num_stages=3 is optimal (tested: stages=5 is 13% slower)
-        #
-        # 6–8 configs total (2 block_n entries dropped when d_state <= 32 or 64).
+        # Search around the default, holding the axes that carry little:
+        # block_l and block_p set GEMM tile efficiency, block_n only the
+        # history-path loop count, num_stages the pipeline depth. block_s (causal
+        # GEMM tile size and s-loop count) and threads (warps per block) are the
+        # two the sweep varies.
         block_n = min(128, self.d_state)
         return (
             [
@@ -648,8 +636,7 @@ class SSDChunkScanFwdKernel(Kernel):
                 if bn <= self.d_state
             ]
             + [
-                # threads=64 (2 warps/block) — more blocks/SM at cost of less ILP
-                # Include block_n=64 to cover the optimal config found via AKO tuning
+                # threads=64 (2 warps/block): more blocks per SM, less ILP.
                 {
                     "block_l": 64,
                     "block_p": 64,

--- a/src/tileops/kernels/mamba/ssd_chunk_state.py
+++ b/src/tileops/kernels/mamba/ssd_chunk_state.py
@@ -167,12 +167,8 @@ def _ssd_chunk_state_fwd_kernel(
                 #
                 #    x_scaled is written directly as dtype (cast in-place):
                 #      x_scaled[ll, pp] = cast(float(x[ll, pp]) * w_tile[ll])
-                #    This eliminates the x_scaled_f32 register fragment
-                #    (block_l * block_p / 32 fp32 regs per thread) and the
-                #    separate T.copy cast step, freeing register budget for
-                #    larger output tiles without changing the shared-memory
-                #    footprint or numerical behavior (the multiply is still
-                #    done in fp32 before truncation to dtype).
+                #    The multiply still runs in fp32, so no fp32 register
+                #    fragment is needed to hold the scaled tile.
                 #
                 #    GEMM:  acc[p, n] += x_scaled^T @ b_tile
                 #           i.e. (block_l x block_p)^T @ (block_l x block_n)
@@ -448,8 +444,7 @@ class SSDChunkStateFwdKernel(Kernel):
         # Grid rationale:
         #   block_n in {64, 128}: 128 covers the full d_state=128 in one tile
         #     and is the default; 64 is retained for d_state<128 shapes.
-        #   block_p in {16, 32, 64}: 16 is the minimum MMA M-atom; 64 only
-        #     viable after the x_scaled_f32 fragment was removed.
+        #   block_p in {16, 32, 64}: 16 is the minimum MMA M-atom.
         #   block_l in {32, 64, 128}: larger K improves GEMM arithmetic
         #     intensity; 32 keeps shared-memory pressure low for small d_head.
         #   threads in {128, 256}: 128 warps = 4, 256 warps = 8; higher thread

--- a/src/tileops/kernels/mamba/ssd_chunk_state.py
+++ b/src/tileops/kernels/mamba/ssd_chunk_state.py
@@ -92,7 +92,6 @@ def _ssd_chunk_state_fwd_kernel(
 ) -> Callable:
     accum_dtype = "float"
 
-    # Derived constants
     B = batch
     C = num_chunks
     Q = chunk_len

--- a/src/tileops/kernels/mamba/ssd_decode.py
+++ b/src/tileops/kernels/mamba/ssd_decode.py
@@ -51,61 +51,19 @@ from tileops.kernels.kernel_base import Kernel
 
 __all__ = ["SSDDecodeKernel"]
 
-# Differences vs. the official Mamba-2 step() in mamba_ssm/modules/mamba2.py
-# (https://github.com/state-spaces/mamba/blob/main/mamba_ssm/modules/mamba2.py)
+# Scope: the SSM state update and output accumulation of one Mamba-2 decode step,
+# as in mamba_ssm/modules/mamba2.py step(). The caller owns the rest of the step.
 #
-# This kernel implements ONLY the SSM state-update + output-accumulation core.
-# The surrounding steps that belong to a complete decode pass are NOT included:
+# Inputs are post-processing: x, B_in, C_in come from in_proj and the causal conv1d
+# (this kernel holds no conv_state); dt is post-softplus with dt_bias already added;
+# A is the pre-computed negative float32 tensor of shape (n_heads, d_head, d_state).
 #
-# 1. in_proj / input splitting
-#    Official: zxbcdt = self.in_proj(hidden_states.squeeze(1))
-#              z0, x0, z, xBC, dt = torch.split(zxbcdt, [...])
-#    Here:     x, B_in, C_in, dt are assumed pre-split and passed in directly.
+# Outputs stop before the epilogue: y_out is (batch, n_heads, d_head) in float32,
+# without the D * x skip connection, the z gate or RMSNormGated, the d_mlp branch,
+# out_proj, or the flatten to (batch, 1, d_model).
 #
-# 2. Causal-conv1d update (produces xBC from conv_state)
-#    Official: conv_state is rolled and convolved with self.conv1d.weight, then
-#              SiLU-activated: xBC = act(conv(conv_state, weight) + bias)
-#              xBC is then split into x, B, C.
-#    Here:     x, B_in, C_in are post-conv inputs; conv_state handling is absent.
-#
-# 3. dt discretization (softplus + dt_bias)
-#    Official: dt = F.softplus(dt + self.dt_bias)   — applied inside step()
-#    Here:     dt is assumed already post-softplus; caller must apply softplus
-#              and add dt_bias before passing dt into this kernel.
-#
-# 4. A parameter derivation
-#    Official: A = -torch.exp(self.A_log.float())   — derived from a log param, then
-#              repeated to (nheads, headdim, d_state) before passing to the triton kernel.
-#    Here:     A is passed directly as a pre-computed (negative) float32 tensor with
-#              shape (n_heads, d_head, d_state), matching the triton path exactly.
-#
-# 5. D skip connection
-#    Official: y = y + rearrange(self.D, "h -> h 1") * x
-#    Here:     NOT applied. Caller must add D * x to y_out after this kernel.
-#
-# 6. Output gate  (two variants in official code)
-#    a) Without RMSNorm:  y = y * self.act(z)   (element-wise SiLU gate)
-#    b) With RMSNorm:     y = self.norm(y, z)   (RMSNormGated)
-#    Here:     Neither variant is applied. Caller must handle gating/norm.
-#
-# 7. Optional MLP branch (d_mlp > 0)
-#    Official: y = torch.cat([F.silu(z0) * x0, y], dim=-1)
-#    Here:     Not present; this kernel has no notion of z0/x0.
-#
-# 8. Output projection
-#    Official: out = self.out_proj(y)   — linear projection back to model dim
-#    Here:     NOT applied. y_out has shape (batch, n_heads, d_head) = (B, H, P).
-#              Official step() returns shape (batch, 1, d_model) after out_proj.
-#
-# 9. Output shape / layout
-#    Official (fallback path): rearrange(y, "b h p -> b (h p)") before out_proj,
-#              final output is (batch, 1, d_model).
-#    Here:     y_out is (batch, n_heads, d_head) in float32, not yet flattened.
-#
-# 10. ngroups == 1 restriction in official fallback
-#     Official fallback (no selective_state_update): asserts ngroups == 1.
-#     Here:     Supports arbitrary ngroups via g = h // HEADS_PER_GROUP indexing,
-#               matching the behaviour of the optimised selective_state_update path.
+# Unlike the official fallback path, ngroups is unrestricted: g = h // HEADS_PER_GROUP
+# indexes B/C the way the optimised selective_state_update does.
 
 
 @functools.lru_cache(maxsize=32)

--- a/src/tileops/kernels/mhc/mhc_post.py
+++ b/src/tileops/kernels/mhc/mhc_post.py
@@ -31,7 +31,6 @@ def _mhc_post_kernel(batch: int, n_expand: int, c_x: int, x_dtype: str = "bfloat
             x_out: T.Tensor([batch, n_expand * c_x], x_dtype),
         ):
             with T.Kernel(batch, c_x // block_C, threads=threads) as (bx, by):
-                # copy the h_post matrix into fragment
                 h_post_shared = T.alloc_shared([n_expand], dtype)
                 x_layer_out_shared = T.alloc_shared([block_C], dtype)
                 x_res_shared = T.alloc_shared([n_expand, block_C], dtype)

--- a/src/tileops/kernels/mhc/mhc_pre.py
+++ b/src/tileops/kernels/mhc/mhc_pre.py
@@ -59,12 +59,11 @@ def _mhc_pre_kernel(batch: int, n_expand: int, c_x: int, x_dtype: str = "bfloat1
                         x[bx * block_x_b : (bx + 1) * block_x_b, k * block_C : (k + 1) * block_C],
                         x_shared,
                     )
-                    # TODO: <*important> try to figure out why "T.copy" does not work...
-                    # (probably a mbarrier failure)
-                    # T.copy(phi[k * block_C : (k + 1) * block_C, :], phi_shared)
+                    # Staged element-wise: T.copy on this slice hits an mbarrier
+                    # failure in TileLang.
                     for i, j in T.Parallel(block_C, phi_dim):
                         phi_shared[i, j] = phi[k * block_C + i, j]
-                    # When the batch size is smaller than 16, wgmma cannot be used... :(
+                    # Serial multiply-accumulate: wgmma needs a batch of at least 16.
                     for i, j in T.Parallel(block_x_b, phi_dim):
                         for iter in T.Serial(block_C):
                             acc_x_phi[i, j] += x_shared[i, iter] * phi_shared[iter, j]
@@ -94,7 +93,6 @@ def _mhc_pre_kernel(batch: int, n_expand: int, c_x: int, x_dtype: str = "bfloat1
             H_res_0: T.Tensor([batch, n_expand, n_expand], dtype),
         ):
             with T.Kernel(batch // block_x_b, threads=threads) as (bx):
-                # needs binding
                 h_pre_shared = T.alloc_shared([block_x_b, n_expand], dtype)
                 h_post_shared = T.alloc_shared([block_x_b, n_expand], dtype)
                 h_res_shared = T.alloc_shared([block_x_b, n_expand, n_expand], dtype)
@@ -115,8 +113,8 @@ def _mhc_pre_kernel(batch: int, n_expand: int, c_x: int, x_dtype: str = "bfloat1
 
                 T.copy(h_res_shared, h_res_frag)
 
-                # move b to shared memory...
-                # TODO: Coalesced Memory Access
+                # Stage b in shared memory.
+                # TODO: coalesce this access.
                 for i in T.Parallel(n_expand * n_expand + 2 * n_expand):
                     b_shared[i] = b[i]
 
@@ -164,8 +162,7 @@ def _mhc_pre_kernel(batch: int, n_expand: int, c_x: int, x_dtype: str = "bfloat1
                 h_out_shared = T.alloc_shared([n_expand, n_expand], dtype)
 
                 eps = sinkhorn_eps
-                # exponential function...
-                # get the max value first...
+                # Max-shifted exponential.
                 for i, j in T.Parallel(n_expand, n_expand):
                     h_out_shared[i, j] = H_res_0[bx, i, j]
 
@@ -390,7 +387,7 @@ class MHCPreKernel(Kernel):
     def forward(
         self, phi, x, b, alpha_pre, alpha_post, alpha_res, sinkhorn_repeat, sinkhorn_eps=0.02
     ):
-        # H_pre, H_post, H_res_0, H_res are tensors need to be allocated....
+        # H_pre, H_post, H_res_0 and H_res are allocated by the caller.
         r = torch.empty([self.batch], device=x.device, dtype=self.weights_dtype)
         H = torch.empty(
             [self.batch, self.n_expand * self.n_expand + 2 * self.n_expand],

--- a/src/tileops/kernels/moe/permute_align.py
+++ b/src/tileops/kernels/moe/permute_align.py
@@ -63,7 +63,6 @@ def _make_align_kernel(numel: int, num_experts: int, block_size: int):
                 tx = T.get_thread_binding()
                 num_warps = threads // 32
 
-                # --- Shared memory ---
                 s_counts = T.alloc_shared([num_experts], "int32")
                 s_vals = T.alloc_shared([threads], "int32")
                 s_warp_sum = T.alloc_shared([num_warps], "int32")

--- a/src/tileops/kernels/moe/unpermute.py
+++ b/src/tileops/kernels/moe/unpermute.py
@@ -48,11 +48,10 @@ def _make_unpermute_kernel(
     threads -> 28 elems/thread = 3.5x VEC). Accumulation is in float32, cast to
     dtype on store.
     """
-    # Cap threads at 256 (the sweep optimum at H=7168: 512 is ~3% slower and
-    # 1024 spills the fp32 acc[H] accumulator to local memory) but scale with
-    # hidden_size // VEC and keep power-of-2 alignment, so small hidden sizes
-    # retain 128-bit (VEC=8) vectorized load/store instead of slow scalar 16-bit
-    # ops (e.g. H=512 -> 64 threads of 8 elems each, ~14% faster than 256).
+    # Cap threads at 256: 1024 spills the fp32 acc[H] accumulator to local
+    # memory. Below the cap, scale with hidden_size // VEC and keep power-of-2
+    # alignment so small hidden sizes retain 128-bit (VEC=8) vectorized
+    # load/store instead of scalar 16-bit ops (e.g. H=512 -> 64 threads of 8).
     VEC = 8  # 8 x bf16/fp16 = 128 bits
     threads = min(256, hidden_size // VEC)
     if threads > 0:

--- a/src/tileops/kernels/norm/batch_norm.py
+++ b/src/tileops/kernels/norm/batch_norm.py
@@ -30,8 +30,6 @@ __all__ = [
     "BatchNormFwdTrainKernel",
 ]
 
-# Config helpers
-
 # L threshold for the persistent (single global read) training path.
 # x_shared uses L * sizeof(dtype) bytes per block:
 #   L=8192, fp16 → 16 KB — well within H100 shared memory limits.
@@ -166,12 +164,10 @@ def _batch_norm_fwd_train_kernel(
                 T.reduce_sum(xsum_frag, sum_result, dim=1)
                 T.reduce_sum(xsq_frag, sq_result, dim=1)
 
-                # Statistics.
                 mean_val = sum_result[0] / T.cast(L, accum_dtype)
                 var_val = sq_result[0] / T.cast(L, accum_dtype) - mean_val * mean_val
                 rstd_val = T.cast(1.0, accum_dtype) / T.sqrt(var_val + T.cast(eps, accum_dtype))
 
-                # Save for backward.
                 mean_out[bc] = mean_val
                 rstd_out[bc] = rstd_val
 
@@ -541,13 +537,11 @@ def _batch_norm_bwd_kernel(
                             do_frag[_i, j] += go_val
                             do_xhat_frag[_i, j] += go_val * x_hat
 
-                # Cross-thread reduction.
                 sum_do = T.alloc_fragment([1], accum_dtype)
                 sum_do_xhat = T.alloc_fragment([1], accum_dtype)
                 T.reduce_sum(do_frag, sum_do, dim=1)
                 T.reduce_sum(do_xhat_frag, sum_do_xhat, dim=1)
 
-                # Write grad_bias and grad_weight.
                 grad_bias[bc] = sum_do[0]
                 grad_weight[bc] = sum_do_xhat[0]
 

--- a/src/tileops/kernels/norm/fused_add_norm.py
+++ b/src/tileops/kernels/norm/fused_add_norm.py
@@ -95,7 +95,6 @@ def _fused_add_layer_norm_kernel(M, N, eps, dtype):
                         i
                     ] * T.cast(weight[j], "float32") + T.cast(bias[j], "float32")
 
-                # Write y
                 T.copy(r_local, shared_x)
                 T.copy(shared_x, y[pid_m * block_m, 0])
 
@@ -246,7 +245,6 @@ def _fused_add_rms_norm_kernel(M, N, eps, dtype):
                         x_local[i, j], "float32"
                     )
 
-                # Sum of squares
                 T.reduce_sum(xsq_f32, sumsq, dim=1)
 
                 # rrms = rsqrt(mean(sq) + eps)
@@ -259,7 +257,6 @@ def _fused_add_rms_norm_kernel(M, N, eps, dtype):
                         T.cast(x_local[i, j], "float32") * rrms[i] * T.cast(weight[j], "float32")
                     )
 
-                # Write y
                 T.copy(r_local, shared_x)
                 T.copy(shared_x, y[pid_m * block_m, 0])
 

--- a/src/tileops/kernels/norm/rms_norm.py
+++ b/src/tileops/kernels/norm/rms_norm.py
@@ -42,7 +42,6 @@ def _rms_norm_kernel(M, N, eps, dtype):
                 sumsq = T.alloc_fragment((block_m,), "float32")
                 rrms = T.alloc_fragment((block_m,), "float32")
 
-                # Load input row block
                 T.copy(x[pid_m * block_m, 0], shared_buf)
                 T.copy(shared_buf, x_local)
 
@@ -52,7 +51,6 @@ def _rms_norm_kernel(M, N, eps, dtype):
                         x_local[i, j], "float32"
                     )
 
-                # Sum of squares along hidden dim
                 T.reduce_sum(xsq_f32, sumsq, dim=1)
 
                 # rrms = rsqrt(mean(x^2) + eps), using original N (not padded)
@@ -65,7 +63,6 @@ def _rms_norm_kernel(M, N, eps, dtype):
                         T.cast(x_local[i, j], "float32") * rrms[i] * T.cast(weight[j], "float32")
                     )
 
-                # Write output
                 T.copy(x_local, shared_buf)
                 T.copy(shared_buf, y[pid_m * block_m, 0])
 

--- a/src/tileops/kernels/reduction/_primitives.py
+++ b/src/tileops/kernels/reduction/_primitives.py
@@ -581,8 +581,7 @@ def make_reduce_epilogue(op_kind: str):
             f"Expected one of {sorted(_REDUCE_KINDS)}."
         )
 
-    # All reduce epilogues currently use a simple copy; sub-category PRs
-    # will specialize the bodies (e.g. abs for L1 norm, noop for max/min).
+    # Every reduce kind shares one epilogue: a copy of the reduced fragment.
     @T.macro
     def epilogue(result, output):
         T.copy(result, output)
@@ -945,9 +944,9 @@ class RowTiledAutotuneMixin:
                             continue
                         configs.append({"block_m": bm, "threads": t, "tile_n": 0})
             else:
-                # Tiled regime: use block_m=1 with each tile_n candidate.
-                # Each distinct tile_n triggers a kernel recompilation, so
-                # we only vary threads within each tile_n regime.
+                # Tiled regime: block_m=1 with each tile_n candidate. Each
+                # distinct tile_n triggers a kernel recompilation, so only
+                # threads vary within a tile_n regime.
                 for t in threads_list:
                     configs.append({"block_m": 1, "threads": t, "tile_n": tile_n})
 

--- a/src/tileops/kernels/reduction/cumulative.py
+++ b/src/tileops/kernels/reduction/cumulative.py
@@ -379,9 +379,6 @@ def _cumulative_kernel(M: int, N: int, op_kind: str, dtype: str):
     return _func
 
 
-# CumulativeKernel class
-
-
 class CumulativeKernel(Kernel):
     """Inclusive prefix scan kernel (cumsum / cumprod).
 

--- a/src/tileops/kernels/reduction/logical_reduce.py
+++ b/src/tileops/kernels/reduction/logical_reduce.py
@@ -284,7 +284,6 @@ def _logical_reduce_kernel(M: int, N: int, op_kind: str, dtype: str, partial: bo
                     for i in T.Parallel(block_m):
                         out_local[i] = T.cast(result[i] > 0.5, "int8")
 
-                # Write output
                 T.copy(out_local, out[pid_m * block_m])
 
         @T.prim_func
@@ -391,7 +390,6 @@ def _logical_reduce_kernel_tiled(
                     for i in T.Parallel(block_m):
                         out_local[i] = T.cast(acc[i] > 0.5, "int8")
 
-                # Write output
                 T.copy(out_local, out[pid_m * block_m])
 
         @T.prim_func

--- a/src/tileops/kernels/reduction/reduce.py
+++ b/src/tileops/kernels/reduction/reduce.py
@@ -124,7 +124,6 @@ def _simple_reduce_kernel(M, N, op_kind, dtype, out_dtype=None):
                         for j in T.Parallel(N_padded):
                             x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
 
-                # Reduce
                 if op_kind == "sum":
                     T.reduce_sum(x_f32, acc, dim=1)
                 elif op_kind == "mean":
@@ -146,7 +145,6 @@ def _simple_reduce_kernel(M, N, op_kind, dtype, out_dtype=None):
                 for i in T.Parallel(block_m):
                     out_local[i] = T.cast(acc[i], out_dtype)
 
-                # Write output
                 T.copy(out_local, out[pid_m * block_m])
 
         return main
@@ -423,7 +421,6 @@ def _welford_reduce_kernel(M, N, op_kind, correction, dtype):
                             for j in T.Parallel(N_padded):
                                 x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
 
-                    # Mean
                     T.reduce_sum(x_f32, row_sum, dim=1)
                     for i in T.Parallel(block_m):
                         mean_val[i] = row_sum[i] / float(N)
@@ -481,7 +478,6 @@ def _welford_reduce_kernel(M, N, op_kind, correction, dtype):
                             for j in T.Parallel(N_padded):
                                 x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
 
-                    # Mean
                     T.reduce_sum(x_f32, row_sum, dim=1)
                     for i in T.Parallel(block_m):
                         mean_val[i] = row_sum[i] / float(N)
@@ -827,9 +823,6 @@ def _welford_merge_kernel(A, B, op_kind, correction, count_per, out_dtype, threa
         return main
 
     return _func
-
-
-# ReduceKernel class
 
 
 class ReduceKernel(Kernel):

--- a/src/tileops/kernels/reduction/softmax.py
+++ b/src/tileops/kernels/reduction/softmax.py
@@ -610,9 +610,6 @@ def _compute_padded_cols(N: int, tile_n: int) -> int:
     return num_tiles * tile_n
 
 
-# Kernel class
-
-
 def _elem_bytes(dtype: torch.dtype) -> int:
     """Return bytes per element for the given dtype."""
     return torch.tensor([], dtype=dtype).element_size()

--- a/src/tileops/kernels/reduction/vector_norm.py
+++ b/src/tileops/kernels/reduction/vector_norm.py
@@ -231,9 +231,6 @@ def _inf_merge_kernel(A: int, B: int, out_dtype: str, threads: int):
     return _func
 
 
-# VectorNormKernel class
-
-
 class VectorNormKernel(Kernel):
     """L1 / L2 / Inf norm forward kernel.
 

--- a/src/tileops/kernels/rope.py
+++ b/src/tileops/kernels/rope.py
@@ -349,9 +349,6 @@ def _make_rope_non_neox_2d(
     return kernel
 
 
-# Kernel base class for RoPE
-
-
 class _RopeKernelBase(Kernel):
     """Base class for all RoPE kernel variants.
 

--- a/src/tileops/kernels/topk_selector.py
+++ b/src/tileops/kernels/topk_selector.py
@@ -125,7 +125,6 @@ def _topk_selector_kernel(batch, seq_len, seq_len_kv, kv_group, topk, in_dtype, 
                         bin_id = convert_to_uint16(index_score[bx, seq_row, input_idx, g])
                         l_bin_id32 = T.Cast(T.int32, bin_id)
                         if l_bin_id32 > l_threshold_bin_id:
-                            # need a pos = T.atomic_add(s_histogram[bin_id32+1], 1)
                             l_pos = T.atomic_add(s_histogram[l_bin_id32 + 1], 1, return_prev=True)
                             if l_pos < topk:
                                 index[bx, seq_row, g, l_pos] = input_idx

--- a/src/tileops/ops/__init__.py
+++ b/src/tileops/ops/__init__.py
@@ -93,7 +93,7 @@ from .pool import (
     MeanPoolingFwdOp,
 )
 
-# --- Reduction ops (uncomment as sub-category PRs land) ---
+# --- Reduction ops ---
 from .reduction import (
     AllFwdOp,
     AmaxFwdOp,  # ReduceMaxOp

--- a/src/tileops/ops/elementwise/__init__.py
+++ b/src/tileops/ops/elementwise/__init__.py
@@ -284,5 +284,4 @@ for _cls in [
 ]:
     _register_unary_inplace_custom_op(_cls)
 
-# Clean up loop variable
 del _cls

--- a/src/tileops/ops/gemm/bmm.py
+++ b/src/tileops/ops/gemm/bmm.py
@@ -207,9 +207,8 @@ class BmmFp8KNFwdOp(Op):
         self.dispatch_kernel(kernel_map)
         self._active_sig: Optional[tuple] = None
         self._active: Optional[Kernel] = None
-        # Shape-signatures for which we've already emitted the "slow path"
-        # warning; keeps a single BmmFp8KNFwdOp from spamming the log on every
-        # forward when a caller consistently passes b in [B,K,N] layout.
+        # Shape-signatures whose "slow path" warning has already been emitted, so a
+        # single BmmFp8KNFwdOp warns once per shape rather than on every forward.
         self._kn_warned: Set[Tuple[int, int, int, int]] = set()
         self.batch: Optional[int] = None
         self.m: Optional[int] = None

--- a/src/tileops/ops/mamba/cb_producer.py
+++ b/src/tileops/ops/mamba/cb_producer.py
@@ -52,7 +52,6 @@ class CBProducerFwdOp(Op):
         self.d_state = d_state
         self.tune = tune
 
-        # Use standard Op dispatch pattern
         self.dispatch_kernel(kernel_map)
 
     def _get_kernel(self, inputs: "tuple[torch.Tensor | None, ...]", dtype: torch.dtype) -> Kernel:

--- a/src/tileops/ops/mamba/mamba2_fwd.py
+++ b/src/tileops/ops/mamba/mamba2_fwd.py
@@ -269,8 +269,8 @@ class Mamba2FwdOp(Op):
 
         # ── 4. SSDStatePassing ───────────────────────────────────────────────
         chunk_states_flat = chunk_states.reshape(batch, num_chunks, n_heads, d_head * d_state)
-        # Extract last dA value per chunk - use contiguous() to ensure a contiguous layout
-        # Note: since this is a slice of a 4D tensor, it is non-contiguous and will always copy
+        # Last dA value per chunk. The slice of a 4D tensor is non-contiguous, so
+        # contiguous() always copies.
         dA_chunk_cumsum = dA_cumsum[..., chunk_size - 1].contiguous()  # (B, H, C)
 
         init_flat = (
@@ -287,7 +287,7 @@ class Mamba2FwdOp(Op):
 
         # Unflatten to (B, C, H, P, N) in float32 (accum_dtype) for chunk_scan.
         prev_states = prev_states_flat.reshape(batch, num_chunks, n_heads, d_head, d_state)
-        # dt_out is now in dtype (no cast needed) - DaCumsum outputs typed dt directly
+        # DaCumsum outputs dt_out already typed, so chunk_scan takes it uncast.
 
         # ── 5. SSDChunkScan ──────────────────────────────────────────────────
         y = self._chunk_scan_op.forward(x, cb, dA_cumsum, C, prev_states, dt_out)

--- a/src/tileops/ops/norm/instance_norm.py
+++ b/src/tileops/ops/norm/instance_norm.py
@@ -311,9 +311,9 @@ class InstanceNormFwdOp(Op):
 
         if not self.use_input_stats:
             # Eval-mode path: y = (x - running_mean[c]) / sqrt(running_var[c] + eps).
-            # Pure elementwise per-channel; matches torch.nn.functional.instance_norm
-            # (use_input_stats=False) numerics bit-for-bit (verified) by computing in
-            # fp32 then casting to x.dtype.
+            # Pure elementwise per-channel. Computing in fp32 and casting to x.dtype
+            # matches torch.nn.functional.instance_norm(use_input_stats=False)
+            # bit-for-bit.
             mean_b = running_mean.reshape(self._running_stats_broadcast_shape)
             var_b = running_var.reshape(self._running_stats_broadcast_shape)
             y = (x.float() - mean_b) * torch.rsqrt(var_b + self.eps)

--- a/src/tileops/ops/pool.py
+++ b/src/tileops/ops/pool.py
@@ -465,7 +465,7 @@ class _AvgPoolFwdOpBase(Op):
     def _use_spatial_fast_path(self) -> bool:
         # Strict 1d/3d policy: an explicit generic-kernel override opts out of
         # the spatial fast path unless the spatial kernel is also explicit.
-        # AvgPool2dFwdOp overrides this with its laxer historical policy.
+        # AvgPool2dFwdOp overrides this with a laxer 2d policy.
         return (
             not self.ceil_mode
             and self.count_include_pad
@@ -705,8 +705,8 @@ class AvgPool2dFwdOp(_AvgPoolFwdOpBase):
         }
 
     def _use_spatial_fast_path(self) -> bool:
-        # Laxer historical 2d policy: an explicit generic-kernel override does
-        # not opt out of the spatial fast path (asymmetric with 1d/3d).
+        # Laxer 2d policy: an explicit generic-kernel override does not opt out
+        # of the spatial fast path (asymmetric with 1d/3d).
         return (
             not self.ceil_mode
             and self.count_include_pad

--- a/src/tileops/ops/reduction/__init__.py
+++ b/src/tileops/ops/reduction/__init__.py
@@ -6,9 +6,6 @@ This package will host stateless dispatchers for reduction operators
 kernels are implemented.
 """
 
-# Placeholder imports for reduction ops.
-# Each sub-category PR uncomments its own lines.
-
 # --- LogicalReduceKernel ops ---
 # --- ArgreduceKernel ops ---
 from .argreduce import ArgmaxFwdOp, ArgminFwdOp

--- a/src/tileops/ops/reduction/reduce.py
+++ b/src/tileops/ops/reduction/reduce.py
@@ -62,9 +62,6 @@ __all__ = [
 ]
 
 
-# Shared base class for all reduce ops
-
-
 class _ReduceOpBase(Op):
     """Common base for all reduce ops (simple, Welford, argreduce, logical, vector_norm).
 

--- a/src/tileops/ops/rope.py
+++ b/src/tileops/ops/rope.py
@@ -336,9 +336,6 @@ def _longrope_freqs(
     )
 
 
-# Base Op class for RoPE
-
-
 class _RopeOpBase(Op):
     """Base class for all RoPE ops.
 
@@ -937,5 +934,4 @@ for _cls in [RopeNeoxFwdOp, RopeNonNeoxFwdOp, RopeLlama31FwdOp, RopeYarnFwdOp, R
 
 _register_rope_position_ids_custom_op(RopeNeoxPositionIdsFwdOp)
 
-# Clean up loop variable
 del _cls

--- a/tests/kernels/test_v_tile.py
+++ b/tests/kernels/test_v_tile.py
@@ -26,7 +26,7 @@ _H_RECURRENCE_BUILDERS = [
 
 @pytest.mark.parametrize("build", _H_RECURRENCE_BUILDERS)
 def test_h_recurrence_rejects_previously_defaulted_narrow_v_tile(build) -> None:
-    # The shape whose default config formerly selected block_v = 8.
+    # A shape whose default config would otherwise reach block_v = 8.
     with pytest.raises(ValueError, match=str(GEMM_MIN_N)):
         build(1, 4, 128, 64, 64, 64, "float16", block_v=8)
 

--- a/tests/ops/test_argreduce.py
+++ b/tests/ops/test_argreduce.py
@@ -25,9 +25,6 @@ def _call(op, x: torch.Tensor) -> torch.Tensor:
     return cast(torch.Tensor, op(x))
 
 
-# Fixtures
-
-
 class ArgreduceBasicFixture(FixtureBase):
     PARAMS = [
         (
@@ -143,9 +140,6 @@ class SpecArgreduceFixture(FixtureBase):
     ]
 
 
-# TestBase helpers — inherit gen_inputs() from workload classes
-
-
 class ArgreduceTest(ArgmaxWorkload, TestBase):
     """Parameterized test helper for argreduce ops."""
 
@@ -172,9 +166,6 @@ def _exact_compare(output: torch.Tensor, output_ref: torch.Tensor) -> None:
         f"  output_ref: {output_ref[:10]}...\n"
         f"  mismatches: {(output != output_ref).sum().item()} / {output.numel()}"
     )
-
-
-# ArgmaxFwdOp tests
 
 
 @ArgreduceBasicFixture
@@ -303,9 +294,6 @@ def test_argmax_spec_dim(shape: tuple, dim: int, keepdim: bool, dtype: torch.dty
     assert y.shape == ref.shape, f"shape mismatch: {y.shape} vs {ref.shape}"
     assert y.dtype == torch.int64
     assert torch.equal(y, ref), f"spec dim={dim} argmax mismatch: {(y != ref).sum().item()}"
-
-
-# ArgminFwdOp tests
 
 
 @ArgreduceBasicFixture

--- a/tests/ops/test_batch_norm.py
+++ b/tests/ops/test_batch_norm.py
@@ -27,9 +27,6 @@ class BatchNormFwdTest(BatchNormFwdWorkload, TestBase):
     pass
 
 
-# Fixtures
-
-
 class BatchNormFwdFixture(FixtureBase):
     """(N, C, *spatial, dtype, training)"""
 
@@ -79,12 +76,6 @@ class BatchNormBwdFixture(FixtureBase):
             ],
         ),
     ]
-
-
-# Test helpers
-
-
-# Test functions
 
 
 @BatchNormFwdFixture

--- a/tests/ops/test_binary_arith.py
+++ b/tests/ops/test_binary_arith.py
@@ -90,9 +90,6 @@ def test_coalesce_broadcast_dims(a_shape, b_shape, expected_ndim) -> None:
     assert len(b_strides) == len(coalesced_shape)
 
 
-# Shared helpers
-
-
 def _get_tolerances(dtype: torch.dtype) -> tuple[float, float]:
     if dtype == torch.float32:
         return 1e-5, 1e-5

--- a/tests/ops/test_bitwise.py
+++ b/tests/ops/test_bitwise.py
@@ -17,8 +17,6 @@ from tileops.ops.elementwise import (
 )
 from workloads.elementwise import BitwiseNotWorkload, BitwiseWorkload
 
-# Shared helpers
-
 
 def _exact_compare(output: torch.Tensor, output_ref: torch.Tensor) -> None:
     """Exact comparison for integer outputs."""
@@ -36,9 +34,6 @@ class BitwiseTest(BitwiseWorkload, TestBase):
 
     def ref_program(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
         return self.ref_fn(a, b)
-
-
-# BitwiseAnd op
 
 
 class BitwiseAndFixture(FixtureBase):
@@ -60,9 +55,6 @@ def test_bitwise_and_op(n_total: int) -> None:
     test.check(op, *test.gen_inputs(), compare=_exact_compare)
 
 
-# BitwiseOr op
-
-
 class BitwiseOrFixture(FixtureBase):
     PARAMS = [
         (
@@ -80,9 +72,6 @@ def test_bitwise_or_op(n_total: int) -> None:
     test = BitwiseTest(n_total, torch.bitwise_or)
     op = BitwiseOrFwdOp()
     test.check(op, *test.gen_inputs(), compare=_exact_compare)
-
-
-# BitwiseXor op
 
 
 class BitwiseXorFixture(FixtureBase):
@@ -195,9 +184,6 @@ def test_bool_bitwise_fast_path(
         out = op(a, b)
     assert out.dtype == torch.bool
     _exact_compare(out, ref)
-
-
-# BitwiseNot op
 
 
 class BitwiseFixture(FixtureBase):

--- a/tests/ops/test_comparison.py
+++ b/tests/ops/test_comparison.py
@@ -11,8 +11,6 @@ from tests.test_base import FixtureBase, TestBase
 from tileops.ops.elementwise import EqFwdOp, GeFwdOp, GtFwdOp, LeFwdOp, LtFwdOp, NeFwdOp
 from workloads.elementwise import RandnPairWorkload
 
-# Shared helpers
-
 
 def _bool_compare(output: torch.Tensor, output_ref: torch.Tensor) -> None:
     """Exact comparison for boolean outputs."""
@@ -31,9 +29,6 @@ class ComparisonTest(RandnPairWorkload, TestBase):
 
     def ref_program(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
         return self.ref_fn(a, b)
-
-
-# Eq op
 
 
 class EqFixture(FixtureBase):
@@ -56,9 +51,6 @@ def test_eq_op(n_total: int, dtype: torch.dtype) -> None:
     test.check(op, *test.gen_inputs(), compare=_bool_compare)
 
 
-# Ne op
-
-
 class NeFixture(FixtureBase):
     PARAMS = [
         (
@@ -77,9 +69,6 @@ def test_ne_op(n_total: int, dtype: torch.dtype) -> None:
     test = ComparisonTest(n_total, dtype, torch.ne)
     op = NeFwdOp()
     test.check(op, *test.gen_inputs(), compare=_bool_compare)
-
-
-# Gt op
 
 
 class GtFixture(FixtureBase):
@@ -102,9 +91,6 @@ def test_gt_op(n_total: int, dtype: torch.dtype) -> None:
     test.check(op, *test.gen_inputs(), compare=_bool_compare)
 
 
-# Lt op
-
-
 class LtFixture(FixtureBase):
     PARAMS = [
         (
@@ -125,9 +111,6 @@ def test_lt_op(n_total: int, dtype: torch.dtype) -> None:
     test.check(op, *test.gen_inputs(), compare=_bool_compare)
 
 
-# Ge op
-
-
 class GeFixture(FixtureBase):
     PARAMS = [
         (
@@ -146,9 +129,6 @@ def test_ge_op(n_total: int, dtype: torch.dtype) -> None:
     test = ComparisonTest(n_total, dtype, torch.ge)
     op = GeFwdOp()
     test.check(op, *test.gen_inputs(), compare=_bool_compare)
-
-
-# Le op
 
 
 class LeFixture(FixtureBase):

--- a/tests/ops/test_cumulative.py
+++ b/tests/ops/test_cumulative.py
@@ -11,8 +11,6 @@ import torch
 from tests.test_base import FixtureBase, TestBase
 from workloads.reduction import CumulativeWorkload
 
-# Fixtures
-
 
 class CumulativeBasicFixture(FixtureBase):
     PARAMS = [
@@ -83,9 +81,6 @@ class Cumulative1DFixture(FixtureBase):
     ]
 
 
-# TestBase helpers
-
-
 class CumulativeTest(CumulativeWorkload, TestBase):
     """Parameterized test helper for cumulative ops."""
 
@@ -112,9 +107,6 @@ def _cumprod_tol(dtype: torch.dtype) -> dict:
     if dtype == torch.float32:
         return {"atol": 1e-3, "rtol": 1e-3}
     return {"atol": 5e-2, "rtol": 5e-2}
-
-
-# CumsumFwdOp tests
 
 
 @CumulativeBasicFixture
@@ -189,9 +181,6 @@ def test_cumsum_dynamic_shape_kernel_cache() -> None:
     assert len(list(op.iter_kernels())) == 1
     op(x2)
     assert len(list(op.iter_kernels())) == 2
-
-
-# CumprodFwdOp tests
 
 
 @CumulativeBasicFixture

--- a/tests/ops/test_deltanet_chunkwise_bwd.py
+++ b/tests/ops/test_deltanet_chunkwise_bwd.py
@@ -52,9 +52,6 @@ def deltanet_autograd_bwd_torch(do, q, k, v, beta, chunk_size):
 # Autograd-based reference: differentiable forward -> torch.autograd.grad
 
 
-# Backward correctness tests
-
-
 def _get_tolerances(dtype: torch.dtype) -> dict:
     if dtype == torch.float32:
         return {"atol": 1e-3, "rtol": 1e-3}

--- a/tests/ops/test_deltanet_fwd.py
+++ b/tests/ops/test_deltanet_fwd.py
@@ -10,9 +10,6 @@ class DeltaNetFwdTest(DeltaNetFwdWorkload, TestBase):
     pass
 
 
-# Forward correctness tests
-
-
 def _get_tolerances(dtype: torch.dtype) -> dict:
     if dtype == torch.float32:
         return {"atol": 1e-3, "rtol": 1e-3}

--- a/tests/ops/test_deltanet_recurrence.py
+++ b/tests/ops/test_deltanet_recurrence.py
@@ -18,9 +18,6 @@ class DeltaNetDecodeTest(DeltaNetDecodeWorkload, TestBase):
     pass
 
 
-# Correctness tests
-
-
 def _get_tolerances(dtype: torch.dtype) -> dict:
     if dtype == torch.float32:
         return {"atol": 5e-4, "rtol": 5e-4}

--- a/tests/ops/test_docstring_args_match_signature.py
+++ b/tests/ops/test_docstring_args_match_signature.py
@@ -74,6 +74,6 @@ def test_inherited_ctor_args_exist(name):
 @pytest.mark.smoke
 def test_sweep_still_sees_inheriting_classes():
     assert len(_CASES) >= 20, f"only {len(_CASES)} found; the filter broke"
-    # A canary that inherits its constructor and documents it: the shape this sweep
-    # exists for. ``RoundFwdOp`` was it until ``decimals`` gave it one of its own.
+    # A canary that inherits its constructor and documents it, which is the shape
+    # this sweep exists for.
     assert "AddFwdOp" in _CASES

--- a/tests/ops/test_elementwise_unary_activation_alignment.py
+++ b/tests/ops/test_elementwise_unary_activation_alignment.py
@@ -185,7 +185,6 @@ def test_gelu_approximate_runs_through_forward(approximate: str) -> None:
     assert torch.allclose(y, expected, rtol=1e-2, atol=1e-2)
 
 
-# Frozen ``__init__`` signatures for every unary activation Op. The
-# refactor pulling shared ``__init__`` / ``forward`` / ``_eager_forward``
-# logic up into a base or mixin must keep these byte-identical, because
-# downstream code (tests, benches, codegen) relies on them.
+# Frozen ``__init__`` signatures for every unary activation Op. Tests, benches
+# and codegen read them, so pulling shared ``__init__`` / ``forward`` /
+# ``_eager_forward`` logic into a base or mixin must keep them byte-identical.

--- a/tests/ops/test_fused_gated.py
+++ b/tests/ops/test_fused_gated.py
@@ -17,8 +17,6 @@ from tileops.kernels.elementwise import (
 from tileops.ops.elementwise import GeluAndMulFwdOp, GeluTanhAndMulFwdOp, SiluAndMulFwdOp
 from workloads.elementwise import GatedRandnWorkload
 
-# SiluAndMul
-
 
 class SiluAndMulFixture(FixtureBase):
     PARAMS = [
@@ -82,9 +80,6 @@ def test_silu_and_mul_lazy_op_rebinds_shape() -> None:
         assert (op.M, op.N, op.dtype) == (m, n, torch.float16)
 
 
-# GeluAndMul
-
-
 class GeluAndMulFixture(FixtureBase):
     PARAMS = [
         (
@@ -113,9 +108,6 @@ def test_gelu_and_mul_op(m: int, n: int, dtype: torch.dtype) -> None:
     op = GeluAndMulFwdOp()
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
-
-
-# GeluTanhAndMul
 
 
 class GeluTanhAndMulFixture(FixtureBase):

--- a/tests/ops/test_fused_moe_experts.py
+++ b/tests/ops/test_fused_moe_experts.py
@@ -44,11 +44,10 @@ def _torch_ref_moe_activation(hidden, w1, w2, topk_weights, topk_ids, activation
     E, twoF, _ = w1.shape
     F_dim = twoF // 2
     # gelu_and_mul: PyTorch's F.gelu(x, approximate="none") is exact erf GELU,
-    # which matches GeluAndMulFwdKernel's `x * 0.5 * (1 + erf(x/sqrt(2)))`. We
-    # pass approximate="none" explicitly so this is locked at the test level —
-    # PyTorch's default happens to be "none", but a different default in some
-    # future version would silently switch the reference to tanh approximation
-    # (which is GeluTanhAndMulFwdKernel, a separate registry entry).
+    # which matches GeluAndMulFwdKernel's `x * 0.5 * (1 + erf(x/sqrt(2)))`.
+    # approximate="none" is passed explicitly: PyTorch's default happens to be
+    # "none", but a changed default would silently switch the reference to the
+    # tanh approximation (GeluTanhAndMulFwdKernel, a separate registry entry).
     # Resolve once outside the per-expert loop so an unsupported activation
     # raises immediately rather than silently falling back to a wrong
     # reference value when this helper is extended.

--- a/tests/ops/test_gated_deltanet_chunkwise_bwd.py
+++ b/tests/ops/test_gated_deltanet_chunkwise_bwd.py
@@ -61,9 +61,6 @@ def gated_deltanet_autograd_bwd_torch(do, q, k, v, g, beta, chunk_size):
 # Autograd-based reference: differentiable forward → torch.autograd.grad
 
 
-# Backward correctness tests
-
-
 def _get_tolerances(dtype: torch.dtype) -> dict:
     if dtype == torch.float32:
         return {"atol": 1e-2, "rtol": 1e-2}

--- a/tests/ops/test_gated_deltanet_fwd.py
+++ b/tests/ops/test_gated_deltanet_fwd.py
@@ -31,9 +31,6 @@ class GatedDeltaNetFwdTest(GatedDeltaNetFwdWorkload, TestBase):
     pass
 
 
-# Forward correctness tests
-
-
 def _get_tolerances(dtype: torch.dtype) -> dict:
     # Tolerances are looser than docs/design/testing.md defaults (fp16: 1e-3, bf16: 1.6e-2)
     # because Gated DeltaNet uses sequential chunk recurrence: each chunk's hidden

--- a/tests/ops/test_gated_deltanet_recurrence.py
+++ b/tests/ops/test_gated_deltanet_recurrence.py
@@ -18,9 +18,6 @@ class GatedDeltaNetDecodeTest(GatedDeltaNetDecodeWorkload, TestBase):
     pass
 
 
-# Correctness tests
-
-
 def _get_tolerances(dtype: torch.dtype) -> dict:
     if dtype == torch.float32:
         # Keep fp32 tolerance aligned with the scalar decode reference path;

--- a/tests/ops/test_gla_chunkwise_bwd.py
+++ b/tests/ops/test_gla_chunkwise_bwd.py
@@ -59,9 +59,6 @@ def _fla_autograd_bwd(
     return dq, dk, dv, dg
 
 
-# Backward correctness tests
-
-
 class GLABwdFixture(FixtureBase):
     PARAMS = [
         (

--- a/tests/ops/test_gla_chunkwise_fwd.py
+++ b/tests/ops/test_gla_chunkwise_fwd.py
@@ -15,9 +15,6 @@ except ImportError:
     chunk_gla = None
 
 
-# Forward correctness tests
-
-
 class GLAFwdFixture(FixtureBase):
     PARAMS = [
         (
@@ -65,7 +62,6 @@ def test_gla_fwd(
         print(f"  FLA vs ref o: cosine={cos:.6f}")
         assert cos > 0.99, f"FLA vs ref o cosine too low: {cos:.6f}"
 
-    # --- TileOPs ---
     fwd_op = GLAFwdOp(
         chunk_size=BC,
         scale=scale,

--- a/tests/ops/test_gla_recurrence.py
+++ b/tests/ops/test_gla_recurrence.py
@@ -15,8 +15,6 @@ try:
 except ImportError:
     fused_recurrent_gla = None
 
-# Correctness tests
-
 
 def _get_tolerances(dtype: torch.dtype) -> dict:
     if dtype == torch.float32:
@@ -120,7 +118,6 @@ def test_gla_decode_vs_fla(
     gk = -torch.rand(B, H, DK, device="cuda", dtype=dtype)
     state = torch.randn(B, H, DK, DV, device="cuda", dtype=dtype) * 0.1
 
-    # TileOPs
     op = GLADecodeFwdOp(scale=scale, tune=tune)
     with torch.no_grad():
         o_tile, s_tile = op(q, k, v, gk, state)

--- a/tests/ops/test_kernel_selection.py
+++ b/tests/ops/test_kernel_selection.py
@@ -58,10 +58,9 @@ def _prefill_key(op: GroupedQueryAttentionPrefillFwdOp, **call_facts: object) ->
     return op.select_kernel_key(PACKED_PREFILL_KEYS, op.attention_call(**facts))
 
 
-# Region -> dispatch key the pre-refactor selectors landed on. One row per
-# capability region the attention ops used to encode: FP8, sliding window, the
-# H200 square causal fast path, warp-specialized causal dense, plain dense,
-# ragged varlen.
+# Region -> dispatch key. One row per capability region of the packed-prefill
+# slot: FP8, sliding window, the H200 square causal fast path, warp-specialized
+# causal dense, plain dense, ragged varlen.
 _PREFILL_DISPATCH = [
     ("square-causal-h200", {}, {}, "gqa_prefill_square_fwd_kernel"),
     ("square-causal-bf16", {"dtype": torch.bfloat16}, {}, "gqa_prefill_square_fwd_kernel"),

--- a/tests/ops/test_logical.py
+++ b/tests/ops/test_logical.py
@@ -12,8 +12,6 @@ from tests.test_base import FixtureBase, TestBase, exact_compare
 from tileops.ops.elementwise import LogicalAndFwdOp, LogicalNotFwdOp, LogicalOrFwdOp
 from workloads.elementwise import LogicalNotWorkload, LogicalWorkload
 
-# Shared helpers
-
 
 def _bool_compare(output: torch.Tensor, output_ref: torch.Tensor) -> None:
     """Exact comparison for boolean outputs."""
@@ -34,9 +32,6 @@ class LogicalTest(LogicalWorkload, TestBase):
         return self.ref_fn(a.bool(), b.bool())
 
 
-# LogicalAnd op
-
-
 class LogicalAndFixture(FixtureBase):
     PARAMS = [
         (
@@ -55,9 +50,6 @@ def test_logical_and_op(n_total: int, dtype: torch.dtype) -> None:
     test = LogicalTest(n_total, dtype, torch.logical_and)
     op = LogicalAndFwdOp()
     test.check(op, *test.gen_inputs(), compare=_bool_compare)
-
-
-# LogicalOr op
 
 
 class LogicalOrFixture(FixtureBase):
@@ -144,9 +136,6 @@ def test_logical_and_bool_broadcast() -> None:
     with torch.no_grad():
         out = op(a, b)
     _bool_compare(out, ref)
-
-
-# LogicalNot op
 
 
 class LogicalFixture(FixtureBase):

--- a/tests/ops/test_logical_reduce.py
+++ b/tests/ops/test_logical_reduce.py
@@ -13,8 +13,6 @@ from tests.test_base import FixtureBase, TestBase
 from tileops.kernels.reduction.logical_reduce import LogicalReduceKernel
 from workloads.reduction import AnyWorkload
 
-# Fixtures
-
 
 class LogicalReduceBasicFixture(FixtureBase):
     PARAMS = [
@@ -130,9 +128,6 @@ class LogicalReduceKeepdimFixture(FixtureBase):
     ]
 
 
-# TestBase helpers — inherit gen_inputs() from workload classes
-
-
 class LogicalReduceTest(AnyWorkload, TestBase):
     """Parameterized test helper for logical reduce ops."""
 
@@ -209,9 +204,6 @@ def _make_nd_input(shape: tuple, dtype: torch.dtype) -> torch.Tensor:
     if dtype == torch.bool:
         return torch.randint(0, 2, shape, dtype=torch.bool, device="cuda")
     return torch.randn(shape, dtype=dtype, device="cuda")
-
-
-# AnyFwdOp tests
 
 
 @LogicalReduceBasicFixture
@@ -298,9 +290,6 @@ def test_any_keepdim(shape: tuple, dim: int, dtype: torch.dtype) -> None:
     assert torch.equal(y, ref), f"any keepdim dim={dim} mismatch: {(y != ref).sum().item()}"
 
 
-# AllFwdOp tests
-
-
 @LogicalReduceBasicFixture
 def test_all_op(m: int, n: int, dtype: torch.dtype) -> None:
     from tileops.ops.reduction.logical_reduce import AllFwdOp
@@ -383,9 +372,6 @@ def test_all_keepdim(shape: tuple, dim: int, dtype: torch.dtype) -> None:
     assert y.dtype == torch.bool
     assert y.shape == ref.shape, f"keepdim shape mismatch: {y.shape} vs {ref.shape}"
     assert torch.equal(y, ref), f"all keepdim dim={dim} mismatch: {(y != ref).sum().item()}"
-
-
-# CountNonzeroFwdOp tests
 
 
 @LogicalReduceBasicFixture

--- a/tests/ops/test_moe_fused_topk.py
+++ b/tests/ops/test_moe_fused_topk.py
@@ -216,8 +216,9 @@ def _check(test: FusedTopKWorkload) -> None:
     torch.testing.assert_close(out_w_sorted, ref_w_sorted, rtol=1e-3, atol=1e-3)
 
     # topk_ids must select experts whose scores are valid top-k scores.
-    # When two experts have identical scores (fp32 ties), either is a valid selection;
-    # we verify that each selected weight >= the (K+1)-th largest weight.
+    # When two experts have identical scores (fp32 ties), either is a valid
+    # selection, so the assertion is that each selected weight >= the
+    # (K+1)-th largest weight.
     gating_f32 = gating.to(torch.float32)
     if test.scoring_func == "softmax":
         all_scores = torch.softmax(gating_f32, dim=-1)

--- a/tests/ops/test_moe_fused_topk.py
+++ b/tests/ops/test_moe_fused_topk.py
@@ -39,12 +39,6 @@ def fused_topk_torch(
     return topk_weights, topk_ids.int()
 
 
-# Reference implementation
-
-
-# Test fixture
-
-
 class FusedTopKFixture(FixtureBase):
     PARAMS = [
         (
@@ -190,9 +184,6 @@ class FusedTopKFixture(FixtureBase):
             ],
         ),
     ]
-
-
-# Tests
 
 
 def _check(test: FusedTopKWorkload) -> None:

--- a/tests/ops/test_moe_permute_align.py
+++ b/tests/ops/test_moe_permute_align.py
@@ -19,9 +19,6 @@ class MoePermuteAlignTest(MoePermuteAlignWorkload, TestBase):
     pass
 
 
-# Fixture
-
-
 class MoePermuteAlignFixture(FixtureBase):
     PARAMS = [
         (
@@ -45,9 +42,6 @@ class MoePermuteAlignFixture(FixtureBase):
             ],
         ),
     ]
-
-
-# TestBase subclass
 
 
 # Custom comparator
@@ -114,9 +108,6 @@ def _permute_align_compare(
     assert (sorted_ids[:n].cpu()[padding_mask] == numel).all(), (
         "Padding slots must equal sentinel (numel)"
     )
-
-
-# Tests
 
 
 @MoePermuteAlignFixture

--- a/tests/ops/test_moe_shared_fused_moe_distributed.py
+++ b/tests/ops/test_moe_shared_fused_moe_distributed.py
@@ -46,8 +46,6 @@ try:
 except ImportError:
     _VLLM_AVAILABLE = False
 
-# Helpers
-
 
 def _setup_vllm_distributed(tp_size: int) -> tuple[int, int]:
     """Initialize torch.distributed + vLLM model parallel groups.
@@ -99,9 +97,6 @@ def _teardown_vllm_distributed():
             cleanup_dist_env_and_memory()
     if dist.is_initialized():
         dist.destroy_process_group()
-
-
-# Fixtures
 
 
 class TPFixture:

--- a/tests/ops/test_reduce.py
+++ b/tests/ops/test_reduce.py
@@ -14,8 +14,6 @@ from workloads.reduction import (
     SumWorkload,
 )
 
-# Fixtures
-
 
 class ReduceBasicFixture(FixtureBase):
     PARAMS = [
@@ -119,9 +117,6 @@ class BesselFixture(FixtureBase):
     ]
 
 
-# TestBase helpers — inherit gen_inputs() from workload classes
-
-
 class ReduceTest(SumWorkload, TestBase):
     """Parameterized test helper for simple reduce ops (sum/mean/amax/amin)."""
 
@@ -183,9 +178,6 @@ def _tol(dtype: torch.dtype) -> dict:
     if dtype == torch.float32:
         return {"atol": 1e-4, "rtol": 1e-4}
     return {"atol": 1e-2, "rtol": 1e-2}
-
-
-# SumFwdOp tests
 
 
 @ReduceBasicFixture
@@ -356,9 +348,6 @@ def test_sum_4d(b0: int, b1: int, b2: int, n: int, dtype: torch.dtype) -> None:
     assert torch.allclose(y, ref, **tol), f"4D max err: {(y - ref).abs().max()}"
 
 
-# MeanFwdOp tests
-
-
 @ReduceBasicFixture
 def test_mean_op(m: int, n: int, dtype: torch.dtype) -> None:
     from tileops.ops.reduction.reduce import MeanFwdOp
@@ -366,9 +355,6 @@ def test_mean_op(m: int, n: int, dtype: torch.dtype) -> None:
     test = ReduceTest(m, n, dtype, "mean")
     op = MeanFwdOp(dim=-1)
     test.check(op, *test.gen_inputs(), **_tol(dtype))
-
-
-# AminFwdOp tests
 
 
 @ReduceBasicFixture
@@ -380,9 +366,6 @@ def test_amin_op(m: int, n: int, dtype: torch.dtype) -> None:
     test.check(op, *test.gen_inputs(), **_tol(dtype))
 
 
-# AmaxFwdOp tests
-
-
 @ReduceBasicFixture
 def test_amax_op(m: int, n: int, dtype: torch.dtype) -> None:
     from tileops.ops.reduction.reduce import AmaxFwdOp
@@ -390,9 +373,6 @@ def test_amax_op(m: int, n: int, dtype: torch.dtype) -> None:
     test = ReduceTest(m, n, dtype, "amax")
     op = AmaxFwdOp(dim=-1)
     test.check(op, *test.gen_inputs(), **_tol(dtype))
-
-
-# ProdFwdOp tests
 
 
 @ReduceBasicFixture
@@ -404,9 +384,6 @@ def test_prod_op(m: int, n: int, dtype: torch.dtype) -> None:
     # Prod is more numerically sensitive
     tol = {"atol": 5e-2, "rtol": 5e-2} if dtype != torch.float32 else {"atol": 1e-3, "rtol": 1e-3}
     test.check(op, *test.gen_inputs(), **tol)
-
-
-# StdFwdOp tests
 
 
 @ReduceBasicFixture
@@ -427,9 +404,6 @@ def test_std_bessel(m: int, n: int, dtype: torch.dtype, correction: int) -> None
     test.check(op, *test.gen_inputs(), **_tol(dtype))
 
 
-# VarFwdOp tests
-
-
 @ReduceBasicFixture
 def test_var_op(m: int, n: int, dtype: torch.dtype) -> None:
     from tileops.ops.reduction.reduce import VarFwdOp
@@ -446,9 +420,6 @@ def test_var_bessel(m: int, n: int, dtype: torch.dtype, correction: int) -> None
     test = WelfordTest(m, n, dtype, "var", correction=correction)
     op = VarFwdOp(correction=correction, dim=-1)
     test.check(op, *test.gen_inputs(), **_tol(dtype))
-
-
-# VarMeanFwdOp tests
 
 
 @ReduceBasicFixture

--- a/tests/ops/test_reduce_dim_none.py
+++ b/tests/ops/test_reduce_dim_none.py
@@ -13,8 +13,6 @@ import torch
 
 from tests.test_base import FixtureBase
 
-# Fixtures
-
 
 class DimNoneFixture(FixtureBase):
     PARAMS = [
@@ -57,9 +55,6 @@ class DimNoneFixture(FixtureBase):
             ],
         ),
     ]
-
-
-# Helpers
 
 
 def _tol(dtype: torch.dtype) -> dict:

--- a/tests/ops/test_reduce_multidim.py
+++ b/tests/ops/test_reduce_multidim.py
@@ -13,8 +13,6 @@ import torch
 
 from tests.test_base import FixtureBase
 
-# Fixtures
-
 
 class MultiDimFixture(FixtureBase):
     PARAMS = [
@@ -62,9 +60,6 @@ class MultiDimFixture(FixtureBase):
             ],
         ),
     ]
-
-
-# Helpers
 
 
 def _tol(dtype: torch.dtype) -> dict:

--- a/tests/ops/test_rope.py
+++ b/tests/ops/test_rope.py
@@ -23,8 +23,6 @@ import torch
 from tests.test_base import FixtureBase, TestBase
 from workloads.rope import RopeWorkload
 
-# Reference implementations (pure PyTorch)
-
 
 def _compute_freqs_cis_base(
     head_dim: int,
@@ -324,9 +322,6 @@ def _get_tolerances(dtype: torch.dtype) -> tuple[float, float]:
         return 1e-3, 1e-3
     else:
         return 1.6e-2, 1.6e-2
-
-
-# Fixtures
 
 
 class RopeBasicFixture(FixtureBase):

--- a/tests/ops/test_special_elementwise_conformance.py
+++ b/tests/ops/test_special_elementwise_conformance.py
@@ -15,10 +15,8 @@ import torch
 import tileops.ops.elementwise as elementwise_mod
 from tileops.manifest import load_manifest
 
-# Construction and call signatures, for every op in the family
-#
-# Replaces the five per-op signature tests this file used to carry: the rule is the
-# same for all of them, and it is the one the manifest states.
+# Construction and call signatures, for every op in the family. One rule covers
+# them all, and it is the one the manifest states.
 
 _ELEMENTWISE_OPS = sorted(n for n in elementwise_mod.__all__ if n.endswith("FwdOp"))
 
@@ -131,8 +129,8 @@ def test_clamp_tensor_bounds_parity(input_shape, min_shape, max_shape, dtype):
     inp = torch.randn(input_shape, device="cuda", dtype=dtype)
     mn = torch.randn(min_shape, device="cuda", dtype=dtype) - 0.5
     mx = torch.randn(max_shape, device="cuda", dtype=dtype) + 0.5
-    # Make max >= min where tested ranges overlap; PyTorch clamp tolerates
-    # mismatch but we want a meaningful ref.
+    # Make max >= min where tested ranges overlap: PyTorch clamp tolerates a
+    # mismatch, but the reference is only meaningful without one.
     ref = torch.clamp(inp, mn, mx)
 
     op = ClampFwdOp()

--- a/tests/ops/test_vector_norm.py
+++ b/tests/ops/test_vector_norm.py
@@ -12,8 +12,6 @@ from tests.test_base import FixtureBase, TestBase, allclose_compare
 from tileops.kernels.reduction.vector_norm import VectorNormKernel
 from workloads.reduction import L1NormWorkload
 
-# Fixtures
-
 
 class VectorNormBasicFixture(FixtureBase):
     PARAMS = [
@@ -83,9 +81,6 @@ class VectorNorm1DFixture(FixtureBase):
             ],
         ),
     ]
-
-
-# TestBase helpers — inherit gen_inputs() from workload classes
 
 
 # Map op_kind to the ord parameter for torch.linalg.vector_norm
@@ -164,9 +159,6 @@ def _make_op(
     return cls(dim=dim, keepdim=keepdim, kernel_map=kernel_map, tune=tune)
 
 
-# L1NormFwdOp tests
-
-
 @VectorNormBasicFixture
 def test_l1_norm_op(m: int, n: int, dtype: torch.dtype) -> None:
     test = VectorNormTest(m, n, dtype, "l1")
@@ -216,9 +208,6 @@ def test_l1_1d(n: int, dtype: torch.dtype) -> None:
     allclose_compare(y.view_as(ref), ref, atol=atol, rtol=rtol)
 
 
-# L2NormFwdOp tests
-
-
 @VectorNormBasicFixture
 def test_l2_norm_op(m: int, n: int, dtype: torch.dtype) -> None:
     test = VectorNormTest(m, n, dtype, "l2")
@@ -266,9 +255,6 @@ def test_l2_1d(n: int, dtype: torch.dtype) -> None:
     y = op(x)
     atol, rtol = _get_tolerances(dtype)
     allclose_compare(y.view_as(ref), ref, atol=atol, rtol=rtol)
-
-
-# InfNormFwdOp tests
 
 
 @VectorNormBasicFixture
@@ -427,8 +413,6 @@ def test_spec_dim0_keepdim(op_kind: str, dtype: torch.dtype) -> None:
     atol, rtol = _get_tolerances(dtype)
     allclose_compare(y, ref, atol=atol, rtol=rtol)
 
-
-# Dtype smoke tests
 
 _DTYPE_SMOKE_M, _DTYPE_SMOKE_N = 64, 512
 

--- a/tests/ops/test_welford_non_aligned.py
+++ b/tests/ops/test_welford_non_aligned.py
@@ -14,8 +14,6 @@ import torch
 from tests.test_base import FixtureBase, TestBase
 from workloads.workload_base import RandnWorkload
 
-# Test helpers
-
 
 class WelfordNonAlignedTest(RandnWorkload, TestBase):
     def __init__(self, shape: tuple, dtype, op_kind: str, correction: int = 1):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -114,7 +114,7 @@ class TestBase(WorkloadBase):
             f"outputs: {len(outputs)} and outputs_ref: {len(outputs_ref)} have different size"
         )
 
-        # Compute error metrics before comparison (so we report even on failure).
+        # Error metrics before the comparison, so a failing case still reports them.
         max_abs_err = 0.0
         for output, output_ref in zip(outputs, outputs_ref, strict=True):
             if output_ref is not None:

--- a/tests/test_reclaim_action.py
+++ b/tests/test_reclaim_action.py
@@ -36,9 +36,6 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 RECLAIM_SCRIPT = REPO_ROOT / ".github" / "actions" / "reclaim-runner-disk" / "reclaim_cache.sh"
 
 
-# Test helpers
-
-
 def _age_path(path: Path, *, days: float) -> None:
     """Backdate mtime+atime of every file under ``path`` by ``days`` days."""
     past = time.time() - days * 86400

--- a/tests/test_tier_validation.py
+++ b/tests/test_tier_validation.py
@@ -20,8 +20,6 @@ import torch
 
 from tests.conftest import _freeze_value, pytest_collection_modifyitems
 
-# Helpers to build mock pytest.Items
-
 
 def _make_item(
     *,
@@ -92,7 +90,6 @@ class TestSmokeCount:
             _make_item(name="test_op[1]", markers=["smoke"], tune=False),
             _make_item(name="test_op[2]", markers=["full"], tune=False),
         ]
-        # Should not raise
         pytest_collection_modifyitems(items)
 
 

--- a/tests/trace/test_payload.py
+++ b/tests/trace/test_payload.py
@@ -19,7 +19,6 @@ def preserve_trace_state():
     try:
         yield
     finally:
-        # Restore original state
         if original_enabled:
             trace.enable(output=original_output)
         else:
@@ -30,7 +29,6 @@ def test_payload_api_signature(preserve_trace_state):
     """Test that payload parameter is accepted by trace APIs."""
     trace.disable()
 
-    # Test range() accepts payload
     @tilelang.jit(out_idx=trace.out_idx(1))
     def build1():
         @T.prim_func
@@ -40,7 +38,6 @@ def test_payload_api_signature(preserve_trace_state):
 
         return trace.finalize(kernel)
 
-    # Should compile without error
     kernel = build1()
     assert kernel is not None
 
@@ -55,7 +52,6 @@ def test_payload_with_range_start_end(preserve_trace_state, tmp_path):
         def kernel(out: T.Tensor((16,), "float32")):
             with T.Kernel(1, threads=16):
                 tx = T.get_thread_binding()
-                # Test range_start accepts payload
                 tok = trace.range_start("test_range", payload=42)
                 out[tx] = T.float32(tx)
                 trace.range_end(tok)
@@ -64,21 +60,17 @@ def test_payload_with_range_start_end(preserve_trace_state, tmp_path):
 
     kernel = build()
 
-    # When tracing is enabled, kernel returns (output, slots)
     result = kernel()
     assert isinstance(result, (tuple, list)), "Expected (output, slots) tuple"
 
     output_tensor, slots = result
 
-    # Verify kernel output
     expected = torch.arange(16, dtype=torch.float32, device="cuda")
     assert torch.allclose(output_tensor, expected)
 
-    # Decode and verify payload is 42
     events = trace.decode(kernel, slots)
     slices = [e for e in events if e.name == "test_range"]
 
-    # Should have exactly one slice with payload 42
     assert len(slices) == 1, f"Expected exactly one test_range slice, got {len(slices)}"
     assert slices[0].payload == 42, f"Expected payload 42, got {slices[0].payload}"
 
@@ -96,7 +88,6 @@ def test_payload_backward_compatibility(preserve_trace_state):
                 with trace.range("test"):
                     pass
 
-                # With lane but no payload
                 with trace.range("test2", lane="compute"):
                     pass
 
@@ -129,7 +120,6 @@ def test_implicit_thread_blocks_with_payload_e2e(preserve_trace_state, tmp_path)
             # This triggers the __tl_thread_idx_x() writer-election fallback
             with T.Kernel(1, threads=16):
                 tx = T.get_thread_binding()
-                # Explicit payload=42 (user-provided constant)
                 with trace.range("test_range", payload=42):
                     out[tx] = T.float32(tx)
 
@@ -144,11 +134,9 @@ def test_implicit_thread_blocks_with_payload_e2e(preserve_trace_state, tmp_path)
 
     output_tensor, slots = result
 
-    # Verify kernel output
     expected = torch.arange(16, dtype=torch.float32, device="cuda")
     assert torch.allclose(output_tensor, expected)
 
-    # Decode and verify payload
     events = trace.decode(kernel, slots)
     slices = [e for e in events if e.name == "test_range"]
 
@@ -174,7 +162,6 @@ def test_dynamic_payload_runtime_expr(preserve_trace_state, tmp_path):
     def build():
         @T.prim_func
         def kernel(out: T.Tensor((4,), "float32")):
-            # Use simple T.Kernel with threads=4
             with T.Kernel(1, threads=4):
                 tx = T.get_thread_binding()
                 # Explicitly use loop index as payload - this is a user-provided runtime PrimExpr
@@ -191,11 +178,9 @@ def test_dynamic_payload_runtime_expr(preserve_trace_state, tmp_path):
 
     output_tensor, slots = result
 
-    # Verify kernel output
     expected = torch.tensor([0.0, 1.0, 2.0, 3.0], dtype=torch.float32, device="cuda")
     assert torch.allclose(output_tensor, expected)
 
-    # Decode and verify payload values
     events = trace.decode(kernel, slots)
     loop_slices = [e for e in events if e.name == "loop_iter"]
 

--- a/workloads/elementwise.py
+++ b/workloads/elementwise.py
@@ -627,7 +627,8 @@ def draw_special_floats(shape: tuple, dtype: torch.dtype) -> tuple[torch.Tensor]
     return (x,)
 
 
-# Domain名 -> draw。持有映射的是这一层,调用方只给名字,静态可见。
+# Domain name -> draw function. The mapping lives here, so a caller names a
+# domain rather than passing a draw, and the set is statically visible.
 PAIR_DOMAINS = {
     "normal": draw_normal_pair,
     "positive": draw_positive_pair,


### PR DESCRIPTION
## problems

- Comments quote measurements as the reason for a default: `0.0413 -> 0.0328 ms`, `stages=5 is 13% slower`, `512 is ~3% slower`, `8.0us -> 14.3us`. The number goes stale on the next machine; the constraint it stood in for is what a reader needs.
- Tuning-run provenance stands in for the rule: "NCU evidence", "the optimal config found via AKO tuning".
- Edit history: "64 only viable after the x_scaled_f32 fragment was removed", "the shape whose default config formerly selected block_v = 8".
- Process metadata points at PRs: "uncomment as sub-category PRs land".
- Residue: `# is this a accumulate operator?` (6 sites), `# @property / # params unused` above a live method, one Chinese comment in an otherwise English file.
- 627 lines restate the line below them: `# Fragments` above `alloc_fragment`, `# Write outputs` above the `T.copy` that writes them, `# ArgmaxFwdOp tests` above `def test_argmax_*`, `# sub` above `pytest.param("sub", ...)`.
- The Qwen-adapted prefill kernels carry `[STAGE 0] 3` and `S2[V] W` markers whose legend never came with them.

## changes

- Dropped the measurement from every comment quoting one; kept the constraint it justified.
- Rewrote autotune-config rationales to name the axes the sweep varies, not the run that found them.
- Replaced history narration with the current-state statement; removed the PR-referencing placeholders and the dead residue.
- Condensed the 55-line `ssd_decode.py` header to the caller contract: what arrives pre-processed, what the kernel does not do, where ngroups differs from the official fallback.
- Deleted 627 restating lines across 106 files.
- Kept math, layouts, algorithm-step markers, reasons, `FIXME(staged-rollout)` blocks, and the `# Outputs` divider in `T.prim_func` signatures — the only marker of where a parameter list stops taking inputs.
- Test node delta: 0 — 4350 nodes before and after.

Every hunk removes only comment or blank lines. `pre-commit` and `scripts/validate_manifest.py` pass; 254 GPU tests over the most-edited files pass.