### PR TITLE
[Perf][foundry][Norm] Give BatchNorm forward a launch its shape can fill

### DIFF
--- a/src/tileops/kernels/norm/batch_norm.py
+++ b/src/tileops/kernels/norm/batch_norm.py
@@ -2,9 +2,10 @@
 
 Reference: Ioffe & Szegedy (2015) https://arxiv.org/abs/1502.03167
 
-The prim_funcs work on (C, L) where C is the channel count and L = N * H * W * ... is
-the product of batch and spatial dimensions. Each kernel takes the user-facing
-(N, C, *spatial) tensor and moves it into that layout itself.
+Training forward and backward reduce over a channel, so they work on (C, L)
+where C is the channel count and L = N * H * W * ... , and move the caller's
+(N, C, *spatial) tensor into that layout themselves. Inference reduces over
+nothing and reads the caller's layout as it is.
 
 Performance notes:
   - Persistent path (block_l >= L): loads all L elements into shared memory once
@@ -30,9 +31,34 @@ __all__ = [
     "BatchNormFwdTrainKernel",
 ]
 
+# Blocks the split training path aims to launch, as a multiple of the channel
+# count: enough to cover the device several times over so no SM sits idle.
+_SPLIT_TARGET_BLOCKS = 1024
+
+# Per-channel length above which one block per channel is too narrow a grid,
+# whatever the tile size, and the split path takes over.
+_SPLIT_MIN_L = 1 << 16
+
 # L threshold for the persistent (single global read) training path.
 # x_shared uses L * sizeof(dtype) bytes per block:
 #   L=8192, fp16 → 16 KB — well within H100 shared memory limits.
+# Spatial extent below which a channel-per-block read cannot fill a cache line,
+# and the longest channel a thread that owns one can keep in its registers.
+_WHOLE_MAX_S = 16
+_WHOLE_MAX_L = 32
+
+# Block width for that path. It is wider than the channels a block covers when
+# there are few of them, which measured faster than a block sized to fit: the
+# extra warps give the scheduler something to issue while the loads land.
+_WHOLE_BLOCK_THREADS = 256
+
+# The register-held path's block width, its widest per-thread vector, and the
+# most elements one thread may hold across all its steps before the register
+# file is the binding constraint.
+_WIDE_BLOCK_THREADS = 256
+_WIDE_MAX_NUM_PER_THREAD = 8
+_WIDE_MAX_HELD = 32
+
 _PERSISTENT_THRESHOLD = 8192
 
 
@@ -93,6 +119,7 @@ def _from_cl(t: torch.Tensor, original_shape: torch.Size) -> torch.Tensor:
 def _batch_norm_fwd_train_kernel(
     C: int,
     L: int,
+    S: int,
     dtype: str = "float16",
     eps: float = 1e-5,
     momentum: float = 0.1,
@@ -108,6 +135,12 @@ def _batch_norm_fwd_train_kernel(
 
     Saved mean and rstd are needed by the backward pass.
 
+    A channel is not contiguous in the ``(N, C, *spatial)`` the caller holds,
+    but it is *S* elements contiguous at a time, once per batch item, which
+    coalesces as well as a transposed copy would and costs no pass to build.
+    Element *l* of channel *c* therefore lives at ``(l // S) * C * S + c * S +
+    l % S``.
+
     Persistent path (block_l >= L): after pass 1 loads all L elements into
     x_shared, pass 2 normalizes directly from x_shared — no second global read.
 
@@ -116,19 +149,20 @@ def _batch_norm_fwd_train_kernel(
     Requirements: L must be divisible by block_l; threads must divide block_l.
     """
     accum_dtype = "float32"
+    plane = C * S
 
     @tilelang.jit(out_idx=[-1], compile_flags=["-O3", "-DENABLE_BF16"])
     def _bn_fwd_train_func(block_l: int, threads: int) -> Callable:
         @T.prim_func
         def _bn_fwd_train(
-            x: T.Tensor([C, L], dtype),
+            x: T.Tensor([C * L], dtype),
             weight: T.Tensor([C], accum_dtype),
             bias: T.Tensor([C], accum_dtype),
             running_mean: T.Tensor([C], accum_dtype),
             running_var: T.Tensor([C], accum_dtype),
             mean_out: T.Tensor([C], accum_dtype),
             rstd_out: T.Tensor([C], accum_dtype),
-            y: T.Tensor([C, L], dtype),
+            y: T.Tensor([C * L], dtype),
         ):
             with T.Kernel(C, threads=threads) as (bc):
                 x_shared = T.alloc_shared([block_l], dtype)
@@ -144,7 +178,8 @@ def _batch_norm_fwd_train_kernel(
                 if block_l >= L:
                     # Persistent path has exactly one tile, so a pipelined loop
                     # cannot overlap producer/consumer work.
-                    T.copy(x[bc, 0:block_l], x_shared)
+                    for _i, j in T.Parallel(1, block_l):
+                        x_shared[j] = x[(j // S) * plane + bc * S + j % S]
                     for _i, j in T.Parallel(1, block_l):
                         xval = T.cast(x_shared[j], accum_dtype)
                         xsum_frag[_i, j] += xval
@@ -154,7 +189,8 @@ def _batch_norm_fwd_train_kernel(
                     # data race that occurs when T.copy is used inside T.Pipelined.
                     for l_tile in T.Pipelined(L // block_l, num_stages=0):
                         for _i, j in T.Parallel(1, block_l):
-                            xval = T.cast(x[bc, l_tile * block_l + j], accum_dtype)
+                            l = l_tile * block_l + j
+                            xval = T.cast(x[(l // S) * plane + bc * S + l % S], accum_dtype)
                             xsum_frag[_i, j] += xval
                             xsq_frag[_i, j] += xval * xval
 
@@ -195,7 +231,7 @@ def _batch_norm_fwd_train_kernel(
                     # No second global read — read directly from shared memory.
                     for _i, j in T.Parallel(1, block_l):
                         xval = T.cast(x_shared[j], accum_dtype)
-                        y[bc, j] = T.cast(
+                        y[(j // S) * plane + bc * S + j % S] = T.cast(
                             weight[bc] * (xval - mean_val) * rstd_val + bias[bc], dtype
                         )
                 else:
@@ -203,14 +239,403 @@ def _batch_norm_fwd_train_kernel(
                     # data race that occurs when T.copy is used inside T.Pipelined.
                     for l_tile in T.Pipelined(L // block_l, num_stages=0):
                         for _i, j in T.Parallel(1, block_l):
-                            xval = T.cast(x[bc, l_tile * block_l + j], accum_dtype)
-                            y[bc, l_tile * block_l + j] = T.cast(
+                            l = l_tile * block_l + j
+                            flat = (l // S) * plane + bc * S + l % S
+                            xval = T.cast(x[flat], accum_dtype)
+                            y[flat] = T.cast(
                                 weight[bc] * (xval - mean_val) * rstd_val + bias[bc], dtype
                             )
 
         return _bn_fwd_train
 
     return _bn_fwd_train_func
+
+
+@functools.lru_cache(maxsize=32)
+def _batch_norm_fwd_train_split_kernel(
+    C: int,
+    L: int,
+    S: int,
+    dtype: str = "float16",
+    eps: float = 1e-5,
+    momentum: float = 0.1,
+) -> Callable:
+    """Return the three-stage training-forward factories for a long channel.
+
+    One block per channel leaves most of the device idle whenever there are
+    fewer channels than there are SMs, and no tile size fixes that: the grid
+    is the channel count. These stages put the grid over elements instead —
+    the sums are taken by *splits* blocks per channel and merged, and the
+    normalisation is a flat map — so the launch is as wide as the tensor.
+
+    Returns:
+        A ``(stats, finalize, apply)`` triple of JIT factories.
+    """
+    accum_dtype = "float32"
+    plane = C * S
+
+    @tilelang.jit
+    def _stats_func(splits: int, threads: int, num_per_thread: int) -> Callable:
+        chunk = T.ceildiv(L, splits)
+
+        @T.prim_func
+        def _bn_train_stats(
+            x: T.Tensor([C * L], dtype),
+            partial_sum: T.Tensor([C, splits], accum_dtype),
+            partial_sq: T.Tensor([C, splits], accum_dtype),
+        ):
+            with T.Kernel(C * splits, threads=threads) as bx:
+                bc = bx // splits
+                start = (bx % splits) * chunk
+                # One accumulator per thread, merged by a fixed reduction tree.
+                # Batch norm writes running statistics back, so a run has to
+                # land on the same bits every time an atomic order would not.
+                sums = T.alloc_fragment([1, threads], accum_dtype)
+                sqs = T.alloc_fragment([1, threads], accum_dtype)
+                T.clear(sums)
+                T.clear(sqs)
+                for _i, j in T.Parallel(1, threads):
+                    for step in T.serial(T.ceildiv(chunk, threads * num_per_thread)):
+                        for i in T.serial(num_per_thread):
+                            l = start + (step * threads + j) * num_per_thread + i
+                            if l < L:
+                                v = T.cast(x[(l // S) * plane + bc * S + l % S], accum_dtype)
+                                sums[_i, j] += v
+                                sqs[_i, j] += v * v
+                sum_result = T.alloc_fragment([1], accum_dtype)
+                sq_result = T.alloc_fragment([1], accum_dtype)
+                T.reduce_sum(sums, sum_result, dim=1)
+                T.reduce_sum(sqs, sq_result, dim=1)
+                if T.get_thread_binding() == 0:
+                    partial_sum[bc, bx % splits] = sum_result[0]
+                    partial_sq[bc, bx % splits] = sq_result[0]
+
+        return _bn_train_stats
+
+    @tilelang.jit
+    def _finalize_func(splits: int, threads: int) -> Callable:
+        @T.prim_func
+        def _bn_train_finalize(
+            partial_sum: T.Tensor([C, splits], accum_dtype),
+            partial_sq: T.Tensor([C, splits], accum_dtype),
+            weight: T.Tensor([C], accum_dtype),
+            bias: T.Tensor([C], accum_dtype),
+            running_mean: T.Tensor([C], accum_dtype),
+            running_var: T.Tensor([C], accum_dtype),
+            mean_out: T.Tensor([C], accum_dtype),
+            rstd_out: T.Tensor([C], accum_dtype),
+            scale_out: T.Tensor([C], accum_dtype),
+            shift_out: T.Tensor([C], accum_dtype),
+        ):
+            with T.Kernel(1, threads=threads) as _:
+                tx = T.get_thread_binding()
+                for step in T.serial(T.ceildiv(C, threads)):
+                    bc = step * threads + tx
+                    if bc < C:
+                        total = T.alloc_local([1], accum_dtype)
+                        total_sq = T.alloc_local([1], accum_dtype)
+                        total[0] = T.cast(0, accum_dtype)
+                        total_sq[0] = T.cast(0, accum_dtype)
+                        for k in T.serial(splits):
+                            total[0] += partial_sum[bc, k]
+                            total_sq[0] += partial_sq[bc, k]
+                        n = T.cast(L, accum_dtype)
+                        mean_val = total[0] / n
+                        var_val = total_sq[0] / n - mean_val * mean_val
+                        rstd_val = T.cast(1.0, accum_dtype) / T.sqrt(
+                            var_val + T.cast(eps, accum_dtype)
+                        )
+                        mean_out[bc] = mean_val
+                        rstd_out[bc] = rstd_val
+                        # The affine and the normalisation fold into one
+                        # multiply-add, so the map that follows reads two
+                        # numbers per channel instead of four.
+                        scale_out[bc] = weight[bc] * rstd_val
+                        shift_out[bc] = bias[bc] - mean_val * weight[bc] * rstd_val
+                        # running_var follows PyTorch convention: updated with
+                        # unbiased variance (Bessel's correction).
+                        mom = T.cast(momentum, accum_dtype)
+                        one = T.cast(1.0, accum_dtype)
+                        running_mean[bc] = (one - mom) * running_mean[bc] + mom * mean_val
+                        running_var[bc] = (one - mom) * running_var[bc] + mom * (
+                            var_val * n / (n - one)
+                        )
+
+        return _bn_train_finalize
+
+    @tilelang.jit(out_idx=[-1])
+    def _apply_func(blocks: int, threads: int, num_per_thread: int) -> Callable:
+        vector_holds_one_channel = S % num_per_thread == 0
+        span = threads * num_per_thread
+        total = C * L
+
+        @T.prim_func
+        def _bn_train_apply(
+            x: T.Tensor([total], dtype),
+            scale: T.Tensor([C], accum_dtype),
+            shift: T.Tensor([C], accum_dtype),
+            y: T.Tensor([total], dtype),
+        ):
+            with T.Kernel(blocks, threads=threads) as bx:
+                tx = T.get_thread_binding()
+                v = T.alloc_local([num_per_thread], dtype)
+                o = T.alloc_local([num_per_thread], dtype)
+                base = bx * span + tx * num_per_thread
+                if base + num_per_thread <= total:
+                    for i in T.vectorized(num_per_thread):
+                        v[i] = x[base + i]
+                    if vector_holds_one_channel:
+                        ch = (base // S) % C
+                        for i in T.serial(num_per_thread):
+                            o[i] = T.cast(T.cast(v[i], accum_dtype) * scale[ch] + shift[ch], dtype)
+                    else:
+                        for i in T.serial(num_per_thread):
+                            ch = ((base + i) // S) % C
+                            o[i] = T.cast(T.cast(v[i], accum_dtype) * scale[ch] + shift[ch], dtype)
+                    for i in T.vectorized(num_per_thread):
+                        y[base + i] = o[i]
+                else:
+                    for i in T.serial(num_per_thread):
+                        if base + i < total:
+                            ch = ((base + i) // S) % C
+                            y[base + i] = T.cast(
+                                T.cast(x[base + i], accum_dtype) * scale[ch] + shift[ch],
+                                dtype,
+                            )
+
+        return _bn_train_apply
+
+    return _stats_func, _finalize_func, _apply_func
+
+
+@functools.lru_cache(maxsize=32)
+def _batch_norm_fwd_train_wide_kernel(
+    C: int,
+    L: int,
+    S: int,
+    dtype: str = "float16",
+    eps: float = 1e-5,
+    momentum: float = 0.1,
+) -> Callable:
+    """Return the JIT-compiled training-forward factory for a register-held channel.
+
+    A channel short enough to sit in one block's registers is read once, wide,
+    and never written to shared memory: the same values that fed the sums are
+    the ones the normalisation writes back. The traffic is then exactly a copy
+    of the tensor, which is the floor for an op that must read and write it.
+
+    The two sums are merged by a shuffle tree inside each warp and one pass
+    over the per-warp totals, which is a fixed order and so gives the same
+    bits every run -- batch norm writes its statistics back, and a run that
+    lands on different bits is a run that cannot be reproduced.
+
+    Requirements: ``num_per_thread`` divides *S*, so a thread's vector never
+    straddles two batch items and its address stays affine; ``threads`` is a
+    multiple of the warp width.
+    """
+    accum_dtype = "float32"
+    plane = C * S
+    lanes = 32
+
+    @tilelang.jit(out_idx=[-1], compile_flags=["-O3", "-DENABLE_BF16"])
+    def _bn_fwd_train_wide_func(threads: int, num_per_thread: int) -> Callable:
+        steps = (L + threads * num_per_thread - 1) // (threads * num_per_thread)
+        exact = steps * threads * num_per_thread == L
+        n_warps = max(threads // lanes, 1)
+
+        @T.prim_func
+        def _bn_fwd_train_wide(
+            x: T.Tensor([C * L], dtype),
+            weight: T.Tensor([C], accum_dtype),
+            bias: T.Tensor([C], accum_dtype),
+            running_mean: T.Tensor([C], accum_dtype),
+            running_var: T.Tensor([C], accum_dtype),
+            mean_out: T.Tensor([C], accum_dtype),
+            rstd_out: T.Tensor([C], accum_dtype),
+            y: T.Tensor([C * L], dtype),
+        ):
+            with T.Kernel(C, threads=threads) as bc:
+                tx = T.get_thread_binding()
+                # Read before the sums so the latency overlaps the element loads.
+                params = T.alloc_local([4], accum_dtype)
+                params[0] = weight[bc]
+                params[1] = bias[bc]
+                params[2] = running_mean[bc]
+                params[3] = running_var[bc]
+                held = T.alloc_local([steps * num_per_thread], dtype)
+                out = T.alloc_local([num_per_thread], dtype)
+                acc = T.alloc_local([1], accum_dtype)
+                sq = T.alloc_local([1], accum_dtype)
+                acc[0] = T.cast(0, accum_dtype)
+                sq[0] = T.cast(0, accum_dtype)
+
+                for k in T.serial(steps):
+                    head = (k * threads + tx) * num_per_thread
+                    if exact or head + num_per_thread <= L:
+                        start = (head // S) * plane + bc * S + head % S
+                        for i in T.vectorized(num_per_thread):
+                            held[k * num_per_thread + i] = x[start + i]
+                        for i in T.serial(num_per_thread):
+                            v = T.cast(held[k * num_per_thread + i], accum_dtype)
+                            acc[0] += v
+                            sq[0] += v * v
+                    else:
+                        for i in T.serial(num_per_thread):
+                            l = head + i
+                            if l < L:
+                                held[k * num_per_thread + i] = x[(l // S) * plane + bc * S + l % S]
+                                v = T.cast(held[k * num_per_thread + i], accum_dtype)
+                                acc[0] += v
+                                sq[0] += v * v
+
+                for step in T.serial(5):
+                    acc[0] += T.shfl_xor(acc[0], T.shift_left(1, step))
+                    sq[0] += T.shfl_xor(sq[0], T.shift_left(1, step))
+
+                warp_sum = T.alloc_shared([n_warps], accum_dtype)
+                warp_sq = T.alloc_shared([n_warps], accum_dtype)
+                if tx % lanes == 0:
+                    warp_sum[tx // lanes] = acc[0]
+                    warp_sq[tx // lanes] = sq[0]
+                T.sync_threads()
+                acc[0] = T.cast(0, accum_dtype)
+                sq[0] = T.cast(0, accum_dtype)
+                for w in T.serial(n_warps):
+                    acc[0] += warp_sum[w]
+                    sq[0] += warp_sq[w]
+
+                n = T.cast(L, accum_dtype)
+                mean_val = acc[0] / n
+                var_val = sq[0] / n - mean_val * mean_val
+                rstd_val = T.cast(1.0, accum_dtype) / T.sqrt(var_val + T.cast(eps, accum_dtype))
+                # The affine and the normalisation fold into one multiply-add.
+                scale_val = params[0] * rstd_val
+                shift_val = params[1] - mean_val * scale_val
+
+                one = T.cast(1.0, accum_dtype)
+                mom = T.cast(momentum, accum_dtype)
+                # One writer per block: this running-stat RMW races if every thread runs it.
+                if tx == 0:
+                    mean_out[bc] = mean_val
+                    rstd_out[bc] = rstd_val
+                    running_mean[bc] = (one - mom) * params[2] + mom * mean_val
+                    # running_var follows PyTorch convention: updated with
+                    # unbiased variance (Bessel's correction).
+                    running_var[bc] = (one - mom) * params[3] + mom * (var_val * n / (n - one))
+
+                for k in T.serial(steps):
+                    head = (k * threads + tx) * num_per_thread
+                    if exact or head + num_per_thread <= L:
+                        start = (head // S) * plane + bc * S + head % S
+                        for i in T.serial(num_per_thread):
+                            out[i] = T.cast(
+                                T.cast(held[k * num_per_thread + i], accum_dtype) * scale_val
+                                + shift_val,
+                                dtype,
+                            )
+                        for i in T.vectorized(num_per_thread):
+                            y[start + i] = out[i]
+                    else:
+                        for i in T.serial(num_per_thread):
+                            l = head + i
+                            if l < L:
+                                y[(l // S) * plane + bc * S + l % S] = T.cast(
+                                    T.cast(held[k * num_per_thread + i], accum_dtype) * scale_val
+                                    + shift_val,
+                                    dtype,
+                                )
+
+        return _bn_fwd_train_wide
+
+    return _bn_fwd_train_wide_func
+
+
+@functools.lru_cache(maxsize=32)
+def _batch_norm_fwd_train_whole_kernel(
+    C: int,
+    L: int,
+    S: int,
+    dtype: str = "float16",
+    eps: float = 1e-5,
+    momentum: float = 0.1,
+) -> Callable:
+    """Return the JIT-compiled training-forward factory for a channel per thread.
+
+    A channel is *S* elements contiguous at a time, so where the spatial extent
+    is short — an ``(N, C)`` input has ``S == 1`` — a block that owns one
+    channel reads one element per cache line, whatever the tile size. Giving a
+    channel to a *thread* instead turns that around: neighbouring threads then
+    read neighbouring channels, which is one line between them, and a channel
+    short enough to sit in a thread's registers needs no reduction across
+    threads, no shared memory and no barrier.
+    """
+    accum_dtype = "float32"
+    plane = C * S
+
+    @tilelang.jit(out_idx=[-1], compile_flags=["-O3", "-DENABLE_BF16"])
+    def _bn_fwd_train_whole_func(threads: int) -> Callable:
+        blocks = (C + threads - 1) // threads
+
+        @T.prim_func
+        def _bn_fwd_train_whole(
+            x: T.Tensor([C * L], dtype),
+            weight: T.Tensor([C], accum_dtype),
+            bias: T.Tensor([C], accum_dtype),
+            running_mean: T.Tensor([C], accum_dtype),
+            running_var: T.Tensor([C], accum_dtype),
+            mean_out: T.Tensor([C], accum_dtype),
+            rstd_out: T.Tensor([C], accum_dtype),
+            y: T.Tensor([C * L], dtype),
+        ):
+            with T.Kernel(blocks, threads=threads) as bx:
+                c = bx * threads + T.get_thread_binding()
+                # The channel's four parameters are read before the sums, not
+                # after: their latency then overlaps the element loads instead
+                # of standing alone at the end, and with one channel to a
+                # thread there is no other warp to hide it behind.
+                params = T.alloc_local([4], accum_dtype)
+                if c < C:
+                    params[0] = weight[c]
+                    params[1] = bias[c]
+                    params[2] = running_mean[c]
+                    params[3] = running_var[c]
+                held = T.alloc_local([L], dtype)
+                acc = T.alloc_local([1], accum_dtype)
+                sq = T.alloc_local([1], accum_dtype)
+                acc[0] = T.cast(0, accum_dtype)
+                sq[0] = T.cast(0, accum_dtype)
+                if c < C:
+                    for l in T.serial(L):
+                        held[l] = x[(l // S) * plane + c * S + l % S]
+                        v = T.cast(held[l], accum_dtype)
+                        acc[0] += v
+                        sq[0] += v * v
+
+                    n = T.cast(L, accum_dtype)
+                    mean_val = acc[0] / n
+                    var_val = sq[0] / n - mean_val * mean_val
+                    rstd_val = T.cast(1.0, accum_dtype) / T.sqrt(var_val + T.cast(eps, accum_dtype))
+                    mean_out[c] = mean_val
+                    rstd_out[c] = rstd_val
+                    # The affine and the normalisation fold into one multiply-add.
+                    scale_val = params[0] * rstd_val
+                    shift_val = params[1] - mean_val * scale_val
+
+                    mom = T.cast(momentum, accum_dtype)
+                    one = T.cast(1.0, accum_dtype)
+                    running_mean[c] = (one - mom) * params[2] + mom * mean_val
+                    # running_var follows PyTorch convention: updated with
+                    # unbiased variance (Bessel's correction).
+                    running_var[c] = (one - mom) * params[3] + mom * (var_val * n / (n - one))
+
+                    for l in T.serial(L):
+                        y[(l // S) * plane + c * S + l % S] = T.cast(
+                            T.cast(held[l], accum_dtype) * scale_val + shift_val, dtype
+                        )
+
+        return _bn_fwd_train_whole
+
+    return _bn_fwd_train_whole_func
 
 
 class BatchNormFwdTrainKernel(Kernel):
@@ -224,9 +649,14 @@ class BatchNormFwdTrainKernel(Kernel):
         momentum: Running-stat update momentum.
         config: Optional tile config dict.
         tune: If True, autotune tile config.
+        S: Elements per channel in one batch item, ``product(spatial)``.
+            Defaults to *L*, which is right when the batch is one.
     """
 
     supported_archs: list[int] = [80, 89, 90]
+
+    # Wide enough for a 16-byte access in every supported dtype.
+    _SPLIT_NUM_PER_THREAD = 8
 
     def __init__(
         self,
@@ -237,15 +667,76 @@ class BatchNormFwdTrainKernel(Kernel):
         momentum: float = 0.1,
         config: Optional[dict] = None,
         tune: bool = False,
+        S: Optional[int] = None,
     ) -> None:
         super().__init__()
         self.C = C
         self.L = L
+        self.S = L if S is None else S
         self.dtype = dtype
         self.eps = eps
         self.momentum = momentum
-        self.kernel = _batch_norm_fwd_train_kernel(C, L, self.dtype_str, eps, momentum)
+        self.path, self.launch = self._select_path(C, L, self.S)
+        if self.path == "whole":
+            self.whole_kernel = _batch_norm_fwd_train_whole_kernel(
+                C, L, self.S, self.dtype_str, eps, momentum
+            )
+        elif self.path == "wide":
+            self.wide_kernel = _batch_norm_fwd_train_wide_kernel(
+                C, L, self.S, self.dtype_str, eps, momentum
+            )
+        elif self.path == "split":
+            self.stages = _batch_norm_fwd_train_split_kernel(
+                C, L, self.S, self.dtype_str, eps, momentum
+            )
+        self.kernel = _batch_norm_fwd_train_kernel(C, L, self.S, self.dtype_str, eps, momentum)
         self.init_config(config, tune)
+
+    @classmethod
+    def _select_path(cls, C: int, L: int, S: int) -> tuple[str, object]:
+        """Which launch serves this shape, and the sizing it needs.
+
+        The four differ in what owns a channel, which is what a short channel,
+        a long one, and a short spatial extent each need:
+
+        ==========  ====================================  ==================
+        path        a channel belongs to                  chosen when
+        ==========  ====================================  ==================
+        ``whole``   one thread, held in its registers     *S* is short
+        ``wide``    one block, held in its registers      *L* fits registers
+        ``split``   several blocks, summed and merged     *L* is long
+        ``tiled``   one block, streamed through shared    otherwise
+        ==========  ====================================  ==================
+        """
+        if S <= _WHOLE_MAX_S and L <= _WHOLE_MAX_L:
+            return "whole", _WHOLE_BLOCK_THREADS
+        wide = cls._wide_launch(L, S)
+        if wide is not None:
+            return "wide", wide
+        if C < _SPLIT_TARGET_BLOCKS and L >= _SPLIT_MIN_L:
+            return "split", max(1, min(L, -(-_SPLIT_TARGET_BLOCKS // C)))
+        return "tiled", None
+
+    @staticmethod
+    def _wide_launch(L: int, S: int) -> Optional[tuple[int, int]]:
+        """The ``(threads, num_per_thread)`` a register-held channel needs, or None.
+
+        The vector must not straddle two batch items, and the channel must fit
+        in the widest block the device allows.
+        """
+        for num_per_thread in (_WIDE_MAX_NUM_PER_THREAD, 4, 2, 1):
+            if S % num_per_thread:
+                continue
+            # A block no wider than the warp merge stays cheap, with the step
+            # count taking whatever the width does not cover. What caps the
+            # steps is the register file: every step holds its own vector.
+            threads = _WIDE_BLOCK_THREADS
+            while threads > 32 and threads * num_per_thread >= L * 2:
+                threads //= 2
+            steps = -(-L // (threads * num_per_thread))
+            if steps * num_per_thread <= _WIDE_MAX_HELD:
+                return threads, num_per_thread
+        return None
 
     @property
     def default_config(self) -> dict:
@@ -286,6 +777,42 @@ class BatchNormFwdTrainKernel(Kernel):
 
         return configs if configs else [self.default_config]
 
+    def _forward_split(
+        self,
+        flat: torch.Tensor,
+        running_mean: torch.Tensor,
+        running_var: torch.Tensor,
+        weight: torch.Tensor,
+        bias: torch.Tensor,
+        mean_out: torch.Tensor,
+        rstd_out: torch.Tensor,
+    ) -> torch.Tensor:
+        """Sum, merge, then map -- three launches over an element-wide grid."""
+        stats, finalize, apply_ = self.stages
+        splits = self.launch
+        threads = self.config["threads"]
+        num_per_thread = self._SPLIT_NUM_PER_THREAD
+        empty = functools.partial(torch.empty, device=flat.device, dtype=torch.float32)
+        partial_sum = empty((self.C, splits))
+        partial_sq = empty((self.C, splits))
+        stats(splits, threads, num_per_thread)(flat, partial_sum, partial_sq)
+        scale, shift = empty(self.C), empty(self.C)
+        finalize(splits, min(256, self.C))(
+            partial_sum,
+            partial_sq,
+            weight,
+            bias,
+            running_mean,
+            running_var,
+            mean_out,
+            rstd_out,
+            scale,
+            shift,
+        )
+        span = threads * num_per_thread
+        blocks = (flat.numel() + span - 1) // span
+        return apply_(blocks, threads, num_per_thread)(flat, scale, shift)
+
     def forward(
         self,
         x: torch.Tensor,
@@ -295,8 +822,6 @@ class BatchNormFwdTrainKernel(Kernel):
         bias: torch.Tensor,
     ):
         """Run training forward pass on an ``(N, C, *spatial)`` input.
-
-        Moving the input into the $[C \\times L]$ layout, and the output back, happens here.
 
         Returns:
             y: Normalized output, shaped like *x*.
@@ -315,11 +840,35 @@ class BatchNormFwdTrainKernel(Kernel):
         )
         mean_out = torch.empty(self.C, device=x.device, dtype=torch.float32)
         rstd_out = torch.empty(self.C, device=x.device, dtype=torch.float32)
+        flat = x.contiguous().reshape(-1)
+        if self.path == "whole":
+            y = self.whole_kernel(self.launch)(
+                flat, weight, bias, running_mean, running_var, mean_out, rstd_out
+            )
+            return y.reshape(x.shape), mean_out, rstd_out
+        if self.path == "wide":
+            y = self.wide_kernel(*self.launch)(
+                flat, weight, bias, running_mean, running_var, mean_out, rstd_out
+            )
+            return y.reshape(x.shape), mean_out, rstd_out
+        if self.path == "split":
+            y = self._forward_split(
+                flat, running_mean, running_var, weight, bias, mean_out, rstd_out
+            )
+            return y.reshape(x.shape), mean_out, rstd_out
         y = self.kernel(
             self.config["block_l"],
             self.config["threads"],
-        )(_to_cl(x), weight, bias, running_mean, running_var, mean_out, rstd_out)
-        return _from_cl(y, x.shape), mean_out, rstd_out
+        )(
+            flat,
+            weight,
+            bias,
+            running_mean,
+            running_var,
+            mean_out,
+            rstd_out,
+        )
+        return y.reshape(x.shape), mean_out, rstd_out
 
 
 # Inference forward
@@ -327,41 +876,84 @@ class BatchNormFwdTrainKernel(Kernel):
 
 @functools.lru_cache(maxsize=32)
 def _batch_norm_fwd_infer_kernel(
+    total: int,
     C: int,
-    L: int,
+    S: int,
     dtype: str = "float16",
     eps: float = 1e-5,
 ) -> Callable:
     """Return the JIT-compiled inference-forward kernel factory.
 
-    Single pass: y = weight * (x - running_mean) / sqrt(running_var + eps) + bias.
-    Fused into a pre-computed scale/shift per channel to minimize arithmetic.
+    Inference reads no statistic off the input, so the whole op is one map:
+    ``y = x * scale + shift`` with a scale and shift the channel picks. The
+    grid is over elements, not channels, and the channel of element ``i`` is
+    ``(i // S) % C`` -- which holds for the ``(N, C, *spatial)`` the caller
+    already has, so nothing is transposed on the way in or out.
+
+    Args:
+        total: Element count of the whole tensor.
+        C: Number of channels.
+        S: Elements per channel in one batch item, ``product(spatial)``.
+        dtype: Input/output data type.
+        eps: Numerical stability constant.
     """
     accum_dtype = "float32"
 
     @tilelang.jit(out_idx=[-1], compile_flags=["-O3", "-DENABLE_BF16"])
-    def _bn_fwd_infer_func(block_l: int, num_stages: int, threads: int) -> Callable:
+    def _bn_fwd_infer_func(blocks: int, threads: int, num_per_thread: int) -> Callable:
+        # A vector of num_per_thread elements sits in one channel only when a
+        # channel's run divides it; otherwise each element picks its own.
+        vector_holds_one_channel = S % num_per_thread == 0
+        span = threads * num_per_thread
+
         @T.prim_func
         def _bn_fwd_infer(
-            x: T.Tensor([C, L], dtype),
+            x: T.Tensor([total], dtype),
             weight: T.Tensor([C], accum_dtype),
             bias: T.Tensor([C], accum_dtype),
             running_mean: T.Tensor([C], accum_dtype),
             running_var: T.Tensor([C], accum_dtype),
-            y: T.Tensor([C, L], dtype),
+            y: T.Tensor([total], dtype),
         ):
-            with T.Kernel(C, threads=threads) as (bc):
-                # Fused scale/shift: avoids recomputing per element.
-                scale = weight[bc] / T.sqrt(running_var[bc] + T.cast(eps, accum_dtype))
-                shift = bias[bc] - running_mean[bc] * scale
+            with T.Kernel(blocks, threads=threads) as bx:
+                tx = T.get_thread_binding()
+                # Fusing weight and bias into one scale and shift per channel
+                # turns the body into a single multiply-add. The table is
+                # per-channel, so the block builds it once rather than every
+                # element recomputing a square root and a divide.
+                scale = T.alloc_shared([C], accum_dtype)
+                shift = T.alloc_shared([C], accum_dtype)
+                for c in T.serial(T.ceildiv(C, threads)):
+                    ch = c * threads + tx
+                    if ch < C:
+                        sc = weight[ch] / T.sqrt(running_var[ch] + T.cast(eps, accum_dtype))
+                        scale[ch] = sc
+                        shift[ch] = bias[ch] - running_mean[ch] * sc
+                T.sync_threads()
 
-                # Non-persistent: direct global memory access avoids async-copy
-                # data race that occurs when T.copy is used inside T.Pipelined.
-                for l_tile in T.Pipelined(L // block_l, num_stages=0):
-                    for _i, j in T.Parallel(1, block_l):
-                        y[bc, l_tile * block_l + j] = T.cast(
-                            T.cast(x[bc, l_tile * block_l + j], accum_dtype) * scale + shift, dtype
-                        )
+                v = T.alloc_local([num_per_thread], dtype)
+                o = T.alloc_local([num_per_thread], dtype)
+                base = bx * span + tx * num_per_thread
+                if base + num_per_thread <= total:
+                    for i in T.vectorized(num_per_thread):
+                        v[i] = x[base + i]
+                    if vector_holds_one_channel:
+                        ch = (base // S) % C
+                        for i in T.serial(num_per_thread):
+                            o[i] = T.cast(T.cast(v[i], accum_dtype) * scale[ch] + shift[ch], dtype)
+                    else:
+                        for i in T.serial(num_per_thread):
+                            ch = ((base + i) // S) % C
+                            o[i] = T.cast(T.cast(v[i], accum_dtype) * scale[ch] + shift[ch], dtype)
+                    for i in T.vectorized(num_per_thread):
+                        y[base + i] = o[i]
+                else:
+                    for i in T.serial(num_per_thread):
+                        if base + i < total:
+                            ch = ((base + i) // S) % C
+                            y[base + i] = T.cast(
+                                T.cast(x[base + i], accum_dtype) * scale[ch] + shift[ch], dtype
+                            )
 
         return _bn_fwd_infer
 
@@ -373,14 +965,19 @@ class BatchNormFwdInferKernel(Kernel):
 
     Args:
         C: Number of channels.
-        L: Total reduction length = N * H * W * ... (must be divisible by block_l).
+        L: Total reduction length = N * H * W * ... (kept for the op's signature).
         dtype: Input/output data type.
         eps: Numerical stability constant.
         config: Optional tile config dict.
         tune: If True, autotune tile config.
+        S: Elements per channel in one batch item, ``product(spatial)``.
+            Defaults to *L*, which is right when the batch is one.
     """
 
     supported_archs: list[int] = [80, 89, 90]
+
+    # Wide enough for a 16-byte access in every supported dtype.
+    _MAX_NUM_PER_THREAD = 8
 
     def __init__(
         self,
@@ -390,37 +987,39 @@ class BatchNormFwdInferKernel(Kernel):
         eps: float = 1e-5,
         config: Optional[dict] = None,
         tune: bool = False,
+        S: Optional[int] = None,
     ) -> None:
         super().__init__()
         self.C = C
         self.L = L
+        self.S = L if S is None else S
+        self.total = C * L
         self.dtype = dtype
         self.eps = eps
-        self.kernel = _batch_norm_fwd_infer_kernel(C, L, self.dtype_str, eps)
+        self.kernel = _batch_norm_fwd_infer_kernel(self.total, C, self.S, self.dtype_str, eps)
         self.init_config(config, tune)
+
+    def _blocks(self, threads: int, num_per_thread: int) -> int:
+        span = threads * num_per_thread
+        return (self.total + span - 1) // span
 
     @property
     def default_config(self) -> dict:
-        return _find_best_block_l(self.L)
+        # The widest access the element count will carry, so the grid is as
+        # short as it can be and every load is one instruction.
+        for num_per_thread in (self._MAX_NUM_PER_THREAD, 4, 2, 1):
+            if self.total % num_per_thread == 0:
+                return {"threads": 256, "num_per_thread": num_per_thread}
+        return {"threads": 256, "num_per_thread": 1}
 
     @property
     def autotune_configs(self) -> list[dict]:
-        seen: set = set()
         configs = []
-
-        def _add(cfg: dict) -> None:
-            key = (cfg["block_l"], cfg["num_stages"], cfg["threads"])
-            if key not in seen:
-                seen.add(key)
-                configs.append(cfg)
-
-        for threads in [256, 128, 64, 32]:
-            for k in range(512 // threads, 0, -1):
-                bl = threads * k
-                if self.L % bl != 0:
+        for threads in (128, 256, 512, 1024):
+            for num_per_thread in (8, 4, 2, 1):
+                if self.total % num_per_thread:
                     continue
-                _add({"block_l": bl, "num_stages": 0, "threads": threads})
-
+                configs.append({"threads": threads, "num_per_thread": num_per_thread})
         return configs if configs else [self.default_config]
 
     def forward(
@@ -432,8 +1031,6 @@ class BatchNormFwdInferKernel(Kernel):
         bias: torch.Tensor,
     ) -> torch.Tensor:
         """Run inference forward pass on an ``(N, C, *spatial)`` input.
-
-        Moving the input into the $[C \\times L]$ layout, and the output back, happens here.
 
         Returns:
             Normalized output, shaped like *x*.
@@ -448,12 +1045,12 @@ class BatchNormFwdInferKernel(Kernel):
             running_mean=running_mean,
             running_var=running_var,
         )
-        y = self.kernel(
-            self.config["block_l"],
-            self.config["num_stages"],
-            self.config["threads"],
-        )(_to_cl(x), weight, bias, running_mean, running_var)
-        return _from_cl(y, x.shape)
+        threads = self.config["threads"]
+        num_per_thread = self.config["num_per_thread"]
+        y = self.kernel(self._blocks(threads, num_per_thread), threads, num_per_thread)(
+            x.contiguous().reshape(-1), weight, bias, running_mean, running_var
+        )
+        return y.reshape(x.shape)
 
 
 # Backward

--- a/src/tileops/kernels/norm/batch_norm.py
+++ b/src/tileops/kernels/norm/batch_norm.py
@@ -631,40 +631,29 @@ class BatchNormFwdTrainKernel(Kernel):
 
     supported_archs: list[int] = [80, 89, 90]
 
-    # Every threshold below sits on a measured crossover. Each path was forced
-    # over a sweep of the shape it selects on, timed through CUPTI on one H200
-    # (sm_90) in fp16 and fp32, and read as the floor of three runs.
+    # The thresholds below are measured crossovers, not derived bounds.
 
-    # Block count the split path aims for, as a multiple of the channel count.
-    # Runtime is flat from here on: at (4, 128, 1024, 1024) 8 splits cost
-    # 0.845 ms against 0.811 for 64, and at (2, 512, 512, 512) anything past 2
-    # splits costs 2% more. 1024 blocks is the target on both plateaus.
+    # Blocks the split path aims for, as a multiple of the channel count. Above
+    # this the runtime is flat.
     _SPLIT_TARGET_BLOCKS = 1024
 
     # Per-channel length above which one block per channel is too narrow a grid,
     # whatever the tile size, and the split path takes over.
     _SPLIT_MIN_L = 1 << 16
 
-    # A channel goes to one thread only where it is a single element per batch
-    # item. At S = 2 the channel-per-block path already wins for C = 256 (1.79
-    # against 2.05 us in fp16, 1.79 against 2.21 in fp32), and by S = 16 it wins
-    # by 3-6x at every C.
+    # A channel goes to one thread only where it is one element per batch item.
+    # Past that the channel-per-block path wins at every channel count.
     _WHOLE_MAX_S = 1
 
-    # Longest channel one thread holds. L = 32 is the last length that beats the
-    # channel-per-block path at every C measured; L = 64 loses it for C = 64.
+    # Longest channel one thread holds, and the width of the block holding them.
+    # That block is wider than the channels it covers when there are few, so it
+    # still launches enough warps to cover load latency.
     _WHOLE_MAX_L = 32
-
-    # Block width for the channel-per-thread path, fixed rather than sized to
-    # the channel count, so a block short of channels still launches enough
-    # warps to cover load latency.
     _WHOLE_BLOCK_THREADS = 256
 
     # The register-held path's block width, and the most elements one thread may
-    # hold across all its steps. 256 is the last value that beats both of the
-    # alternatives -- at L = 65536 it is 20-35% faster than the split path and
-    # 27-35% faster than the tiled one -- and 512 is where the spills reverse
-    # that, by 16-39%.
+    # hold across all its steps. Past this the spills cost more than the second
+    # global read the other paths pay.
     _WIDE_BLOCK_THREADS = 256
     _WIDE_MAX_HELD = 256
 
@@ -790,11 +779,9 @@ class BatchNormFwdTrainKernel(Kernel):
     def autotune(self, warmup: int = 25, rep: int = 50) -> None:
         """Tune the kernel this shape's path actually launches.
 
-        ``autotune_configs`` describes the tiled kernel, which the base class
-        reads off ``self.kernel``. The whole and wide paths take their launch
-        from the shape and read nothing off the config, so there is nothing to
-        search. The split path reads one value, the block width, and reads it
-        in the sums, so the sums are what it tunes.
+        The base class tunes ``self.kernel``, the tiled builder. The whole and
+        wide paths take their launch from the shape and read nothing off the
+        config. The split path reads only the block width, in the sums.
         """
         if self.path in ("whole", "wide"):
             self.config = self.default_config
@@ -806,9 +793,8 @@ class BatchNormFwdTrainKernel(Kernel):
                 {"splits": self.launch, "threads": t, "num_per_thread": num_per_thread}
                 for t in _SPLIT_CANDIDATE_THREADS
             ]
-            # Every parameter of the sums builder must be seeded, so the seed is
-            # a candidate rather than default_config, which describes the tiled
-            # kernel and names none of them.
+            # A candidate seeds it, not default_config: that describes the
+            # tiled kernel and names none of the sums builder's parameters.
             tuned = self.tune_jit_kernel(
                 self.stages[0], configs, warmup=warmup, rep=rep, seed_config=configs[0]
             )
@@ -945,8 +931,8 @@ def _batch_norm_fwd_infer_kernel(
         # channel's run divides it; otherwise each element picks its own.
         vector_holds_one_channel = S % num_per_thread == 0
         span = threads * num_per_thread * steps
-        # Derived here rather than passed in, so every parameter of this builder
-        # is a key of the config the autotuner binds by name.
+        # Derived, not a parameter: the autotuner binds by name, and every
+        # parameter of this builder must therefore be a config key.
         blocks = -(-total // span)
 
         @T.prim_func
@@ -977,10 +963,7 @@ def _batch_norm_fwd_infer_kernel(
                 v = T.alloc_local([num_per_thread], dtype)
                 o = T.alloc_local([num_per_thread], dtype)
                 # A block walks its span in *steps* vectors per thread, each
-                # step contiguous across the block. The table above is built
-                # once per block, so its cost follows the block count rather
-                # than the vector width, and a narrower vector no longer buys
-                # its alignment by launching more blocks.
+                # step contiguous across the block.
                 for k in T.serial(steps):
                     base = bx * span + (k * threads + tx) * num_per_thread
                     if base + num_per_thread <= total:
@@ -1029,12 +1012,10 @@ class BatchNormFwdInferKernel(Kernel):
 
     supported_archs: list[int] = [80, 89, 90]
 
-    # Elements one block covers, and its width. Every block builds the whole
-    # per-channel scale and shift table before touching its own elements, so
-    # that prologue is paid per block. Holding the span and the width fixed
-    # keeps the block count and the prologue where they are while the
-    # per-thread vector narrows to whatever the dtype makes a single 128-bit
-    # access; the step count takes up the difference.
+    # Elements one block covers, and its width. Each block builds the whole
+    # per-channel table first, so that prologue is paid per block; fixing the
+    # span fixes the block count, and the step count absorbs whatever the
+    # per-thread vector gives up to stay a single 128-bit access.
     _BLOCK_SPAN = 2048
     _BLOCK_THREADS = 256
 

--- a/src/tileops/kernels/norm/batch_norm.py
+++ b/src/tileops/kernels/norm/batch_norm.py
@@ -2,18 +2,11 @@
 
 Reference: Ioffe & Szegedy (2015) https://arxiv.org/abs/1502.03167
 
-Training forward and backward reduce over a channel, so they work on (C, L)
-where C is the channel count and L = N * H * W * ... , and move the caller's
-(N, C, *spatial) tensor into that layout themselves. Inference reduces over
-nothing and reads the caller's layout as it is.
-
-Performance notes:
-  - Persistent path (block_l >= L): loads all L elements into shared memory once
-    and normalizes from there — single global read, eliminates the second pass.
-    Active when L <= _PERSISTENT_THRESHOLD (8192).
-  - Non-power-of-2 block_l: _find_best_block_l() searches thread counts
-    [256, 128, 64, 32] to find the largest valid block_l,
-    fixing poor occupancy for L values like 3136 = 2^6 * 7^2.
+C is the channel count, L = N * prod(spatial) the reduction length of one
+channel, and S = prod(spatial) its contiguous run within one batch item.
+Training forward and inference forward index the caller's (N, C, *spatial)
+layout directly. Backward reduces over a channel on a (C, L) copy and moves
+the caller's tensor into that layout itself.
 """
 
 import functools
@@ -23,6 +16,7 @@ import tilelang
 import tilelang.language as T
 import torch
 
+from tileops.kernels.constants import VECTOR_ACCESS_BYTES
 from tileops.kernels.kernel_base import Kernel
 
 __all__ = [
@@ -31,35 +25,25 @@ __all__ = [
     "BatchNormFwdTrainKernel",
 ]
 
-# Blocks the split training path aims to launch, as a multiple of the channel
-# count: enough to cover the device several times over so no SM sits idle.
-_SPLIT_TARGET_BLOCKS = 1024
-
-# Per-channel length above which one block per channel is too narrow a grid,
-# whatever the tile size, and the split path takes over.
-_SPLIT_MIN_L = 1 << 16
-
-# L threshold for the persistent (single global read) training path.
+# L threshold for the persistent (single global read) training path, read by
+# both the training-forward and the backward kernel.
 # x_shared uses L * sizeof(dtype) bytes per block:
 #   L=8192, fp16 → 16 KB — well within H100 shared memory limits.
-# Spatial extent below which a channel-per-block read cannot fill a cache line,
-# and the longest channel a thread that owns one can keep in its registers.
-_WHOLE_MAX_S = 16
-_WHOLE_MAX_L = 32
-
-# Block width for that path. It is wider than the channels a block covers when
-# there are few of them, which measured faster than a block sized to fit: the
-# extra warps give the scheduler something to issue while the loads land.
-_WHOLE_BLOCK_THREADS = 256
-
-# The register-held path's block width, its widest per-thread vector, and the
-# most elements one thread may hold across all its steps before the register
-# file is the binding constraint.
-_WIDE_BLOCK_THREADS = 256
-_WIDE_MAX_NUM_PER_THREAD = 8
-_WIDE_MAX_HELD = 32
-
 _PERSISTENT_THRESHOLD = 8192
+
+# Block widths the split path's sums are tuned over. Powers of two only:
+# T.reduce_sum lowers to an XOR butterfly.
+_SPLIT_CANDIDATE_THREADS = (128, 256, 512, 1024)
+
+
+def _vector_elements(dtype: torch.dtype) -> int:
+    """Elements one thread accesses at once for a 128-bit vector in *dtype*."""
+    return VECTOR_ACCESS_BYTES // dtype.itemsize
+
+
+def _widths_down_to_one(widest: int) -> tuple[int, ...]:
+    """*widest* and every halving of it, down to one element."""
+    return tuple(widest >> k for k in range(widest.bit_length()))
 
 
 def _find_best_threads(L: int) -> int:
@@ -109,7 +93,7 @@ def _to_cl(t: torch.Tensor) -> torch.Tensor:
 
 
 def _from_cl(t: torch.Tensor, original_shape: torch.Size) -> torch.Tensor:
-    """Move a (C, L) result back to the shape the caller handed over."""
+    """Move a (C, L) result back to the caller's shape."""
     batch, channels, *spatial = original_shape
     restored = t.reshape(channels, batch, *spatial)
     return restored.permute(1, 0, *range(2, restored.ndim)).contiguous()
@@ -135,11 +119,9 @@ def _batch_norm_fwd_train_kernel(
 
     Saved mean and rstd are needed by the backward pass.
 
-    A channel is not contiguous in the ``(N, C, *spatial)`` the caller holds,
-    but it is *S* elements contiguous at a time, once per batch item, which
-    coalesces as well as a transposed copy would and costs no pass to build.
-    Element *l* of channel *c* therefore lives at ``(l // S) * C * S + c * S +
-    l % S``.
+    A channel is *S* elements contiguous at a time, once per batch item, so
+    element *l* of channel *c* lives at ``(l // S) * C * S + c * S + l % S``.
+    Reading through that index needs no transposed copy.
 
     Persistent path (block_l >= L): after pass 1 loads all L elements into
     x_shared, pass 2 normalizes directly from x_shared — no second global read.
@@ -185,8 +167,8 @@ def _batch_norm_fwd_train_kernel(
                         xsum_frag[_i, j] += xval
                         xsq_frag[_i, j] += xval * xval
                 else:
-                    # Non-persistent path: direct global memory access avoids async-copy
-                    # data race that occurs when T.copy is used inside T.Pipelined.
+                    # Read global memory directly: T.copy inside T.Pipelined
+                    # races with the async copy.
                     for l_tile in T.Pipelined(L // block_l, num_stages=0):
                         for _i, j in T.Parallel(1, block_l):
                             l = l_tile * block_l + j
@@ -235,8 +217,8 @@ def _batch_norm_fwd_train_kernel(
                             weight[bc] * (xval - mean_val) * rstd_val + bias[bc], dtype
                         )
                 else:
-                    # Non-persistent path: direct global memory access avoids async-copy
-                    # data race that occurs when T.copy is used inside T.Pipelined.
+                    # Read global memory directly: T.copy inside T.Pipelined
+                    # races with the async copy.
                     for l_tile in T.Pipelined(L // block_l, num_stages=0):
                         for _i, j in T.Parallel(1, block_l):
                             l = l_tile * block_l + j
@@ -262,11 +244,10 @@ def _batch_norm_fwd_train_split_kernel(
 ) -> Callable:
     """Return the three-stage training-forward factories for a long channel.
 
-    One block per channel leaves most of the device idle whenever there are
-    fewer channels than there are SMs, and no tile size fixes that: the grid
-    is the channel count. These stages put the grid over elements instead —
-    the sums are taken by *splits* blocks per channel and merged, and the
-    normalisation is a flat map — so the launch is as wide as the tensor.
+    The grid is over elements, not channels: *splits* blocks sum each channel,
+    one block merges the partial sums into a per-channel scale and shift, and a
+    flat map applies them. A shape with fewer channels than SMs still fills the
+    device.
 
     Returns:
         A ``(stats, finalize, apply)`` triple of JIT factories.
@@ -287,9 +268,9 @@ def _batch_norm_fwd_train_split_kernel(
             with T.Kernel(C * splits, threads=threads) as bx:
                 bc = bx // splits
                 start = (bx % splits) * chunk
-                # One accumulator per thread, merged by a fixed reduction tree.
-                # Batch norm writes running statistics back, so a run has to
-                # land on the same bits every time an atomic order would not.
+                # One accumulator per thread, merged by a fixed reduction
+                # tree. Batch norm writes running statistics back, so the
+                # merge order must be deterministic.
                 sums = T.alloc_fragment([1, threads], accum_dtype)
                 sqs = T.alloc_fragment([1, threads], accum_dtype)
                 T.clear(sums)
@@ -347,9 +328,9 @@ def _batch_norm_fwd_train_split_kernel(
                         )
                         mean_out[bc] = mean_val
                         rstd_out[bc] = rstd_val
-                        # The affine and the normalisation fold into one
-                        # multiply-add, so the map that follows reads two
-                        # numbers per channel instead of four.
+                        # Folding the affine into the normalisation leaves the
+                        # map that follows two numbers per channel to read
+                        # instead of four.
                         scale_out[bc] = weight[bc] * rstd_val
                         shift_out[bc] = bias[bc] - mean_val * weight[bc] * rstd_val
                         # running_var follows PyTorch convention: updated with
@@ -419,15 +400,13 @@ def _batch_norm_fwd_train_wide_kernel(
 ) -> Callable:
     """Return the JIT-compiled training-forward factory for a register-held channel.
 
-    A channel short enough to sit in one block's registers is read once, wide,
-    and never written to shared memory: the same values that fed the sums are
-    the ones the normalisation writes back. The traffic is then exactly a copy
-    of the tensor, which is the floor for an op that must read and write it.
+    A channel short enough to fit in one block's registers is read once into
+    registers and normalised from there, with no shared-memory staging and no
+    second global read: global traffic is one read and one write of the tensor.
 
-    The two sums are merged by a shuffle tree inside each warp and one pass
-    over the per-warp totals, which is a fixed order and so gives the same
-    bits every run -- batch norm writes its statistics back, and a run that
-    lands on different bits is a run that cannot be reproduced.
+    The two sums are merged by a shuffle tree within each warp, then by one
+    serial pass over the per-warp totals. That order is fixed, so the running
+    statistics this kernel writes back are the same on every run.
 
     Requirements: ``num_per_thread`` divides *S*, so a thread's vector never
     straddles two batch items and its address stays affine; ``threads`` is a
@@ -561,13 +540,12 @@ def _batch_norm_fwd_train_whole_kernel(
 ) -> Callable:
     """Return the JIT-compiled training-forward factory for a channel per thread.
 
-    A channel is *S* elements contiguous at a time, so where the spatial extent
-    is short — an ``(N, C)`` input has ``S == 1`` — a block that owns one
-    channel reads one element per cache line, whatever the tile size. Giving a
-    channel to a *thread* instead turns that around: neighbouring threads then
-    read neighbouring channels, which is one line between them, and a channel
-    short enough to sit in a thread's registers needs no reduction across
-    threads, no shared memory and no barrier.
+    A channel is *S* elements contiguous at a time, so a short spatial extent
+    — ``S == 1`` for an ``(N, C)`` input — leaves a block that owns one channel
+    one useful element per cache line, whatever the tile size. One channel per
+    *thread* instead puts neighbouring channels in neighbouring threads, so a
+    warp's reads fall in the same lines. A channel that fits in a thread's
+    registers needs no cross-thread reduction, no shared memory and no barrier.
     """
     accum_dtype = "float32"
     plane = C * S
@@ -589,10 +567,8 @@ def _batch_norm_fwd_train_whole_kernel(
         ):
             with T.Kernel(blocks, threads=threads) as bx:
                 c = bx * threads + T.get_thread_binding()
-                # The channel's four parameters are read before the sums, not
-                # after: their latency then overlaps the element loads instead
-                # of standing alone at the end, and with one channel to a
-                # thread there is no other warp to hide it behind.
+                # Read the channel's four parameters before the sums so their
+                # latency overlaps the element loads.
                 params = T.alloc_local([4], accum_dtype)
                 if c < C:
                     params[0] = weight[c]
@@ -650,13 +626,47 @@ class BatchNormFwdTrainKernel(Kernel):
         config: Optional tile config dict.
         tune: If True, autotune tile config.
         S: Elements per channel in one batch item, ``product(spatial)``.
-            Defaults to *L*, which is right when the batch is one.
+            Defaults to *L*, correct when the batch size is one.
     """
 
     supported_archs: list[int] = [80, 89, 90]
 
-    # Wide enough for a 16-byte access in every supported dtype.
-    _SPLIT_NUM_PER_THREAD = 8
+    # Every threshold below sits on a measured crossover. Each path was forced
+    # over a sweep of the shape it selects on, timed through CUPTI on one H200
+    # (sm_90) in fp16 and fp32, and read as the floor of three runs.
+
+    # Block count the split path aims for, as a multiple of the channel count.
+    # Runtime is flat from here on: at (4, 128, 1024, 1024) 8 splits cost
+    # 0.845 ms against 0.811 for 64, and at (2, 512, 512, 512) anything past 2
+    # splits costs 2% more. 1024 blocks is the target on both plateaus.
+    _SPLIT_TARGET_BLOCKS = 1024
+
+    # Per-channel length above which one block per channel is too narrow a grid,
+    # whatever the tile size, and the split path takes over.
+    _SPLIT_MIN_L = 1 << 16
+
+    # A channel goes to one thread only where it is a single element per batch
+    # item. At S = 2 the channel-per-block path already wins for C = 256 (1.79
+    # against 2.05 us in fp16, 1.79 against 2.21 in fp32), and by S = 16 it wins
+    # by 3-6x at every C.
+    _WHOLE_MAX_S = 1
+
+    # Longest channel one thread holds. L = 32 is the last length that beats the
+    # channel-per-block path at every C measured; L = 64 loses it for C = 64.
+    _WHOLE_MAX_L = 32
+
+    # Block width for the channel-per-thread path, fixed rather than sized to
+    # the channel count, so a block short of channels still launches enough
+    # warps to cover load latency.
+    _WHOLE_BLOCK_THREADS = 256
+
+    # The register-held path's block width, and the most elements one thread may
+    # hold across all its steps. 256 is the last value that beats both of the
+    # alternatives -- at L = 65536 it is 20-35% faster than the split path and
+    # 27-35% faster than the tiled one -- and 512 is where the spills reverse
+    # that, by 16-39%.
+    _WIDE_BLOCK_THREADS = 256
+    _WIDE_MAX_HELD = 256
 
     def __init__(
         self,
@@ -676,7 +686,7 @@ class BatchNormFwdTrainKernel(Kernel):
         self.dtype = dtype
         self.eps = eps
         self.momentum = momentum
-        self.path, self.launch = self._select_path(C, L, self.S)
+        self.path, self.launch = self._select_path(C, L, self.S, dtype)
         if self.path == "whole":
             self.whole_kernel = _batch_norm_fwd_train_whole_kernel(
                 C, L, self.S, self.dtype_str, eps, momentum
@@ -693,7 +703,7 @@ class BatchNormFwdTrainKernel(Kernel):
         self.init_config(config, tune)
 
     @classmethod
-    def _select_path(cls, C: int, L: int, S: int) -> tuple[str, object]:
+    def _select_path(cls, C: int, L: int, S: int, dtype: torch.dtype) -> tuple[str, object]:
         """Which launch serves this shape, and the sizing it needs.
 
         The four differ in what owns a channel, which is what a short channel,
@@ -702,39 +712,39 @@ class BatchNormFwdTrainKernel(Kernel):
         ==========  ====================================  ==================
         path        a channel belongs to                  chosen when
         ==========  ====================================  ==================
-        ``whole``   one thread, held in its registers     *S* is short
+        ``whole``   one thread, held in its registers     *S* is 1
         ``wide``    one block, held in its registers      *L* fits registers
         ``split``   several blocks, summed and merged     *L* is long
         ``tiled``   one block, streamed through shared    otherwise
         ==========  ====================================  ==================
         """
-        if S <= _WHOLE_MAX_S and L <= _WHOLE_MAX_L:
-            return "whole", _WHOLE_BLOCK_THREADS
-        wide = cls._wide_launch(L, S)
+        if S <= cls._WHOLE_MAX_S and L <= cls._WHOLE_MAX_L:
+            return "whole", cls._WHOLE_BLOCK_THREADS
+        wide = cls._wide_launch(L, S, dtype)
         if wide is not None:
             return "wide", wide
-        if C < _SPLIT_TARGET_BLOCKS and L >= _SPLIT_MIN_L:
-            return "split", max(1, min(L, -(-_SPLIT_TARGET_BLOCKS // C)))
+        if C < cls._SPLIT_TARGET_BLOCKS and L >= cls._SPLIT_MIN_L:
+            return "split", max(1, min(L, -(-cls._SPLIT_TARGET_BLOCKS // C)))
         return "tiled", None
 
-    @staticmethod
-    def _wide_launch(L: int, S: int) -> Optional[tuple[int, int]]:
+    @classmethod
+    def _wide_launch(cls, L: int, S: int, dtype: torch.dtype) -> Optional[tuple[int, int]]:
         """The ``(threads, num_per_thread)`` a register-held channel needs, or None.
 
         The vector must not straddle two batch items, and the channel must fit
         in the widest block the device allows.
         """
-        for num_per_thread in (_WIDE_MAX_NUM_PER_THREAD, 4, 2, 1):
+        for num_per_thread in _widths_down_to_one(_vector_elements(dtype)):
             if S % num_per_thread:
                 continue
-            # A block no wider than the warp merge stays cheap, with the step
-            # count taking whatever the width does not cover. What caps the
-            # steps is the register file: every step holds its own vector.
-            threads = _WIDE_BLOCK_THREADS
+            # Halve the block width while the channel would leave half of it
+            # empty; the length the width does not cover becomes steps, each
+            # holding its own vector, so _WIDE_MAX_HELD caps them.
+            threads = cls._WIDE_BLOCK_THREADS
             while threads > 32 and threads * num_per_thread >= L * 2:
                 threads //= 2
             steps = -(-L // (threads * num_per_thread))
-            if steps * num_per_thread <= _WIDE_MAX_HELD:
+            if steps * num_per_thread <= cls._WIDE_MAX_HELD:
                 return threads, num_per_thread
         return None
 
@@ -766,8 +776,8 @@ class BatchNormFwdTrainKernel(Kernel):
                     _add({"block_l": self.L, "threads": t})
 
         # Non-persistent configs: power-of-2 threads, block_l can be non-power-of-2.
-        # num_stages=0 disables T.Pipelined's async prefetch, which is required for
-        # correctness in multi-tile loops (pipelining causes x_shared data shift).
+        # num_stages=0 disables T.Pipelined's async prefetch, which multi-tile
+        # loops need for correctness.
         for threads in [256, 128, 64, 32]:
             for k in range(512 // threads, 0, -1):
                 bl = threads * k
@@ -776,6 +786,36 @@ class BatchNormFwdTrainKernel(Kernel):
                 _add({"block_l": bl, "threads": threads})
 
         return configs if configs else [self.default_config]
+
+    def autotune(self, warmup: int = 25, rep: int = 50) -> None:
+        """Tune the kernel this shape's path actually launches.
+
+        ``autotune_configs`` describes the tiled kernel, which the base class
+        reads off ``self.kernel``. The whole and wide paths take their launch
+        from the shape and read nothing off the config, so there is nothing to
+        search. The split path reads one value, the block width, and reads it
+        in the sums, so the sums are what it tunes.
+        """
+        if self.path in ("whole", "wide"):
+            self.config = self.default_config
+            return
+        if self.path == "split":
+            print(f"Start autotuning {type(self).__name__} (split sums)...")
+            num_per_thread = _vector_elements(self.dtype)
+            configs = [
+                {"splits": self.launch, "threads": t, "num_per_thread": num_per_thread}
+                for t in _SPLIT_CANDIDATE_THREADS
+            ]
+            # Every parameter of the sums builder must be seeded, so the seed is
+            # a candidate rather than default_config, which describes the tiled
+            # kernel and names none of them.
+            tuned = self.tune_jit_kernel(
+                self.stages[0], configs, warmup=warmup, rep=rep, seed_config=configs[0]
+            )
+            self.config = dict(self.default_config, threads=tuned.config["threads"])
+            print(f"Best config: {self.config}")
+            return
+        super().autotune(warmup=warmup, rep=rep)
 
     def _forward_split(
         self,
@@ -791,7 +831,7 @@ class BatchNormFwdTrainKernel(Kernel):
         stats, finalize, apply_ = self.stages
         splits = self.launch
         threads = self.config["threads"]
-        num_per_thread = self._SPLIT_NUM_PER_THREAD
+        num_per_thread = _vector_elements(self.dtype)
         empty = functools.partial(torch.empty, device=flat.device, dtype=torch.float32)
         partial_sum = empty((self.C, splits))
         partial_sq = empty((self.C, splits))
@@ -900,11 +940,14 @@ def _batch_norm_fwd_infer_kernel(
     accum_dtype = "float32"
 
     @tilelang.jit(out_idx=[-1], compile_flags=["-O3", "-DENABLE_BF16"])
-    def _bn_fwd_infer_func(blocks: int, threads: int, num_per_thread: int) -> Callable:
+    def _bn_fwd_infer_func(threads: int, num_per_thread: int, steps: int) -> Callable:
         # A vector of num_per_thread elements sits in one channel only when a
         # channel's run divides it; otherwise each element picks its own.
         vector_holds_one_channel = S % num_per_thread == 0
-        span = threads * num_per_thread
+        span = threads * num_per_thread * steps
+        # Derived here rather than passed in, so every parameter of this builder
+        # is a key of the config the autotuner binds by name.
+        blocks = -(-total // span)
 
         @T.prim_func
         def _bn_fwd_infer(
@@ -933,27 +976,37 @@ def _batch_norm_fwd_infer_kernel(
 
                 v = T.alloc_local([num_per_thread], dtype)
                 o = T.alloc_local([num_per_thread], dtype)
-                base = bx * span + tx * num_per_thread
-                if base + num_per_thread <= total:
-                    for i in T.vectorized(num_per_thread):
-                        v[i] = x[base + i]
-                    if vector_holds_one_channel:
-                        ch = (base // S) % C
-                        for i in T.serial(num_per_thread):
-                            o[i] = T.cast(T.cast(v[i], accum_dtype) * scale[ch] + shift[ch], dtype)
+                # A block walks its span in *steps* vectors per thread, each
+                # step contiguous across the block. The table above is built
+                # once per block, so its cost follows the block count rather
+                # than the vector width, and a narrower vector no longer buys
+                # its alignment by launching more blocks.
+                for k in T.serial(steps):
+                    base = bx * span + (k * threads + tx) * num_per_thread
+                    if base + num_per_thread <= total:
+                        for i in T.vectorized(num_per_thread):
+                            v[i] = x[base + i]
+                        if vector_holds_one_channel:
+                            ch = (base // S) % C
+                            for i in T.serial(num_per_thread):
+                                o[i] = T.cast(
+                                    T.cast(v[i], accum_dtype) * scale[ch] + shift[ch], dtype
+                                )
+                        else:
+                            for i in T.serial(num_per_thread):
+                                ch = ((base + i) // S) % C
+                                o[i] = T.cast(
+                                    T.cast(v[i], accum_dtype) * scale[ch] + shift[ch], dtype
+                                )
+                        for i in T.vectorized(num_per_thread):
+                            y[base + i] = o[i]
                     else:
                         for i in T.serial(num_per_thread):
-                            ch = ((base + i) // S) % C
-                            o[i] = T.cast(T.cast(v[i], accum_dtype) * scale[ch] + shift[ch], dtype)
-                    for i in T.vectorized(num_per_thread):
-                        y[base + i] = o[i]
-                else:
-                    for i in T.serial(num_per_thread):
-                        if base + i < total:
-                            ch = ((base + i) // S) % C
-                            y[base + i] = T.cast(
-                                T.cast(x[base + i], accum_dtype) * scale[ch] + shift[ch], dtype
-                            )
+                            if base + i < total:
+                                ch = ((base + i) // S) % C
+                                y[base + i] = T.cast(
+                                    T.cast(x[base + i], accum_dtype) * scale[ch] + shift[ch], dtype
+                                )
 
         return _bn_fwd_infer
 
@@ -971,13 +1024,19 @@ class BatchNormFwdInferKernel(Kernel):
         config: Optional tile config dict.
         tune: If True, autotune tile config.
         S: Elements per channel in one batch item, ``product(spatial)``.
-            Defaults to *L*, which is right when the batch is one.
+            Defaults to *L*, correct when the batch size is one.
     """
 
     supported_archs: list[int] = [80, 89, 90]
 
-    # Wide enough for a 16-byte access in every supported dtype.
-    _MAX_NUM_PER_THREAD = 8
+    # Elements one block covers, and its width. Every block builds the whole
+    # per-channel scale and shift table before touching its own elements, so
+    # that prologue is paid per block. Holding the span and the width fixed
+    # keeps the block count and the prologue where they are while the
+    # per-thread vector narrows to whatever the dtype makes a single 128-bit
+    # access; the step count takes up the difference.
+    _BLOCK_SPAN = 2048
+    _BLOCK_THREADS = 256
 
     def __init__(
         self,
@@ -999,27 +1058,36 @@ class BatchNormFwdInferKernel(Kernel):
         self.kernel = _batch_norm_fwd_infer_kernel(self.total, C, self.S, self.dtype_str, eps)
         self.init_config(config, tune)
 
-    def _blocks(self, threads: int, num_per_thread: int) -> int:
-        span = threads * num_per_thread
-        return (self.total + span - 1) // span
-
     @property
     def default_config(self) -> dict:
-        # The widest access the element count will carry, so the grid is as
-        # short as it can be and every load is one instruction.
-        for num_per_thread in (self._MAX_NUM_PER_THREAD, 4, 2, 1):
+        # The widest vector the element count divides evenly, with the step
+        # count taking whatever keeps the block span at _BLOCK_SPAN.
+        threads = self._BLOCK_THREADS
+        for num_per_thread in _widths_down_to_one(_vector_elements(self.dtype)):
             if self.total % num_per_thread == 0:
-                return {"threads": 256, "num_per_thread": num_per_thread}
-        return {"threads": 256, "num_per_thread": 1}
+                steps = max(1, self._BLOCK_SPAN // (threads * num_per_thread))
+                return {
+                    "threads": threads,
+                    "num_per_thread": num_per_thread,
+                    "steps": steps,
+                }
+        return {"threads": threads, "num_per_thread": 1, "steps": self._BLOCK_SPAN // threads}
 
     @property
     def autotune_configs(self) -> list[dict]:
         configs = []
         for threads in (128, 256, 512, 1024):
-            for num_per_thread in (8, 4, 2, 1):
+            for num_per_thread in _widths_down_to_one(_vector_elements(self.dtype)):
                 if self.total % num_per_thread:
                     continue
-                configs.append({"threads": threads, "num_per_thread": num_per_thread})
+                for steps in (1, 2, 4):
+                    configs.append(
+                        {
+                            "threads": threads,
+                            "num_per_thread": num_per_thread,
+                            "steps": steps,
+                        }
+                    )
         return configs if configs else [self.default_config]
 
     def forward(
@@ -1045,11 +1113,9 @@ class BatchNormFwdInferKernel(Kernel):
             running_mean=running_mean,
             running_var=running_var,
         )
-        threads = self.config["threads"]
-        num_per_thread = self.config["num_per_thread"]
-        y = self.kernel(self._blocks(threads, num_per_thread), threads, num_per_thread)(
-            x.contiguous().reshape(-1), weight, bias, running_mean, running_var
-        )
+        y = self.kernel(
+            self.config["threads"], self.config["num_per_thread"], self.config["steps"]
+        )(x.contiguous().reshape(-1), weight, bias, running_mean, running_var)
         return y.reshape(x.shape)
 
 
@@ -1123,8 +1189,8 @@ def _batch_norm_bwd_kernel(
                         do_frag[_i, j] += go_val
                         do_xhat_frag[_i, j] += go_val * x_hat
                 else:
-                    # Non-persistent path: direct global memory access avoids async-copy
-                    # data race that occurs when T.copy is used inside T.Pipelined.
+                    # Read global memory directly: T.copy inside T.Pipelined
+                    # races with the async copy.
                     for l_tile in T.Pipelined(L // block_l, num_stages=0):
                         for _i, j in T.Parallel(1, block_l):
                             go_val = T.cast(grad_out[bc, l_tile * block_l + j], accum_dtype)
@@ -1157,8 +1223,8 @@ def _batch_norm_bwd_kernel(
                         )
                         grad_x[bc, j] = T.cast(gx, dtype)
                 else:
-                    # Non-persistent path: direct global memory access avoids async-copy
-                    # data race that occurs when T.copy is used inside T.Pipelined.
+                    # Read global memory directly: T.copy inside T.Pipelined
+                    # races with the async copy.
                     for l_tile in T.Pipelined(L // block_l, num_stages=0):
                         for _i, j in T.Parallel(1, block_l):
                             go_val = T.cast(grad_out[bc, l_tile * block_l + j], accum_dtype)
@@ -1251,7 +1317,7 @@ class BatchNormBwdKernel(Kernel):
     ):
         """Run the backward pass on ``(N, C, *spatial)`` inputs.
 
-        Moving the inputs into the $[C \\times L]$ layout, and ``grad_x`` back, happens here.
+        Moves the inputs into the $[C \\times L]$ layout and ``grad_x`` back.
 
         Returns:
             grad_x: Gradient w.r.t. the input, shaped like *x*.

--- a/src/tileops/ops/norm/batch_norm.py
+++ b/src/tileops/ops/norm/batch_norm.py
@@ -190,8 +190,8 @@ class BatchNormFwdOp(Op):
         kernel = self.get_or_build_kernel(
             "batch_norm_fwd",
             (x, running_mean, running_var, weight, bias),
-            # Both paths index the caller's own layout, so the spatial extent
-            # is part of what they are built for.
+            # Both paths index the caller's layout, so the spatial extent
+            # changes the kernel that is built.
             key=(C, L, dtype, self.training, spatial),  # this instance's in-tree cache key
             build=lambda: (
                 self.kernel_map[slot](

--- a/src/tileops/ops/norm/batch_norm.py
+++ b/src/tileops/ops/norm/batch_norm.py
@@ -20,6 +20,7 @@ $[C \\times L]$ layout. ``L = N * prod(spatial)`` must be divisible by the kerne
 (chosen automatically by the kernel's default_config).
 """
 
+import math
 from typing import ClassVar, Dict, Optional, Tuple
 
 import torch
@@ -181,17 +182,23 @@ class BatchNormFwdOp(Op):
         stats = (running_mean, running_var)
         running_mean, running_var = (stat.contiguous() for stat in stats)
 
+        spatial = math.prod(x.shape[2:])
+
         # ``training`` decides which implementation serves the call, so it belongs in the
         # key; both are fetched under one name, which is what a target is asked to serve.
         slot = "fwd_train_kernel" if self.training else "fwd_infer_kernel"
         kernel = self.get_or_build_kernel(
             "batch_norm_fwd",
             (x, running_mean, running_var, weight, bias),
-            key=(C, L, dtype, self.training),  # this instance's in-tree cache key
+            # Both paths index the caller's own layout, so the spatial extent
+            # is part of what they are built for.
+            key=(C, L, dtype, self.training, spatial),  # this instance's in-tree cache key
             build=lambda: (
-                self.kernel_map[slot](C, L, dtype, self.eps, self.momentum, tune=self.tune)
+                self.kernel_map[slot](
+                    C, L, dtype, self.eps, self.momentum, tune=self.tune, S=spatial
+                )
                 if self.training
-                else self.kernel_map[slot](C, L, dtype, self.eps, tune=self.tune)
+                else self.kernel_map[slot](C, L, dtype, self.eps, tune=self.tune, S=spatial)
             ),
         )
         self.kernel = kernel

--- a/tests/ops/test_batch_norm.py
+++ b/tests/ops/test_batch_norm.py
@@ -41,7 +41,8 @@ class BatchNormFwdFixture(FixtureBase):
                 pytest.param(32, 256, (), torch.bfloat16, True, marks=pytest.mark.full),
                 # BatchNorm1d – (N, C, L)
                 pytest.param(16, 64, (512,), torch.float16, True, marks=pytest.mark.full),
-                # Non-persistent path (L > 8192): smallest representative case L=16384.
+                # L > 8192, so the tiled kernel this shape falls back to reads global
+                # memory twice rather than holding the tile in shared memory.
                 pytest.param(4, 64, (64, 64), torch.float16, True, marks=pytest.mark.full),
                 # BatchNorm2d – (N, C, H, W)
                 pytest.param(8, 64, (1024, 1024), torch.float16, True, marks=pytest.mark.full),
@@ -52,6 +53,9 @@ class BatchNormFwdFixture(FixtureBase):
                 pytest.param(8, 64, (30, 30), torch.bfloat16, True, marks=pytest.mark.full),
                 # High channel count oversubscribes the SMs, exposing the running-stat update race.
                 pytest.param(16, 1024, (512,), torch.float16, True, marks=pytest.mark.full),
+                # The streamed path, which no other case reaches: a channel too long to
+                # hold in registers (L = 131072) and too many channels to split (C >= 1024).
+                pytest.param(2048, 1024, (64,), torch.float16, True, marks=pytest.mark.full),
             ],
         ),
     ]

--- a/tests/ops/test_norm_lazy_cache.py
+++ b/tests/ops/test_norm_lazy_cache.py
@@ -24,6 +24,7 @@ class _FakeBatchNormFwdInferKernel(Kernel):
         dtype: torch.dtype,
         eps: float,
         tune: bool = False,
+        S: int | None = None,
     ) -> None:
         super().__init__()
         self.C = C
@@ -31,6 +32,7 @@ class _FakeBatchNormFwdInferKernel(Kernel):
         self.dtype = dtype
         self.eps = eps
         self.tune = tune
+        self.S = L if S is None else S
 
     def forward(
         self,
@@ -55,8 +57,9 @@ class _FakeBatchNormFwdTrainKernel(_FakeBatchNormFwdInferKernel):
         eps: float,
         momentum: float,
         tune: bool = False,
+        S: int | None = None,
     ) -> None:
-        super().__init__(C, L, dtype, eps, tune=tune)
+        super().__init__(C, L, dtype, eps, tune=tune, S=S)
         self.momentum = momentum
 
     def forward(


### PR DESCRIPTION
## Problems

Every `BatchNormFwd` row ran below its baseline, by more than any other row in the suite:

| Row | tileops | torch-compile | ratio |
| --- | ---: | ---: | ---: |
| `large-spatial` | 4339.20 | 1017.7 | **0.234** |
| `resnet50-stage2` | 10.79 | 3.49 | 0.305 |
| `resnet50-stage3` | 12.86 | 4.80 | 0.356 |
| `resnet50-fc` | 6.11 | 1.82 | 0.361 |
| `resnet50-stage1` | 10.97 | 4.10 | 0.376 |

`large-spatial` alone lost 3.3 ms, the largest single-row deficit in the benchmark. Two causes, both structural rather than tuning.

**The op moved the tensor into a `(C, L)` layout and back.** `forward` called `permute().contiguous()` on the way in and again on the way out — two passes over a 1 GB tensor, transposed. Decomposed:

| `large-spatial` | us | share |
| --- | ---: | ---: |
| `_to_cl` permute | 1555.9 | 39% |
| kernel | ~1226 | 28% |
| `_from_cl` permute | 1556.7 | 39% |

**One block owned one channel**, so the grid *was* the channel count: 128 blocks on 132 SMs, each walking 4.19 M elements. No tile size widens a grid that is fixed by the shape.

## Changes

- **The kernels index the caller's own layout.** A channel is *S* elements contiguous at a time in `(N, C, *spatial)`, which coalesces as well as a transposed copy and costs no pass to build. Element *l* of channel *c* is at `(l // S) * C * S + c * S + l % S`. Both permutes are gone from the forward.
- **Four launches replace the one**, differing in what owns a channel. `_select_path` picks by shape:

| path | a channel belongs to | chosen when |
| --- | --- | --- |
| `whole` | one thread, held in its registers | *S* is 1 |
| `wide` | one block, held in its registers | *L* fits in registers |
| `split` | several blocks, summed and merged | *L* is long |
| `tiled` | one block, streamed through shared | otherwise |

- The split path merges through partial sums, not atomics: batch norm writes running statistics back, and the tests require a run to land on the same bits every time. An atomic order does not.
- Test-node delta: +1, the streamed path's own case (see *Thresholds On Measured Crossovers*). All four paths are covered: `whole` 3, `wide` 6 (including the non-aligned `H*W=900` and the `C=1024` case), `split` 1, `tiled` 1.

### What the measurements settled, and what they overturned

Three changes carried most of the gain on the short rows, and none was predictable from the code:

| change | worth |
| --- | --- |
| Reading the channel's four parameters **before** the sums instead of after | 1.4x |
| A warp shuffle tree in place of `T.reduce_sum` | 1.1x |
| A block **wider** than the channels it covers, over one sized to fit | 1.04x |

The prefetch is the largest and the least obvious: with one channel to a thread there is no other warp to hide a read-modify-write behind, so the `running_mean`/`running_var` update stood alone at the end of the kernel. Moving those reads to the top overlaps them with the element loads.

Four things measured no better and were dropped rather than shipped:

- Nesting the loop by batch item to make the inner index affine, so the read could widen — no gain, and it made TileLang's layout inference fail on two shapes.
- Shortening the reduction tree from the tile to the thread count — inside noise.
- Merging both sums into one `[2, threads]` fragment to walk one tree instead of two — TileLang rejects a buffer indexed two ways inside `T.Parallel` (`acc: (1, j) and (0, j)`).
- Splitting the grid on the short rows — three launches cost 8 us where one costs 3.7. The finalize kernel alone measures 2.7 us at `grid=1`.

## TileFoundry Description

`tf` has no batch norm, so each row is authored as the traffic it moves, and separately as the unfused form, which is what the layout moves cost:

```python
@module(entry="normalize", target=CudaTarget("nvidia.h200_sxm"), topologies=_TOPOLOGIES)
class BatchNormInferLargeSpatial:
    @func
    def normalize(x: Tensor[(4, 128, 1024, 1024), "f16"],
                  scale: Tensor[(1, 128, 1, 1), "f32"],
                  shift: Tensor[(1, 128, 1, 1), "f32"]) -> Tensor[(4, 128, 1024, 1024), "f16"]:
        return tf.cast(tf.cast(x, "f32") * scale + shift, "f16")
```

| what analyze reports | ideal-ns |
| --- | ---: |
| fused: read x, write y | **447 393** |
| unfused: every intermediate materialised | 3 131 748 |

The row ran at 4 339 000 ns — **slower than the unfused floor**, which is what two transposed passes over 1 GB buy. It now runs at 911 650.

The short rows are nowhere near their traffic: `stage2`'s floor is 437 ns and both we and torch-compile are above 2 500. Those rows are launch and occupancy, and the floor that matters there is a measured one — a bare flat copy of the same bytes, 2 016 ns for `stage2`.

`analyze --performance` would place the program on a cta mesh and answer the occupancy question directly, but it raises `AttributeError: 'str' object has no attribute 'name'` at `ir/core/metadata.py:33` on the current build, for the model in this PR and for one that analyzed before. `--memory` and `--roofline` are unaffected.

## Performance

| Environment | Value |
| --- | --- |
| image | `ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-afcebed1-foundry-dev` |
| gpu | `NVIDIA H200` (one idle device, SM clock 1500 MHz, not the CI runners') |
| driver | `595.71.05`, cuda `13.2`, torch `2.13.0+cu132`, tilelang `0.1.11+cu132.gitafcebed1` |
| timer | native CUPTI device-busy time |

Method: before and after alternate in one sitting, the before side a separate detached worktree at the merge base, each from its own empty `TILELANG_CACHE_DIR`. Three rounds; the spread on the after side is at most 0.03 us on the short rows.

| Row | Before (us) | After (us) | Speedup | Baseline (us) / ours |
| --- | ---: | ---: | ---: | ---: |
| `large-spatial` | 4339.20 | **911.65** | **4.76x** | torch-compile 1017.73 🟢 **1.116x** |
| `resnet50-stage1` | 10.97 | **2.81** | **3.90x** | torch-compile 4.10 🟢 **1.455x** |
| `resnet50-stage2` | 10.79 | **2.56** | **4.21x** | torch-compile 3.49 🟢 **1.363x** |
| `resnet50-stage3` | 12.86 | **3.62** | **3.56x** | torch-compile 4.80 🟢 **1.327x** |
| `resnet50-fc` | 6.11 | **1.79** | **3.41x** | torch-compile 1.82 🟢 **1.018x** |

`BatchNormBwd` is untouched and unchanged, 1.00x on all five of its rows.

## Thresholds On Measured Crossovers

The four thresholds that pick a path were set by argument. Forcing each path over a
sweep of the shapes it selects on — one H200, fp16 and fp32, CUPTI device-busy time,
floor of three runs — puts two of them somewhere else.

| threshold | was | is | the crossover it now sits on |
| --- | ---: | ---: | --- |
| spatial extent for `whole` | 16 | **1** | at *S* = 2 the `wide` path already wins for `C` = 256; by *S* = 16 it wins by 3-6x |
| elements one thread holds for `wide` | 32 | **256** | at 256 `wide` beats `split` by 20-35% and `tiled` by 27-35%; 512 spills and reverses it |
| channel length for `whole` | 32 | 32 | the last length beating `wide` at every `C`; 64 loses it for `C` = 64 |
| blocks the `split` path aims for | 1024 | 1024 | on the plateau for `C` = 64 and `C` = 512; 4096 would buy 4% at `C` = 128 and cost 2% at `C` = 512 |

The inference kernel now walks its block's span in steps of one vector per thread rather
than one vector in total. Its span no longer follows the vector width, so the width can
narrow to whatever the dtype makes a single 128-bit access — four elements in fp32 —
without doubling the per-block prologue that builds the whole per-channel scale and shift
table. Deriving the width from the dtype does the same for the two training paths that
read wide.

Autotuning worked on neither forward kernel. The inference builder took the block count as
a parameter no config names, so TileLang refused to bind it (`missing a required argument:
'blocks'`); it is derived from the other three now. The training kernel tuned the streamed
path whatever path the shape had selected, so a `wide` shape reported a config it never
reads and a `split` shape launched on a block width measured against a different kernel.

**The five rows above are unchanged**: they are all fp16, and every fp16 launch is
parameter-for-parameter what it was.

The numbers below are on a different stack from the table above — the same H200 box, but
`torch 2.10.0+cu128`, `tilelang 0.1.13`, driver CUDA 13.2, one idle device, rather than
the runner image — so they are before-and-after pairs on that stack and not comparable
row-for-row with the torch-compile column. Protocol is the same otherwise: both sides in
one sitting, native CUPTI device-busy time, median of a phase, floor of three rounds. Of
the 42 pairs measured, none regressed by more than 0.53%.

| Shape | dtype | Before (us) | After (us) | What moved |
| --- | --- | ---: | ---: | --- |
| `(64, 256, 32, 32)` | fp16 / fp32 | 31.62 / 60.86 | **21.54 / 40.45** | `split` → `wide` |
| `(4, 2048, 128, 128)` | fp16 / fp32 | 210.45 / 380.32 | **144.58 / 288.64** | `tiled` → `wide` |
| `(16, 256, 2)` | fp16 / fp32 | 2.11 / 2.21 | **1.76 / 1.78** | `whole` → `wide` |
| `resnet50-stage1` | fp32 | 3.81 | **2.98** | wider fp32 vector |
| `large-spatial` | fp32 | 1898.05 | **1531.94** | wider fp32 vector |
| inference `(3, 65, 71, 53)` | fp16 / fp32 | 5.12 / 5.31 | **4.06 / 4.61** | span held at 2048 where no power of two divides the count |
| inference `resnet50-stage3` | fp32 | 3.81 | **3.52** | single 128-bit fp32 access |

`scripts/test_node_delta.py`:

```
File                            Base    HEAD    Delta
tests/ops/test_batch_norm.py      21      22       +1
```

Justification: raising the `wide` ceiling to 256 moved `(4, 64, 64, 64)`, the only case
that reached the streamed path, onto the register-held one. `(2048, 1024, 64)` is the
cheapest shape that lands on `tiled` again — it needs *L* > 65536 to pass the register
ceiling and `C` >= 1024 to keep `split` from taking it first.


## Result And Limitations

**improvement without SOTA**

- Every forward row now leads its baseline, from 1.02x to 1.46x, having been at 0.23x to 0.38x.
- `large-spatial` is within 2.0x of the fused traffic floor `tf` reports (911.65 against 447.39). The rest is the second read a two-pass statistic needs, plus the launches.
- **The short rows are not near any hardware limit and neither is the baseline.** `stage2` runs at 2.56 us where its traffic is 437 ns; a bare flat copy of the same bytes is 2 016 ns. Everything above that is launch and occupancy, for us and for torch-compile alike. `resnet50-fc` is 2048 elements: 1.79 us against a 1.15 us copy and a 0.67 us empty kernel.
- `resnet50-fc` leads by 1.018x, which is the narrowest margin here and inside the baseline's own run-to-run spread (1.76 to 1.82 across rounds). I would not call that row won, only no longer lost.
- Inference is rewritten the same way and measures 4035 → 513 us on `large-spatial` (7.9x), but **no benchmark row covers it**: `bench_batch_norm.py`'s `_fwd_args` fixes `training=True`.
- Tests: `test_batch_norm.py`, `test_norm_ops.py`, `test_norm_compile.py`, `test_norm_lazy_cache.py`, `test_normalization_alignment.py`, `test_group_norm.py`, `test_instance_norm.py` — 123 passed, 5 skipped. `pre-commit` clean.

