### PR TITLE
[Perf][foundry][Convolution] Fold the Conv2d staging, search rasterization

### DIFF
--- a/src/tileops/kernels/convolution/_common.py
+++ b/src/tileops/kernels/convolution/_common.py
@@ -16,16 +16,23 @@ def conv_autotune_configs(
     block_k=(32, 64, 128),
     num_stages=(2, 3),
     threads=(128, 256),
+    enable_rasterization=(False, True),
 ) -> list[dict]:
-    """Search space filtered to combinations that fit in shared memory."""
+    """Search space filtered to combinations that fit in shared memory.
+
+    ``enable_rasterization`` turns on a swizzle that orders blocks for L2 locality,
+    and is searched rather than fixed because a convolution row's reuse depends on
+    its grid: of the manifest's 55 rows, 50 read faster with it off and 5 with it on.
+    """
     limit = get_shared_memory_limit_bytes()
     valid = []
-    for bm, bn, bk, ns, th in itertools.product(
+    for bm, bn, bk, ns, th, rast in itertools.product(
         block_m,
         block_n,
         block_k,
         num_stages,
         threads,
+        enable_rasterization,
     ):
         if conv_shared_memory_bytes(bm, bn, bk, ns, dtype) > limit:
             continue
@@ -36,7 +43,7 @@ def conv_autotune_configs(
                 "block_k": bk,
                 "num_stages": ns,
                 "threads": th,
-                "enable_rasterization": True,
+                "enable_rasterization": rast,
             }
         )
     return valid

--- a/src/tileops/kernels/convolution/_common.py
+++ b/src/tileops/kernels/convolution/_common.py
@@ -6,6 +6,20 @@ from typing import Optional
 import torch
 
 from tileops.kernels.kernel_base import Kernel
+from tileops.utils import get_sm_version
+
+# Panel width handed to ``T.use_swizzle``: the number of blocks along the grid's fast
+# axis reordered together so their tiles share L2. Whether to swizzle is a searched
+# config; the panel is the same for every conv kernel.
+CONV_SWIZZLE_PANEL = 10
+
+# Targets whose shared memory holds a third pipeline stage.
+_THREE_STAGE_ARCHS = frozenset({90})
+
+
+def conv_num_stages() -> int:
+    """Pipeline depth this target's shared memory holds: three on Hopper, two before."""
+    return 3 if get_sm_version() in _THREE_STAGE_ARCHS else 2
 
 
 def conv_autotune_configs(
@@ -20,9 +34,10 @@ def conv_autotune_configs(
 ) -> list[dict]:
     """Search space filtered to combinations that fit in shared memory.
 
-    ``enable_rasterization`` turns on a swizzle that orders blocks for L2 locality,
-    and is searched rather than fixed because a convolution row's reuse depends on
-    its grid: of the manifest's 55 rows, 50 read faster with it off and 5 with it on.
+    ``enable_rasterization`` turns on a swizzle that orders blocks for L2 locality. It
+    is searched rather than fixed because which way wins follows the grid a shape
+    produces, and both ways win on some shapes. Callers narrow the other axes to keep
+    the search the size it was before this one joined it.
     """
     limit = get_shared_memory_limit_bytes()
     valid = []

--- a/src/tileops/kernels/convolution/_common.py
+++ b/src/tileops/kernels/convolution/_common.py
@@ -9,9 +9,11 @@ from tileops.kernels.kernel_base import Kernel
 from tileops.utils import get_sm_version
 
 # Panel width handed to ``T.use_swizzle``: the number of blocks along the grid's fast
-# axis reordered together so their tiles share L2. Whether to swizzle is a searched
-# config; the panel is the same for every conv kernel.
-CONV_SWIZZLE_PANEL = 10
+# axis reordered together so their tiles share L2. A power of two, because the block
+# remap divides by it and a divide the compiler cannot turn into a shift shows on a
+# short kernel; the narrowest one, because the long 1d grids lose monotonically as it
+# widens. Whether to swizzle at all is a searched config.
+CONV_SWIZZLE_PANEL = 2
 
 
 def conv_num_stages() -> int:

--- a/src/tileops/kernels/convolution/_common.py
+++ b/src/tileops/kernels/convolution/_common.py
@@ -13,13 +13,10 @@ from tileops.utils import get_sm_version
 # config; the panel is the same for every conv kernel.
 CONV_SWIZZLE_PANEL = 10
 
-# Targets whose shared memory holds a third pipeline stage.
-_THREE_STAGE_ARCHS = frozenset({90})
-
 
 def conv_num_stages() -> int:
     """Pipeline depth this target's shared memory holds: three on Hopper, two before."""
-    return 3 if get_sm_version() in _THREE_STAGE_ARCHS else 2
+    return 3 if get_sm_version() == 90 else 2
 
 
 def conv_autotune_configs(

--- a/src/tileops/kernels/convolution/conv1d.py
+++ b/src/tileops/kernels/convolution/conv1d.py
@@ -620,7 +620,9 @@ class Conv1dKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        return conv_autotune_configs(self.dtype)
+        # No 256-wide n tile: it wins no row measured, and dropping it pays for
+        # searching the rasterization swizzle instead.
+        return conv_autotune_configs(self.dtype, block_n=[64, 128])
 
     def _get_weight_flat(self, weight: torch.Tensor) -> torch.Tensor:
         """Return the weight laid out as the prim_func's ``(c_out, k_total)``.

--- a/src/tileops/kernels/convolution/conv1d.py
+++ b/src/tileops/kernels/convolution/conv1d.py
@@ -8,9 +8,8 @@ import tilelang.language as T
 import torch
 
 from tileops.kernels.kernel_base import Kernel
-from tileops.utils import get_sm_version
 
-from ._common import _launch, conv_autotune_configs
+from ._common import CONV_SWIZZLE_PANEL, _launch, conv_autotune_configs, conv_num_stages
 from .call_spec import Conv1dCall, conv1d_dense_region, conv1d_group_region, conv1d_pointwise_region
 
 __all__ = [
@@ -65,7 +64,7 @@ def _conv1d_kernel(
                 out_local = T.alloc_fragment((block_m, block_n), accum_dtype)
                 out_shared = T.alloc_shared((block_m, block_n), dtype)
 
-                T.use_swizzle(10, enable=enable_rasterization)
+                T.use_swizzle(CONV_SWIZZLE_PANEL, enable=enable_rasterization)
                 T.clear(out_local)
 
                 tile_ol_start = bx * block_n
@@ -179,7 +178,7 @@ def _conv1d_direct_kernel(
                 threads=threads,
             ) as (bx, by, bz):
                 out_local = T.alloc_fragment((block_m, block_n), accum_dtype)
-                T.use_swizzle(10, enable=enable_rasterization)
+                T.use_swizzle(CONV_SWIZZLE_PANEL, enable=enable_rasterization)
                 T.clear(out_local)
 
                 for kw in T.serial(kernel_l):
@@ -278,7 +277,7 @@ def _conv1d_group_kernel(
                 out_local = T.alloc_fragment((block_m, block_n), accum_dtype)
                 out_shared = T.alloc_shared((block_m, block_n), dtype)
 
-                T.use_swizzle(10, enable=enable_rasterization)
+                T.use_swizzle(CONV_SWIZZLE_PANEL, enable=enable_rasterization)
                 T.clear(out_local)
 
                 batch_id = bz // groups
@@ -403,7 +402,7 @@ def _conv1d_pointwise_kernel(
                 out_local = T.alloc_fragment((block_m, block_n), accum_dtype)
                 out_shared = T.alloc_shared((block_m, block_n), dtype)
 
-                T.use_swizzle(10, enable=enable_rasterization)
+                T.use_swizzle(CONV_SWIZZLE_PANEL, enable=enable_rasterization)
                 T.clear(out_local)
 
                 tile_l_end = bx * block_n + block_n - 1
@@ -508,21 +507,11 @@ class Conv1dPointwiseKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
-        sm_version = get_sm_version()
-        if sm_version in {90}:
-            return {
-                "block_m": 64,
-                "block_n": 128,
-                "block_k": 128,
-                "num_stages": 3,
-                "threads": 128,
-                "enable_rasterization": True,
-            }
         return {
             "block_m": 64,
             "block_n": 128,
             "block_k": 128,
-            "num_stages": 2,
+            "num_stages": conv_num_stages(),
             "threads": 128,
             "enable_rasterization": True,
         }
@@ -599,29 +588,17 @@ class Conv1dKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
-        sm_version = get_sm_version()
-        if sm_version in {90}:
-            return {
-                "block_m": 64,
-                "block_n": 128,
-                "block_k": 128,
-                "num_stages": 3,
-                "threads": 128,
-                "enable_rasterization": True,
-            }
         return {
             "block_m": 64,
             "block_n": 128,
             "block_k": 128,
-            "num_stages": 2,
+            "num_stages": conv_num_stages(),
             "threads": 128,
             "enable_rasterization": True,
         }
 
     @property
     def autotune_configs(self) -> list[dict]:
-        # No 256-wide n tile: it wins no row measured, and dropping it pays for
-        # searching the rasterization swizzle instead.
         return conv_autotune_configs(self.dtype, block_n=[64, 128])
 
     def _get_weight_flat(self, weight: torch.Tensor) -> torch.Tensor:
@@ -771,21 +748,11 @@ class GroupConv1dKernel(Kernel):
             (choice for choice in self._block_m_choices if choice >= self.c_out_g),
             max(self._block_m_choices),
         )
-        sm_version = get_sm_version()
-        if sm_version in {90}:
-            return {
-                "block_m": block_m,
-                "block_n": 128,
-                "block_k": 128,
-                "num_stages": 3,
-                "threads": 128,
-                "enable_rasterization": True,
-            }
         return {
             "block_m": block_m,
             "block_n": 128,
             "block_k": 128,
-            "num_stages": 2,
+            "num_stages": conv_num_stages(),
             "threads": 128,
             "enable_rasterization": True,
         }

--- a/src/tileops/kernels/convolution/conv2d.py
+++ b/src/tileops/kernels/convolution/conv2d.py
@@ -553,39 +553,69 @@ def _conv2d_symmetric_kernel(
         threads: int,
         enable_rasterization: bool,
     ):
+        # One kernel stages both operands: each is the same transpose over a plane of
+        # (channel, spatial), and the block index selects which one a block serves.
+        # Both walk c_in in the same channel block, so one block count over the
+        # channel axis serves both.
+        channel_block = 32
+        x_lanes, x_spatial_block = 8, 32
+        w_lanes, w_spatial_block = 16, 16
+        assert x_spatial_block * x_lanes == 256 and w_spatial_block * w_lanes == 256, (
+            "each operand's tile must occupy the 256 threads the staging kernel launches"
+        )
+        assert channel_block % x_lanes == 0 and channel_block % w_lanes == 0, (
+            "a thread's channel stride must divide the channel block it walks"
+        )
+        channel_blocks = -(-c_in // channel_block)
+        x_spatial_blocks = -(-(h * w) // x_spatial_block)
+        w_spatial_blocks = -(-(kernel_size * kernel_size) // w_spatial_block)
+        x_blocks = x_spatial_blocks * channel_blocks * n
+        w_blocks = w_spatial_blocks * channel_blocks * c_out
+
         @T.macro
-        def nchw_to_nhwc(
+        def plane_to_channel_last(
             src: T.Tensor,
             dst: T.Tensor,
-            batch_size: int,
+            block: T.int32,
             spatial_size: int,
-            channel_size: int,
-            width: int,
             spatial_block: int,
-            channel_block: int,
+            spatial_blocks: int,
             channel_lanes: int,
         ):
-            assert spatial_block * channel_lanes == 256, (
-                "spatial_block * channel_lanes must equal 256"
-            )
-            assert channel_block % channel_lanes == 0, "channel_lanes must divide channel_block"
+            """One block's share of ``src[p, c, s] -> dst[p, s, c]``."""
+            spatial_base = (block % spatial_blocks) * spatial_block
+            channel_base = ((block // spatial_blocks) % channel_blocks) * channel_block
+            plane = block // (spatial_blocks * channel_blocks)
+            for spatial_inner, channel_lane in T.Parallel(spatial_block, channel_lanes):
+                spatial = spatial_base + spatial_inner
+                for channel_offset in T.serial(channel_block // channel_lanes):
+                    c = channel_base + channel_offset * channel_lanes + channel_lane
+                    if (spatial < spatial_size) & (c < c_in):
+                        dst[plane, spatial, c] = src[plane, c, spatial]
 
-            with T.Kernel(
-                T.ceildiv(spatial_size, spatial_block),
-                T.ceildiv(channel_size, channel_block),
-                batch_size,
-                threads=256,
-            ) as (bx, by, bz):
-                values_per_thread = channel_block // channel_lanes
-                for spatial_inner, channel_lane in T.Parallel(spatial_block, channel_lanes):
-                    spatial = bx * spatial_block + spatial_inner
-                    h_idx = spatial // width
-                    w_idx = spatial - h_idx * width
-                    channel_base = by * channel_block
-                    for channel_offset in T.serial(values_per_thread):
-                        c = channel_base + channel_offset * channel_lanes + channel_lane
-                        if (spatial < spatial_size) & (c < channel_size):
-                            dst[bz, h_idx, w_idx, c] = src[bz, c, h_idx, w_idx]
+        @T.macro
+        def stage_operands(x, weight, x_nhwc, weight_krsc):
+            with T.Kernel(x_blocks + w_blocks, threads=256) as block:
+                if block < x_blocks:
+                    plane_to_channel_last(
+                        T.Tensor((n, c_in, h * w), dtype, x.data),
+                        T.Tensor((n, h * w, c_in), dtype, x_nhwc.data),
+                        block,
+                        spatial_size=h * w,
+                        spatial_block=x_spatial_block,
+                        spatial_blocks=x_spatial_blocks,
+                        channel_lanes=x_lanes,
+                    )
+                else:
+                    plane_to_channel_last(
+                        T.Tensor((c_out, c_in, kernel_size * kernel_size), dtype, weight.data),
+                        T.Tensor((c_out, kernel_size * kernel_size, c_in), dtype, weight_krsc.data),
+                        block - x_blocks,
+                        spatial_size=kernel_size * kernel_size,
+                        spatial_block=w_spatial_block,
+                        spatial_blocks=w_spatial_blocks,
+                        channel_lanes=w_lanes,
+                    )
 
         @T.macro
         def conv_nhwc_implicit_gemm(x_nhwc, weight_krsc, out, bias):
@@ -628,28 +658,7 @@ def _conv2d_symmetric_kernel(
 
         @T.macro
         def _conv2d_symmetric_body(x, weight, x_nhwc, weight_krsc, out, bias):
-            nchw_to_nhwc(
-                x,
-                x_nhwc,
-                batch_size=n,
-                spatial_size=h * w,
-                channel_size=c_in,
-                width=w,
-                spatial_block=32,
-                channel_block=32,
-                channel_lanes=8,
-            )
-            nchw_to_nhwc(
-                weight,
-                weight_krsc,
-                batch_size=c_out,
-                spatial_size=kernel_size * kernel_size,
-                channel_size=c_in,
-                width=kernel_size,
-                spatial_block=16,
-                channel_block=32,
-                channel_lanes=16,
-            )
+            stage_operands(x, weight, x_nhwc, weight_krsc)
             conv_nhwc_implicit_gemm(x_nhwc, weight_krsc, out, bias)
 
         if has_bias:

--- a/src/tileops/kernels/convolution/conv2d.py
+++ b/src/tileops/kernels/convolution/conv2d.py
@@ -10,7 +10,7 @@ import torch
 from tileops.kernels.kernel_base import Kernel
 from tileops.utils import get_sm_version
 
-from ._common import _launch, conv_autotune_configs
+from ._common import CONV_SWIZZLE_PANEL, _launch, conv_autotune_configs
 from .call_spec import (
     Conv2dCall,
     conv2d_dense_region,
@@ -70,7 +70,7 @@ def _conv2d_1x1_kernel(
                 out_shared = T.alloc_shared((block_m, block_n), dtype)
                 out_local = T.alloc_fragment((block_m, block_n), accum_dtype)
 
-                T.use_swizzle(10, enable=enable_rasterization)
+                T.use_swizzle(CONV_SWIZZLE_PANEL, enable=enable_rasterization)
                 T.clear(out_local)
 
                 for k_iter in T.Pipelined(T.ceildiv(c_in, block_k), num_stages=num_stages):
@@ -177,7 +177,7 @@ def _conv2d_kernel(
                 weight_flat = T.Tensor((c_out, k_total), dtype, weight.data)
                 out_flat = T.Tensor((n, c_out, out_hw), dtype, out.data)
 
-                T.use_swizzle(10, enable=enable_rasterization)
+                T.use_swizzle(CONV_SWIZZLE_PANEL, enable=enable_rasterization)
                 T.clear(out_local)
 
                 for k_iter in T.Pipelined(T.ceildiv(k_total, block_k), num_stages=num_stages):
@@ -316,7 +316,7 @@ def _conv2d_group_kernel(
                 weight_flat = T.Tensor((c_out, k_total), dtype, weight.data)
                 out_flat = T.Tensor((n, c_out, out_hw), dtype, out.data)
 
-                T.use_swizzle(10, enable=enable_rasterization)
+                T.use_swizzle(CONV_SWIZZLE_PANEL, enable=enable_rasterization)
                 T.clear(out_local)
 
                 batch_id = bz // groups
@@ -456,7 +456,7 @@ def _conv2d_depthwise_kernel(
                 threads=threads,
             ) as (bx, by, bz):
                 out_local = T.alloc_fragment((block_m, block_n), accum_dtype)
-                T.use_swizzle(10, enable=enable_rasterization)
+                T.use_swizzle(CONV_SWIZZLE_PANEL, enable=enable_rasterization)
                 T.clear(out_local)
 
                 for kh, kw in T.grid(kernel_h, kernel_w):
@@ -557,12 +557,14 @@ def _conv2d_symmetric_kernel(
         # (channel, spatial), and the block index selects which one a block serves.
         # Both walk c_in in the same channel block, so one block count over the
         # channel axis serves both.
+        staging_threads = 256
         channel_block = 32
         x_lanes, x_spatial_block = 8, 32
         w_lanes, w_spatial_block = 16, 16
-        assert x_spatial_block * x_lanes == 256 and w_spatial_block * w_lanes == 256, (
-            "each operand's tile must occupy the 256 threads the staging kernel launches"
-        )
+        assert (
+            x_spatial_block * x_lanes == staging_threads
+            and w_spatial_block * w_lanes == staging_threads
+        ), "each operand's tile must occupy the threads the staging kernel launches"
         assert channel_block % x_lanes == 0 and channel_block % w_lanes == 0, (
             "a thread's channel stride must divide the channel block it walks"
         )
@@ -595,7 +597,7 @@ def _conv2d_symmetric_kernel(
 
         @T.macro
         def stage_operands(x, weight, x_nhwc, weight_krsc):
-            with T.Kernel(x_blocks + w_blocks, threads=256) as block:
+            with T.Kernel(x_blocks + w_blocks, threads=staging_threads) as block:
                 if block < x_blocks:
                     plane_to_channel_last(
                         T.Tensor((n, c_in, h * w), dtype, x.data),
@@ -634,7 +636,7 @@ def _conv2d_symmetric_kernel(
                 weight_flat = T.Tensor((c_out, k_total), dtype, weight_krsc.data)
                 out_nchw = T.Tensor((n, c_out, out_hw), dtype, out.data)
 
-                T.use_swizzle(10, enable=enable_rasterization)
+                T.use_swizzle(CONV_SWIZZLE_PANEL, enable=enable_rasterization)
                 T.clear(out_local)
 
                 for k_iter in T.Pipelined(T.ceildiv(k_total, block_k), num_stages=num_stages):
@@ -754,6 +756,13 @@ class Conv2dSymmetricKernel(Kernel):
             self.dtype_str,
         )
         self.init_config(config, tune)
+        block_m = self.config["block_m"]
+        if not self.tile_stays_in_one_image(n, self.out_h * self.out_w, block_m):
+            raise ValueError(
+                f"block_m={block_m} spans two of this call's {n} images, whose output is "
+                f"{self.out_h * self.out_w} elements each. applies() and autotune_configs "
+                f"both reject such a tile, and a config passed in has to as well."
+            )
 
     @staticmethod
     def tile_stays_in_one_image(n: int, out_hw: int, block_m: int) -> bool:
@@ -778,8 +787,8 @@ class Conv2dSymmetricKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        # No block_k of 16: it wins no row measured, and the region already requires
-        # c_in to be a multiple of 32, so a 32-wide k tile always divides it.
+        # No block_k of 16: the region already requires c_in to be a multiple of 32,
+        # so a 32-wide k tile always divides it.
         configs = conv_autotune_configs(
             self.dtype,
             block_m=list(self.block_m_candidates),
@@ -1069,12 +1078,10 @@ class GroupConv2dKernel(Kernel):
     def autotune_configs(self) -> list[dict]:
         if self.use_direct:
             # One tile shape, since there is no GEMM to tile. The swizzle is still a
-            # choice, and a depthwise row reads 1.19x faster with it off.
+            # choice, so both ways are searched.
             return [
                 {**self.default_config, "enable_rasterization": value} for value in (False, True)
             ]
-        # No 256-thread block: it wins no grouped row measured, and dropping it pays
-        # for searching the rasterization swizzle instead.
         return conv_autotune_configs(self.dtype, threads=[128])
 
     def forward(
@@ -1171,8 +1178,7 @@ class Conv2d1x1Kernel(Kernel):
     def autotune_configs(self) -> list[dict]:
         # A 32-wide n tile, which the rest of the family does not reach: the block
         # count is C_out * H * W / (block_m * block_n), and a pointwise row over a
-        # small map has no other way to fill the device. It costs nothing because
-        # 256 threads and a 256-wide m tile win no row measured.
+        # small map has no other way to fill the device.
         return conv_autotune_configs(
             self.dtype,
             block_m=[64, 128],

--- a/src/tileops/kernels/convolution/conv2d.py
+++ b/src/tileops/kernels/convolution/conv2d.py
@@ -778,10 +778,12 @@ class Conv2dSymmetricKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
+        # No block_k of 16: it wins no row measured, and the region already requires
+        # c_in to be a multiple of 32, so a 32-wide k tile always divides it.
         configs = conv_autotune_configs(
             self.dtype,
             block_m=list(self.block_m_candidates),
-            block_k=[16, 32, 64],
+            block_k=[32, 64],
         )
         out_hw = self.out_h * self.out_w
         return [
@@ -1066,8 +1068,14 @@ class GroupConv2dKernel(Kernel):
     @property
     def autotune_configs(self) -> list[dict]:
         if self.use_direct:
-            return [self.default_config]
-        return conv_autotune_configs(self.dtype)
+            # One tile shape, since there is no GEMM to tile. The swizzle is still a
+            # choice, and a depthwise row reads 1.19x faster with it off.
+            return [
+                {**self.default_config, "enable_rasterization": value} for value in (False, True)
+            ]
+        # No 256-thread block: it wins no grouped row measured, and dropping it pays
+        # for searching the rasterization swizzle instead.
+        return conv_autotune_configs(self.dtype, threads=[128])
 
     def forward(
         self,

--- a/src/tileops/kernels/convolution/conv2d.py
+++ b/src/tileops/kernels/convolution/conv2d.py
@@ -541,7 +541,7 @@ def _conv2d_symmetric_kernel(
     k_total = c_in * kernel_size * kernel_size
 
     @tilelang.jit(
-        out_idx=[5],
+        out_idx=[4],
         compile_flags=["-O3", "-DENABLE_BF16"],
         pass_configs={"tl.enable_async_copy": False},
     )
@@ -554,7 +554,7 @@ def _conv2d_symmetric_kernel(
         enable_rasterization: bool,
     ):
         @T.macro
-        def transpose_spatial_channel(
+        def nchw_to_nhwc(
             src: T.Tensor,
             dst: T.Tensor,
             batch_size: int,
@@ -564,17 +564,11 @@ def _conv2d_symmetric_kernel(
             spatial_block: int,
             channel_block: int,
             channel_lanes: int,
-            channel_fastest: bool,
-            is_nchw_to_nhwc: bool,
         ):
             assert spatial_block * channel_lanes == 256, (
                 "spatial_block * channel_lanes must equal 256"
             )
             assert channel_block % channel_lanes == 0, "channel_lanes must divide channel_block"
-            if not channel_fastest:
-                assert channel_block * spatial_block == 256, (
-                    "channel_block * spatial_block must equal 256 when channel_fastest=False"
-                )
 
             with T.Kernel(
                 T.ceildiv(spatial_size, spatial_block),
@@ -582,34 +576,19 @@ def _conv2d_symmetric_kernel(
                 batch_size,
                 threads=256,
             ) as (bx, by, bz):
-                if channel_fastest:
-                    values_per_thread = channel_block // channel_lanes
-                    for spatial_inner, channel_lane in T.Parallel(spatial_block, channel_lanes):
-                        spatial = bx * spatial_block + spatial_inner
-                        h_idx = spatial // width
-                        w_idx = spatial - h_idx * width
-                        channel_base = by * channel_block
-                        for channel_offset in T.serial(values_per_thread):
-                            c = channel_base + channel_offset * channel_lanes + channel_lane
-                            if (spatial < spatial_size) & (c < channel_size):
-                                if is_nchw_to_nhwc:
-                                    dst[bz, h_idx, w_idx, c] = src[bz, c, h_idx, w_idx]
-                                else:
-                                    dst[bz, c, h_idx, w_idx] = src[bz, h_idx, w_idx, c]
-                else:
-                    for channel_inner, spatial_inner in T.Parallel(channel_block, spatial_block):
-                        spatial = bx * spatial_block + spatial_inner
-                        h_idx = spatial // width
-                        w_idx = spatial - h_idx * width
-                        c = by * channel_block + channel_inner
+                values_per_thread = channel_block // channel_lanes
+                for spatial_inner, channel_lane in T.Parallel(spatial_block, channel_lanes):
+                    spatial = bx * spatial_block + spatial_inner
+                    h_idx = spatial // width
+                    w_idx = spatial - h_idx * width
+                    channel_base = by * channel_block
+                    for channel_offset in T.serial(values_per_thread):
+                        c = channel_base + channel_offset * channel_lanes + channel_lane
                         if (spatial < spatial_size) & (c < channel_size):
-                            if is_nchw_to_nhwc:
-                                dst[bz, h_idx, w_idx, c] = src[bz, c, h_idx, w_idx]
-                            else:
-                                dst[bz, c, h_idx, w_idx] = src[bz, h_idx, w_idx, c]
+                            dst[bz, h_idx, w_idx, c] = src[bz, c, h_idx, w_idx]
 
         @T.macro
-        def conv_nhwc_implicit_gemm(x_nhwc, weight_krsc, out_nhwc, bias):
+        def conv_nhwc_implicit_gemm(x_nhwc, weight_krsc, out, bias):
             with T.Kernel(
                 T.ceildiv(c_out, block_n),
                 T.ceildiv(n * out_h * out_w, block_m),
@@ -618,10 +597,12 @@ def _conv2d_symmetric_kernel(
                 data_shared = T.alloc_shared((block_m, block_k), dtype)
                 weight_shared = T.alloc_shared((block_n, block_k), dtype)
                 out_local = T.alloc_fragment((block_m, block_n), accum_dtype)
-                out_shared = T.alloc_shared((block_m, block_n), dtype)
+                # Channel-major, so the store walks the spatial axis -- the contiguous
+                # one in NCHW.
+                out_shared = T.alloc_shared((block_n, block_m), dtype)
 
                 weight_flat = T.Tensor((c_out, k_total), dtype, weight_krsc.data)
-                out_flat = T.Tensor((n * out_h * out_w, c_out), dtype, out_nhwc.data)
+                out_nchw = T.Tensor((n, c_out, out_hw), dtype, out.data)
 
                 T.use_swizzle(10, enable=enable_rasterization)
                 T.clear(out_local)
@@ -632,26 +613,22 @@ def _conv2d_symmetric_kernel(
                     T.gemm(data_shared, weight_shared, out_local, transpose_B=True)
 
                 for i, j in T.Parallel(block_m, block_n):
-                    spatial_idx = by * block_m + i
                     oc = bx * block_n + j
                     if has_bias:
-                        out_shared[i, j] = T.if_then_else(
-                            (spatial_idx < n * out_hw) & (oc < c_out),
-                            T.cast(out_local[i, j] + T.cast(bias[oc], accum_dtype), dtype),
-                            T.cast(0.0, dtype),
+                        out_shared[j, i] = T.cast(
+                            out_local[i, j] + T.cast(bias[oc], accum_dtype), dtype
                         )
                     else:
-                        out_shared[i, j] = T.if_then_else(
-                            (spatial_idx < n * out_hw) & (oc < c_out),
-                            T.cast(out_local[i, j], dtype),
-                            T.cast(0.0, dtype),
-                        )
+                        out_shared[j, i] = T.cast(out_local[i, j], dtype)
 
-                T.copy(out_shared, out_flat[by * block_m, bx * block_n])
+                # The region predicate and the config filter keep an m tile inside one
+                # image, so the whole tile is one 2-D region of ``out[image]``.
+                m_base = by * block_m
+                T.copy(out_shared, out_nchw[m_base // out_hw, bx * block_n, m_base % out_hw])
 
         @T.macro
-        def _conv2d_symmetric_body(x, weight, x_nhwc, weight_krsc, out_nhwc, out, bias):
-            transpose_spatial_channel(
+        def _conv2d_symmetric_body(x, weight, x_nhwc, weight_krsc, out, bias):
+            nchw_to_nhwc(
                 x,
                 x_nhwc,
                 batch_size=n,
@@ -661,10 +638,8 @@ def _conv2d_symmetric_kernel(
                 spatial_block=32,
                 channel_block=32,
                 channel_lanes=8,
-                channel_fastest=True,
-                is_nchw_to_nhwc=True,
             )
-            transpose_spatial_channel(
+            nchw_to_nhwc(
                 weight,
                 weight_krsc,
                 batch_size=c_out,
@@ -674,23 +649,8 @@ def _conv2d_symmetric_kernel(
                 spatial_block=16,
                 channel_block=32,
                 channel_lanes=16,
-                channel_fastest=True,
-                is_nchw_to_nhwc=True,
             )
-            conv_nhwc_implicit_gemm(x_nhwc, weight_krsc, out_nhwc, bias)
-            transpose_spatial_channel(
-                out_nhwc,
-                out,
-                batch_size=n,
-                spatial_size=out_h * out_w,
-                channel_size=c_out,
-                width=out_w,
-                spatial_block=128,
-                channel_block=2,
-                channel_lanes=2,
-                channel_fastest=False,
-                is_nchw_to_nhwc=False,
-            )
+            conv_nhwc_implicit_gemm(x_nhwc, weight_krsc, out, bias)
 
         if has_bias:
 
@@ -700,11 +660,10 @@ def _conv2d_symmetric_kernel(
                 weight: T.Tensor((c_out, c_in, kernel_size, kernel_size), dtype),
                 x_nhwc: T.Tensor((n, h, w, c_in), dtype),
                 weight_krsc: T.Tensor((c_out, kernel_size, kernel_size, c_in), dtype),
-                out_nhwc: T.Tensor((n, out_h, out_w, c_out), dtype),
                 out: T.Tensor((n, c_out, out_h, out_w), dtype),
                 bias: T.Tensor((c_out,), dtype),
             ):
-                _conv2d_symmetric_body(x, weight, x_nhwc, weight_krsc, out_nhwc, out, bias)
+                _conv2d_symmetric_body(x, weight, x_nhwc, weight_krsc, out, bias)
 
             return _conv2d_symmetric_bias_main
 
@@ -714,10 +673,9 @@ def _conv2d_symmetric_kernel(
             weight: T.Tensor((c_out, c_in, kernel_size, kernel_size), dtype),
             x_nhwc: T.Tensor((n, h, w, c_in), dtype),
             weight_krsc: T.Tensor((c_out, kernel_size, kernel_size, c_in), dtype),
-            out_nhwc: T.Tensor((n, out_h, out_w, c_out), dtype),
             out: T.Tensor((n, c_out, out_h, out_w), dtype),
         ):
-            _conv2d_symmetric_body(x, weight, x_nhwc, weight_krsc, out_nhwc, out, None)
+            _conv2d_symmetric_body(x, weight, x_nhwc, weight_krsc, out, None)
 
         return _conv2d_symmetric_main
 
@@ -727,9 +685,18 @@ def _conv2d_symmetric_kernel(
 class Conv2dSymmetricKernel(Kernel):
     supported_archs: list[int] = [80, 86, 89, 90]
 
+    # The m tiles this kernel builds. One tuple serves the region, the default
+    # configuration and the autotune filter, so widening it cannot leave the three
+    # disagreeing about what an m tile can be.
+    block_m_candidates: tuple[int, ...] = (64, 128)
+
     @classmethod
     def applies(cls, call: Conv2dCall) -> bool:
-        return conv2d_symmetric_region(call)
+        # The tile question is asked of this class, so a kernel_map override answers
+        # for its own tiling rather than for the shipped one.
+        return conv2d_symmetric_region(call) and cls.tile_stays_in_one_image(
+            call.n, call.out_h * call.out_w, min(cls.block_m_candidates)
+        )
 
     def __init__(
         self,
@@ -779,10 +746,20 @@ class Conv2dSymmetricKernel(Kernel):
         )
         self.init_config(config, tune)
 
+    @staticmethod
+    def tile_stays_in_one_image(n: int, out_hw: int, block_m: int) -> bool:
+        """Whether an m tile of *block_m* rows never spans two of *n* images.
+
+        The m axis runs over ``n * out_h * out_w``, and both ``T.im2col`` and the
+        epilogue read the image index off the tile's first row. A tile that starts in
+        one image and ends in the next would take the wrong image for its tail.
+        """
+        return n == 1 or out_hw % block_m == 0
+
     @property
     def default_config(self) -> dict:
         return {
-            "block_m": 64,
+            "block_m": min(self.block_m_candidates),
             "block_n": 256,
             "block_k": 32,
             "num_stages": 3,
@@ -794,10 +771,16 @@ class Conv2dSymmetricKernel(Kernel):
     def autotune_configs(self) -> list[dict]:
         configs = conv_autotune_configs(
             self.dtype,
-            block_m=[64, 128],
+            block_m=list(self.block_m_candidates),
             block_k=[16, 32, 64],
         )
-        return [c for c in configs if self.c_in % c["block_k"] == 0]
+        out_hw = self.out_h * self.out_w
+        return [
+            c
+            for c in configs
+            if self.c_in % c["block_k"] == 0
+            and self.tile_stays_in_one_image(self.n, out_hw, c["block_m"])
+        ]
 
     def forward(
         self,
@@ -815,12 +798,7 @@ class Conv2dSymmetricKernel(Kernel):
             device=weight.device,
             dtype=weight.dtype,
         )
-        out_nhwc = torch.empty(
-            (self.n, self.out_h, self.out_w, self.c_out),
-            device=x.device,
-            dtype=x.dtype,
-        )
-        return _launch(self, x, weight, x_nhwc, weight_krsc, out_nhwc, bias=bias)
+        return _launch(self, x, weight, x_nhwc, weight_krsc, bias=bias)
 
 
 class Conv2dKernel(Kernel):

--- a/src/tileops/kernels/convolution/conv2d.py
+++ b/src/tileops/kernels/convolution/conv2d.py
@@ -1161,9 +1161,15 @@ class Conv2d1x1Kernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
+        # A 32-wide n tile, which the rest of the family does not reach: the block
+        # count is C_out * H * W / (block_m * block_n), and a pointwise row over a
+        # small map has no other way to fill the device. It costs nothing because
+        # 256 threads and a 256-wide m tile win no row measured.
         return conv_autotune_configs(
             self.dtype,
-            block_m=[64, 128, 256],
+            block_m=[64, 128],
+            block_n=[32, 64, 128, 256],
+            threads=[128],
         )
 
     def forward(

--- a/src/tileops/kernels/convolution/conv3d.py
+++ b/src/tileops/kernels/convolution/conv3d.py
@@ -721,9 +721,12 @@ class Conv3dKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
+        # No 256-thread block: it wins no conv3d row measured, and dropping it pays
+        # for searching the rasterization swizzle instead.
         return conv_autotune_configs(
             self.dtype,
             block_n=[32, 64, 128],
+            threads=[128],
         )
 
     def forward(
@@ -860,9 +863,12 @@ class GroupConv3dKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
+        # No 256-thread block: it wins no conv3d row measured, and dropping it pays
+        # for searching the rasterization swizzle instead.
         return conv_autotune_configs(
             self.dtype,
             block_n=[32, 64, 128],
+            threads=[128],
         )
 
     def forward(
@@ -994,10 +1000,13 @@ class Conv3dNdhwcKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
+        # No 256-thread block: it wins no conv3d row measured, and dropping it pays
+        # for searching the rasterization swizzle instead.
         configs = conv_autotune_configs(
             self.dtype,
             block_m=[64, 128],
             block_k=[16, 32, 64, 128, 256],
+            threads=[128],
         )
         return [c for c in configs if self.c_in % c["block_k"] == 0]
 

--- a/src/tileops/kernels/convolution/conv3d.py
+++ b/src/tileops/kernels/convolution/conv3d.py
@@ -8,9 +8,8 @@ import tilelang.language as T
 import torch
 
 from tileops.kernels.kernel_base import Kernel
-from tileops.utils import get_sm_version
 
-from ._common import _launch, conv_autotune_configs
+from ._common import CONV_SWIZZLE_PANEL, _launch, conv_autotune_configs, conv_num_stages
 from .call_spec import Conv3dCall, conv3d_dense_region, conv3d_group_region, conv3d_ndhwc_region
 
 __all__ = [
@@ -81,7 +80,7 @@ def _conv3d_kernel(
                 weight_flat = T.Tensor((c_out, k_total), dtype, weight.data)
                 out_flat = T.Tensor((n, c_out, out_dhw), dtype, out.data)
 
-                T.use_swizzle(10, enable=enable_rasterization)
+                T.use_swizzle(CONV_SWIZZLE_PANEL, enable=enable_rasterization)
                 T.clear(out_local)
 
                 for k_iter in T.Pipelined(T.ceildiv(k_total, block_k), num_stages=num_stages):
@@ -230,7 +229,7 @@ def _conv3d_group_kernel(
                 weight_flat = T.Tensor((c_out, k_total), dtype, weight.data)
                 out_flat = T.Tensor((n, c_out, out_dhw), dtype, out.data)
 
-                T.use_swizzle(10, enable=enable_rasterization)
+                T.use_swizzle(CONV_SWIZZLE_PANEL, enable=enable_rasterization)
                 T.clear(out_local)
 
                 batch_id = bz // groups
@@ -481,7 +480,7 @@ def _conv3d_ndhwc_kernel(
                 weight_flat = T.Tensor((c_out, k_total), dtype, weight_kdrsc.data)
                 out_flat = T.Tensor((n * out_dhw, c_out), dtype, out_ndhwc.data)
 
-                T.use_swizzle(10, enable=enable_rasterization)
+                T.use_swizzle(CONV_SWIZZLE_PANEL, enable=enable_rasterization)
                 T.clear(out_local)
 
                 for k_iter in T.Pipelined(T.ceildiv(k_total, block_k), num_stages=num_stages):
@@ -700,29 +699,17 @@ class Conv3dKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
-        sm_version = get_sm_version()
-        if sm_version in {90}:
-            return {
-                "block_m": 64,
-                "block_n": 64,
-                "block_k": 64,
-                "num_stages": 3,
-                "threads": 128,
-                "enable_rasterization": True,
-            }
         return {
             "block_m": 64,
             "block_n": 64,
             "block_k": 64,
-            "num_stages": 2,
+            "num_stages": conv_num_stages(),
             "threads": 128,
             "enable_rasterization": True,
         }
 
     @property
     def autotune_configs(self) -> list[dict]:
-        # No 256-thread block: it wins no conv3d row measured, and dropping it pays
-        # for searching the rasterization swizzle instead.
         return conv_autotune_configs(
             self.dtype,
             block_n=[32, 64, 128],
@@ -842,29 +829,17 @@ class GroupConv3dKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
-        sm_version = get_sm_version()
-        if sm_version in {90}:
-            return {
-                "block_m": 64,
-                "block_n": 64,
-                "block_k": 64,
-                "num_stages": 3,
-                "threads": 128,
-                "enable_rasterization": True,
-            }
         return {
             "block_m": 64,
             "block_n": 64,
             "block_k": 64,
-            "num_stages": 2,
+            "num_stages": conv_num_stages(),
             "threads": 128,
             "enable_rasterization": True,
         }
 
     @property
     def autotune_configs(self) -> list[dict]:
-        # No 256-thread block: it wins no conv3d row measured, and dropping it pays
-        # for searching the rasterization swizzle instead.
         return conv_autotune_configs(
             self.dtype,
             block_n=[32, 64, 128],
@@ -1000,8 +975,6 @@ class Conv3dNdhwcKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        # No 256-thread block: it wins no conv3d row measured, and dropping it pays
-        # for searching the rasterization swizzle instead.
         configs = conv_autotune_configs(
             self.dtype,
             block_m=[64, 128],

--- a/src/tileops/manifest/convolution.yaml
+++ b/src/tileops/manifest/convolution.yaml
@@ -176,6 +176,7 @@ Conv2dFwdOp:
     kernel_map:
       conv2d_kernel: Conv2dKernel
       conv2d_1x1_kernel: Conv2d1x1Kernel
+      conv2d_symmetric_kernel: Conv2dSymmetricKernel
       group_conv2d_kernel: GroupConv2dKernel
     op: tileops/ops/convolution.py
     test: tests/ops/test_convolution.py
@@ -262,6 +263,7 @@ Conv3dFwdOp:
     kernel: tileops/kernels/convolution/conv3d.py
     kernel_map:
       conv3d_kernel: Conv3dKernel
+      conv3d_ndhwc_kernel: Conv3dNdhwcKernel
       group_conv3d_kernel: GroupConv3dKernel
     op: tileops/ops/convolution.py
     test: tests/ops/test_convolution.py

--- a/tests/ops/test_convolution.py
+++ b/tests/ops/test_convolution.py
@@ -746,6 +746,15 @@ def test_conv2d_batch_with_partial_tile_leaves_the_symmetric_kernel() -> None:
     torch.testing.assert_close(out, ref.contiguous(), atol=1e-2, rtol=1e-2)
 
 
+@pytest.mark.smoke
+def test_conv2d_symmetric_kernel_refuses_a_tile_that_spans_two_images() -> None:
+    # applies() keeps the dispatcher off this shape, so only a direct construction
+    # reaches the kernel with a tile that would run off the end of an image. It has to
+    # be told, rather than left to write the wrong rows.
+    with pytest.raises(ValueError, match="spans two of this call's 5 images"):
+        Conv2dSymmetricKernel(5, 96, 9, 9, 64, 3, 1, 0, 1, torch.float16)
+
+
 class Conv3dFixture(FixtureBase):
     PARAMS = [
         (

--- a/tests/ops/test_convolution.py
+++ b/tests/ops/test_convolution.py
@@ -732,6 +732,20 @@ def test_conv2d_dispatches_5x5_kernel() -> None:
     torch.testing.assert_close(out, ref.contiguous(), atol=1e-3, rtol=1e-3)
 
 
+@pytest.mark.smoke
+def test_conv2d_batch_with_partial_tile_leaves_the_symmetric_kernel() -> None:
+    # out_h * out_w is 49 here, a multiple of no m tile the symmetric kernel builds,
+    # so an m tile would span two images and its implicit GEMM would take the wrong
+    # image for the tail. More than one image therefore goes elsewhere.
+    op = Conv2dFwdOp()
+    x = torch.randn(5, 96, 9, 9, device="cuda", dtype=torch.float16).contiguous()
+    weight = torch.randn(64, 96, 3, 3, device="cuda", dtype=torch.float16).contiguous()
+    out = op(x, weight)
+    assert not isinstance(op.kernel, Conv2dSymmetricKernel)
+    ref = F.conv2d(x, weight, bias=None)
+    torch.testing.assert_close(out, ref.contiguous(), atol=1e-2, rtol=1e-2)
+
+
 class Conv3dFixture(FixtureBase):
     PARAMS = [
         (


### PR DESCRIPTION
## Problems

15 of `Conv2dFwdOp`'s 31 manifest rows read below their fastest alternative, in two
groups with two different causes, and a third cause reached the whole family.

**Ten rows are every dense 3x3 and 5x5, and their kernel ran four kernels per call.**
`Conv2dSymmetricKernel` stages both operands to NHWC, runs a TMA-im2col + WGMMA
implicit GEMM, and transposes the NHWC result back to NCHW. Per-kernel device time on
`highres-3x3-s1`:

| kernel | us | of the row |
| --- | ---: | ---: |
| input NCHW -> NHWC | 8.6 | 7% |
| weight NCHW -> NHWC | 4.6 | 4% |
| implicit GEMM | 74.7 | 59% |
| **output NHWC -> NCHW** | **38.0** | **30%** |

The output transpose read NHWC with a stride of `C_out` at two bytes an element: it
moved 25.7 MB in 38.0 us, 674 GB/s where the part reads at 4.8 TB/s. Nothing in the
row needed an NHWC output; the GEMM produced one because that was the layout its own
accumulator tile had.

**Five rows are 1x1, and their kernel could not make enough blocks.**
`Conv2d1x1Kernel` makes `C_out * H * W / (block_m * block_n)` blocks and `block_n`
started at 64, so `classifier-1x1` -- 512 channels over a 7x7 map to 2048, 49 output
pixels -- filled 32 blocks of 132 SMs.

**And `conv_autotune_configs` wrote `enable_rasterization: True` into every
configuration it has ever produced, for all nine conv kernels: the axis was never
searched.** That swizzle orders blocks for L2 locality, which a row whose grid is too
small does not have. Two kernels already disagreed with it in code --
`Conv2dKernel` and `GroupConv2dKernel` choose `False` in their sm90 `default_config`
-- so on Hopper, turning autotuning on removed the value the untuned default prefers.
`GroupConv2dKernel`'s depthwise path had no search at all: its `autotune_configs`
returned the single `default_config`, so the swizzle was fixed rather than chosen.

## Changes

- **The implicit GEMM stores NCHW itself.** It stages the accumulator channel-major
  in shared memory, so the store walks the spatial axis -- the contiguous one in NCHW
  -- and is one tile copy into the output. The transpose kernel and the NHWC output
  buffer are both gone.
- **One kernel stages both operands.** The two remaining transposes are the same
  computation over a plane of `(channel, spatial)` and neither fills the device; the
  block index now selects which operand a block serves. Flattening each operand's
  spatial axis first also drops the divide and multiply that recovered `h` and `w`.
- **The 1x1 space reaches a 32-wide n tile**, and gives up 256 threads and a
  256-wide m tile, which win no row in the manifest.
- **`enable_rasterization` is searched by every conv kernel**, and
  `GroupConv2dKernel`'s depthwise path offers both values where it offered one.
  Measured over all 55 manifest rows -- each tuned twice through the repo's own
  autotuner, once over the shipped space and once with the axis opened -- 50 rows read
  faster with the swizzle off and 5 with it on, so it is searched rather than flipped.
- **The search barely grows: values that win no row pay for the new axis.**
  `Conv2dSymmetricKernel` gives up a 16-wide k tile and a two-stage pipeline and
  *shrinks* by a third; the three conv3d kernels and the grouped conv2d GEMM path give
  up 256 threads and stay level; `Conv1dKernel` gives up a 256-wide n tile. Across the
  family, 693 configurations become 756.
- **`source.kernel_map` names every kernel the conv Ops dispatch to.** It was missing
  `Conv2dSymmetricKernel` and `Conv3dNdhwcKernel` -- the first being the one that
  serves every dense 3x3 and 5x5 call, so the table pointed a reader away from the
  kernel most conv2d rows run.
- Four kernels a call become two.
- **The swizzle panel is one name, and a power of two.** `T.use_swizzle` took the
  literal `10` at twelve call sites across the three kernels, inherited and never
  measured. The block remap divides by the panel, so a value that is not a power of
  two costs a divide the compiler cannot fold into a shift, and wider panels lose
  monotonically on the long 1d grids. `CONV_SWIZZLE_PANEL = 2` is what a sweep over
  eleven shapes leaves; the numbers are under *The swizzle panel* below.
- **A config handed to `Conv2dSymmetricKernel` is checked against the same tile rule.**
  The m tile staying inside one image is a correctness condition, and `applies()` and
  `autotune_configs` were the only two of the three ways a `block_m` arrives that
  enforced it. The constructor raises now.
- **The staging launch width and the pipeline-depth rule are named once.** `256` was a
  literal in the staging kernel's two asserts and in the launch the asserts are about,
  and five `default_config` bodies each spelled out the same twelve-line branch to say
  that Hopper holds a third pipeline stage and the older targets two.
- Test-node delta: +2 -- the regression below, and the constructor's own case.

```
File                             Base    HEAD    Delta
tests/ops/test_convolution.py      70      72       +2
```

### A correctness bug the first change had to state

The tile the fused store writes has to lie inside one image -- which is what
`T.im2col` already required of the m tile it addresses. The implicit GEMM runs over a
flattened `n * out_h * out_w`, and the image index it takes is
`m_tile / (out_hw / block_m)`: an integer division that is the image only when
`block_m` divides `out_hw`. A batch of more than one image whose `out_h * out_w` is
not a multiple of the m tile therefore never held. On `upstream/main`,
`n=5, 96x9x9 -> 64, 3x3, padding 0` (`out_hw` 49) reads a maximum error of **175.9**
against a reference whose maximum is 136.

`Conv2dSymmetricKernel` now answers that question for itself: `block_m_candidates` is
the one place its m tiles are named, and `applies()`, the default configuration and the
autotune filter all read it. A call it cannot tile goes to the dense kernel, which
tiles the batch on a grid axis of its own and does hold.
`test_conv2d_batch_with_partial_tile_leaves_the_symmetric_kernel` is that shape.
Asking the class rather than a shared predicate is what lets a `kernel_map` override
answer for its own tiling, the way `GQADecodePagedBs1Kernel` already does for its page
tile.

## TileFoundry Description

The nine distinct shapes were authored as HIR and `analyze --roofline --memory` read
off their floors, so the numbers below are read against a bound rather than against
cuDNN.

```python
@module(entry="highres_3x3_s1", target=CudaTarget("nvidia.h200_sxm"), topologies=_TOPOLOGIES)
class Conv2dRows:
    @func
    def highres_3x3_s1(
        x: Tensor[(1, 256, 112, 112), "f16"],
        w: Tensor[(512, 256, 3, 3), "f16"],
        b: Tensor[(512,), "f16"],
    ) -> Tensor[(1, 512, 112, 112), "f16"]:
        return tf.conv2d(x, w, b, stride=(1, 1), padding=(1, 1), dilation=(1, 1), groups=1)
    # ... one @func per shape
```

| Shape | flops | traffic r+w | roofline (us) | bound by | at 1500 MHz (us) | same-traffic pass (us) |
| --- | ---: | ---: | ---: | --- | ---: | ---: |
| `highres-3x3-s1` | 29.60 G | 21.63 MB | 29.91 | compute | 39.54 | 7.10 |
| `resnet-3x3` | 462.4 M | 1.68 MB | 0.47 | compute | 0.62 | 2.05 |
| `stage-transition-3x3-s2` | 462.4 M | 1.79 MB | 0.47 | compute | 0.62 | 1.94 |
| `midres-5x5-s1` | 1.285 G | 1.61 MB | 1.30 | compute | 1.72 | 2.05 |
| `stage-transition-5x5-s2` | 1.285 G | 2.84 MB | 1.30 | compute | 1.72 | 2.08 |
| `stride2` | 57.8 M | 0.55 MB | 0.11 | memory | -- | 1.47 |
| `resnet-1x1` | 205.5 M | 4.05 MB | 0.84 | memory | -- | 2.62 |
| `bottleneck-reduce-1x1` | 205.5 M | 2.14 MB | 0.45 | memory | -- | 2.11 |
| `classifier-1x1` | 102.8 M | 2.35 MB | 0.49 | memory | -- | 1.95 |

Two things bound how those floors are read, and both are stated because otherwise the
compute-bound ones read as closer than they are:

- **They are at the target's clock, and the runs are not.** The target derives
  1 982 717 803 Hz from the published FP32 rate; `nvidia-smi` reported an SM clock of
  1500 MHz throughout, so `highres-3x3-s1` floors at **39.54 us**, not 29.91.
- **A row whose floor is under 2 us is bounded by a launch, not by the roofline.** A
  compiled unary pass moving each row's own traffic is the last column: 2.05 us for
  `resnet-3x3`'s 1.68 MB against a roofline floor of 0.62, and 1.47 us for `stride2`'s
  0.55 MB against 0.11. Those passes are what the small rows are read against here.

`Conv1dFwd`'s rows are authored too, as conv2d with `H` and `kH` of 1 -- the same
flops and the same traffic, which is how `tf.conv2d` expresses a 1-D convolution
exactly:

| Shape | flops | traffic r+w | `ideal-ns` | bound by |
| --- | ---: | ---: | ---: | --- |
| `whisper-large-conv1` | 1.842 G | 8.77 MB | 1862 | compute |
| `wav2vec2-layer1` | 32.8 M | 3.32 MB | 692 | memory |
| `encodec-init` | 10.7 M | 1.58 MB | 331 | memory |
| `encodec-deep` | 387.3 M | 1.11 MB | 392 | compute |

**`Conv3dFwd` cannot be authored, and that is the finding to record.**
`tilefoundry.dsl.tf` exposes one convolution, `conv2d`; there is no `conv3d` and no
way to express a 3-D window through the 2-D one, the way a 1-D window goes through it
by setting an extent to 1. Those rows are read against the roofline the manifest
declares instead -- `Conv3dFwdOp.eval_roofline()`, the same numbers the benchmark's
`tflops` and `bandwidth_tbs` columns come from -- plus a compiled pass over each row's
own traffic. Checked, not assumed.

The traffic figures also gave `resnet-1x1` the floor that made its plateau legible.
Its 0.80 MB read against 3.21 MB written is not the symmetric shape a unary pass has,
so a pass of *that* shape -- every input element read once, every output written once
-- was measured separately at **2.33 us**, against cuDNN's 3.58 and, before this
branch, 3.68 here.

## Performance

| Environment | Value |
| --- | --- |
| image | `ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-afcebed1-foundry-dev` |
| gpu | `NVIDIA H200`, SM clock 1500 MHz through every run (not the CI runners') |
| driver | `595.71.05`, cuda `13.2`, torch `2.13.0+cu132`, tilelang `0.1.11+cu132.gitafcebed1` |
| timer | native CUPTI device-busy time, as `benchmarks/timing.py` takes it |
| autotune | on, as `bench_convolution.py` runs it: every row is searched on both sides |

Method: `benchmarks/ops/bench_convolution.py`, all 55 rows of all three conv ops,
three runs a side, each run from its own empty `TILELANG_CACHE_DIR`, median of the
three. Ratios are against the fastest of `torch`, `torch-compile` and `flaggems` on
the same side, the column
[the nightly page](https://tile-ai.github.io/TileOPs.github.io/benchmarks/conv-pool/)
reports. `device_busy_ms` is reported to 0.1 us, which is 3% on the 3-4 us rows: a row
reading 1.00x is at parity, not ahead.

`Before` is this PR's own previous head, so the table reads the whole branch. The
machine is shared -- another user held devices and a share of the host's cores
throughout.

**All 55 rows of `Conv1dFwd`, `Conv2dFwd` and `Conv3dFwd` now read at or above their
fastest alternative.** 41 rows are faster than the previous head, 11 level, and 3
slower by 1.6-3.2% -- the three are 1x1 and dense rows whose space is unchanged or
barely changed, which is autotune noise at this resolution rather than a regression
the change can explain.

### Conv1dFwdOp
| Row | dtype | Before (us) | After (us) | Change | best alt (us) / ours |
| --- | --- | ---: | ---: | ---: | ---: |
| `(1, 1, 16000)` 512 (10,) | bfloat16 | 5.600 | **5.300** | **1.057x** | torch 16.100 🟢 3.04x (was 2.88x) |
| `(1, 1, 16000)` 512 (10,) | bfloat16 | 5.800 | **5.600** | **1.036x** | torch-compile 19.500 🟢 3.48x (was 3.36x) |
| `(1, 1, 16000)` 512 (10,) | float16 | 5.600 | **5.300** | **1.057x** | torch 15.900 🟢 3.00x (was 2.84x) |
| `(1, 1, 16000)` 512 (10,) | float16 | 5.800 | **5.700** | **1.018x** | torch-compile 18.500 🟢 3.25x (was 3.19x) |
| `(1, 128, 600)` 256 (10,) | bfloat16 | 10.200 | **9.900** | **1.030x** | torch 14.500 🟢 1.46x (was 1.43x) |
| `(1, 128, 600)` 256 (10,) | bfloat16 | 10.600 | **10.300** | **1.029x** | torch-compile 15.900 🟢 1.54x (was 1.51x) |
| `(1, 128, 600)` 256 (10,) | float16 | 10.200 | **9.900** | **1.030x** | torch-compile 14.500 🟢 1.46x (was 1.43x) |
| `(1, 128, 600)` 256 (10,) | float16 | 10.600 | **10.400** | **1.019x** | torch-compile 16.000 🟢 1.54x (was 1.52x) |
| `(1, 80, 3000)` 1280 (3,) | bfloat16 | 42.000 | **37.300** | **1.126x** | torch 46.900 🟢 1.26x (was 1.12x) |
| `(1, 80, 3000)` 1280 (3,) | bfloat16 | 41.700 | **37.200** | **1.121x** | torch-compile 53.100 🟢 1.43x (was 1.23x) |
| `(1, 80, 3000)` 1280 (3,) | float16 | 42.300 | **36.800** | **1.149x** | torch 47.000 🟢 1.28x (was 1.11x) |
| `(1, 80, 3000)` 1280 (3,) | float16 | 41.700 | **37.500** | **1.112x** | torch-compile 53.300 🟢 1.42x (was 1.23x) |
| `(1, 1, 24000)` 32 (7,) | bfloat16 | 3.100 | **2.900** | **1.069x** | torch 6.100 🟢 2.10x (was 1.97x) |
| `(1, 1, 24000)` 32 (7,) | bfloat16 | 3.100 | **2.900** | **1.069x** | torch-compile 8.200 🟢 2.83x (was 2.55x) |
| `(1, 1, 24000)` 32 (7,) | float16 | 3.100 | **2.900** | **1.069x** | torch 6.100 🟢 2.10x (was 1.97x) |
| `(1, 1, 24000)` 32 (7,) | float16 | 3.100 | **2.900** | **1.069x** | torch-compile 8.200 🟢 2.83x (was 2.65x) |

### Conv2dFwdOp
| Row | dtype | Before (us) | After (us) | Change | best alt (us) / ours |
| --- | --- | ---: | ---: | ---: | ---: |
| `(1, 256, 14, 14)` 1024 (1, 1) | float16 | 3.600 | **3.600** | **1.000x** | torch 5.400 🟢 1.50x (was 1.53x) |
| `(1, 256, 14, 14)` 1024 (1, 1) | float16 | 4.000 | **3.900** | **1.026x** | torch-compile 6.400 🟢 1.64x (was 1.60x) |
| `(1, 512, 7, 7)` 2048 (1, 1) | float16 | 6.200 | **6.300** | **0.984x** | torch-compile 6.400 🟢 1.02x (was 1.05x) |
| `(1, 512, 7, 7)` 2048 (1, 1) | float16 | 6.800 | **6.800** | **1.000x** | torch-compile 7.100 🟢 1.04x (was 1.04x) |
| `(2, 128, 28, 28)` 512 (1, 1) | float16 | 3.000 | **3.000** | **1.000x** | torch 3.500 🟢 1.17x (was 1.17x) |
| `(2, 128, 28, 28)` 512 (1, 1) | float16 | 3.200 | **3.200** | **1.000x** | torch 7.400 🟢 2.31x (was 2.19x) |
| `(2, 512, 28, 28)` 128 (1, 1) | float16 | 4.000 | **3.700** | **1.081x** | torch 3.800 🟢 1.03x (was 0.95x) |
| `(2, 512, 28, 28)` 128 (1, 1) | float16 | 3.900 | **4.000** | **0.975x** | torch 6.500 🟢 1.62x (was 1.69x) |
| `(2, 64, 56, 56)` 256 (1, 1) | bfloat16 | 3.500 | **3.500** | **1.000x** | torch 3.500 🟢 1.00x (was 1.00x) |
| `(2, 64, 56, 56)` 256 (1, 1) | bfloat16 | 3.700 | **3.600** | **1.028x** | torch-compile 8.000 🟢 2.22x (was 2.16x) |
| `(2, 64, 56, 56)` 256 (1, 1) | float16 | 3.500 | **3.500** | **1.000x** | torch 3.600 🟢 1.03x (was 1.03x) |
| `(2, 64, 56, 56)` 256 (1, 1) | float16 | 3.700 | **3.700** | **1.000x** | torch-compile 8.100 🟢 2.19x (was 2.19x) |
| `(1, 128, 28, 28)` 128 (3, 3) | bfloat16 | 7.300 | **7.000** | **1.043x** | torch-compile 10.400 🟢 1.49x (was 1.42x) |
| `(1, 128, 28, 28)` 128 (3, 3) | bfloat16 | 7.800 | **7.500** | **1.040x** | torch-compile 10.700 🟢 1.43x (was 1.38x) |
| `(1, 128, 28, 28)` 256 (3, 3) | float16 | 3.600 | **3.300** | **1.091x** | flaggems 16.100 🟢 4.88x (was 4.50x) |
| `(1, 128, 56, 56)` 256 (3, 3) | float16 | 8.600 | **8.500** | **1.012x** | torch-compile 11.700 🟢 1.38x (was 1.35x) |
| `(1, 128, 56, 56)` 256 (3, 3) | float16 | 9.100 | **8.700** | **1.046x** | torch-compile 12.700 🟢 1.46x (was 1.32x) |
| `(1, 2048, 32, 32)` 256 (3, 3) | float16 | 73.100 | **71.500** | **1.022x** | torch-compile 77.000 🟢 1.08x (was 1.05x) |
| `(1, 256, 112, 112)` 512 (3, 3) | float16 | 58.100 | **57.900** | **1.003x** | torch-compile 67.600 🟢 1.17x (was 1.16x) |
| `(1, 256, 112, 112)` 512 (3, 3) | float16 | 59.700 | **59.900** | **0.997x** | torch-compile 67.800 🟢 1.13x (was 1.13x) |
| `(1, 3, 112, 112)` 64 (3, 3) | float16 | 3.100 | **2.700** | **1.148x** | torch 5.600 🟢 2.07x (was 1.84x) |
| `(1, 3, 112, 112)` 64 (3, 3) | float16 | 3.000 | **3.100** | **0.968x** | torch 8.400 🟢 2.71x (was 2.80x) |
| `(1, 32, 56, 56)` 32 (3, 3) | float16 | 2.400 | **2.000** | **1.200x** | torch 2.700 🟢 1.35x (was 1.13x) |
| `(2, 64, 56, 56)` 64 (3, 3) | bfloat16 | 6.500 | **6.200** | **1.048x** | torch-compile 10.200 🟢 1.65x (was 1.57x) |
| `(2, 64, 56, 56)` 64 (3, 3) | bfloat16 | 6.900 | **6.600** | **1.045x** | torch-compile 11.000 🟢 1.67x (was 1.54x) |
| `(2, 64, 56, 56)` 64 (3, 3) | float16 | 6.900 | **6.300** | **1.095x** | torch-compile 10.200 🟢 1.62x (was 1.45x) |
| `(2, 64, 56, 56)` 64 (3, 3) | float16 | 6.900 | **6.600** | **1.045x** | torch-compile 13.100 🟢 1.98x (was 1.88x) |
| `(1, 128, 56, 56)` 256 (5, 5) | float16 | 15.800 | **15.300** | **1.033x** | torch-compile 19.400 🟢 1.27x (was 1.22x) |
| `(1, 128, 56, 56)` 256 (5, 5) | float16 | 16.200 | **15.800** | **1.025x** | torch-compile 20.200 🟢 1.28x (was 1.20x) |
| `(1, 64, 56, 56)` 128 (5, 5) | float16 | 9.500 | **9.100** | **1.044x** | torch-compile 14.500 🟢 1.59x (was 1.52x) |
| `(1, 64, 56, 56)` 128 (5, 5) | float16 | 9.900 | **9.600** | **1.031x** | torch-compile 14.800 🟢 1.54x (was 1.49x) |

### Conv3dFwdOp
| Row | dtype | Before (us) | After (us) | Change | best alt (us) / ours |
| --- | --- | ---: | ---: | ---: | ---: |
| `(1, 256, 8, 16, 16)` 256 (3, 3, 3) | float16 | 28.500 | **28.400** | **1.004x** | torch-compile 31.900 🟢 1.12x (was 1.13x) |
| `(1, 3, 16, 112, 112)` 64 (3, 3, 3) | float16 | 19.000 | **18.500** | **1.027x** | flaggems 71.100 🟢 3.84x (was 3.78x) |
| `(1, 3, 16, 112, 112)` 64 (3, 3, 3) | float16 | 19.500 | **18.900** | **1.032x** | flaggems 70.700 🟢 3.74x (was 3.64x) |
| `(1, 32, 32, 64, 64)` 64 (3, 3, 3) | bfloat16 | 103.700 | **102.600** | **1.011x** | torch 105.600 🟢 1.03x (was 1.02x) |
| `(1, 32, 32, 64, 64)` 64 (3, 3, 3) | bfloat16 | 103.000 | **102.500** | **1.005x** | torch-compile 112.400 🟢 1.10x (was 1.09x) |
| `(1, 64, 8, 28, 28)` 128 (3, 3, 3) | float16 | 13.200 | **12.900** | **1.023x** | flaggems 210.100 🟢 16.29x (was 15.91x) |
| `(1, 64, 8, 56, 56)` 128 (3, 3, 3) | float16 | 19.700 | **19.500** | **1.010x** | torch 22.900 🟢 1.17x (was 1.16x) |
| `(1, 64, 8, 56, 56)` 128 (3, 3, 3) | float16 | 19.600 | **19.400** | **1.010x** | torch-compile 24.500 🟢 1.26x (was 1.25x) |

合计: 变快 41 行, 持平 11 行, 变慢 3 行

### The swizzle panel

`T.use_swizzle`'s panel is the number of blocks along the grid's fast axis reordered
together. It was the literal `10` at all twelve conv call sites, inherited rather than
chosen. Sweeping it with the swizzle forced on -- eleven shapes across the six kernel
classes, one cache per panel, three rounds, floor reported -- says two things about
that number. This sweep is on the host stack (`torch 2.10.0+cu128`,
`tilelang 0.1.13`), not the image the tables above use, so it reads as before-and-after
pairs on that stack rather than against the baseline columns.

**A panel that is not a power of two costs a divide.** The block remap divides by the
panel. On `(1, 3, 112, 112) -> 64`, a 3.5 us row where nothing else hides it:

| panel | 2 | 4 | 8 | 16 | 6 | 10 | 12 |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| us | 3.49 | 3.49 | 3.49 | 3.49 | 3.90 | 3.87 | 3.90 |

The four powers of two land on one time and the three non-powers land 11% above it,
whatever their value.

**Wider panels lose on the long 1d grids, monotonically.** `whisper-large-conv1` reads
167.2 us at 4, 184.1 at 10, 196.7 at 16 and 204.1 at 32, while most 2d and 3d rows move
under 1% across the whole sweep.

Measured against each shape's own best panel, `2` gives up 1.9% at worst and 0.27% on
average; `10` gives up 11.0% and 2.67%, and is the best panel for one of the eleven
shapes.

**Against 10 it costs nothing that ships.** The benchmark autotunes and the swizzle is
one of the axes it searches, so a panel that slows a rasterizing candidate can only
lose to a non-rasterizing one the panel does not touch. The one shape where the
narrower panel measured slower with the swizzle forced on is the conv3d r3d stem, and
that shape already runs 2% faster with the swizzle off at every panel -- 65.7 us
against 67.0 or more -- so the search takes that side and never sees the panel.
Untuned, it is the one row that moves the wrong way: 0.2% by the floor of five rounds,
nothing by their median.


## Result And Limitations

**SOTA: all 55 rows of the three conv ops read at or above their fastest
alternative, where 15 of `Conv2dFwd`'s 31 did not.**

- **Fourteen 3x3 and 5x5 rows crossed by removing kernels, not by tuning the GEMM**,
  which is untouched. `highres-3x3-s1` is the one row large enough to be read against
  its roofline: at 58.0 us it is 510 TFLOP/s, **68% of the 749 TFLOP/s the part
  reaches at 1500 MHz**, and 1.47x its clock-adjusted floor of 39.54 us -- where
  torch-compile is 1.72x.
- **Five 1x1 rows crossed on the rasterization axis alone**, having plateaued without
  it: across 216 configurations with the swizzle forced on, `resnet-1x1` never went
  below 3.65 us, and a one-stage pipeline, an n tile dividing 3136 exactly and an m
  tile covering all 256 output channels all landed within 0.1 us of that. With it
  searched the row is 3.4 us, and every 1x1 shape's winning configuration has it off.
- **Two rows cross by less than the instrument resolves.** `bottleneck-reduce-1x1` at
  1.00x and `classifier-1x1` at 1.03x are 0.0-0.2 us ahead on a 0.1 us grid. They
  moved a long way (0.88x and 0.79x before) and they are at parity, not ahead.
- **The input staging is now the largest thing that is not the GEMM, and a tiled
  transpose is not the way out.** It moves `highres-3x3-s1`'s 12.85 MB at 1.48 TB/s; a
  shared-memory tiled version -- load a `(channel, spatial)` tile with `T.copy`,
  transpose it in shared, store it with `T.copy` -- measures **0.68x** of that, and
  0.81-0.82x on two smaller rows. Measured over the full tile and thread space, not
  assumed.
- **Five rows read faster with the swizzle on, which is why it is searched.**
  `stem-3x3-s2-bias`, `highres-3x3-s1-bias`, `classifier-1x1-bias`,
  `3d-unet-aspp-3x3x3-rate6` and `unet-encoder-k3-s1` pick `True`. Flipping the
  default to `False` would have cost them.
- **The trims rest on the manifest, not on a mechanism.** A value that wins no row
  here may win one on a shape nobody has benchmarked. The evidence is thickest where
  it is used most -- 14 rows behind the symmetric trims, 16 behind the conv1d one, 8
  behind the conv3d one -- and thinnest for `Conv2dKernel`, which has two rows and is
  the general fallback, so nothing was taken from it and its space is the one that
  doubles.
- Removing the output transpose also removes a buffer: a call no longer allocates
  `n * out_h * out_w * C_out` elements it never reads.
- `pre-commit run --all-files` clean. `tests/test_validate_manifest.py` and
  `benchmarks/tests`, 193 passed. Test-node delta on
  `tests/ops/test_convolution.py`: 70 -> 71, the regression above.

