### PR TITLE
[Perf][foundry][Elementwise] Raise pow through exp2, and clamp nan_to_num

### DIFF
--- a/src/tileops/kernels/elementwise/arithmetic.py
+++ b/src/tileops/kernels/elementwise/arithmetic.py
@@ -151,15 +151,48 @@ class RemainderFwdKernel(BinaryKernel):
 
 
 class PowFwdKernel(BinaryKernel):
-    """Element-wise power: y = a ** b."""
+    """Element-wise power: y = a ** b.
+
+    Raised as ``exp2(b * log2|a|)``, two hardware instructions where ``powf``
+    is a series, with the sign a negative base carries put back afterwards.
+
+    The error of that form scales with ``|b * log2(a)|`` where ``powf`` holds
+    a flat 0.6 ulp of float32; ``PowFwdOp`` tabulates what that costs across
+    the input range.
+    """
 
     SUPPORTED_DTYPES = _FLOAT_DTYPES
 
     @staticmethod
     def op_func(a, b):
-        a_f32 = T.Cast("float32", a)
-        b_f32 = T.Cast("float32", b)
-        return T.Cast(a.dtype, T.pow(a_f32, b_f32))
+        base = T.Cast("float32", a)
+        expo = T.Cast("float32", b)
+        zero = T.cast(0.0, "float32")
+        one = T.cast(1.0, "float32")
+        # log2 of zero and of infinity carry through exp2 to the answers pow
+        # gives there. A base of one is the exception: its log is zero, and
+        # zero times an infinite exponent is NaN where pow answers one.
+        magnitude = T.if_then_else(T.abs(base) == one, one, T.exp2(expo * T.log2(T.abs(base))))
+        whole = T.round(expo)
+        # A negative base turns the sign on an odd whole exponent, and answers
+        # NaN on a fractional one -- unless it is infinite, where every
+        # exponent is defined.
+        signed = T.if_then_else(
+            T.fmod(T.abs(whole), T.cast(2.0, "float32")) == one, -magnitude, magnitude
+        )
+        # Only a finite nonzero negative base answers NaN on a fractional
+        # exponent. Zero and infinity are defined for every exponent.
+        defined = T.Or(whole == expo, T.Or(T.isinf(base), base == zero))
+        # The sign bit, not ``base < 0``: pow carries the sign of a negative
+        # zero into its result, and ``-0.0 < 0`` is false.
+        negative = T.copysign(one, base) < zero
+        out = T.if_then_else(
+            negative,
+            T.if_then_else(defined, signed, T.cast(float("nan"), "float32")),
+            magnitude,
+        )
+        # Every base to the zeroth is one, which the magnitude misses at zero.
+        return T.Cast(a.dtype, T.if_then_else(expo == zero, one, out))
 
 
 class FloorDivideFwdKernel(BinaryKernel):

--- a/src/tileops/kernels/elementwise/arithmetic.py
+++ b/src/tileops/kernels/elementwise/arithmetic.py
@@ -153,12 +153,8 @@ class RemainderFwdKernel(BinaryKernel):
 class PowFwdKernel(BinaryKernel):
     """Element-wise power: y = a ** b.
 
-    Raised as ``exp2(b * log2|a|)``, two hardware instructions where ``powf``
-    is a series, with the sign a negative base carries put back afterwards.
-
-    The error of that form scales with ``|b * log2(a)|`` where ``powf`` holds
-    a flat 0.6 ulp of float32; ``PowFwdOp`` tabulates what that costs across
-    the input range.
+    Computed as ``exp2(b * log2|a|)`` with the sign of a negative base
+    restored. Error scales with ``|b * log2(a)|``; ``PowFwdOp`` tabulates it.
     """
 
     SUPPORTED_DTYPES = _FLOAT_DTYPES
@@ -169,29 +165,25 @@ class PowFwdKernel(BinaryKernel):
         expo = T.Cast("float32", b)
         zero = T.cast(0.0, "float32")
         one = T.cast(1.0, "float32")
-        # log2 of zero and of infinity carry through exp2 to the answers pow
-        # gives there. A base of one is the exception: its log is zero, and
-        # zero times an infinite exponent is NaN where pow answers one.
+        # |a| == 1 is the exception: log2 is zero, and 0 * inf is NaN where
+        # pow answers one.
         magnitude = T.if_then_else(T.abs(base) == one, one, T.exp2(expo * T.log2(T.abs(base))))
         whole = T.round(expo)
-        # A negative base turns the sign on an odd whole exponent, and answers
-        # NaN on a fractional one -- unless it is infinite, where every
-        # exponent is defined.
+        # A negative base flips the sign on an odd whole exponent.
         signed = T.if_then_else(
             T.fmod(T.abs(whole), T.cast(2.0, "float32")) == one, -magnitude, magnitude
         )
-        # Only a finite nonzero negative base answers NaN on a fractional
-        # exponent. Zero and infinity are defined for every exponent.
+        # Only a finite nonzero negative base is NaN on a fractional exponent.
         defined = T.Or(whole == expo, T.Or(T.isinf(base), base == zero))
-        # The sign bit, not ``base < 0``: pow carries the sign of a negative
-        # zero into its result, and ``-0.0 < 0`` is false.
+        # Sign bit, not ``base < 0``: pow carries the sign of -0.0, and
+        # ``-0.0 < 0`` is false.
         negative = T.copysign(one, base) < zero
         out = T.if_then_else(
             negative,
             T.if_then_else(defined, signed, T.cast(float("nan"), "float32")),
             magnitude,
         )
-        # Every base to the zeroth is one, which the magnitude misses at zero.
+        # x ** 0 is one; the magnitude gives NaN at base zero.
         return T.Cast(a.dtype, T.if_then_else(expo == zero, one, out))
 
 

--- a/src/tileops/kernels/elementwise/nan_to_num.py
+++ b/src/tileops/kernels/elementwise/nan_to_num.py
@@ -28,8 +28,8 @@ def _make_nan_to_num_kernel(
     -> fragment store for coalesced memory access.
     """
     out_dtype = output_dtype or dtype
-    # A clamp stands in for the two tests and the selects they feed only when
-    # the infinities go to the dtype's own ends.
+    # A clamp replaces the infinity tests only when the replacements are the
+    # dtype's own ends; otherwise it would move finite values too.
     _info = torch.finfo(str2dtype[dtype]) if dtype in str2dtype else None
     clamps = bool(_info is not None and posinf_val == _info.max and neginf_val == _info.min)
 

--- a/src/tileops/kernels/elementwise/nan_to_num.py
+++ b/src/tileops/kernels/elementwise/nan_to_num.py
@@ -4,6 +4,9 @@ import functools
 
 import tilelang
 import tilelang.language as T
+import torch
+
+from tileops.utils import str2dtype
 
 from ._base import (
     ParametricUnaryKernel,
@@ -25,6 +28,10 @@ def _make_nan_to_num_kernel(
     -> fragment store for coalesced memory access.
     """
     out_dtype = output_dtype or dtype
+    # A clamp stands in for the two tests and the selects they feed only when
+    # the infinities go to the dtype's own ends.
+    _info = torch.finfo(str2dtype[dtype]) if dtype in str2dtype else None
+    clamps = bool(_info is not None and posinf_val == _info.max and neginf_val == _info.min)
 
     if is_fp8:
 
@@ -75,16 +82,28 @@ def _make_nan_to_num_kernel(
                         nan_r = T.cast(nan_val, val.dtype)
                         pos_r = T.cast(posinf_val, val.dtype)
                         neg_r = T.cast(neginf_val, val.dtype)
-                        result = T.if_then_else(
-                            T.isnan(v32),
-                            nan_r,
-                            T.if_then_else(
-                                T.isinf(v32),
-                                T.if_then_else(v32 > T.cast(0, "float32"), pos_r, neg_r),
-                                val,
-                            ),
-                        )
-                        y_reg[k] = result
+                        if clamps:
+                            y_reg[k] = T.if_then_else(
+                                T.isnan(v32),
+                                nan_r,
+                                T.cast(
+                                    T.min(
+                                        T.max(v32, T.cast(neginf_val, "float32")),
+                                        T.cast(posinf_val, "float32"),
+                                    ),
+                                    val.dtype,
+                                ),
+                            )
+                        else:
+                            y_reg[k] = T.if_then_else(
+                                T.isnan(v32),
+                                nan_r,
+                                T.if_then_else(
+                                    T.isinf(v32),
+                                    T.if_then_else(v32 > T.cast(0, "float32"), pos_r, neg_r),
+                                    val,
+                                ),
+                            )
                     T.copy(y_reg, y[bx * block_size : (bx + 1) * block_size])
 
             return main

--- a/src/tileops/ops/elementwise/arithmetic.py
+++ b/src/tileops/ops/elementwise/arithmetic.py
@@ -129,6 +129,25 @@ class PowFwdOp(BinaryOp):
     Conforms to ``torch.pow(input, exponent)``: the second operand carries
     the manifest-declared name ``exponent`` rather than the generic
     ``other`` so the L1 signature check matches the manifest.
+
+    **Accuracy grows with the exponent, unlike torch's.** The power is raised
+    as ``exp2(exponent * log2|input|)``, and the error of that form scales with
+    ``|exponent * log2(input)|`` rather than staying flat. Measured against a
+    float64 reference, in units of a float32 ulp:
+
+    | ``input`` | ``exponent`` | here | ``torch.pow`` |
+    | --- | --- | --- | --- |
+    | 0.9 to 1.1 | -1 to 1 | 1.2 | 0.5 |
+    | 0.5 to 2 | -2 to 2 | 1.8 | 0.6 |
+    | 0.25 to 4 | -3 to 3 | 3.4 | 0.6 |
+    | 0.01 to 100 | -3 to 3 | 10.6 | 0.6 |
+    | 1e-6 to 1e6 | -2 to 2 | 22.5 | 0.6 |
+
+    A few ulp is below what a float16 or bfloat16 result can hold and is
+    what a network's activations and normalisations sit in. Callers raising
+    a base far from one to a large exponent, or comparing results for
+    equality, should know that the bound is the table above and not a
+    constant.
     """
 
     _op_name = "pow"

--- a/src/tileops/ops/elementwise/arithmetic.py
+++ b/src/tileops/ops/elementwise/arithmetic.py
@@ -130,8 +130,8 @@ class PowFwdOp(BinaryOp):
     the manifest-declared name ``exponent`` rather than the generic
     ``other`` so the L1 signature check matches the manifest.
 
-    **Accuracy grows with the exponent, unlike torch's.** The power is raised
-    as ``exp2(exponent * log2|input|)``, and the error of that form scales with
+    Accuracy differs from ``torch.pow``: the power is computed as
+    ``exp2(exponent * log2|input|)``, whose error scales with
     ``|exponent * log2(input)|`` rather than staying flat. Measured against a
     float64 reference, in units of a float32 ulp:
 
@@ -143,11 +143,9 @@ class PowFwdOp(BinaryOp):
     | 0.01 to 100 | -3 to 3 | 10.6 | 0.6 |
     | 1e-6 to 1e6 | -2 to 2 | 22.5 | 0.6 |
 
-    A few ulp is below what a float16 or bfloat16 result can hold and is
-    what a network's activations and normalisations sit in. Callers raising
-    a base far from one to a large exponent, or comparing results for
-    equality, should know that the bound is the table above and not a
-    constant.
+    The bound is the table above, not a constant. Callers raising a base far
+    from one to a large exponent, or comparing results for equality, need to
+    account for it.
     """
 
     _op_name = "pow"


### PR DESCRIPTION
## Problems

Two elementwise rows read below their baseline for the same reason: the body costs more than the memory it rides on.

| Row | tileops | baseline | a compiled pass over the same bytes |
| --- | ---: | ---: | ---: |
| `PowFwd` `hidden-state-prefill` float32 | 38.53 | torch 36.80 | 26.30 |
| `NanToNumFwd` `elementwise-16M` float16 | 18.72 | torch-compile 18.05 | 17.89 |

`pow` sat 46% above that pass. The traffic is identical, so the difference is arithmetic a memory-bound row has the latency to hide and did not.

## Changes

- **`pow` raises `a**b` as `exp2(b * log2|a|)`** -- two hardware instructions where `powf` is a series -- and puts back the sign a negative base carries.
- **`nan_to_num` clamps.** Where the infinity replacements are the dtype's own max and min (the default, and a constant the builder already holds), the two tests and three selects collapse to one test and a clamp. Explicit replacements keep the tests; a clamp would move finite values lying outside them.
- Test-node delta: 0.

### The accuracy `pow` trades, which is in the op's docstring and not only here

`powf` holds a flat 0.6 ulp of float32 whatever the input. The `exp2` form does not: its error grows with `|b * log2 a|`. Measured against a float64 reference, in float32 ulp:

| `input` | `exponent` | here | `torch.pow` |
| --- | --- | --- | ---: |
| 0.9 to 1.1 | -1 to 1 | **1.2** | 0.5 |
| 0.5 to 2 | -2 to 2 | **1.8** | 0.6 |
| 0.25 to 4 | -3 to 3 | **3.4** | 0.6 |
| 0.01 to 100 | -3 to 3 | **10.6** | 0.6 |
| 1e-6 to 1e6 | -2 to 2 | **22.5** | 0.6 |

A few ulp is below what a float16 or bfloat16 result can hold and is where a network's activations and normalisations sit. A caller raising a base far from one to a large exponent, or comparing results for equality, needs the table rather than a constant, so `PowFwdOp`'s docstring carries it.

**Everything else about `pow` is unchanged, including the parts IEEE makes awkward.** Against `torch.pow` over a grid of every combination of `{-8, -2, -1.5, -1, -0.5, -0, 0, 0.5, 1, 2, 8, inf, -inf, nan}` with the same exponents, in all three float dtypes: **0 of 196 differ** in each. Signed zeros are compared bit for bit rather than by value, which is what caught two of the three breaks this rewrite went through:

| case | why the first draft got it wrong |
| --- | --- |
| `pow(-2, 3)` | `log2` of a negative is NaN; the sign of an odd whole exponent has to be restored |
| `pow(-inf, 0.5)` | a negative base answers NaN on a fractional exponent only where it is finite |
| `pow(-0.0, -3)` = `-inf` | `-0.0 < 0` is false, so the sign path needs the sign bit, not a comparison |
| `pow(1, inf)` | `log2(1)` is zero and `0 * inf` is NaN, where pow answers one |

`nan_to_num` is exact by construction and was checked against torch over 3 dtypes, 4 shapes and 4 replacement settings, including the explicit values that take the untouched path: **every element equal**.

## TileFoundry Description

`tf` has neither `pow` nor `nan_to_num`, so each row is authored as the traffic it moves, which is what the roofline needs and what both rows are:

```python
@module(entry="touch", target=CudaTarget("nvidia.h200_sxm"), topologies=_TOPOLOGIES)
class HiddenStatePrefill:
    @func
    def touch(a: Tensor[(2048, 4096), "f32"], b: Tensor[(2048, 4096), "f32"]) -> Tensor[(2048, 4096), "f32"]:
        return a * b
```

Two reads and a write, as `pow` has. Measured, that pass runs at **26.30 us**, and `pow` now runs at 27.8 -- within 6% of moving the bytes and doing nothing. Before the change it was 38.5.

## Performance

| Environment | Value |
| --- | --- |
| image | `ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-afcebed1-foundry-dev` |
| gpu | `NVIDIA H200` (one idle device, SM clock 1500 MHz, not the CI runners') |
| driver | `595.71.05`, cuda `13.2`, torch `2.13.0+cu132`, tilelang `0.1.11+cu132.gitafcebed1` |
| timer | native CUPTI device-busy time |

Method: before and after alternate in one sitting, the before side a separate detached worktree at the merge base so neither tree is edited mid-run, each from its own empty `TILELANG_CACHE_DIR`.

| Row | dtype | Before (us) | After (us) | Speedup | Baseline (us) / ours |
| --- | --- | ---: | ---: | ---: | ---: |
| `PowFwd` `hidden-state-prefill` | float32 | 38.528 | **27.808** | **1.39x** | torch 36.800 🟢 1.32x |
| `NanToNumFwd` `elementwise-16M` | float16 | 18.720 | **18.112** | **1.034x** | torch-compile 18.048 🟡 0.996x |

Three rounds each, `pow` 27.744 to 27.872 and `nan_to_num` 18.112 in two of three.

## Result And Limitations

**improvement without SOTA**

- `pow` leads torch by 1.32x and sits within 6% of the cost of moving its bytes.
- **`nan_to_num` ties rather than leads**, at 18.112 against 18.048, and sits 0.22 us above the same-traffic floor. I did not find what the rest is: clamping in the native dtype instead of float32 measures the same, and no launch width moved it.
- **`pow`'s error is no longer bounded by a constant.** The table above is the contract now. This was taken deliberately, for a library whose `pow` feeds activations, and the op's docstring says so where a caller will read it.
- Tests: `tests/ops/test_elementwise_binary_broadcast.py`, `test_special_elementwise.py`, `test_elementwise_compile.py`, `test_elementwise_config_dtype.py`, `test_special_elementwise_conformance.py`, 394 passed. `pre-commit` clean, including the op docstring lint.
