### PR TITLE
[Perf][MoE] Fuse tight decode PrePermute

### DIFF
--- a/src/tileops/kernels/moe/permute_contiguous.py
+++ b/src/tileops/kernels/moe/permute_contiguous.py
@@ -12,9 +12,6 @@ from tileops.kernels.moe.call_spec import PrePermuteCall
 
 __all__ = ["MoePrePermuteContiguousKernel"]
 
-_SCAN_THREADS = 1024
-_SUPPORTED_LAYOUTS = frozenset(("tight_physical_psum", "aligned_per_row"))
-
 
 def _fused_tight_plan(num_tokens: int, numel: int, hidden_size: int) -> bool:
     """Whether one cooperative tight launch beats the scan/gather pair.
@@ -330,13 +327,14 @@ class MoePrePermuteContiguousKernel(Kernel):
     """Build one contiguous PrePermute specialization from ``call.layout``."""
 
     supported_archs: list[int] = [80, 86, 89, 90]
+    _SUPPORTED_LAYOUT_KEYS = frozenset(("tight_physical_psum", "aligned_per_row"))
 
     @classmethod
     def applies(cls, call: PrePermuteCall) -> bool:
         layout = call.layout
         return getattr(
             layout, "selection_key", None
-        ) in _SUPPORTED_LAYOUTS and call.input_dtype in (torch.bfloat16, torch.float16)
+        ) in cls._SUPPORTED_LAYOUT_KEYS and call.input_dtype in (torch.bfloat16, torch.float16)
 
     def __init__(
         self,
@@ -347,7 +345,7 @@ class MoePrePermuteContiguousKernel(Kernel):
         super().__init__()
         layout = call.layout
         self.layout_key = getattr(layout, "selection_key", "")
-        if self.layout_key not in _SUPPORTED_LAYOUTS:
+        if self.layout_key not in self._SUPPORTED_LAYOUT_KEYS:
             raise ValueError(f"unsupported contiguous PrePermute layout: {self.layout_key!r}")
         self.num_tokens = call.num_tokens
         self.top_k = call.top_k
@@ -386,7 +384,9 @@ class MoePrePermuteContiguousKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
-        return {"threads": _SCAN_THREADS}
+        # One CTA owns count, prefix sum, and scatter. Callers may override this
+        # kernel-local default through ``config``.
+        return {"threads": 1024}
 
     def forward(
         self,

--- a/src/tileops/kernels/moe/permute_contiguous.py
+++ b/src/tileops/kernels/moe/permute_contiguous.py
@@ -1,5 +1,6 @@
 """Layout-specialized contiguous materialization for staged MoE PrePermute."""
 
+import functools
 from typing import Optional
 
 import tilelang
@@ -15,11 +16,77 @@ _SCAN_THREADS = 1024
 _SUPPORTED_LAYOUTS = frozenset(("tight_physical_psum", "aligned_per_row"))
 
 
+def _fused_tight_plan(num_tokens: int, numel: int, hidden_size: int) -> bool:
+    """Whether one cooperative tight launch beats the scan/gather pair.
+
+    Tiny routing problems benefit directly from losing a launch.  At production
+    widths, decode benefits as well, while prefill spends more time holding the
+    cooperative grid across the barrier than the removed launch costs.  The
+    thresholds are the H200 sweep boundary, following the measured planner style
+    used by the fused split-row softmax path.
+    """
+    return numel <= 64 or (num_tokens <= 512 and hidden_size >= 2048)
+
+
+def _make_tight_scan_body(numel: int, num_experts: int, top_k: int, threads: int):
+    """Shared tight count/prefix/scatter body for split and fused launches."""
+
+    @T.macro
+    def scan(
+        flat_ids,
+        physical_ends,
+        permuted_idx,
+        inverse_indices,
+        write_offsets,
+        counts,
+        offsets,
+        slot_buf,
+    ):
+        tx = T.get_thread_binding()
+        for i in T.serial(T.ceildiv(num_experts, threads)):
+            idx = i * threads + tx
+            if idx < num_experts:
+                counts[idx] = T.int32(0)
+        T.sync_threads()
+
+        for i in T.serial(T.ceildiv(numel, threads)):
+            idx = i * threads + tx
+            if idx < numel:
+                T.atomic_add(counts[flat_ids[idx]], 1)
+        T.sync_threads()
+
+        if tx == 0:
+            offsets[0] = T.int64(0)
+            for expert in T.serial(num_experts):
+                offsets[expert + 1] = offsets[expert] + T.Cast(T.int64, counts[expert])
+        T.sync_threads()
+
+        for i in T.serial(T.ceildiv(num_experts, threads)):
+            idx = i * threads + tx
+            if idx < num_experts:
+                physical_ends[idx] = T.Cast(T.int32, offsets[idx + 1])
+                write_offsets[idx] = T.Cast(T.int32, offsets[idx])
+        T.sync_threads()
+
+        for i in T.serial(T.ceildiv(numel, threads)):
+            idx = i * threads + tx
+            if idx < numel:
+                expert = flat_ids[idx]
+                slot_buf[0] = T.atomic_add(write_offsets[expert], T.int32(1), return_prev=True)
+                slot = slot_buf[0]
+                permuted_idx[slot] = idx // T.int32(top_k)
+                inverse_indices[idx] = slot
+
+    return scan
+
+
 def _make_tight_scan(numel: int, num_experts: int, top_k: int):
     """Count assignments and produce tight physical-PSUM metadata."""
 
     @tilelang.jit(out_idx=[], compile_flags=["-O3"])
     def _scan(threads: int):
+        scan = _make_tight_scan_body(numel, num_experts, top_k, threads)
+
         @T.prim_func
         def _scan_main(
             flat_ids: T.Tensor([numel], "int32"),
@@ -29,46 +96,19 @@ def _make_tight_scan(numel: int, num_experts: int, top_k: int):
             write_offsets: T.Tensor([num_experts], "int32"),
         ):
             with T.Kernel(1, threads=threads) as (_,):
-                tx = T.get_thread_binding()
                 counts = T.alloc_shared([num_experts], "int32")
                 offsets = T.alloc_shared([num_experts + 1], "int64")
                 slot_buf = T.alloc_local([1], "int32")
-
-                for i in T.serial(T.ceildiv(num_experts, threads)):
-                    idx = i * threads + tx
-                    if idx < num_experts:
-                        counts[idx] = T.int32(0)
-                T.sync_threads()
-
-                for i in T.serial(T.ceildiv(numel, threads)):
-                    idx = i * threads + tx
-                    if idx < numel:
-                        T.atomic_add(counts[flat_ids[idx]], 1)
-                T.sync_threads()
-
-                if tx == 0:
-                    offsets[0] = T.int64(0)
-                    for expert in T.serial(num_experts):
-                        offsets[expert + 1] = offsets[expert] + T.Cast(T.int64, counts[expert])
-                T.sync_threads()
-
-                for i in T.serial(T.ceildiv(num_experts, threads)):
-                    idx = i * threads + tx
-                    if idx < num_experts:
-                        physical_ends[idx] = T.Cast(T.int32, offsets[idx + 1])
-                        write_offsets[idx] = T.Cast(T.int32, offsets[idx])
-                T.sync_threads()
-
-                for i in T.serial(T.ceildiv(numel, threads)):
-                    idx = i * threads + tx
-                    if idx < numel:
-                        expert = flat_ids[idx]
-                        slot_buf[0] = T.atomic_add(
-                            write_offsets[expert], T.int32(1), return_prev=True
-                        )
-                        slot = slot_buf[0]
-                        permuted_idx[slot] = idx // T.int32(top_k)
-                        inverse_indices[idx] = slot
+                scan(
+                    flat_ids,
+                    physical_ends,
+                    permuted_idx,
+                    inverse_indices,
+                    write_offsets,
+                    counts,
+                    offsets,
+                    slot_buf,
+                )
 
         return _scan_main
 
@@ -200,20 +240,90 @@ def _make_gather(
                     row = bid * rows_per_block + local_row
                     if row < physical_rows:
                         source = permuted_idx[row]
-                        if source < num_tokens:
+                        if not zero_fill:
                             T.copy(
                                 hidden_states[source, 0:hidden_size],
                                 expert_input[row, 0:hidden_size],
                             )
-                        elif zero_fill:
-                            for i in T.serial(T.ceildiv(hidden_size, threads)):
-                                column = i * threads + tx
-                                if column < hidden_size:
-                                    expert_input[row, column] = T.Cast(dtype, 0)
+                        else:
+                            if source < num_tokens:
+                                T.copy(
+                                    hidden_states[source, 0:hidden_size],
+                                    expert_input[row, 0:hidden_size],
+                                )
+                            else:
+                                for i in T.serial(T.ceildiv(hidden_size, threads)):
+                                    column = i * threads + tx
+                                    if column < hidden_size:
+                                        expert_input[row, column] = T.Cast(dtype, 0)
 
         return _gather_main
 
     return _gather
+
+
+@functools.lru_cache(maxsize=64)
+def _make_fused_tight(
+    num_tokens: int,
+    numel: int,
+    num_experts: int,
+    top_k: int,
+    hidden_size: int,
+    dtype: str,
+    grid: int,
+    rows_per_block: int,
+):
+    """Build tight metadata and gather rows in one cooperative launch."""
+    vector = 8
+    gather_threads = min(1024, hidden_size // vector)
+    while gather_threads > 0 and hidden_size % gather_threads != 0:
+        gather_threads -= 1
+    scan_threads = 1 << min(10, max(0, numel - 1).bit_length())
+    threads = max(gather_threads, scan_threads, 1)
+    scan = _make_tight_scan_body(numel, num_experts, top_k, threads)
+
+    @tilelang.jit(out_idx=[], compile_flags=["-O3", "-DENABLE_BF16"])
+    def _fused():
+        @T.prim_func
+        def _fused_main(
+            hidden_states: T.Tensor([num_tokens, hidden_size], dtype),
+            flat_ids: T.Tensor([numel], "int32"),
+            physical_ends: T.Tensor([num_experts], "int32"),
+            permuted_idx: T.Tensor([numel], "int32"),
+            inverse_indices: T.Tensor([numel], "int32"),
+            write_offsets: T.Tensor([num_experts], "int32"),
+            expert_input: T.Tensor([numel, hidden_size], dtype),
+        ):
+            with T.Kernel(grid, threads=threads) as (bid,):
+                counts = T.alloc_shared([num_experts], "int32")
+                offsets = T.alloc_shared([num_experts + 1], "int64")
+                slot_buf = T.alloc_local([1], "int32")
+
+                if bid == 0:
+                    scan(
+                        flat_ids,
+                        physical_ends,
+                        permuted_idx,
+                        inverse_indices,
+                        write_offsets,
+                        counts,
+                        offsets,
+                        slot_buf,
+                    )
+
+                T.sync_grid()
+
+                for local_row in T.serial(rows_per_block):
+                    row = bid * rows_per_block + local_row
+                    if row < numel:
+                        T.copy(
+                            hidden_states[permuted_idx[row], 0:hidden_size],
+                            expert_input[row, 0:hidden_size],
+                        )
+
+        return _fused_main
+
+    return _fused
 
 
 class MoePrePermuteContiguousKernel(Kernel):
@@ -244,6 +354,8 @@ class MoePrePermuteContiguousKernel(Kernel):
         self.num_experts = call.num_experts
         self.hidden_size = call.hidden_size
         self.dtype = call.input_dtype
+        self.h200 = call.h200
+        self.sm_count = call.sm_count
         self.numel = call.num_tokens * call.top_k
         self.alignment = getattr(layout, "alignment", 1)
         self.capacity = (
@@ -296,16 +408,42 @@ class MoePrePermuteContiguousKernel(Kernel):
         inverse_indices = torch.empty(self.numel, dtype=torch.int32, device=device)
         write_offsets = torch.empty(self.num_experts, dtype=torch.int32, device=device)
 
-        self._scan_fn(self.config["threads"])(
-            flat_ids,
-            layout_metadata,
-            permuted_idx,
-            inverse_indices,
-            write_offsets,
-        )
-
         expert_input = torch.empty(
             (self.capacity, self.hidden_size), dtype=self.dtype, device=device
         )
-        self._gather_fn()(hidden_states, permuted_idx, expert_input)
+        use_fused_tight = (
+            self.layout_key == "tight_physical_psum"
+            and self.h200
+            and _fused_tight_plan(self.num_tokens, self.numel, self.hidden_size)
+        )
+        if use_fused_tight:
+            rows_per_block = max(1, (self.numel + self.sm_count - 1) // self.sm_count)
+            grid = (self.numel + rows_per_block - 1) // rows_per_block
+            _make_fused_tight(
+                self.num_tokens,
+                self.numel,
+                self.num_experts,
+                self.top_k,
+                self.hidden_size,
+                self.dtype_str,
+                grid,
+                rows_per_block,
+            )()(
+                hidden_states,
+                flat_ids,
+                layout_metadata,
+                permuted_idx,
+                inverse_indices,
+                write_offsets,
+                expert_input,
+            )
+        else:
+            self._scan_fn(self.config["threads"])(
+                flat_ids,
+                layout_metadata,
+                permuted_idx,
+                inverse_indices,
+                write_offsets,
+            )
+            self._gather_fn()(hidden_states, permuted_idx, expert_input)
         return expert_input, layout_metadata, inverse_indices

--- a/src/tileops/ops/moe/staged.py
+++ b/src/tileops/ops/moe/staged.py
@@ -11,7 +11,7 @@ from tileops.kernels.moe import MoePrePermuteContiguousKernel, MoeUnpermuteKerne
 from tileops.kernels.moe.call_spec import MGroupedGemmCall, PostPermuteCall, PrePermuteCall
 from tileops.ops.compile_boundary import get_instance
 from tileops.ops.op_base import Op
-from tileops.utils import get_sm_version
+from tileops.utils import get_sm_version, is_h200
 
 from ..elementwise import SiluAndMulFwdOp
 from .contracts import (
@@ -198,6 +198,7 @@ class MoePrePermuteFwdOp(_StagedOpBase):
             raise TypeError("the current staged pre-permute contract accepts BF16 or FP16 only")
         return PrePermuteCall(
             arch=get_sm_version(device.index),
+            h200=is_h200(device.index),
             layout=self.layout,
             device_type=hidden_states.device.type,
             input_dtype=hidden_states.dtype,

--- a/tests/ops/test_moe_staged_contracts.py
+++ b/tests/ops/test_moe_staged_contracts.py
@@ -8,6 +8,7 @@ import torch
 import tileops.ops.moe.staged as staged_module
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.moe.call_spec import MGroupedGemmCall, PostPermuteCall, PrePermuteCall
+from tileops.kernels.moe.permute_contiguous import _fused_tight_plan
 from tileops.ops import moe as public_moe
 from tileops.ops.moe import (
     ContiguousLayoutSpec,
@@ -27,6 +28,21 @@ from tileops.ops.moe.contracts import (
 )
 
 pytestmark = pytest.mark.smoke
+
+
+@pytest.mark.parametrize(
+    "num_tokens,numel,hidden_size,expected",
+    [
+        (32, 64, 128, True),
+        (512, 1024, 128, False),
+        (512, 4096, 7168, True),
+        (4096, 32768, 7168, False),
+    ],
+)
+def test_fused_tight_plan_keeps_only_measured_wins(
+    num_tokens: int, numel: int, hidden_size: int, expected: bool
+) -> None:
+    assert _fused_tight_plan(num_tokens, numel, hidden_size) is expected
 
 
 def _physical_layout(rows: int = 2, experts: int = 2) -> MaterializedExpertLayout:


### PR DESCRIPTION
## Problem

The aligned/per-row PrePermute refactor put the padding-source guard on the tight gather path, regressing staged PrePermute by about 50%. Tight scan/scatter and gather also remained separate launches, leaving a measurable decode gap.

## Changes

- restore unconditional vectorized copies for tight gather while retaining aligned padding guards and zero-fill
- share one tight count/prefix/scatter macro between split and cooperative paths
- add an H200 cooperative tight specialization with a grid barrier between metadata production and gather
- select the fused path only for measured small/decode wins; retain the two-kernel fallback for prefill, aligned layouts, and non-H200 devices
- propagate the H200 device fact through `PrePermuteCall`

No public API, manifest workload, benchmark scaffold, or Roofline changes.

## Performance

Measured on an idle H200 with Torch 2.13, CUDA 13.2, and CUPTI timing.

| Workload | Unfused TileOPs | Fused TileOPs | Change | vLLM Triton | Kernels |
| --- | ---: | ---: | ---: | ---: | ---: |
| Qwen decode FP16 | 3.0223 ms | 2.9072 ms | -3.8% | 2.9171 ms | 8 → 7 |
| Qwen decode BF16 | 3.0401 ms | 2.9094 ms | -4.3% | 2.9064 ms | 8 → 7 |
| Qwen prefill FP16 | 6.4598 ms | 6.3489 ms | -1.7% | 7.8508 ms | 9 → 9 |
| Qwen prefill BF16 | 6.1700 ms | 6.2472 ms | +1.3% | 7.4906 ms | 9 → 9 |
| DeepSeek decode FP16 | 5.6917 ms | 5.5719 ms | -2.1% | 5.5816 ms | 8 → 7 |
| DeepSeek decode BF16 | 5.7405 ms | 5.5579 ms | -3.2% | 5.5533 ms | 8 → 7 |
| DeepSeek prefill FP16 | 8.6389 ms | 8.7593 ms | +1.4% | 9.5346 ms | 9 → 9 |
| DeepSeek prefill BF16 | 8.4506 ms | 8.3977 ms | -0.6% | 9.2806 ms | 9 → 9 |

Prefill retains the unchanged two-kernel path; its cross-run deltas are measurement variation.

## Standalone PrePermute regression fix

The unnecessary padding-source guard regressed all four tight PrePermute rows by about 50%. Removing that guard only from the tight specialization restores the original unconditional vectorized copy; aligned padding keeps its validation and zero-fill behavior.

| Workload | Regressed | Guard fixed | Change | Kernels |
| --- | ---: | ---: | ---: | ---: |
| small FP16 | 6.1 us | 3.1 us | -49.2% | 2 |
| small BF16 | 5.8 us | 2.9 us | -50.0% | 2 |
| prefill FP16 | 6.9 us | 3.5 us | -49.3% | 2 |
| prefill BF16 | 6.8 us | 3.5 us | -48.5% | 2 |

These are CUPTI device-busy readings. The 5.8-6.9 us nightly regression is no longer present.