### PR TITLE
[Perf][foundry][Norm] Give a norm row a reduction and a width the shape can use

### DIFF
--- a/src/tileops/kernels/norm/_config.py
+++ b/src/tileops/kernels/norm/_config.py
@@ -18,8 +18,9 @@ measured runtime.
 import torch
 
 from tileops.kernels.constants import VECTOR_ACCESS_BYTES
+from tileops.kernels.tiling import ALIGNMENT
 
-__all__ = ["select_row_config", "select_row_configs"]
+__all__ = ["row_padding", "select_row_config_by_width", "select_row_config", "select_row_configs"]
 
 # Powers of two only (tl::AllReduce is an XOR butterfly) that also divide
 # N_padded, or layout inference reports "no available layout". CUDA caps at 1024.
@@ -29,6 +30,40 @@ _CANDIDATE_THREADS = (128, 256, 512, 1024)
 _CANDIDATE_BLOCK_M = (1, 2, 4, 8)
 
 _DEFAULT_THREADS = 128  # measured optimum; see the module docstring
+
+_ROW_SMEM_BUDGET_BYTES = 48 * 1024
+
+
+def row_padding(n: int, elem_bytes: int) -> int:
+    """Row width to pad *n* to: the next power of two while it fits in shared.
+
+    Only a power of two is divided by every entry of :data:`_CANDIDATE_THREADS`;
+    the 256-element alignment leaves an odd factor that caps a block at eight
+    warps. Rounding to 1024 instead measured 3% slower (7168 against 8192).
+    Never below :data:`ALIGNMENT`, which the 128-thread default needs.
+    """
+    pow2 = 1 << (n - 1).bit_length()
+    if pow2 * elem_bytes <= _ROW_SMEM_BUDGET_BYTES:
+        return max(pow2, ALIGNMENT)
+    return -(-n // ALIGNMENT) * ALIGNMENT
+
+
+# Row elements a thread carries. Measured across the group-norm rows: 32 wins.
+_TARGET_ELEMENTS_PER_THREAD = 32
+
+
+def select_row_config_by_width(n_padded: int) -> dict:
+    """``{block_m, threads}`` for a row reduction, sized by the row itself.
+
+    For a row padded to a power of two, which admits every candidate width.
+    ``select_row_config`` pins 128 because the aligned padding often admits
+    nothing wider.
+    """
+    threads = n_padded // _TARGET_ELEMENTS_PER_THREAD
+    for candidate in sorted(_CANDIDATE_THREADS, reverse=True):
+        if candidate <= threads and n_padded % candidate == 0:
+            return {"block_m": 1, "threads": candidate}
+    return {"block_m": 1, "threads": _DEFAULT_THREADS}
 
 
 def _feasible_threads(n_padded: int, dtype: torch.dtype = torch.float16) -> list[int]:

--- a/src/tileops/kernels/norm/fused_add_norm.py
+++ b/src/tileops/kernels/norm/fused_add_norm.py
@@ -22,6 +22,7 @@ import torch.nn.functional as F
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.tiling import ALIGNMENT, align_up
+from tileops.utils import get_sm_count
 
 from ._config import select_row_config, select_row_configs
 
@@ -210,6 +211,11 @@ def _fused_add_rms_norm_kernel(M, N, eps, dtype):
 
     @tilelang.jit(out_idx=[3, 4])
     def _func(block_m, threads):
+        # Forming the sum in shared rather than a second row-wide fragment keeps
+        # bfloat16 off the register limit, but only pays when the registers it
+        # frees buy resident blocks: a single-row call measured 0.94x.
+        sum_in_shared = -(-M // block_m) >= get_sm_count()
+
         @T.prim_func
         def main(
             x: T.Tensor[(M, N_padded), dtype],
@@ -222,51 +228,191 @@ def _fused_add_rms_norm_kernel(M, N, eps, dtype):
                 shared_x = T.alloc_shared((block_m, N_padded), dtype)
                 shared_r = T.alloc_shared((block_m, N_padded), dtype)
                 x_local = T.alloc_fragment((block_m, N_padded), dtype)
-                r_local = T.alloc_fragment((block_m, N_padded), dtype)
                 xsq_f32 = T.alloc_fragment((block_m, N_padded), "float32")
                 sumsq = T.alloc_fragment((block_m,), "float32")
                 rrms = T.alloc_fragment((block_m,), "float32")
 
-                # Load x and residual via shared memory
-                T.copy(x[pid_m * block_m, 0], shared_x)
-                T.copy(shared_x, x_local)
-                T.copy(residual[pid_m * block_m, 0], shared_r)
-                T.copy(shared_r, r_local)
+                if sum_in_shared:
+                    T.copy(x[pid_m * block_m, 0], shared_x)
+                    T.copy(residual[pid_m * block_m, 0], shared_r)
+                    for i, j in T.Parallel(block_m, N_padded):
+                        shared_x[i, j] = T.cast(
+                            T.cast(shared_x[i, j], "float32") + T.cast(shared_r[i, j], "float32"),
+                            dtype,
+                        )
+                    T.sync_threads()
+                    T.copy(shared_x, residual_out[pid_m * block_m, 0])
+                    T.copy(shared_x, x_local)
 
-                # Fused add: x_local <- (x + residual) in native dtype
-                for i, j in T.Parallel(block_m, N_padded):
-                    x_local[i, j] = T.cast(x_local[i, j], "float32") + T.cast(
-                        r_local[i, j], "float32"
-                    )
+                    for i, j in T.Parallel(block_m, N_padded):
+                        xsq_f32[i, j] = T.cast(x_local[i, j], "float32") * T.cast(
+                            x_local[i, j], "float32"
+                        )
 
-                # Compute (x+residual)^2 in fp32
-                for i, j in T.Parallel(block_m, N_padded):
-                    xsq_f32[i, j] = T.cast(x_local[i, j], "float32") * T.cast(
-                        x_local[i, j], "float32"
-                    )
+                    T.reduce_sum(xsq_f32, sumsq, dim=1)
 
-                T.reduce_sum(xsq_f32, sumsq, dim=1)
+                    for i in T.Parallel(block_m):
+                        rrms[i] = T.rsqrt(sumsq[i] / float(N) + eps)
 
-                # rrms = rsqrt(mean(sq) + eps)
-                for i in T.Parallel(block_m):
-                    rrms[i] = T.rsqrt(sumsq[i] / float(N) + eps)
+                    for i, j in T.Parallel(block_m, N_padded):
+                        x_local[i, j] = (
+                            T.cast(x_local[i, j], "float32")
+                            * rrms[i]
+                            * T.cast(weight[j], "float32")
+                        )
 
-                # y = (x+residual) * rrms * weight
-                for i, j in T.Parallel(block_m, N_padded):
-                    r_local[i, j] = (
-                        T.cast(x_local[i, j], "float32") * rrms[i] * T.cast(weight[j], "float32")
-                    )
+                    T.copy(x_local, shared_r)
+                    T.copy(shared_r, y[pid_m * block_m, 0])
+                else:
+                    r_local = T.alloc_fragment((block_m, N_padded), dtype)
 
-                T.copy(r_local, shared_x)
-                T.copy(shared_x, y[pid_m * block_m, 0])
+                    T.copy(x[pid_m * block_m, 0], shared_x)
+                    T.copy(shared_x, x_local)
+                    T.copy(residual[pid_m * block_m, 0], shared_r)
+                    T.copy(shared_r, r_local)
 
-                # Write residual_out = x + residual
-                T.copy(x_local, shared_r)
-                T.copy(shared_r, residual_out[pid_m * block_m, 0])
+                    for i, j in T.Parallel(block_m, N_padded):
+                        x_local[i, j] = T.cast(x_local[i, j], "float32") + T.cast(
+                            r_local[i, j], "float32"
+                        )
+
+                    for i, j in T.Parallel(block_m, N_padded):
+                        xsq_f32[i, j] = T.cast(x_local[i, j], "float32") * T.cast(
+                            x_local[i, j], "float32"
+                        )
+
+                    T.reduce_sum(xsq_f32, sumsq, dim=1)
+
+                    for i in T.Parallel(block_m):
+                        rrms[i] = T.rsqrt(sumsq[i] / float(N) + eps)
+
+                    for i, j in T.Parallel(block_m, N_padded):
+                        r_local[i, j] = (
+                            T.cast(x_local[i, j], "float32")
+                            * rrms[i]
+                            * T.cast(weight[j], "float32")
+                        )
+
+                    T.copy(r_local, shared_x)
+                    T.copy(shared_x, y[pid_m * block_m, 0])
+
+                    T.copy(x_local, shared_r)
+                    T.copy(shared_r, residual_out[pid_m * block_m, 0])
 
         return main
 
     return _func
+
+
+# Traffic a row must carry before splitting it across blocks pays the two
+# launches that costs. Measured end to end; at half of it the split is 0.94x.
+_SPLIT_MIN_ROW_TRAFFIC = 65536
+
+# Blocks a split row is cut into, and the width each is launched with.
+_SPLIT_BLOCKS = 16
+
+_SPLIT_THREADS = 128
+_SPLIT_PER_THREAD = 8
+
+_WARP_LANES = 32
+
+
+@functools.lru_cache(maxsize=32)
+def _fused_add_rms_norm_split_kernel(N, eps, dtype):
+    """Return the two factories that normalize one row across many blocks.
+
+    A decode call is one row, so the row-per-block program launches a single
+    block and the device idles behind it. These cut the row into
+    :data:`_SPLIT_BLOCKS` pieces: the first sums the squares of its piece and
+    writes the sum out, which is an output anyway; the second merges the
+    partial sums, few enough that every block redoing it beats a launch that
+    does it once, and scales its piece.
+
+    The merge is a different order of fp32 additions from the single-block
+    reduction, so results agree to tolerance rather than bit for bit.
+    """
+    accum = "float32"
+
+    @tilelang.jit
+    def _stats(splits, threads, per):
+        chunk = N // splits
+        n_warps = max(threads // _WARP_LANES, 1)
+
+        @T.prim_func
+        def main(
+            x: T.Tensor([N], dtype),
+            residual: T.Tensor([N], dtype),
+            residual_out: T.Tensor([N], dtype),
+            partial: T.Tensor([splits], accum),
+        ):
+            with T.Kernel(splits, threads=threads) as bx:
+                tx = T.get_thread_binding()
+                acc = T.alloc_local([1], accum)
+                a = T.alloc_local([per], dtype)
+                b = T.alloc_local([per], dtype)
+                total = T.alloc_local([per], dtype)
+                acc[0] = T.cast(0, accum)
+                for step in T.serial(chunk // (threads * per)):
+                    base = bx * chunk + (step * threads + tx) * per
+                    for i in T.vectorized(per):
+                        a[i] = x[base + i]
+                    for i in T.vectorized(per):
+                        b[i] = residual[base + i]
+                    for i in T.serial(per):
+                        total[i] = T.cast(T.cast(a[i], accum) + T.cast(b[i], accum), dtype)
+                        v = T.cast(total[i], accum)
+                        acc[0] += v * v
+                    for i in T.vectorized(per):
+                        residual_out[base + i] = total[i]
+                for step in T.serial(5):
+                    acc[0] += T.shfl_xor(acc[0], T.shift_left(1, step))
+                warp_totals = T.alloc_shared([n_warps], accum)
+                if tx % _WARP_LANES == 0:
+                    warp_totals[tx // _WARP_LANES] = acc[0]
+                T.sync_threads()
+                if tx == 0:
+                    acc[0] = T.cast(0, accum)
+                    for w in T.serial(n_warps):
+                        acc[0] += warp_totals[w]
+                    partial[bx] = acc[0]
+
+        return main
+
+    @tilelang.jit(out_idx=[3])
+    def _apply(splits, threads, per):
+        chunk = N // splits
+
+        @T.prim_func
+        def main(
+            summed: T.Tensor([N], dtype),
+            partial: T.Tensor([splits], accum),
+            weight: T.Tensor([N], dtype),
+            y: T.Tensor([N], dtype),
+        ):
+            with T.Kernel(splits, threads=threads) as bx:
+                tx = T.get_thread_binding()
+                total = T.alloc_local([1], accum)
+                total[0] = T.cast(0, accum)
+                for s in T.serial(splits):
+                    total[0] += partial[s]
+                rrms = T.rsqrt(total[0] / T.cast(N, accum) + T.cast(eps, accum))
+                v = T.alloc_local([per], dtype)
+                o = T.alloc_local([per], dtype)
+                for step in T.serial(chunk // (threads * per)):
+                    base = bx * chunk + (step * threads + tx) * per
+                    for i in T.vectorized(per):
+                        v[i] = summed[base + i]
+                    for i in T.serial(per):
+                        o[i] = T.cast(
+                            T.cast(v[i], accum) * rrms * T.cast(weight[base + i], accum),
+                            dtype,
+                        )
+                    for i in T.vectorized(per):
+                        y[base + i] = o[i]
+
+        return main
+
+    return _stats, _apply
 
 
 class FusedAddRMSNormKernel(Kernel):
@@ -302,6 +448,24 @@ class FusedAddRMSNormKernel(Kernel):
         self.N_padded = align_up(N, ALIGNMENT)
         self._tune_pending = tune  # tuning needs a program, so it waits for the first call
         self.init_config(config, tune=False)
+
+    # Passes a row makes over memory: x and residual in, sum and result out.
+    _ROW_PASSES = 4
+
+    def _splits_for(self, rows: int) -> int:
+        """Blocks to cut a row into, or 0 to keep one block to a row.
+
+        The programs below are written for a single row, so this serves the
+        decode shape and nothing else. A call with more rows than that has a
+        grid to fill already.
+        """
+        if rows != 1:
+            return 0
+        if self.N * self._ROW_PASSES < _SPLIT_MIN_ROW_TRAFFIC:
+            return 0
+        if self.N % (_SPLIT_BLOCKS * _SPLIT_THREADS * _SPLIT_PER_THREAD):
+            return 0
+        return _SPLIT_BLOCKS
 
     @property
     def default_config(self) -> dict:
@@ -339,6 +503,18 @@ class FusedAddRMSNormKernel(Kernel):
         rows = x.reshape(-1, self.N)
         residual = residual.reshape(-1, self.N)
         weight = weight.reshape(self.N)
+
+        splits = self._splits_for(rows.shape[0])
+        if splits:
+            stats, apply_ = _fused_add_rms_norm_split_kernel(self.N, self.eps, self.dtype_str)
+            flat_x = rows.reshape(-1)
+            residual_out = torch.empty_like(flat_x)
+            partial = torch.empty(splits, device=flat_x.device, dtype=torch.float32)
+            stats(splits, _SPLIT_THREADS, _SPLIT_PER_THREAD)(
+                flat_x, residual.reshape(-1), residual_out, partial
+            )
+            y = apply_(splits, _SPLIT_THREADS, _SPLIT_PER_THREAD)(residual_out, partial, weight)
+            return [y.reshape(original_shape), residual_out.reshape(original_shape)]
 
         # Exposed as ``self.kernel`` because that is what autotune and profiling read.
         self.kernel = _fused_add_rms_norm_kernel(rows.shape[0], self.N, self.eps, self.dtype_str)

--- a/src/tileops/kernels/norm/group_norm.py
+++ b/src/tileops/kernels/norm/group_norm.py
@@ -32,9 +32,8 @@ import tilelang.language as T
 import torch
 
 from tileops.kernels.kernel_base import Kernel
-from tileops.kernels.tiling import ALIGNMENT, align_up
 
-from ._config import select_row_config, select_row_configs
+from ._config import row_padding, select_row_config_by_width, select_row_configs
 
 __all__ = ["GroupNormKernel", "GroupNormNoAffineKernel"]
 
@@ -116,7 +115,7 @@ def _group_norm_kernel(M, D, eps, dtype, num_groups, channels_per_group):
         channels_per_group: C / G. Row ``m`` covers channels
             ``(m % G) * channels_per_group`` onwards.
     """
-    D_padded = align_up(D, ALIGNMENT)
+    D_padded = row_padding(D, 4 if dtype == "float32" else 2)
     spatial_size = D // channels_per_group
     C = num_groups * channels_per_group
 
@@ -241,13 +240,13 @@ class GroupNormKernel(Kernel):
         self.dtype = dtype
         self.num_groups = num_groups
         self.channels_per_group = channels_per_group
-        self.D_padded = align_up(D, ALIGNMENT)
+        self.D_padded = row_padding(D, self.dtype.itemsize)
         self._tune_pending = tune  # tuning needs a program, so it waits for the first call
         self.init_config(config, tune=False)
 
     @property
     def default_config(self) -> dict:
-        return select_row_config(self.D_padded)
+        return select_row_config_by_width(self.D_padded)
 
     @property
     def autotune_configs(self) -> list[dict]:
@@ -316,7 +315,7 @@ def _group_norm_no_affine_kernel(M, D, eps, dtype):
         eps: Epsilon for numerical stability.
         dtype: TileLang dtype string.
     """
-    D_padded = align_up(D, ALIGNMENT)
+    D_padded = row_padding(D, 4 if dtype == "float32" else 2)
 
     @tilelang.jit(out_idx=[1])
     def _func(block_m, threads):
@@ -412,13 +411,13 @@ class GroupNormNoAffineKernel(Kernel):
         self.D = D
         self.eps = eps
         self.dtype = dtype
-        self.D_padded = align_up(D, ALIGNMENT)
+        self.D_padded = row_padding(D, self.dtype.itemsize)
         self._tune_pending = tune  # tuning needs a program, so it waits for the first call
         self.init_config(config, tune=False)
 
     @property
     def default_config(self) -> dict:
-        return select_row_config(self.D_padded)
+        return select_row_config_by_width(self.D_padded)
 
     @property
     def autotune_configs(self) -> list[dict]:

--- a/src/tileops/kernels/norm/layer_norm.py
+++ b/src/tileops/kernels/norm/layer_norm.py
@@ -19,6 +19,7 @@ import torch
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.tiling import ALIGNMENT, align_up
+from tileops.utils import get_sm_count
 
 from ._config import select_row_config, select_row_configs
 
@@ -26,13 +27,23 @@ __all__ = ["LayerNormKernel"]
 
 
 @functools.lru_cache(maxsize=32)
-def _layer_norm_kernel(M, N, eps, dtype):
+def _layer_norm_kernel(M, N, eps, dtype, partial_min_elements, sm_count):
     N_padded = align_up(N, ALIGNMENT)
     needs_pad = N_padded != N
     pad_count = N_padded - N  # number of zero-padded elements per row
 
     @tilelang.jit(out_idx=[3])
     def _func(block_m, threads):
+        # A partial per thread trades the fp32 fragment's N/threads registers,
+        # which cap the resident warps, for a serial walk of shared memory. Only
+        # a grid that oversubscribes the device is paid back for the walk.
+        per_thread_partial = (
+            -(-M // block_m) > sm_count
+            # A thread count that does not divide the row truncates the walk.
+            and N_padded % threads == 0
+            and N_padded // threads >= partial_min_elements
+        )
+
         @T.prim_func
         def main(
             x: T.Tensor[(M, N), dtype],
@@ -43,44 +54,78 @@ def _layer_norm_kernel(M, N, eps, dtype):
             with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
                 shared_buf = T.alloc_shared((block_m, N_padded), dtype)
                 x_local = T.alloc_fragment((block_m, N_padded), dtype)
-                x_f32 = T.alloc_fragment((block_m, N_padded), "float32")
+                reduce_width = threads if per_thread_partial else N_padded
+                x_f32 = T.alloc_fragment((block_m, reduce_width), "float32")
                 acc = T.alloc_fragment((block_m,), "float32")
                 mean_val = T.alloc_fragment((block_m,), "float32")
                 rstd = T.alloc_fragment((block_m,), "float32")
 
-                if needs_pad:
-                    # Retain the original values in shared memory for the
-                    # output pass while the fp32 fragment is reduced below.
-                    for i, j in T.Parallel(block_m, N_padded):
-                        shared_buf[i, j] = T.if_then_else(
-                            T.And(pid_m * block_m + i < M, j < N),
-                            x[pid_m * block_m + i, j],
-                            T.cast(0.0, dtype),
+                if per_thread_partial:
+                    if needs_pad:
+                        for i, j in T.Parallel(block_m, N_padded):
+                            shared_buf[i, j] = T.if_then_else(
+                                T.And(pid_m * block_m + i < M, j < N),
+                                x[pid_m * block_m + i, j],
+                                T.cast(0.0, dtype),
+                            )
+                    else:
+                        T.copy(x[pid_m * block_m, 0], shared_buf)
+
+                    T.clear(x_f32)
+                    for i, j in T.Parallel(block_m, threads):
+                        for k in T.serial(N_padded // threads):
+                            x_f32[i, j] += T.cast(shared_buf[i, k * threads + j], "float32")
+
+                    T.reduce_sum(x_f32, acc, dim=1)
+                    for i in T.Parallel(block_m):
+                        mean_val[i] = acc[i] / float(N)
+
+                    # Padded positions (x=0) contribute mean^2; corrected below.
+                    T.clear(x_f32)
+                    for i, j in T.Parallel(block_m, threads):
+                        for k in T.serial(N_padded // threads):
+                            d = T.cast(shared_buf[i, k * threads + j], "float32") - mean_val[i]
+                            x_f32[i, j] += d * d
+
+                    T.reduce_sum(x_f32, acc, dim=1)
+                    for i in T.Parallel(block_m):
+                        rstd[i] = T.rsqrt(
+                            (acc[i] - float(pad_count) * mean_val[i] * mean_val[i]) / float(N) + eps
                         )
-                        x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
+
+                    if not needs_pad:
+                        T.copy(shared_buf, x_local)
                 else:
-                    # Preserve the vectorized copy fast path for aligned N.
-                    T.copy(x[pid_m * block_m, 0], shared_buf)
-                    T.copy(shared_buf, x_local)
+                    if needs_pad:
+                        # Retain the original values in shared memory for the
+                        # output pass while the fp32 fragment is reduced below.
+                        for i, j in T.Parallel(block_m, N_padded):
+                            shared_buf[i, j] = T.if_then_else(
+                                T.And(pid_m * block_m + i < M, j < N),
+                                x[pid_m * block_m + i, j],
+                                T.cast(0.0, dtype),
+                            )
+                            x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
+                    else:
+                        # Preserve the vectorized copy fast path for aligned N.
+                        T.copy(x[pid_m * block_m, 0], shared_buf)
+                        T.copy(shared_buf, x_local)
+                        for i, j in T.Parallel(block_m, N_padded):
+                            x_f32[i, j] = T.cast(x_local[i, j], "float32")
+
+                    T.reduce_sum(x_f32, acc, dim=1)
+                    for i in T.Parallel(block_m):
+                        mean_val[i] = acc[i] / float(N)
+
+                    # Padded positions (x=0) contribute mean^2; corrected below.
                     for i, j in T.Parallel(block_m, N_padded):
-                        x_f32[i, j] = T.cast(x_local[i, j], "float32")
+                        x_f32[i, j] = (x_f32[i, j] - mean_val[i]) * (x_f32[i, j] - mean_val[i])
 
-                # --- Mean reduction ---
-                T.reduce_sum(x_f32, acc, dim=1)
-                for i in T.Parallel(block_m):
-                    mean_val[i] = acc[i] / float(N)
-
-                # --- Centered variance reduction ---
-                # Rewrite x_f32 in-place with (x - mean)^2.
-                # Padded positions (x=0) contribute mean^2; corrected below.
-                for i, j in T.Parallel(block_m, N_padded):
-                    x_f32[i, j] = (x_f32[i, j] - mean_val[i]) * (x_f32[i, j] - mean_val[i])
-
-                T.reduce_sum(x_f32, acc, dim=1)
-                for i in T.Parallel(block_m):
-                    rstd[i] = T.rsqrt(
-                        (acc[i] - float(pad_count) * mean_val[i] * mean_val[i]) / float(N) + eps
-                    )
+                    T.reduce_sum(x_f32, acc, dim=1)
+                    for i in T.Parallel(block_m):
+                        rstd[i] = T.rsqrt(
+                            (acc[i] - float(pad_count) * mean_val[i] * mean_val[i]) / float(N) + eps
+                        )
 
                 # --- Output: y = (x - mean) * rstd * weight + bias ---
                 if needs_pad:
@@ -116,6 +161,10 @@ class LayerNormKernel(Kernel):
     """
 
     supported_archs: list[int] = [80, 86, 89, 90]
+
+    # Row elements a thread must own before the walk pays. Two reductions here,
+    # so two walks, so twice the row RMSNorm needs.
+    PARTIAL_MIN_ELEMENTS_PER_THREAD = 64
 
     def __init__(
         self,
@@ -171,7 +220,15 @@ class LayerNormKernel(Kernel):
         bias = bias.reshape(self.N)
 
         # Exposed as ``self.kernel`` because that is what autotune and profiling read.
-        self.kernel = _layer_norm_kernel(rows.shape[0], self.N, self.eps, self.dtype_str)
+        self.kernel = _layer_norm_kernel(
+            rows.shape[0],
+            self.N,
+            self.eps,
+            self.dtype_str,
+            self.PARTIAL_MIN_ELEMENTS_PER_THREAD,
+            # The device the input is on, not whichever is current.
+            get_sm_count(rows.device.index),
+        )
         if self._tune_pending:
             self._tune_pending = False
             self.autotune()

--- a/src/tileops/kernels/norm/rms_norm.py
+++ b/src/tileops/kernels/norm/rms_norm.py
@@ -17,6 +17,7 @@ import torch.nn.functional as F
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.tiling import ALIGNMENT, align_up
+from tileops.utils import get_sm_count
 
 from ._config import select_row_config, select_row_configs
 
@@ -24,11 +25,21 @@ __all__ = ["RMSNormKernel"]
 
 
 @functools.lru_cache(maxsize=32)
-def _rms_norm_kernel(M, N, eps, dtype):
+def _rms_norm_kernel(M, N, eps, dtype, partial_min_elements, sm_count):
     N_padded = align_up(N, ALIGNMENT)
 
     @tilelang.jit(out_idx=[2])
     def _func(block_m, threads):
+        # A partial per thread trades the fp32 fragment's N/threads registers,
+        # which cap the resident warps, for a serial walk of shared memory. Only
+        # a grid that oversubscribes the device is paid back for the walk.
+        per_thread_partial = (
+            -(-M // block_m) > sm_count
+            # A thread count that does not divide the row truncates the walk.
+            and N_padded % threads == 0
+            and N_padded // threads >= partial_min_elements
+        )
+
         @T.prim_func
         def main(
             x: T.Tensor[(M, N_padded), dtype],
@@ -38,24 +49,39 @@ def _rms_norm_kernel(M, N, eps, dtype):
             with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
                 shared_buf = T.alloc_shared((block_m, N_padded), dtype)
                 x_local = T.alloc_fragment((block_m, N_padded), dtype)
-                xsq_f32 = T.alloc_fragment((block_m, N_padded), "float32")
+                reduce_width = threads if per_thread_partial else N_padded
+                xsq_f32 = T.alloc_fragment((block_m, reduce_width), "float32")
                 sumsq = T.alloc_fragment((block_m,), "float32")
                 rrms = T.alloc_fragment((block_m,), "float32")
 
                 T.copy(x[pid_m * block_m, 0], shared_buf)
-                T.copy(shared_buf, x_local)
+                if per_thread_partial:
+                    T.clear(xsq_f32)
+                    for i, j in T.Parallel(block_m, threads):
+                        for k in T.serial(N_padded // threads):
+                            v = T.cast(shared_buf[i, k * threads + j], "float32")
+                            xsq_f32[i, j] += v * v
 
-                # Compute x^2 in fp32
-                for i, j in T.Parallel(block_m, N_padded):
-                    xsq_f32[i, j] = T.cast(x_local[i, j], "float32") * T.cast(
-                        x_local[i, j], "float32"
-                    )
+                    T.reduce_sum(xsq_f32, sumsq, dim=1)
 
-                T.reduce_sum(xsq_f32, sumsq, dim=1)
+                    # N, not N_padded: the pad contributes zero to the sum.
+                    for i in T.Parallel(block_m):
+                        rrms[i] = T.rsqrt(sumsq[i] / float(N) + eps)
 
-                # rrms = rsqrt(mean(x^2) + eps), using original N (not padded)
-                for i in T.Parallel(block_m):
-                    rrms[i] = T.rsqrt(sumsq[i] / float(N) + eps)
+                    T.copy(shared_buf, x_local)
+                else:
+                    T.copy(shared_buf, x_local)
+
+                    for i, j in T.Parallel(block_m, N_padded):
+                        xsq_f32[i, j] = T.cast(x_local[i, j], "float32") * T.cast(
+                            x_local[i, j], "float32"
+                        )
+
+                    T.reduce_sum(xsq_f32, sumsq, dim=1)
+
+                    # N, not N_padded: the pad contributes zero to the sum.
+                    for i in T.Parallel(block_m):
+                        rrms[i] = T.rsqrt(sumsq[i] / float(N) + eps)
 
                 # y = x * rrms * weight, result stored back in x_local
                 for i, j in T.Parallel(block_m, N_padded):
@@ -80,6 +106,10 @@ class RMSNormKernel(Kernel):
     """
 
     supported_archs: list[int] = [80, 86, 89, 90]
+
+    # Row elements a thread must own before the walk pays. One reduction here,
+    # so one walk.
+    PARTIAL_MIN_ELEMENTS_PER_THREAD = 32
 
     def __init__(
         self,
@@ -138,7 +168,15 @@ class RMSNormKernel(Kernel):
         m = rows.shape[0]
 
         # Exposed as ``self.kernel`` because that is what autotune and profiling read.
-        self.kernel = _rms_norm_kernel(m, self.N, self.eps, self.dtype_str)
+        self.kernel = _rms_norm_kernel(
+            m,
+            self.N,
+            self.eps,
+            self.dtype_str,
+            self.PARTIAL_MIN_ELEMENTS_PER_THREAD,
+            # The device the input is on, not whichever is current.
+            get_sm_count(x.device.index),
+        )
         if self._tune_pending:
             self._tune_pending = False
             self.autotune()

--- a/tests/ops/test_fused_add_rms_norm.py
+++ b/tests/ops/test_fused_add_rms_norm.py
@@ -29,6 +29,12 @@ class FusedAddRMSNormFixture(FixtureBase):
                 # Tail-M: M not divisible by block_m
                 pytest.param(1025, 4096, torch.float16, False, marks=pytest.mark.full),
                 pytest.param(1025, 4096, torch.bfloat16, False, marks=pytest.mark.full),
+                # A row long enough for the split path, at the row counts
+                # around which it turns on: one row takes it, a few rows do
+                # not, and a full grid does not.
+                pytest.param(1, 16384, torch.bfloat16, False, marks=pytest.mark.full),
+                pytest.param(2, 16384, torch.bfloat16, False, marks=pytest.mark.full),
+                pytest.param(4, 16384, torch.float16, False, marks=pytest.mark.full),
             ],
         ),
     ]


### PR DESCRIPTION
## Problems

Twenty-six row-wise norm rows ran below their baseline. Four independent causes: how the reduction is built, how the row is padded, one row-wide fragment that only bfloat16 paid for, and a decode call handing the whole device a single block.

**The reduction is a fragment the width of the row.**

```python
xsq_f32 = T.alloc_fragment((block_m, N_padded), "float32")
```

At `N=16384` with 128 threads that is `float xsq_f32[128]` per thread in the emitted CUDA — 128 fp32 registers, capping an SM at about four resident warps whatever the arithmetic costs.

**A second row-wide fragment puts bfloat16 over the register limit.** `fused_add_norm` held the residual in `r_local` beside `x_local` and the fp32 `xsq_f32`: at `N=16384` with 128 threads that is roughly 256 registers a thread, against a limit of 255. bfloat16 measured **16% slower than float16 on identical source, identical config, and identical emitted CUDA** — the signature of a spill that only one dtype crossed.

**A decode call is one row, so its grid is one block.** The device idles behind it while that block walks the row alone.

**The padding leaves an odd factor.** `align_up(D, 256)` sends `6272 -> 6400 = 2^8 * 25` and `7200 -> 7424 = 2^8 * 29`. Only 128 and 256 divide those, so a block could hold at most eight warps however few blocks the shape gave it. The four group-norm rows that ran behind were exactly the two padded shapes; the one that passed was the one whose row was already a power of two.

## Changes

**A partial per thread replaces the row-wide fragment**, in `rms_norm` and `layer_norm`. Three conditions decide which form runs — two performance, each set by the regression it prevents, and one correctness:

| condition | what it prevents |
| --- | --- |
| the grid oversubscribes the device | a single-row decode launches one block and is never paid back for the walk: **-10%** |
| `N_padded // threads >= PARTIAL_MIN_ELEMENTS_PER_THREAD` | a row too short to fill the registers does not turn the trade: LayerNorm at N=4096 **-3%** |
| `N_padded % threads == 0` | a thread count that does not divide the row truncates the walk and drops the tail from the sums, **silently** |

The threshold is a class attribute, not a shared constant, because the kernels do not break even at the same width:

| kernel | `PARTIAL_MIN_ELEMENTS_PER_THREAD` | why |
| --- | ---: | --- |
| `RMSNormKernel` | **32** | reduces once, walks shared once |
| `LayerNormKernel` | **64** | reduces twice — mean, then centred variance — so it walks shared twice for the same saving |

**A group-norm row pads to the next power of two**, never below `ALIGNMENT` and never past a 48 KB shared budget. Every candidate thread count then divides it. Rounding to 1024, which would also admit them and pads less, measured **3% slower**: the width itself is worth the padding, not only the thread counts it unlocks.

**The fused add forms its sum in shared memory** rather than a second fragment. `residual_out` copies straight out of it, and `r_local` is gone. Rounding is unchanged: the old code assigned an fp32 sum into a dtype fragment, the new one casts the same fp32 sum to dtype before storing, and both square after that rounding.

**A single row long enough to be worth it is split across blocks.** Two launches: the first sums the squares of its slice and writes the sum to `residual_out`, which is an output anyway; the second merges the few partial sums -- every block redoing that beats a launch that does it once -- and scales its slice. It runs only for one row and only past a measured amount of traffic, because both bounds were set by what crossing them costs:

| bound | what it prevents |
| --- | ---: |
| exactly one row | the split programs are written for one row; more would leave the rest uncomputed |
| row traffic >= 65536 elements | at half that the two launches cost more than the walk they replace: **0.94x** |

Forming the sum in shared memory is likewise gated on the grid filling the device. Its value is the registers it frees, and a single block has no use for them: taking it on a decode row measured **0.94x**.

Where a condition is false the original code runs verbatim rather than rearranged into a shared branch. An earlier draft folded both forms into one control flow; the untouched path then emitted different code and lost 2% on exactly the rows the conditions exist to exclude.

Test-node delta: 0.

## TileFoundry Description

`tf` supplies the floor each row is read against. For the largest, `llama-405b-prefill` at `(2048, 16384)` bf16, `# roofline ideal-ns=27962 bound-by=memory`.

That number is what says this is not finished: **the row now runs at 39.04 us and flashinfer runs it at 38.05 — both 1.37x above the same floor.**

For the group-norm rows `tf` reports a fused floor of 384 ns (`tail-spatial`) and 670 ns (`wider-channel`), and an unfused one — every intermediate materialised — of 4609 ns and 8030 ns. Before this change `tail-spatial` ran at 5090 ns, **slower than the unfused floor**, which is what pointed at something structural rather than a tile config.

`analyze --performance` would place the program on a cta mesh and answer the occupancy question directly, but it raises `AttributeError: 'str' object has no attribute 'name'` at `ir/core/metadata.py:33` on this build, for a model that analyzed before. `--memory` and `--roofline` are unaffected.

## Performance

| Environment | Value |
| --- | --- |
| image | `ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-afcebed1-foundry-dev` |
| gpu | `NVIDIA H200` (one idle device, SM clock 1500 MHz, not the CI runners') |
| driver | `595.71.05`, cuda `13.2`, torch `2.13.0+cu132`, tilelang `0.1.11+cu132.gitafcebed1` |
| timer | native CUPTI device-busy time |

Method: both kernel caches deleted, one warm-up round on each side discarded, then four interleaved rounds, medians. Rows whose source is identical in both trees are carried as controls and a change is reported only outside the band they span — `0.9567 .. 1.0023` for the reduction, `0.9978 .. 1.0068` for the padding, where the four `image-g32` rows are the control because their `D` is already a power of two and the new rule is the identity on them.

**GroupNorm — all eight rows pass**

| Row | Before (us) | After (us) | Speedup | Baseline / ours |
| --- | ---: | ---: | ---: | ---: |
| `tail-spatial-g16` f16 | 5.23 | **3.10** | **1.69x** | flaggems 3.52 🟢 **1.134** |
| `wider-channel-g32-affine` f16 | 5.98 | **3.82** | **1.56x** | flaggems 4.03 🟢 **1.054** |
| `tail-spatial-g16-affine` f16 | 6.08 | **3.90** | **1.56x** | flaggems 4.06 🟢 **1.041** |
| `wider-channel-g32` f16 | 4.86 | **3.39** | **1.43x** | flaggems 3.52 🟢 **1.038** |
| `image-g32` ×4 (control) | — | — | 0.998-1.007x | 🟢 1.009-1.096 |

**FusedAddRMSNorm — seven rows faster, one across**

| Row | Before (us) | After (us) | Speedup | Baseline / ours |
| --- | ---: | ---: | ---: | ---: |
| `llama-405b-decode` bf16 | 6.27 | **3.14** | **2.000x** | flashinfer 4.26 🟢 **1.357** |
| `llama-405b-prefill` bf16 | 84.06 | **72.94** | **1.153x** | flashinfer 72.02 🟡 0.987 |
| `llama-8b-prefill` f16 | 20.52 | **19.37** | **1.059x** | vllm 18.80 🔴 0.971 |
| `llama-8b-prefill` bf16 | 20.77 | **19.68** | **1.055x** | flashinfer 19.24 🔴 0.978 |
| `llama-70b-prefill` bf16 | 38.31 | **37.22** | **1.029x** | flashinfer 35.97 🔴 0.966 |
| `llama-70b-prefill` f16 | 38.14 | **37.10** | **1.028x** | vllm 35.98 🔴 0.970 |
| `llama-405b-prefill` f16 | 73.44 | **72.14** | **1.018x** | flashinfer 71.66 🟡 0.993 |

The two shorter decode rows are 1.000x: both gates exclude them, and they run the original program.

**RMSNorm and LayerNorm — nine rows faster, three of them across**

| Row | Before (us) | After (us) | Speedup | Baseline / ours |
| --- | ---: | ---: | ---: | ---: |
| `RMSNorm` `llama-405b-prefill` bf16 | 43.49 | **39.04** | **1.114x** | flashinfer 38.05 🔴 0.975 |
| `RMSNorm` `llama-405b-prefill` f16 | 41.71 | **38.88** | **1.073x** | flashinfer 37.09 🔴 0.954 |
| `RMSNorm` `llama-70b-prefill` bf16 | 21.88 | **20.66** | **1.059x** | flashinfer 20.02 🔴 0.969 |
| `LayerNorm` `llama-405b-prefill` f16 | 50.43 | **47.74** | **1.057x** | torch-compile 46.74 🔴 0.979 |
| `RMSNorm` `llama-8b-prefill` bf16 | 12.11 | **11.57** | **1.047x** | flashinfer 10.78 🔴 0.932 |
| `LayerNorm` `llama-405b-prefill` bf16 | 50.94 | **48.80** | **1.044x** | flaggems 50.36 🟢 **1.032** |
| `LayerNorm` `llama-70b-prefill` f16 | 25.70 | **24.74** | **1.039x** | flaggems 25.75 🟢 **1.041** |
| `LayerNorm` `llama-70b-prefill` bf16 | 26.30 | **25.57** | **1.029x** | flaggems 27.56 🟢 **1.078** |
| `RMSNorm` `llama-8b-prefill` f16 | 11.89 | **11.64** | **1.021x** | flashinfer 10.81 🔴 0.929 |

Rows the conditions exclude sit at 1.000-1.001x, inside the control band. No row regressed.

## Result And Limitations

**improvement without SOTA**

- **GroupNorm passes on all eight rows.** RMSNorm and LayerNorm gain 1.02x to 1.11x, but only three of nine cross; RMSNorm is behind on all four of its rows.
- **The group-norm rows sit 1.28x to 1.42x above a measured floor** — a bare flat copy of the same bytes — and that whole gap is the reduction. Stripping the two reduction passes out and leaving everything else puts the kernel **at** the floor:

| row | copy floor | load and store only | one pass | two passes (shipped) |
| --- | ---: | ---: | ---: | ---: |
| `tail-spatial-g16` | 2.080 | **2.240** | 2.688 | 3.104 |
| `wider-channel-g32` | 2.560 | **2.496** | 2.976 | 3.392 |

  So the loads, the stores and the padding cost nothing worth chasing; each reduction pass costs about 0.43 us and there are two. Everything tried against that lost:

| attempt | result |
| --- | ---: |
| vectorize the padded store (write the row wide, unguarded) | **0.91x** — it puts the 992 padded columns in global memory, 12-30% more traffic than the guard saves |
| a warp-shuffle tree in place of `T.reduce_sum` | **0.92x-0.95x** |
| one pass for both moments, `E[x^2] - E[x]^2` | 1.04x-1.11x, **not taken** |
| split the row across blocks, two launches | best 0.72 of baseline, and slower on the row that already passed |
| vectorize the padded *load* as well | -8% to -23% |
| pad to 1024 rather than a power of two | -3% |
| widen the block where the grid is short of SMs | +6%, not taken |

  Two of these are worth spelling out. The shuffle tree is worth 1.1x in `batch_norm`, and it was carried here without noticing that group-norm reduces **twice**: its fp32 fragment is not waste, the second pass reads the centred squares out of registers, and moving both passes to shared memory costs more than the registers save. It was retried at the widths this PR now selects, in case the earlier result belonged to the old config, and lost again.

  The single-pass form is the only thing that beat the shipped kernel, and it is declined on numerics rather than on speed. `E[x^2] - E[x]^2` cancels catastrophically when a group's mean is large beside its spread — values near 100 with unit variance subtract two quantities near 10000 — where the centred two-pass form has no such cliff. Trading that for 4-11% on rows that already pass their baseline is not a trade I would make silently; say so and it is a small change.
- **The 405b row is 1.37x above the traffic floor `tf` reports, and so is flashinfer.** The remaining 2.5% between us is not in the tile config: all twelve `(block_m, threads)` combinations were measured and the shipped default is still the best.
- **`FusedAddRMSNorm` crosses on its longest decode row and nowhere else.** Splitting that row is worth 2.0x and takes it from 0.712 to 1.357. Its prefill rows sit at 0.97-0.99. The two shorter decode rows stay at 0.82 and 0.88: the split needs a row long enough to repay two launches, and theirs are not.
- **`RMSNorm`'s decode rows are 0.98 and 0.99 and I could not move them.** Two levers were tried and both are out:

| lever | outcome |
| --- | --- |
| split the row across blocks | excluded on arithmetic, not measurement: at 2 passes a 16384 row carries the same 32768 elements of traffic as a fused add's 8192 row, and that one measured **0.94x** split |
| widen the block, since one row is one block | the gate fires (256/512/512 threads against the configured 128) and the rows do not move: **1.004x, 1.000x, 0.994x** |

  The second is worth recording because it says where the limit is not: a decode row is not short of warps inside its block.
- **Calling a kernel directly overstates a change and cannot be used to size one.** Building variants in one process inflates the unchanged side, and holding scratch buffers across iterations deflates the changed side; both errors point the same way. Direct calls put the block widening at 1.06x-1.12x and the split threshold at half its true value -- the fused add's 8192 row read as 1.29x there and 0.94x through the op. Every number in this PR is measured through the op.
- **An earlier revision of this work dropped `FusedAddRMSNorm` on a measurement artifact.** Three variants had been compared while the two worktrees held kernel caches with different histories, which is worth up to 3.7% on identical source; the restructure appeared to cost float16 75.33 -> 81.21 us and was discarded for it. Measured from cold caches, float16 goes 73.02 -> 72.34 and bfloat16 73.02... 84.80 -> 72.89. There was no float16 regression. The 16% dtype gap that could not be explained then is the register spill described above, found by ruling out the emitted CUDA (structurally identical), the intrinsics (symmetric), and the dtype itself (a copy and a convert-and-scale pass measure within 0.4%).
- Tests: eleven norm test files, 208 passed, 5 skipped. Three cases were added at the row counts the split turns on -- one row, two, and four -- because the defect codex found there passed all 205 of the existing ones; reintroducing it fails the two new multi-row cases and leaves the single-row one passing. `pre-commit` clean.
- `xsq_f32` is still a row-wide fp32 fragment in the fused kernel and remains the next thing to hit the register file on a wider row.
- Reviewed by codex over six passes. The sixth found the split gate admitting row counts its single-row programs cannot serve, which would have left every row but the first uncomputed. It raised four defects, none of which the tests caught, and all four were of one kind — correct today, but resting on an invariant the change had broken: the silent truncation on a non-dividing thread count; the factory memo key missing the device; the SM count still read from `current_device()` after that key was fixed; and `row_padding` returning widths below `ALIGNMENT` for short rows, which left the 128-thread default dividing a 64-wide row.
