### PR TITLE
[Perf][foundry][Reduction] Fold four bools per word in any and all

### DIFF
--- a/src/tileops/kernels/reduction/logical_reduce.py
+++ b/src/tileops/kernels/reduction/logical_reduce.py
@@ -42,6 +42,7 @@ from tileops.kernels.reduction.call_spec import (
     logical_edge_fused_region,
     logical_reduce_region,
 )
+from tileops.utils import WARP_LANES
 
 __all__ = [
     "LogicalReduceEdgeFusedKernel",
@@ -299,102 +300,6 @@ def _logical_reduce_kernel(M: int, N: int, op_kind: str, dtype: str, partial: bo
     return _func
 
 
-_PACKED_WORD_BYTES = 4
-_PACKED_VEC = 4
-_PACKED_MAX_THREADS = 128
-
-
-def packed_fold_config(n: int) -> tuple[int, int]:
-    """Threads and words a thread folds, for a row of *n* bools.
-
-    Four words a thread is one 16-byte access. The block covers the row in one
-    step where it can, and stops at 128 threads: the grid is one block a row, so
-    a wider block leaves lanes with nothing to fold.
-    """
-    words = -(-n // _PACKED_WORD_BYTES)
-    threads = min(_PACKED_MAX_THREADS, max(32, align_up(-(-words // _PACKED_VEC), 32)))
-    return threads, _PACKED_VEC
-
-
-def packed_fold_applies(op_kind: str, dtype_str: str, block_m: int, x: torch.Tensor) -> bool:
-    """Whether the rows of *x* can be folded a word at a time.
-
-    Reading four bytes as one word needs them contiguous, a whole number of
-    words to a row, and a storage offset a word boundary -- ``view`` refuses an
-    unaligned one. One block per row keeps the words a block reads adjacent.
-    """
-    return (
-        op_kind in ("any", "all")
-        and dtype_str == "int8"
-        and block_m == 1
-        and x.is_contiguous()
-        and x.storage_offset() % _PACKED_WORD_BYTES == 0
-        and x.shape[-1] % _PACKED_WORD_BYTES == 0
-    )
-
-
-def _packed_term(op_kind: str, w):
-    """What one word contributes to the fold: nonzero where the row's answer turns.
-
-    ``any`` asks whether a byte is set, which the word itself answers. ``all``
-    asks whether one is clear, and ``(w - 0x01010101) & ~w & 0x80808080`` is
-    nonzero exactly when some byte of *w* is zero. Both then fold with ``or``.
-
-    Set means nonzero, not one: a bool tensor may hold any other byte, and both
-    the general path and ``torch.all`` read it as true.
-    """
-    if op_kind == "any":
-        return w
-    ones = T.Cast("uint32", 0x01010101)
-    high = T.Cast("uint32", 0x80808080)
-    # ``w ^ ~0`` rather than ``~w``: CUDA gives the vector types no operator~.
-    flip = T.Cast("uint32", 0xFFFFFFFF)
-    return (w - ones) & (w ^ flip) & high
-
-
-@functools.lru_cache(maxsize=32)
-def _logical_reduce_kernel_packed(m: int, n: int, op_kind: str):
-    """Build an any/all kernel that folds four bools per word.
-
-    One block a row, folding into registers, where the general path stages the
-    row through shared memory and widens every byte to fp32 first.
-    """
-    words = n // _PACKED_WORD_BYTES
-
-    @tilelang.jit(out_idx=[1])
-    def _func(threads: int, vec: int):
-        step = threads * vec
-        steps = words // step
-        exact = steps * step == words
-
-        @T.prim_func
-        def main(x: T.Tensor((m, words), "uint32"), out: T.Tensor((m,), "int8")):
-            with T.Kernel(m, threads=threads) as bm:
-                acc = T.alloc_fragment((threads, vec), "uint32")
-                lane = T.alloc_fragment((threads,), "uint32")
-                red = T.alloc_fragment((1,), "uint32")
-                T.clear(acc)
-                for k in T.serial(steps):
-                    for i, j in T.Parallel(threads, vec):
-                        acc[i, j] = acc[i, j] | _packed_term(
-                            op_kind, x[bm, (k * threads + i) * vec + j]
-                        )
-                if not exact:
-                    for i, j in T.Parallel(threads, vec):
-                        idx = steps * step + i * vec + j
-                        with T.If(idx < words):  # noqa: SIM117
-                            with T.Then():
-                                acc[i, j] = acc[i, j] | _packed_term(op_kind, x[bm, idx])
-                T.reduce_max(acc, lane, dim=1)
-                T.reduce_max(lane, red, dim=0)
-                found = red[0] != T.Cast("uint32", 0)
-                out[bm] = T.Cast("int8", T.Not(found) if op_kind == "all" else found)
-
-        return main
-
-    return _func
-
-
 @functools.lru_cache(maxsize=32)
 def _logical_reduce_kernel_tiled(
     M: int, N: int, op_kind: str, dtype: str, tile_n: int, partial: bool = False
@@ -532,6 +437,106 @@ class LogicalReduceKernel(Kernel):
         tune: Whether to autotune (default False).
         device_index: CUDA device the input lives on, for the shared-memory budget.
     """
+
+    #: A word holds this many bool bytes, and a thread folds a whole vector of
+    #: them at once.
+    _WORD_BYTES = 4
+    _VECTOR_BYTES = 16
+    #: Widest block the packed fold takes. One block owns one row, so a wider
+    #: one only adds lanes with no words left to fold.
+    _PACKED_MAX_THREADS = 128
+
+    def _packed_fold_applies(self, x: torch.Tensor) -> bool:
+        """Whether the rows of *x* can be folded a word at a time.
+
+        Reading four bytes as one word needs them contiguous, a whole number of
+        words to a row, and a storage offset on a word boundary -- ``view``
+        refuses an unaligned one. One block a row keeps a block's words adjacent.
+        """
+        return (
+            self.op_kind in ("any", "all")
+            and self.dtype_to_str(self._kernel_dtype) == "int8"
+            and self.config["block_m"] == 1
+            and x.is_contiguous()
+            and x.storage_offset() % self._WORD_BYTES == 0
+            and x.shape[-1] % self._WORD_BYTES == 0
+        )
+
+    def _packed_fold_launch(self) -> tuple[int, int]:
+        """Threads, and words each folds, for one row of this kernel's shape.
+
+        The block covers the row in one step where it can.
+        """
+        vec = self._VECTOR_BYTES // self._WORD_BYTES
+        words = self.N // self._WORD_BYTES
+        threads = min(
+            self._PACKED_MAX_THREADS,
+            max(WARP_LANES, align_up(ceildiv_int(words, vec), WARP_LANES)),
+        )
+        return threads, vec
+
+    @staticmethod
+    def _packed_word_term(op_kind: str, w):
+        """What one word contributes: nonzero where the row's answer turns.
+
+        ``any`` asks whether a byte is set, which the word itself answers.
+        ``all`` asks whether one is clear, and ``(w - 0x01010101) & ~w &
+        0x80808080`` is nonzero exactly when some byte of *w* is zero. Both then
+        fold with ``or``.
+
+        Set means nonzero, not one: a bool tensor may hold any other byte, and
+        both the general path and ``torch.all`` read it as true.
+        """
+        if op_kind == "any":
+            return w
+        ones = T.Cast("uint32", 0x01010101)
+        high = T.Cast("uint32", 0x80808080)
+        # ``w ^ ~0`` rather than ``~w``: CUDA gives the vector types no operator~.
+        flip = T.Cast("uint32", 0xFFFFFFFF)
+        return (w - ones) & (w ^ flip) & high
+
+    @staticmethod
+    @functools.lru_cache(maxsize=32)
+    def _packed_kernel(m: int, words: int, op_kind: str):
+        """Build an any/all kernel that folds four bools per word.
+
+        One block a row, folding into registers, where the general path stages
+        the row through shared memory and widens every byte to fp32 first.
+        """
+        term = LogicalReduceKernel._packed_word_term
+
+        @tilelang.jit(out_idx=[1])
+        def _func(threads: int, vec: int):
+            step = threads * vec
+            steps = words // step
+            exact = steps * step == words
+
+            @T.prim_func
+            def main(x: T.Tensor((m, words), "uint32"), out: T.Tensor((m,), "int8")):
+                with T.Kernel(m, threads=threads) as bm:
+                    acc = T.alloc_fragment((threads, vec), "uint32")
+                    lane = T.alloc_fragment((threads,), "uint32")
+                    red = T.alloc_fragment((1,), "uint32")
+                    T.clear(acc)
+                    for k in T.serial(steps):
+                        for i, j in T.Parallel(threads, vec):
+                            acc[i, j] = acc[i, j] | term(
+                                op_kind, x[bm, (k * threads + i) * vec + j]
+                            )
+                    if not exact:
+                        for i, j in T.Parallel(threads, vec):
+                            idx = steps * step + i * vec + j
+                            with T.If(idx < words):  # noqa: SIM117
+                                with T.Then():
+                                    acc[i, j] = acc[i, j] | term(op_kind, x[bm, idx])
+                    T.reduce_max(acc, lane, dim=1)
+                    T.reduce_max(lane, red, dim=0)
+                    found = red[0] != T.Cast("uint32", 0)
+                    out[bm] = T.Cast("int8", T.Not(found) if op_kind == "all" else found)
+
+            return main
+
+        return _func
 
     supported_archs: list[int] = [80, 86, 89, 90]
     general: bool = True
@@ -676,10 +681,10 @@ class LogicalReduceKernel(Kernel):
         here.
         """
         dtype_str = self.dtype_to_str(self._kernel_dtype)
-        if packed_fold_applies(self.op_kind, dtype_str, self.config["block_m"], x):
-            threads, vec = packed_fold_config(self.N)
-            program = _logical_reduce_kernel_packed(self.M, self.N, self.op_kind)
-            words = self.N // _PACKED_WORD_BYTES
+        if self._packed_fold_applies(x):
+            words = self.N // self._WORD_BYTES
+            threads, vec = self._packed_fold_launch()
+            program = self._packed_kernel(self.M, words, self.op_kind)
             counted = program(threads, vec)(x.view(torch.uint32).view(self.M, words))
             return counted.view(torch.bool)
         if self._needs_tiling:
@@ -696,11 +701,12 @@ class LogicalReduceKernel(Kernel):
 
 
 class LogicalReduceEdgeFusedKernel(Kernel):
-    """Fused H200 logical reduction for a prefix and suffix axis set.
+    """Fused logical reduction for a prefix and suffix axis set.
 
-    One block reduces one kept column, walking the leading axis serially while
-    reducing each contiguous trailing row. The general logical reducer remains
-    responsible for non-edge layouts and for rows that require N-tiling.
+    ``applies`` states which devices reach it. One block reduces one kept column,
+    walking the leading axis serially while reducing each contiguous trailing
+    row. The general logical reducer remains responsible for non-edge layouts
+    and for rows that require N-tiling.
     """
 
     supported_archs: list[int] = [90]

--- a/src/tileops/kernels/reduction/logical_reduce.py
+++ b/src/tileops/kernels/reduction/logical_reduce.py
@@ -299,6 +299,93 @@ def _logical_reduce_kernel(M: int, N: int, op_kind: str, dtype: str, partial: bo
     return _func
 
 
+_PACKED_WORD_BYTES = 4
+_PACKED_VEC = 4
+_PACKED_MAX_THREADS = 128
+
+
+def packed_fold_config(n: int) -> tuple[int, int]:
+    """Threads and words a thread folds, for a row of *n* bools.
+
+    Four words a thread is one 16-byte access. The width covers the row in one
+    step where it can, and stops at 128 threads: the grid is one block a row, so
+    a wider block only leaves lanes with nothing to fold.
+    """
+    words = -(-n // _PACKED_WORD_BYTES)
+    threads = min(_PACKED_MAX_THREADS, max(32, align_up(-(-words // _PACKED_VEC), 32)))
+    return threads, _PACKED_VEC
+
+
+def packed_fold_applies(
+    op_kind: str, dtype_str: str, block_m: int, n: int, contiguous: bool
+) -> bool:
+    """Whether a row of *n* bools can be folded a word at a time.
+
+    ``any`` is a byte-wise or and ``all`` a byte-wise and over 0/1 bytes, and
+    both agree with the same operation on the word four of those bytes pack
+    into. That reinterpretation needs a contiguous row of whole words, and one
+    block per row for the words a block reads to be adjacent.
+    """
+    return (
+        op_kind in ("any", "all")
+        and dtype_str == "int8"
+        and block_m == 1
+        and contiguous
+        and n % _PACKED_WORD_BYTES == 0
+    )
+
+
+@functools.lru_cache(maxsize=32)
+def _logical_reduce_kernel_packed(m: int, n: int, op_kind: str):
+    """Build an any/all kernel that folds four bools per word.
+
+    One block per row, folding into registers. The general path stages the row
+    through shared memory and widens every byte to fp32 first.
+    """
+    words = n // _PACKED_WORD_BYTES
+    ones = (1 << 32) - 1 if op_kind == "all" else 0
+
+    @tilelang.jit(out_idx=[1])
+    def _func(threads: int, vec: int):
+        step = threads * vec
+        steps = words // step
+        exact = steps * step == words
+
+        @T.prim_func
+        def main(x: T.Tensor((m, words), "uint32"), out: T.Tensor((m,), "int8")):
+            with T.Kernel(m, threads=threads) as bm:
+                acc = T.alloc_fragment((threads, vec), "uint32")
+                lane = T.alloc_fragment((threads,), "uint32")
+                red = T.alloc_fragment((1,), "uint32")
+                if op_kind == "all":
+                    T.fill(acc, ones)
+                else:
+                    T.clear(acc)
+                for k in T.serial(steps):
+                    for i, j in T.Parallel(threads, vec):
+                        w = x[bm, (k * threads + i) * vec + j]
+                        acc[i, j] = acc[i, j] | w if op_kind == "any" else acc[i, j] & w
+                if not exact:
+                    for i, j in T.Parallel(threads, vec):
+                        idx = steps * step + i * vec + j
+                        with T.If(idx < words):  # noqa: SIM117
+                            with T.Then():
+                                w = x[bm, idx]
+                                acc[i, j] = acc[i, j] | w if op_kind == "any" else acc[i, j] & w
+                if op_kind == "all":
+                    T.reduce_min(acc, lane, dim=1)
+                    T.reduce_min(lane, red, dim=0)
+                    out[bm] = T.Cast("int8", red[0] == T.Cast("uint32", 0x01010101))
+                else:
+                    T.reduce_max(acc, lane, dim=1)
+                    T.reduce_max(lane, red, dim=0)
+                    out[bm] = T.Cast("int8", red[0] != T.Cast("uint32", 0))
+
+        return main
+
+    return _func
+
+
 @functools.lru_cache(maxsize=32)
 def _logical_reduce_kernel_tiled(
     M: int, N: int, op_kind: str, dtype: str, tile_n: int, partial: bool = False
@@ -580,6 +667,14 @@ class LogicalReduceKernel(Kernel):
         here.
         """
         dtype_str = self.dtype_to_str(self._kernel_dtype)
+        if packed_fold_applies(
+            self.op_kind, dtype_str, self.config["block_m"], self.N, x.is_contiguous()
+        ):
+            threads, vec = packed_fold_config(self.N)
+            program = _logical_reduce_kernel_packed(self.M, self.N, self.op_kind)
+            words = self.N // _PACKED_WORD_BYTES
+            counted = program(threads, vec)(x.view(torch.uint32).view(self.M, words))
+            return counted.view(torch.bool)
         if self._needs_tiling:
             program = _logical_reduce_kernel_tiled(
                 self.M, self.N, self.op_kind, dtype_str, self.config["tile_n"]

--- a/src/tileops/kernels/reduction/logical_reduce.py
+++ b/src/tileops/kernels/reduction/logical_reduce.py
@@ -307,43 +307,59 @@ _PACKED_MAX_THREADS = 128
 def packed_fold_config(n: int) -> tuple[int, int]:
     """Threads and words a thread folds, for a row of *n* bools.
 
-    Four words a thread is one 16-byte access. The width covers the row in one
+    Four words a thread is one 16-byte access. The block covers the row in one
     step where it can, and stops at 128 threads: the grid is one block a row, so
-    a wider block only leaves lanes with nothing to fold.
+    a wider block leaves lanes with nothing to fold.
     """
     words = -(-n // _PACKED_WORD_BYTES)
     threads = min(_PACKED_MAX_THREADS, max(32, align_up(-(-words // _PACKED_VEC), 32)))
     return threads, _PACKED_VEC
 
 
-def packed_fold_applies(
-    op_kind: str, dtype_str: str, block_m: int, n: int, contiguous: bool
-) -> bool:
-    """Whether a row of *n* bools can be folded a word at a time.
+def packed_fold_applies(op_kind: str, dtype_str: str, block_m: int, x: torch.Tensor) -> bool:
+    """Whether the rows of *x* can be folded a word at a time.
 
-    ``any`` is a byte-wise or and ``all`` a byte-wise and over 0/1 bytes, and
-    both agree with the same operation on the word four of those bytes pack
-    into. That reinterpretation needs a contiguous row of whole words, and one
-    block per row for the words a block reads to be adjacent.
+    Reading four bytes as one word needs them contiguous, a whole number of
+    words to a row, and a storage offset a word boundary -- ``view`` refuses an
+    unaligned one. One block per row keeps the words a block reads adjacent.
     """
     return (
         op_kind in ("any", "all")
         and dtype_str == "int8"
         and block_m == 1
-        and contiguous
-        and n % _PACKED_WORD_BYTES == 0
+        and x.is_contiguous()
+        and x.storage_offset() % _PACKED_WORD_BYTES == 0
+        and x.shape[-1] % _PACKED_WORD_BYTES == 0
     )
+
+
+def _packed_term(op_kind: str, w):
+    """What one word contributes to the fold: nonzero where the row's answer turns.
+
+    ``any`` asks whether a byte is set, which the word itself answers. ``all``
+    asks whether one is clear, and ``(w - 0x01010101) & ~w & 0x80808080`` is
+    nonzero exactly when some byte of *w* is zero. Both then fold with ``or``.
+
+    Set means nonzero, not one: a bool tensor may hold any other byte, and both
+    the general path and ``torch.all`` read it as true.
+    """
+    if op_kind == "any":
+        return w
+    ones = T.Cast("uint32", 0x01010101)
+    high = T.Cast("uint32", 0x80808080)
+    # ``w ^ ~0`` rather than ``~w``: CUDA gives the vector types no operator~.
+    flip = T.Cast("uint32", 0xFFFFFFFF)
+    return (w - ones) & (w ^ flip) & high
 
 
 @functools.lru_cache(maxsize=32)
 def _logical_reduce_kernel_packed(m: int, n: int, op_kind: str):
     """Build an any/all kernel that folds four bools per word.
 
-    One block per row, folding into registers. The general path stages the row
-    through shared memory and widens every byte to fp32 first.
+    One block a row, folding into registers, where the general path stages the
+    row through shared memory and widens every byte to fp32 first.
     """
     words = n // _PACKED_WORD_BYTES
-    ones = (1 << 32) - 1 if op_kind == "all" else 0
 
     @tilelang.jit(out_idx=[1])
     def _func(threads: int, vec: int):
@@ -357,29 +373,22 @@ def _logical_reduce_kernel_packed(m: int, n: int, op_kind: str):
                 acc = T.alloc_fragment((threads, vec), "uint32")
                 lane = T.alloc_fragment((threads,), "uint32")
                 red = T.alloc_fragment((1,), "uint32")
-                if op_kind == "all":
-                    T.fill(acc, ones)
-                else:
-                    T.clear(acc)
+                T.clear(acc)
                 for k in T.serial(steps):
                     for i, j in T.Parallel(threads, vec):
-                        w = x[bm, (k * threads + i) * vec + j]
-                        acc[i, j] = acc[i, j] | w if op_kind == "any" else acc[i, j] & w
+                        acc[i, j] = acc[i, j] | _packed_term(
+                            op_kind, x[bm, (k * threads + i) * vec + j]
+                        )
                 if not exact:
                     for i, j in T.Parallel(threads, vec):
                         idx = steps * step + i * vec + j
                         with T.If(idx < words):  # noqa: SIM117
                             with T.Then():
-                                w = x[bm, idx]
-                                acc[i, j] = acc[i, j] | w if op_kind == "any" else acc[i, j] & w
-                if op_kind == "all":
-                    T.reduce_min(acc, lane, dim=1)
-                    T.reduce_min(lane, red, dim=0)
-                    out[bm] = T.Cast("int8", red[0] == T.Cast("uint32", 0x01010101))
-                else:
-                    T.reduce_max(acc, lane, dim=1)
-                    T.reduce_max(lane, red, dim=0)
-                    out[bm] = T.Cast("int8", red[0] != T.Cast("uint32", 0))
+                                acc[i, j] = acc[i, j] | _packed_term(op_kind, x[bm, idx])
+                T.reduce_max(acc, lane, dim=1)
+                T.reduce_max(lane, red, dim=0)
+                found = red[0] != T.Cast("uint32", 0)
+                out[bm] = T.Cast("int8", T.Not(found) if op_kind == "all" else found)
 
         return main
 
@@ -667,9 +676,7 @@ class LogicalReduceKernel(Kernel):
         here.
         """
         dtype_str = self.dtype_to_str(self._kernel_dtype)
-        if packed_fold_applies(
-            self.op_kind, dtype_str, self.config["block_m"], self.N, x.is_contiguous()
-        ):
+        if packed_fold_applies(self.op_kind, dtype_str, self.config["block_m"], x):
             threads, vec = packed_fold_config(self.N)
             program = _logical_reduce_kernel_packed(self.M, self.N, self.op_kind)
             words = self.N // _PACKED_WORD_BYTES


### PR DESCRIPTION
## Problems

`AnyFwdOp` on `mask-validation-4k` and `mask-validation-32k` were the two furthest-behind reduction rows in the nightly, at 0.885x and 0.898x. `AllFwdOp` on the same shapes read 0.934x and 0.931x.

- **The rows read at a fraction of a read's bandwidth.** `analyze` puts them at `bound-by memory` — 131 KB and 1.05 MB once `bool` is counted at torch's byte rather than the model's bit — against 1.95 us and 3.78 us measured. That is 0.15 and 0.28 TB/s.
- **The general path moves a row it does not need to move.** It stages the row into shared memory and widens every byte to fp32 in a fragment before reducing: at `tile_n = 32768` that is a 32 KB shared buffer and a 128 KB fragment per block, for an operation whose whole state is one bit.

## Changes

- `_logical_reduce_kernel_packed` folds the row a word at a time in registers, one block a row, no shared staging and no fp32 widening. `any` folds the word itself; `all` folds `(w - 0x01010101) & ~w & 0x80808080`, which is nonzero exactly when some byte of the word is zero. Both then reduce with `or` and read the answer off one comparison against zero.
- `packed_fold_applies` admits `any` and `all` on a contiguous `int8` buffer whose rows are whole words, whose storage offset is a word boundary, and whose config gives one block a row. Everything else keeps the general path.
- Test-node delta: 0.

Set means nonzero, not one. A `bool` tensor may hold any other byte — `view(torch.bool)` on arbitrary bytes gives one — and `torch.all` reads it as true, as does the general path's per-byte `!= 0`. An earlier version of this branch compared the folded word against `0x01010101` and answered false for a row of `0x02`; the byte-is-clear form is what makes the two agree.

## TileFoundry Description

The rows authored as one reduction over the trailing axis, and the shipped kernel as their runtime twin:

```python
@module(entry="any_32k", target=CudaTarget("nvidia.h200_sxm"), topologies=_TOPOLOGIES)
class AnyMask32k:
    @func
    def any_32k(x: Tensor[(32, 32768), "bool"]) -> Tensor[(32,), "bool"]:
        return tf.reduce(x, kind="max", axes=(1,), keepdim=False)


@runtime_module(AnyMask32k)
class AnyMask32kTwin:
    @runtime_func
    def any_32k(self, x):
        return AnyFwdOp(dim=1)(x)
```

`analyze` gives `traffic=gmem:r131072/w4`, `ideal-ns=28`, `bound-by=memory` for the 32k row and `r16384/w4`, `ideal-ns=4` for the 4k one. It models `bool` as one bit, so torch's byte-per-bool moves eight times that: 1.05 MB and 131 KB. Against those bytes the row now reads at 0.48 TB/s where it read at 0.28.

`check` against that reference, on random inputs:

| Row | Predicate | Result |
| --- | --- | --- |
| `any` over `(32, 4096)` bool | `equal` | 0 of 32 differ, **PASS** |
| `any` over `(32, 32768)` bool | `equal` | 0 of 32 differ, **PASS** |

Random bools are canonical, so a second sweep covers what they do not: every combination of 12 shapes, 6 input patterns and both ops — 144 cases — including rows of raw bytes `0..3` viewed as bool, widths that are not whole words (999, 4094, 257, 1), and a single-element row. All match torch.

## Performance

| Environment | Value |
| --- | --- |
| image | `ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-afcebed1-foundry-dev` |
| gpu | `NVIDIA H200` (one idle device, SM clock 1500 MHz, not the CI runners') |
| driver | `595.71.05`, cuda `13.2`, torch `2.13.0+cu132`, tilelang `0.1.11+cu132.gitafcebed1` |
| timer | native CUPTI device-busy time |

Method: each row on its own, three runs a side, each side from its own empty `TILELANG_CACHE_DIR`; the spread is given because CUPTI quantises to about 0.032 us here.

| Row | Before (us) | After (us) | Speedup | Strongest baseline (us) / ours |
| --- | ---: | ---: | ---: | ---: |
| `all` `mask-validation-32k` | 3.760 - 3.776 | **2.272** | **1.66x** | torch-compile 3.424 🟢 1.51x |
| `any` `mask-validation-32k` | 3.744 - 3.776 | **2.177** | **1.73x** | torch-compile 3.200 🟢 1.47x |
| `all` `mask-validation-4k` | 1.952 | **1.664** | **1.17x** | torch-compile 1.888 🟢 1.13x |
| `any` `mask-validation-4k` | 1.952 | **1.663** | **1.17x** | torch-compile 1.728 🟢 1.04x |

`tests/ops/test_logical_reduce.py` and `test_reduce.py`: 300 passed at the shape the packed path takes and at every shape it declines.

## Result And Limitations

**improvement without SOTA**

- All four rows lead their strongest baseline, and the two worst reduction rows in the nightly move from 0.885x and 0.898x to 1.47x and 1.04x.
- **This contradicts what I wrote in #2028**, where I put these rows down to the launch and grid-barrier floors and said the levers did not reach. That was wrong: the cost was traffic and registers the kernel spent on itself, not the launch.
- **A pre-existing crash, not touched here.** A contiguous bool row whose storage offset is not a word boundary — `big[1:].view(4, 4096)` — fails with `CUDA error: misaligned address` on the general path, on `main` as well as on this branch. The packed gate refuses such a tensor, so this branch does not widen it; the general path's vectorised copy is where it lives.
- **`count_nonzero` is not covered.** It needs a sum, which does not commute with reading four bytes as one word.
