### PR TITLE
[Perf][foundry][Scan] Scan the chunk totals with shuffles, not shared memory

### DIFF
--- a/src/tileops/kernels/reduction/cumulative.py
+++ b/src/tileops/kernels/reduction/cumulative.py
@@ -23,6 +23,7 @@ from tileops.kernels.reduction._primitives import (
     rows_for_axes,
     torch_dtype_nbytes,
 )
+from tileops.utils import WARP_LANES
 
 __all__ = ["CumulativeKernel"]
 
@@ -120,7 +121,8 @@ def _row_scan_kernel(M: int, N: int, op_kind: str, dtype: str, threads: int):
 
     1. The row is staged in shared memory at its own dtype, one padded row of the tile
        per thread chunk, and each thread scans its chunk into registers in fp32.
-    2. The chunk totals are scanned in shared memory, doubling the stride each step.
+    2. The chunk totals are scanned with shuffles inside each warp, and one barrier
+       carries each warp's total to the warps above it.
     3. Each thread adds the prefix ahead of its chunk and writes the chunk back to the
        staging tile, which returns it to global memory.
 
@@ -140,8 +142,9 @@ def _row_scan_kernel(M: int, N: int, op_kind: str, dtype: str, threads: int):
     """
     chunk_len = N // threads
     pad = row_scan_pad(chunk_len, torch_dtype_nbytes(dtype))
-    # Stride-doubling steps to scan `threads` totals.
-    n_steps = threads.bit_length() - 1
+    # Shuffle steps to scan one warp's lanes, and the warps a block holds.
+    n_steps = WARP_LANES.bit_length() - 1
+    n_warps = max(threads // WARP_LANES, 1)
     identity = 0.0 if op_kind == "sum" else 1.0
     combine = (lambda a, b: a + b) if op_kind == "sum" else (lambda a, b: a * b)
 
@@ -155,11 +158,12 @@ def _row_scan_kernel(M: int, N: int, op_kind: str, dtype: str, threads: int):
             with T.Kernel(M, threads=threads) as row:
                 tx = T.get_thread_binding()
                 staged = T.alloc_shared((threads, chunk_len + pad), dtype)
-                totals = T.alloc_shared((threads,), "float32")
+                totals = T.alloc_shared((n_warps,), "float32")
                 chunk = T.alloc_local((chunk_len,), "float32")
                 running = T.alloc_local((1,), "float32")
                 ahead = T.alloc_local((1,), "float32")
                 offset = T.alloc_local((1,), "float32")
+                before = T.alloc_local((1,), "float32")
 
                 for i, j in T.Parallel(threads, chunk_len):
                     staged[i, j] = x[row, i * chunk_len + j]
@@ -169,22 +173,30 @@ def _row_scan_kernel(M: int, N: int, op_kind: str, dtype: str, threads: int):
                 for j in T.serial(chunk_len):
                     running[0] = combine(running[0], T.cast(staged[tx, j], "float32"))
                     chunk[j] = running[0]
-                totals[tx] = running[0]
-                T.sync_threads()
 
                 for step in T.serial(n_steps):
                     stride = T.shift_left(T.int32(1), step)
-                    ahead[0] = T.if_then_else(
-                        tx >= stride, totals[tx - stride], T.cast(identity, "float32")
+                    ahead[0] = T.shfl_up(running[0], stride)
+                    running[0] = T.if_then_else(
+                        tx % WARP_LANES >= stride, combine(running[0], ahead[0]), running[0]
                     )
-                    T.sync_threads()
-                    totals[tx] = combine(totals[tx], ahead[0])
-                    T.sync_threads()
+                if tx % WARP_LANES == WARP_LANES - 1:
+                    totals[tx // WARP_LANES] = running[0]
+                T.sync_threads()
 
-                # T.max keeps the read in range for thread 0, whose branch discards it.
-                offset[0] = T.if_then_else(
-                    tx == 0, T.cast(identity, "float32"), totals[T.max(tx - 1, 0)]
+                # One more shuffle turns the inclusive scan into the exclusive one a
+                # chunk needs. Subtracting the thread's own total would do it for sum
+                # and not for prod; a shuffle holds for any combine.
+                before[0] = T.shfl_up(running[0], 1)
+                before[0] = T.if_then_else(
+                    tx % WARP_LANES == 0, T.cast(identity, "float32"), before[0]
                 )
+                ahead[0] = T.cast(identity, "float32")
+                for w in T.serial(n_warps):
+                    ahead[0] = T.if_then_else(
+                        w < tx // WARP_LANES, combine(ahead[0], totals[w]), ahead[0]
+                    )
+                offset[0] = combine(before[0], ahead[0])
                 for j in T.serial(chunk_len):
                     staged[tx, j] = T.cast(combine(chunk[j], offset[0]), dtype)
                 T.sync_threads()


### PR DESCRIPTION
## Problems

`CumsumFwdOp` on `hidden-state-scan` read 0.919x in float16 and 0.965x in bfloat16 against flag_gems.

- **A cumsum row moves exactly what a copy of it moves**, read N and write N. A compiled unary pass over the same bytes measures **10.14 us** in bfloat16 and **10.27 us** in float16; the row took 10.78 and 11.39. flag_gems sits on those floors, at 10.34 and 10.30.
- **The whole gap was the block scan.** Dropping it from the kernel -- wrong answers, timing only -- takes the row to 10.27 us in float16, which is that dtype's floor. The scan over the per-thread chunk totals cost 1.12 us and everything else cost nothing.
- It scanned 64 values by doubling the stride in shared memory: six steps, **two barriers each**.

## Changes

- Each warp scans its own lanes with `T.shfl_up` and no barrier. The last lane of each warp writes its warp total to shared, one `T.sync_threads()`, and each thread then combines the totals of the warps below its own.
- The exclusive offset a chunk needs comes from one more `T.shfl_up` by one, with the identity at lane 0 -- not from undoing the inclusive scan, which would be a subtraction for `sum` and a division for `prod`. This kernel serves both.
- `totals` shrinks from one entry a thread to one a warp.
- Test-node delta: 0.

## TileFoundry Description

**This row cannot be authored for `analyze`, and that is the finding to record.** `tilefoundry.dsl` exposes 70 ops and none of them is a scan: `tf.cumsum` raises `unsupported call`. Writing it in TIR does not help either -- `HirToTirPass` lowers and returns a Module, but `analyze` reads HIR, and handing it a TIR module raises `'PrimFunction' object has no attribute 'return_type'` from `hir/specialize.py`. Both were checked, not assumed.

What stands in is exact for the roofline: a cumsum reads N and writes N, the same traffic as a unary pass, so the same module gives the same bound.

```python
@module(entry="touch", target=CudaTarget("nvidia.h200_sxm"), topologies=_TOPOLOGIES)
class HiddenStateTraffic:
    @func
    def touch(x: Tensor[(2048, 4096), "f16"]) -> Tensor[(2048, 4096), "f16"]:
        return tf.abs(x)
```

Measured rather than modelled, the same-traffic pass runs at 10.14 us (bfloat16) and 10.27 us (float16), and the ablation above shows the kernel reaches those once the block scan is gone.

`T.cumsum`, TileLang's own primitive, was tried and is not the answer here: on a 4096-wide fragment it measures **51.6 us** against the hand-written scan's 11.4.

## Performance

| Environment | Value |
| --- | --- |
| image | `ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-afcebed1-foundry-dev` |
| gpu | `NVIDIA H200` (one idle device, SM clock 1500 MHz, not the CI runners') |
| driver | `595.71.05`, cuda `13.2`, torch `2.13.0+cu132`, tilelang `0.1.11+cu132.gitafcebed1` |
| timer | native CUPTI device-busy time |

Method: each row on its own, three runs a side, each side from its own empty `TILELANG_CACHE_DIR`.

| Row | dtype | Before (us) | After (us) | Speedup | flag_gems (us) / ours | Same-traffic floor |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| `hidden-state-scan` | bfloat16 | 10.784 | **10.144** | **1.06x** | 10.336 🟢 1.019x | 10.144 |
| `hidden-state-scan` | float16 | 11.392 | **10.656** | **1.07x** | 10.304 🔴 0.967x | 10.272 |

`long-seq-scan` bfloat16, which already led, goes 6.88 -> 6.57.

Correctness: `cumsum` and `cumprod` over 10 shapes and 3 dtypes, including widths that are not multiples of the block and a single-element row. The float32 rows exceed a 1e-3 relative bound on both sides identically -- a long float32 scan against a float64 reference, measured near its zero crossings -- so that is the metric, not this branch.

## Result And Limitations

**improvement without SOTA**

- bfloat16 lands on its traffic floor and leads flag_gems.
- **float16 does not cross, and I could not close it.** Its floor is 10.27 and flag_gems is at 10.30, so the baseline is already there; this branch reaches 10.66. The remaining 0.38 us is the shuffle scan itself -- five shuffles, one barrier, the warp-total combine. Two cheaper formulations were measured and are worse: double-buffering the shared totals to halve the barriers reads 11.94, and letting one thread walk the totals serially reads 13.15.
- **The float16 and bfloat16 floors differ by 0.13 us for identical traffic**, and the difference is already there in a plain unary pass, so it is a property of the path and not of this kernel.
- A one-warp block, which would need no barrier at all, is worse: 32 threads take a 128-element chunk and read 11.81.
- Tests: `tests/ops/test_cumulative.py`, 51 passed. `pre-commit` clean.
