### PR TITLE
[Perf][foundry][Elementwise] Divide float16 with the approximate reciprocal

### DIFF
--- a/src/tileops/kernels/elementwise/arithmetic.py
+++ b/src/tileops/kernels/elementwise/arithmetic.py
@@ -74,17 +74,37 @@ class MulFwdKernel(BinaryKernel):
         return a * b
 
 
+def _approx_fdiv(num, den):
+    """CUDA's ``__fdividef``: one ``div.approx.f32`` where ``/`` is a Newton sequence.
+
+    Two ulp of float32, and defined for a divisor in ``[2**-126, 2**126]``.
+    Only float16 meets both: its magnitudes span ``[2**-24, 2**16]``, and two
+    ulp of float32 cannot reach the eleventh mantissa bit its result rounds to.
+    bfloat16 carries float32's exponent, and a float32 result keeps all 24 bits.
+    """
+    return T.call_extern("float32", "__fdividef", num, den)
+
+
 class DivFwdKernel(BinaryKernel):
     """Element-wise division: y = a / b.
 
     Divides in float32 and rounds once at the store, which is what torch does.
+    A float16 result takes ``_approx_fdiv``, which that rounding absorbs.
     """
 
     SUPPORTED_DTYPES = _FLOAT_DTYPES
 
+    @property
+    def stage_broadcast(self) -> bool:
+        """The extern call scalarises the copies, so keep them off its loop."""
+        return self.dtype == torch.float16 or super().stage_broadcast
+
     @staticmethod
     def op_func(a, b):
-        return T.Cast(a.dtype, T.Cast("float32", a) / T.Cast("float32", b))
+        num, den = T.Cast("float32", a), T.Cast("float32", b)
+        if str(a.dtype) == "float16":
+            return T.Cast(a.dtype, _approx_fdiv(num, den))
+        return T.Cast(a.dtype, num / den)
 
 
 class DivTruncFwdKernel(BinaryKernel):

--- a/src/tileops/kernels/elementwise/arithmetic.py
+++ b/src/tileops/kernels/elementwise/arithmetic.py
@@ -75,12 +75,12 @@ class MulFwdKernel(BinaryKernel):
 
 
 def _approx_fdiv(num, den):
-    """CUDA's ``__fdividef``: one ``div.approx.f32`` where ``/`` is a Newton sequence.
+    """CUDA's ``__fdividef``: one ``div.approx.f32``, two ulp, defined for a
+    divisor in ``[2**-126, 2**126]``.
 
-    Two ulp of float32, and defined for a divisor in ``[2**-126, 2**126]``.
-    Only float16 meets both: its magnitudes span ``[2**-24, 2**16]``, and two
-    ulp of float32 cannot reach the eleventh mantissa bit its result rounds to.
-    bfloat16 carries float32's exponent, and a float32 result keeps all 24 bits.
+    float16 spans ``[2**-24, 2**16]`` and rounds its result to eleven bits, so
+    it meets both bounds. bfloat16 carries float32's exponent and a float32
+    result keeps all 24 bits.
     """
     return T.call_extern("float32", "__fdividef", num, den)
 
@@ -89,7 +89,7 @@ class DivFwdKernel(BinaryKernel):
     """Element-wise division: y = a / b.
 
     Divides in float32 and rounds once at the store, which is what torch does.
-    A float16 result takes ``_approx_fdiv``, which that rounding absorbs.
+    float16 takes ``_approx_fdiv``.
     """
 
     SUPPORTED_DTYPES = _FLOAT_DTYPES


### PR DESCRIPTION
## Problems

`DivFwdOp` was behind its baseline on every float16 row in the nightly, by 1-7%.

- **The row is memory bound, so the divide should have cost nothing.** `analyze` puts `cnn-feat-broadcast` at 51.4 MB and `ideal-ns 10705`, `bound-by memory`. A copy of the same bytes measures 14.335 us on this device; the divide took 15.136 us. The 0.8 us is arithmetic that a memory-bound row has the latency to hide, and did not.
- **`/` on float32 is a Newton sequence.** nvcc emits `div.rn.f32` by default. The baseline this row is measured against does not: inductor's kernel is the same load, upcast, divide, store, and its PTX is `div.full.f32`. The whole gap is the instruction.

## Changes

- `_approx_fdiv` calls `__fdividef`, and `DivFwdKernel.op_func` takes it when the result is float16. bfloat16 and float32 keep the exact divide.
- `DivFwdKernel.stage_broadcast` is true for float16: an extern call is opaque to the vectoriser, so the copies move off the body's loop, as they already do for the NaN builtin in `MaximumFwdKernel`.
- Test-node delta: 0. No manifest, tolerance or public-contract change.

Two properties of float16 make the approximate divide store the IEEE result. `__fdividef` is accurate to 2 ulp of float32 and defined for a divisor in `[2**-126, 2**126]`; a float16 magnitude spans `[2**-24, 2**16]`, and 2 ulp of float32 cannot reach the eleventh mantissa bit the store rounds to. Neither holds for bfloat16, which carries float32's exponent, or for a float32 result, which keeps all 24 bits — hence the dtype gate rather than a compile flag.

`-prec-div=false` would reach `div.full.f32` and cover bfloat16 too, and it is not used here: `CUDABinaryCache.make_key` hashes the generated code but not the nvcc options, so the flag is silently dropped on a warm cache. Verified — an invalid flag raises `nvcc fatal` on a cold cache and nothing on a warm one.

## TileFoundry Description

The row authored as one divide, and the shipped kernel as its runtime twin:

```python
@module(entry="div_bcast", target=CudaTarget("nvidia.h200_sxm"), topologies=_TOPOLOGIES)
class CnnFeatBroadcast:
    @func
    def div_bcast(
        a: Tensor[(16, 256, 56, 56), "f16"],
        b: Tensor[(256, 1, 1), "f16"],
    ) -> Tensor[(16, 256, 56, 56), "f16"]:
        return a / b


@runtime_module(CnnFeatBroadcast)
class CnnFeatBroadcastTwin:
    @runtime_func
    def div_bcast(self, a, b):
        return DivFwdOp()(a, b)
```

`analyze` gives `traffic=gmem:r25690624/w25690112`, `ideal-ns=10705`, `bound-by=memory`. That bound is nominal bandwidth and this device does not reach it: a flat elementwise pass over the same bytes measures **14.335 us**, which is what the row now takes.

`check` against that reference, on random inputs:

| Predicate | Result |
| --- | --- |
| `ulp(max=1)` | `max_ulp 0`, **PASS** |
| `nan_inf` | `nan 0 inf 0`, **PASS** |

Random inputs sample one region, so the claim is also checked over the whole dtype. Every pair of float16 bit patterns — 2^32, NaN and Inf included — divided both ways and rounded to float16:

| | count |
| --- | ---: |
| pairs compared | 4294967296 |
| stored results that differ | 7964 |
| of those, with a **normal** result | **0** |
| max ulp distance | 1 |
| NaN-ness differs | 0 |

Every difference is one ulp of a float16 subnormal, at most 6e-8 absolute, on 1.9e-6 of the domain. The same sweep for bfloat16 with `div.full.f32` gives 0 differing pairs, and with `__fdividef` gives 16.6 million with a normal result — which is why bfloat16 is excluded.

## Performance

| Environment | Value |
| --- | --- |
| image | `ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-afcebed1-foundry-dev` |
| gpu | `NVIDIA H200` (one idle device, SM clock 1500 MHz, not the CI runners') |
| driver | `595.71.05`, cuda `13.2`, torch `2.13.0+cu132`, tilelang `0.1.11+cu132.gitafcebed1` |
| timer | native CUPTI device-busy time |

Method: `benchmarks/ops/bench_binary_elementwise.py` and `bench_elementwise_manifest.py` unmodified, `-k div`, 12 rows, each side from its own empty `TILELANG_CACHE_DIR`. The report rounds to 0.1 us, so the headline row is also measured on its own, A B A B in one sitting, minimum per side.

`cnn-feat-broadcast` float16, dedicated A/B/A/B: **15.136 -> 14.336 us**, against torch-compile 14.399 and a 14.335 us copy floor.

The 12 benchmark rows, before against after, and after against the strongest baseline:

| Shape | dtype | Before (us) | After (us) | Speedup | Baseline (us) / ours |
| --- | --- | ---: | ---: | ---: | ---: |
| `(16, 256, 56, 56)` bcast | float16 | 15.4 | 14.8 | **1.041x** | torch-compile 14.8 🟢 1.000x |
| `1024x4096 by 1x4096` | float16 | 6.5 | 6.2 | **1.048x** | torch-compile 6.3 🟢 1.016x |
| `1024x11008 by 1x11008` | float16 | 13.6 | 13.1 | **1.038x** | torch-compile 13.2 🟢 1.008x |
| `1024x10240 by 1x10240` | float16 | 12.6 | 12.2 | **1.033x** | torch-compile 12.3 🟢 1.008x |
| `(1024, 10240)` | float16 | 18.0 | 17.7 | 1.017x | torch-compile 17.8 🟢 1.006x |
| `(2048, 4096)` | float16 | 14.8 | 14.6 | 1.014x | torch-compile 14.7 🟢 1.007x |
| `(1024, 4096)` | float16 | 8.9 | 8.8 | 1.011x | torch-compile 8.8 🟢 1.000x |
| `(1024, 11008)` | float16 | 18.8 | 18.7 | 1.005x | torch-compile 18.8 🟢 1.005x |

All seven float16 rows improve and all now meet or beat the strongest baseline. The four bfloat16 and float32 rows are byte-identical kernels and move by at most 0.1 us.

## Result And Limitations

**improvement without SOTA**

- Every float16 row leads its strongest baseline, and `cnn-feat-broadcast` sits on the measured copy floor for its traffic, so there is nothing left to take on that row.
- **bfloat16 is still behind and this branch does not move it.** `cnn-feat-broadcast` bfloat16 reads 0.960x against torch-compile. The instruction that would close it is `div.full.f32`, which bfloat16 is exhaustively safe under, and the only way to reach it from TileLang is an nvcc flag the binary cache drops. That cache key is the thing to fix, upstream, before this row can move.
- Tests: `tests/ops/test_elementwise_binary_broadcast.py`, `test_elementwise_compile.py`, `test_elementwise_config_dtype.py`, 179 passed. `pre-commit` clean.
