### PR TITLE
[Perf][foundry][Elementwise] Clamp nan_to_num where the ends are the dtype's own

### DIFF
--- a/src/tileops/kernels/elementwise/nan_to_num.py
+++ b/src/tileops/kernels/elementwise/nan_to_num.py
@@ -4,6 +4,9 @@ import functools
 
 import tilelang
 import tilelang.language as T
+import torch
+
+from tileops.utils import str2dtype
 
 from ._base import (
     ParametricUnaryKernel,
@@ -25,6 +28,10 @@ def _make_nan_to_num_kernel(
     -> fragment store for coalesced memory access.
     """
     out_dtype = output_dtype or dtype
+    # A clamp stands in for the two tests and the selects they feed only when
+    # the infinities go to the dtype's own ends.
+    _info = torch.finfo(str2dtype[dtype]) if dtype in str2dtype else None
+    clamps = bool(_info is not None and posinf_val == _info.max and neginf_val == _info.min)
 
     if is_fp8:
 
@@ -75,16 +82,28 @@ def _make_nan_to_num_kernel(
                         nan_r = T.cast(nan_val, val.dtype)
                         pos_r = T.cast(posinf_val, val.dtype)
                         neg_r = T.cast(neginf_val, val.dtype)
-                        result = T.if_then_else(
-                            T.isnan(v32),
-                            nan_r,
-                            T.if_then_else(
-                                T.isinf(v32),
-                                T.if_then_else(v32 > T.cast(0, "float32"), pos_r, neg_r),
-                                val,
-                            ),
-                        )
-                        y_reg[k] = result
+                        if clamps:
+                            y_reg[k] = T.if_then_else(
+                                T.isnan(v32),
+                                nan_r,
+                                T.cast(
+                                    T.min(
+                                        T.max(v32, T.cast(neginf_val, "float32")),
+                                        T.cast(posinf_val, "float32"),
+                                    ),
+                                    val.dtype,
+                                ),
+                            )
+                        else:
+                            y_reg[k] = T.if_then_else(
+                                T.isnan(v32),
+                                nan_r,
+                                T.if_then_else(
+                                    T.isinf(v32),
+                                    T.if_then_else(v32 > T.cast(0, "float32"), pos_r, neg_r),
+                                    val,
+                                ),
+                            )
                     T.copy(y_reg, y[bx * block_size : (bx + 1) * block_size])
 
             return main


### PR DESCRIPTION
## Problems

`NanToNumFwdOp` on `elementwise-16M` read 0.977x against torch-compile in float16.

- **The body costs more than the memory it rides on.** A compiled unary pass over the same bytes measures 17.89 us and torch-compile's own kernel 18.05; the row took 18.72. The traffic is identical, so the difference is arithmetic a memory-bound row has the latency to hide and did not.
- The body tested for NaN, then for infinity, then for the sign of the infinity, and selected three times.

## Changes

- Where the infinity replacements are the dtype's own max and min, a clamp says the same thing: it sends each infinity to its own end and leaves every finite value alone. Only NaN still needs a test. That is the default and the values are constants the builder already holds, so the choice is made at trace time.
- Explicit replacements keep the tests. A clamp would move finite values lying outside them, so it cannot stand in there.
- Test-node delta: 0.

Checked against torch over 3 dtypes, 4 shapes and 4 replacement settings, including the explicit values that take the untouched path and inputs carrying NaN, both infinities and the dtype extremes: **every element equal**.

## TileFoundry Description

`tf` has no nan_to_num, so the row is authored as the traffic it moves, which is what the roofline needs and what this row is:

```python
@module(entry="touch", target=CudaTarget("nvidia.h200_sxm"), topologies=_TOPOLOGIES)
class Elementwise16M:
    @func
    def touch(x: Tensor[(4096, 4096), "f16"]) -> Tensor[(4096, 4096), "f16"]:
        return tf.abs(x)
```

It reads N and writes N, as nan_to_num does. Measured, that pass runs at **17.89 us**, and a bare TileLang copy at the same shape reaches 17.82 to 17.86 -- so the number is the floor rather than one framework's floor.

## Performance

| Environment | Value |
| --- | --- |
| image | `ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-afcebed1-foundry-dev` |
| gpu | `NVIDIA H200` (one idle device, SM clock 1500 MHz, not the CI runners') |
| driver | `595.71.05`, cuda `13.2`, torch `2.13.0+cu132`, tilelang `0.1.11+cu132.gitafcebed1` |
| timer | native CUPTI device-busy time |

Method: before and after alternate in one sitting, the before side a separate detached worktree at the merge base so neither tree is edited mid-run, each from its own empty `TILELANG_CACHE_DIR`.

| Row | dtype | Before (us) | After (us) | Speedup | torch-compile (us) |
| --- | --- | ---: | ---: | ---: | ---: |
| `NanToNumFwd` `elementwise-16M` | float16 | 18.720 | **18.112** | **1.034x** | 18.048 |

Four rounds, the after side 18.112 in three of them and 18.143 in the fourth; torch-compile 18.047 to 18.048 throughout.

## Result And Limitations

**improvement without SOTA**

- The row moves from 0.977x to parity. It does not lead: 18.112 against 18.048, and it sits 0.22 us above the same-traffic floor. I did not find what the rest is -- clamping in the native dtype instead of float32 measures the same, and no launch width moved it.
- **Three sibling rows were cut from this branch rather than shipped.** `ReciprocalFwd` float16 and bfloat16 and `DivFwd` bfloat16 are all behind for the same reason, and all three are fixed by asking nvcc for `div.full.f32` instead of `div.rn.f32` -- measured 18.53 to 17.92, 18.50 to 17.95, and 15.10 to 14.56, each crossing its baseline, each bit-identical to the exact divide over the whole dtype (every one of the 65536 reciprocal patterns, every one of the 2^32 bfloat16 division pairs).

  They are not here because an nvcc option does not change the generated source, and that is what TileLang's `CUDABinaryCache.make_key` hashes: a flagged kernel is handed an unflagged binary and the option is dropped in silence. Working around it inside this repo means naming the flags in every kernel symbol, which puts a silent constraint on twelve builders -- forget it in one and that path compiles wrong. The fix belongs upstream and is three lines: `make_key` should take the `options` its caller already built, and put them in the key.

  Decomposed, the whole of that win is the flag: with it the thread width is worth a further 0.06 us on float16, and without it narrowing the width is a regression on both dtypes (18.53 to 18.72, 18.46 to 18.78). There is no partial version of this to ship.
- Tests: `tests/ops/test_elementwise_binary_broadcast.py`, `test_elementwise_config_dtype.py`, `test_special_elementwise.py`, `test_elementwise_compile.py`, `test_elementwise_caching_autotune.py`, `test_elementwise_unary_activation_alignment.py`, `test_special_elementwise_conformance.py`, 449 passed. `pre-commit` clean.
