### PR TITLE
[Perf][foundry][Elementwise] Size a decode row's grid from the work, not the dtype

### DIFF
--- a/src/tileops/kernels/elementwise/_base.py
+++ b/src/tileops/kernels/elementwise/_base.py
@@ -60,10 +60,8 @@ class _ElementwiseKernel(Kernel):
     # is one vector load. A body the memory pipe waits on sets 32, keeping a
     # second load in flight while the first element's arithmetic runs.
     BYTES_PER_THREAD: int = 16
-    # How few elements the grid-filling shrink may leave a thread. Four keeps a
-    # staged copy at a useful width, which is what a body cheaper than its own
-    # access wants. A body that costs more than that has latency the extra
-    # blocks can hide, and says so by lowering this.
+    # The floor of the grid-filling shrink. Four keeps a staged copy wide; a body
+    # costing more than its own access lowers it, for the blocks that buys.
     MIN_NUM_PER_THREAD: int = 4
     # Input dtypes admitted; ``None`` admits every dtype the builder handles.
     SUPPORTED_DTYPES = None

--- a/src/tileops/kernels/elementwise/_base.py
+++ b/src/tileops/kernels/elementwise/_base.py
@@ -123,7 +123,9 @@ class _StrategyKernel(_ElementwiseKernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        return elementwise_autotune_configs(self.dtype, self.strategy, self.BYTES_PER_THREAD)
+        return elementwise_autotune_configs(
+            self.dtype, self.strategy, self.BYTES_PER_THREAD, self.MIN_NUM_PER_THREAD
+        )
 
     def init_config(self, config=None, tune=False) -> None:
         Kernel.init_config(self, config, tune)

--- a/src/tileops/kernels/elementwise/_base.py
+++ b/src/tileops/kernels/elementwise/_base.py
@@ -60,6 +60,11 @@ class _ElementwiseKernel(Kernel):
     # is one vector load. A body the memory pipe waits on sets 32, keeping a
     # second load in flight while the first element's arithmetic runs.
     BYTES_PER_THREAD: int = 16
+    # How few elements the grid-filling shrink may leave a thread. Four keeps a
+    # staged copy at a useful width, which is what a body cheaper than its own
+    # access wants. A body that costs more than that has latency the extra
+    # blocks can hide, and says so by lowering this.
+    MIN_NUM_PER_THREAD: int = 4
     # Input dtypes admitted; ``None`` admits every dtype the builder handles.
     SUPPORTED_DTYPES = None
     # Whether bool results are stored through an int8 buffer.
@@ -112,6 +117,7 @@ class _StrategyKernel(_ElementwiseKernel):
             n_total=self.N_total,
             stores_bool=not self._bool_via_int8,
             bytes_per_thread=self.BYTES_PER_THREAD,
+            min_num_per_thread=self.MIN_NUM_PER_THREAD,
             row_broadcast_inner=self.row_broadcast_inner,
         )
 
@@ -473,16 +479,12 @@ class FusedGatedKernel(_StrategyKernel):
 
     @property
     def default_config(self) -> dict:
-        if self.strategy == "explicit_parallel":
-            if self.dtype in (torch.float16, torch.bfloat16):
-                return {"strategy": self.strategy, "threads": 128, "num_per_thread": 8}
-            if self.dtype == torch.float32:
-                return {"strategy": self.strategy, "threads": 256, "num_per_thread": 4}
         return default_launch_config(
             strategy=self.strategy,
             input_dtype=self.dtype,
             output_dtype=self.output_dtype,
             n_total=self.M * self.N,
+            min_num_per_thread=self.MIN_NUM_PER_THREAD,
         )
 
     def forward(self, x):

--- a/src/tileops/kernels/elementwise/_policy.py
+++ b/src/tileops/kernels/elementwise/_policy.py
@@ -41,7 +41,7 @@ def default_launch_config(
     """Return the default launch config for one elementwise specialization.
 
     *bytes_per_thread* is how much each thread carries and *min_num_per_thread*
-    how few elements the shrink below may leave it; see
+    how few elements the shrink below leaves it; see
     ``_ElementwiseKernel.BYTES_PER_THREAD`` and ``MIN_NUM_PER_THREAD``.
     *row_broadcast_inner* is the row extent a broadcast block walks, or
     ``None``; see ``_tail_dominated``.
@@ -102,9 +102,8 @@ def elementwise_autotune_configs(
     """Return the launch configs to time for one elementwise specialization.
 
     The swept elements-per-thread brackets the default the same *bytes_per_thread*
-    produces, so a kernel can always land back on its shipped config. A kernel
-    whose *min_num_per_thread* lets the grid shrink further is swept that far
-    down for the same reason.
+    produces, so a kernel can always land back on its shipped config, and reaches
+    *min_num_per_thread* where a kernel lowers it.
     """
     # A direct body takes no num_per_thread: the key would name no parameter to bind,
     # and the sweep would time one kernel three times over.

--- a/src/tileops/kernels/elementwise/_policy.py
+++ b/src/tileops/kernels/elementwise/_policy.py
@@ -97,11 +97,14 @@ def elementwise_autotune_configs(
     dtype: torch.dtype,
     strategy: str | None = None,
     bytes_per_thread: int = _BYTES_PER_THREAD,
+    min_num_per_thread: int = _MIN_NUM_PER_THREAD,
 ) -> list[dict]:
     """Return the launch configs to time for one elementwise specialization.
 
     The swept elements-per-thread brackets the default the same *bytes_per_thread*
-    produces, so a kernel can always land back on its shipped config.
+    produces, so a kernel can always land back on its shipped config. A kernel
+    whose *min_num_per_thread* lets the grid shrink further is swept that far
+    down for the same reason.
     """
     # A direct body takes no num_per_thread: the key would name no parameter to bind,
     # and the sweep would time one kernel three times over.
@@ -111,7 +114,11 @@ def elementwise_autotune_configs(
         npts = (_FP8_NPT, _FP8_NPT * 2)
     else:
         default = max(_MIN_NUM_PER_THREAD, bytes_per_thread // _torch_dtype_nbytes(dtype))
-        npts = tuple(sorted({max(_MIN_NUM_PER_THREAD, default // 2), default, default * 2}))
+        npts = tuple(
+            sorted(
+                {min_num_per_thread, max(min_num_per_thread, default // 2), default, default * 2}
+            )
+        )
     return [{"threads": t, "num_per_thread": n} for t in _AUTOTUNE_THREADS for n in npts]
 
 

--- a/src/tileops/kernels/elementwise/_policy.py
+++ b/src/tileops/kernels/elementwise/_policy.py
@@ -35,13 +35,16 @@ def default_launch_config(
     n_total: int | None,
     stores_bool: bool = True,
     bytes_per_thread: int = _BYTES_PER_THREAD,
+    min_num_per_thread: int = _MIN_NUM_PER_THREAD,
     row_broadcast_inner: int | None = None,
 ) -> dict:
     """Return the default launch config for one elementwise specialization.
 
-    *bytes_per_thread* is how much each thread carries; see
-    ``_ElementwiseKernel.BYTES_PER_THREAD``. *row_broadcast_inner* is the row
-    extent a broadcast block walks, or ``None``; see ``_tail_dominated``.
+    *bytes_per_thread* is how much each thread carries and *min_num_per_thread*
+    how few elements the shrink below may leave it; see
+    ``_ElementwiseKernel.BYTES_PER_THREAD`` and ``MIN_NUM_PER_THREAD``.
+    *row_broadcast_inner* is the row extent a broadcast block walks, or
+    ``None``; see ``_tail_dominated``.
     """
     # A direct block covers ``threads`` elements where a vectorized one covers
     # ``threads * num_per_thread``: the elements per block, not the thread count,
@@ -67,7 +70,7 @@ def default_launch_config(
     while (
         n_total is not None
         and strategy != "direct"
-        and npt > _MIN_NUM_PER_THREAD
+        and npt > min_num_per_thread
         and n_total < threads * npt * _TARGET_BLOCKS
     ):
         npt //= 2

--- a/src/tileops/kernels/elementwise/activations.py
+++ b/src/tileops/kernels/elementwise/activations.py
@@ -80,6 +80,8 @@ class GeluTanhFwdKernel(FloatUnaryKernel):
 class SiluFwdKernel(FloatUnaryKernel):
     """Element-wise SiLU (Swish): x * sigmoid(x)."""
 
+    MIN_NUM_PER_THREAD = 2
+
     @staticmethod
     def op_func(x):
         """x / (1 + exp2(-x * log2 e)), in fp32.
@@ -494,6 +496,7 @@ class SiluAndMulFwdKernel(FusedGatedKernel):
     """SiLU-and-Mul: y = silu(gate) * value = (gate * sigmoid(gate)) * value."""
 
     SUPPORTED_DTYPES = _FLOAT_DTYPES
+    MIN_NUM_PER_THREAD = 2
 
     @staticmethod
     def activation_func(x):
@@ -511,6 +514,7 @@ class GeluAndMulFwdKernel(FusedGatedKernel):
     """
 
     SUPPORTED_DTYPES = _FLOAT_DTYPES
+    MIN_NUM_PER_THREAD = 2
 
     @staticmethod
     def activation_func(x):
@@ -529,6 +533,7 @@ class GeluTanhAndMulFwdKernel(FusedGatedKernel):
     """
 
     SUPPORTED_DTYPES = _FLOAT_DTYPES
+    MIN_NUM_PER_THREAD = 2
 
     @staticmethod
     def activation_func(x):

--- a/tests/ops/test_elementwise_config_dtype.py
+++ b/tests/ops/test_elementwise_config_dtype.py
@@ -149,14 +149,14 @@ def test_fused_gated_kernel_sets_output_dtype_in_init():
 
 
 @pytest.mark.full
-def test_fused_gated_explicit_uses_occupancy_config():
-    """Fused-gated explicit_parallel uses the 128x8 occupancy config for fp16/bf16.
+def test_fused_gated_explicit_config_follows_the_work():
+    """Fused-gated explicit_parallel sizes its block from the work, not the dtype.
 
-    threads=128, npt=8 keeps block_N = 1024 (same tiling as the old 256x4) while
-    raising occupancy/ILP at large M. fp32 falls back to 256/4: npt=4 already
-    saturates the 128-bit load width, so 128/8 would only add register pressure.
-    The direct strategy keeps the dtype-driven npt, and 256 threads: one element
-    per thread makes the thread count the whole block, so 128 would halve it.
+    A row wide enough to fill the device keeps the widest thread the dtype
+    allows. A row that does not gives the width back until the grid reaches the
+    device, and silu stops at two elements a thread rather than four. The direct
+    strategy keeps the dtype-driven npt, and 256 threads: one element per thread
+    makes the thread count the whole block, so 128 would halve it.
     """
     with (
         patch.object(SiluAndMulFwdKernel, "_build_kernel", return_value=None),
@@ -168,41 +168,61 @@ def test_fused_gated_explicit_uses_occupancy_config():
             dtype=torch.float16,
             config={"strategy": "direct"},
         )
-        explicit_fp16 = SiluAndMulFwdKernel(
-            M=32,
-            N=1024,
+        wide_fp16 = SiluAndMulFwdKernel(
+            M=4096,
+            N=14336,
             dtype=torch.float16,
             config={"strategy": "explicit_parallel"},
         )
-        explicit_bf16 = SiluAndMulFwdKernel(
-            M=32,
-            N=1024,
+        wide_bf16 = SiluAndMulFwdKernel(
+            M=4096,
+            N=14336,
             dtype=torch.bfloat16,
             config={"strategy": "explicit_parallel"},
         )
-        explicit_fp32 = SiluAndMulFwdKernel(
-            M=32,
-            N=1024,
+        decode_bf16 = SiluAndMulFwdKernel(
+            M=1,
+            N=14336,
+            dtype=torch.bfloat16,
+            config={"strategy": "explicit_parallel"},
+        )
+        wide_fp32 = SiluAndMulFwdKernel(
+            M=4096,
+            N=14336,
             dtype=torch.float32,
             config={"strategy": "explicit_parallel"},
         )
     assert direct.default_config["num_per_thread"] == 8
     assert direct.default_config["threads"] == 256
-    assert explicit_fp16.default_config == {
+    assert wide_fp16.default_config == {
         "strategy": "explicit_parallel",
         "threads": 128,
         "num_per_thread": 8,
     }
-    assert explicit_bf16.default_config == {
+    assert wide_bf16.default_config == {
         "strategy": "explicit_parallel",
         "threads": 128,
         "num_per_thread": 8,
     }
-    assert explicit_fp32.default_config == {
+    assert decode_bf16.default_config == {
         "strategy": "explicit_parallel",
-        "threads": 256,
+        "threads": 128,
+        "num_per_thread": 2,
+    }
+    # float32 takes the shared 128 threads rather than the 256 it used to state.
+    assert wide_fp32.default_config == {
+        "strategy": "explicit_parallel",
+        "threads": 128,
         "num_per_thread": 4,
     }
+    # The sweep reaches whatever the default is, or a tuned kernel could not
+    # land back on its shipped config.
+    for kernel in (wide_fp16, wide_bf16, decode_bf16, wide_fp32):
+        cfg = kernel.default_config
+        assert any(
+            c["num_per_thread"] == cfg["num_per_thread"] and c["threads"] == cfg["threads"]
+            for c in kernel.autotune_configs
+        )
 
 
 # Strategy lives in the kernel config dict, not in op/kernel ctor kwargs

--- a/tests/ops/test_elementwise_config_dtype.py
+++ b/tests/ops/test_elementwise_config_dtype.py
@@ -152,11 +152,10 @@ def test_fused_gated_kernel_sets_output_dtype_in_init():
 def test_fused_gated_explicit_config_follows_the_work():
     """Fused-gated explicit_parallel sizes its block from the work, not the dtype.
 
-    A row wide enough to fill the device keeps the widest thread the dtype
-    allows. A row that does not gives the width back until the grid reaches the
-    device, and silu stops at two elements a thread rather than four. The direct
-    strategy keeps the dtype-driven npt, and 256 threads: one element per thread
-    makes the thread count the whole block, so 128 would halve it.
+    A row that fills the device keeps the widest thread its dtype allows; one
+    that does not gives width back until the grid reaches the device, and silu
+    stops at two. The direct strategy keeps 256 threads: one element a thread
+    makes the thread count the whole block.
     """
     with (
         patch.object(SiluAndMulFwdKernel, "_build_kernel", return_value=None),
@@ -209,14 +208,13 @@ def test_fused_gated_explicit_config_follows_the_work():
         "threads": 128,
         "num_per_thread": 2,
     }
-    # float32 takes the shared 128 threads rather than the 256 it used to state.
+    # float32 takes the shared thread count, not the 256 this family stated.
     assert wide_fp32.default_config == {
         "strategy": "explicit_parallel",
         "threads": 128,
         "num_per_thread": 4,
     }
-    # The sweep reaches whatever the default is, or a tuned kernel could not
-    # land back on its shipped config.
+    # A tuned kernel must be able to land back on its shipped config.
     for kernel in (wide_fp16, wide_bf16, decode_bf16, wide_fp32):
         cfg = kernel.default_config
         assert any(


### PR DESCRIPTION
## Problems

`SiluAndMulFwdOp` on `llama-8b-swiglu-decode` was the furthest behind of any elementwise or reduction row in the nightly, at 0.86x. `SiluFwdOp` on `llama-8b-ffn-decode` read 0.94x.

- **The fused-gated family stated its own launch config.** `FusedGatedKernel.default_config` returned a literal `128 x 8` for the half formats, so the shared policy — which halves the block width until the grid reaches the device — never ran for it. A 14336-element row got 14 blocks on 132 SMs.
- **The shrink the policy does run stops at four elements a thread.** Four is what a staged copy wants. `analyze` puts this row's ideal at `30 ns`, `bound-by memory`, against a measured 1.79 us: nothing here is bandwidth, it is one wave of blocks and the latency inside it, and the only lever is how much of the device the wave covers.

## Changes

- `FusedGatedKernel.default_config` calls `default_launch_config` like every other elementwise family. Its `n_total` is `M * N`, so a prefill row keeps the width it had and a decode row gives it back.
- `_ElementwiseKernel.MIN_NUM_PER_THREAD` (4) bounds that shrink, and `default_launch_config` takes it. A body costing more than its own access has latency the extra blocks hide, and lowers it; a cheaper body only loses the access width.
- Four kernels set 2: `SiluFwdKernel`, `SiluAndMulFwdKernel`, `GeluAndMulFwdKernel`, `GeluTanhAndMulFwdKernel`. `GeluFwdKernel` and `GeluTanhFwdKernel` were measured and do not gain, so they are left alone.
- `elementwise_autotune_configs` takes the same floor, or a kernel whose default is 2 could not be tuned back onto it.
- Test-node delta: 0. `test_fused_gated_explicit_uses_occupancy_config` asserted the literal this change removes; it is rewritten as `test_fused_gated_explicit_config_follows_the_work` and now also pins the autotune bracket.

float32 fused-gated moves from the old literal `256 x 4` to the policy's `128 x 4`. Measured: `[2048, 28672]` float32 is 83.6 us before and 83.7 after, inside the noise; `[1, 28672]` float32 goes 1.664 -> 1.536.

## TileFoundry Description

The decode row authored as one gated activation, and the shipped kernel as its runtime twin. The gate and value halves are separate parameters; the shipped op takes them packed, and the traffic is the same either way:

```python
@module(entry="silu_and_mul", target=CudaTarget("nvidia.h200_sxm"), topologies=_TOPOLOGIES)
class SwigluDecode:
    @func
    def silu_and_mul(
        gate: Tensor[(1, 14336), "bf16"],
        value: Tensor[(1, 14336), "bf16"],
    ) -> Tensor[(1, 14336), "bf16"]:
        return tf.silu(gate) * value


@runtime_module(SwigluDecode)
class SwigluDecodeTwin:
    @runtime_func
    def silu_and_mul(self, gate, value):
        return SiluAndMulFwdOp()(torch.cat([gate, value], dim=-1))
```

`analyze` gives `traffic=gmem:r86016/w57344` for the unfused pair and `ideal-ns=30`, `bound-by=memory`. The shipped kernel fuses, so it moves `r57344/w28672` — but the number that matters is the ratio: the row takes 1.54 us against a 30 ns memory-bound ideal, 51x. **This row is not bandwidth bound, it is launch bound**, and an empty kernel on this device measures 1.06 us. That is why the block width, not the access width, is what moves it.

`check` against that reference, on random inputs, with the new config in the log:

| Predicate | Result |
| --- | --- |
| `allclose(atol=2e-2, rtol=2e-2)` | `max_violation 0`, **PASS** |
| `nan_inf` | `nan 0 inf 0`, **PASS** |

## Performance

| Environment | Value |
| --- | --- |
| image | `ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-afcebed1-foundry-dev` |
| gpu | `NVIDIA H200` (one idle device, SM clock 1500 MHz, not the CI runners') |
| driver | `595.71.05`, cuda `13.2`, torch `2.13.0+cu132`, tilelang `0.1.11+cu132.gitafcebed1` |
| timer | native CUPTI device-busy time |

Method: each row measured on its own, three runs a side, each side from its own empty `TILELANG_CACHE_DIR`. CUPTI quantises to about 0.032 us here, so the spread is given rather than a single number. `benchmarks/ops/bench_elementwise_manifest.py` was also run whole on both sides; its report rounds to 0.1 us, which at 1.3 us is 8%, so it is used only to find rows to measure directly.

| Row | dtype | Before (us) | After (us) | Strongest baseline (us) |
| --- | --- | --- | --- | --- |
| `SiluAndMulFwd` `llama-8b-swiglu-decode` | bfloat16 | 1.776 - 1.792 | **1.536 - 1.568** | torch-compile 1.584 (median of 6) 🟢 |
| `GeluAndMulFwd` `ffn-gelu-decode` | bfloat16 | 1.760 - 1.792 | **1.536 - 1.568** | torch-compile 1.568 🟢 |
| `GeluTanhAndMulFwd` `ffn-gelu-tanh-decode` | bfloat16 | 1.792 - 1.808 | **1.536 - 1.568** | torch-compile 1.568 🟢 |
| `SiluFwd` `llama-8b-ffn-decode` | bfloat16 | 1.568 - 1.600 | **1.536** | torch-compile 1.568 (median of 8) 🟡 |
| `SiluAndMulFwd` `[1, 28672]` | float32 | 1.632 - 1.696 | **1.536 - 1.568** | — |

Nothing else moves. The ops that share the policy but not the floor, measured directly at the same 14336-element shape, before against after: `hardsigmoid` 1.408-1.440 / 1.408-1.409, `relu` 1.376-1.408 / 1.408, `hardswish` 1.408-1.440 / 1.408-1.440, `gelu` 1.440-1.472 / 1.472. `SiluAndMul` at `[2048, 28672]` bfloat16 and float32 is unchanged.

## Result And Limitations

**improvement without SOTA**

- The three gated decode rows lead their strongest baseline, and the worst row in the nightly's elementwise set moves from 0.86x to 1.03x.
- **`SiluFwd` decode is a tie, not a lead.** Over eight runs a side its median is 1.537 against torch-compile's 1.568 and its minimum is 1.536 against 1.473, and the repo benchmark reports both at 0.0016 ms with overlapping p10/p90. The nightly's own torch-compile figure for this row is 1.38, which I cannot reproduce on this device at all, so the row may still read below 1.0 there. What this branch can claim for it is 1.568 -> 1.536, not a crossing.
- **The floor is a per-kernel constant, and I could not derive it.** Two elements a thread beats four on a body with a transcendental in it and loses on a cheap one; the discriminator is what the body costs against its own access, which the policy cannot see. It is stated on the four kernels that measurement says want it, and every other kernel is untouched. `gelu` is transcendental and does not want it, so the rule is not "transcendental" either — it is measurement.
- **These rows are near a wall neither side crosses.** An empty kernel is 1.06 us here and the best any implementation reaches is about 1.54. What is left is launch and one dependent memory round trip.
- Tests: `tests/ops/test_activation.py`, `test_elementwise_config_dtype.py`, `test_elementwise_caching_autotune.py`, `test_elementwise_unary_activation_alignment.py`, `test_elementwise_compile.py`, 261 passed. `pre-commit` clean.
