### PR TITLE
[BugFix][attention] Keep Dense GQA backend validation target-neutral

### DIFF
--- a/src/tileops/ops/attention/gqa.py
+++ b/src/tileops/ops/attention/gqa.py
@@ -454,8 +454,8 @@ class GroupedQueryAttentionDenseFwdOp(Op):
         if rope_cos.shape != rope_sin.shape:
             raise ValueError("rope_cos and rope_sin must have the same shape")
 
-    def _validate_supported_call(self, q: torch.Tensor) -> None:
-        """Reject features not implemented by the currently installed Dense kernel."""
+    def _validate_builtin_call(self, q: torch.Tensor) -> None:
+        """Reject features not implemented by the in-tree Dense kernel."""
         if not self.is_causal:
             raise ValueError("Dense GQA currently supports causal attention only")
         if q.shape[-1] != 128:
@@ -495,6 +495,7 @@ class GroupedQueryAttentionDenseFwdOp(Op):
         role = "gqa_dense"
 
         def build() -> Kernel:
+            self._validate_builtin_call(q)
             return self.kernel_map[role](
                 batch=batch,
                 heads=heads,
@@ -561,7 +562,6 @@ class GroupedQueryAttentionDenseFwdOp(Op):
                 combinations violate the contract above.
         """
         self._validate_forward_inputs(q, k, v, q_scale, k_scale, v_scale, rope_cos, rope_sin)
-        self._validate_supported_call(q)
         inputs = self._canonicalize_inputs(q, k, v, q_scale, k_scale, v_scale, rope_cos, rope_sin)
         kernel = self._get_kernel(inputs)
         return kernel(*inputs)


### PR DESCRIPTION
## Summary

- Keep Dense GQA public validation target-neutral.
- Apply the current causal/D=128/FP16-BF16/no-window/no-RoPE restrictions only when building the in-tree kernel.
- Allow external backends to serve manifest-valid calls outside the current builtin kernel region.

## Validation

- Manual CPU external-backend probe: a non-causal D=64 call reached and ran the registered external callable.
- Existing backend seam suite: `35 passed`.
- H200 builtin Dense smoke: `1 passed, 42 deselected`.
- `ruff check` and `ruff format --check` passed.