### PR TITLE
[Feat][Attention] Support dynamic sequence lengths in dense GQA

### DIFF
--- a/src/tileops/kernels/attention/gqa_dense.py
+++ b/src/tileops/kernels/attention/gqa_dense.py
@@ -226,8 +226,6 @@ def _gqa_dense_causal_ws_kernel(
     B,
     H,
     Hkv,
-    Sq,
-    Skv,
     D,
     sm_scale,
     softcap,
@@ -243,10 +241,11 @@ def _gqa_dense_causal_ws_kernel(
     use_softcap = softcap > 0.0
     scale = LOG2E if use_softcap else score_scale * LOG2E
     groups = H // Hkv
-    co = Skv - Sq
     accum = "float"
     half = block_M // 2
     Pol = T.GemmWarpPolicy.FullRow
+    seq_len_q = T.dynamic("seq_len_q")
+    seq_len_kv = T.dynamic("seq_len_kv")
 
     @T.macro
     def apply_softcap(acc_s, rows, cols):
@@ -260,12 +259,12 @@ def _gqa_dense_causal_ws_kernel(
 
     @T.prim_func
     def main(
-        Q: T.Tensor([B, Sq, H, D], dtype),
-        K: T.Tensor([B, Skv, Hkv, D], dtype),
-        V: T.Tensor([B, Skv, Hkv, D], dtype),
-        O: T.Tensor([B, Sq, H, D], dtype),
+        Q: T.Tensor([B, seq_len_q, H, D], dtype),
+        K: T.Tensor([B, seq_len_kv, Hkv, D], dtype),
+        V: T.Tensor([B, seq_len_kv, Hkv, D], dtype),
+        O: T.Tensor([B, seq_len_q, H, D], dtype),
     ):
-        with T.Kernel(T.ceildiv(Sq, block_M), H, B, threads=threads) as (bx, by, bz):
+        with T.Kernel(T.ceildiv(seq_len_q, block_M), H, B, threads=threads) as (bx, by, bz):
             Qs = T.alloc_shared([2, half, D], dtype)
             Ks = T.alloc_shared([nsK, block_N, D], dtype)
             Vs = T.alloc_shared([nsV, block_N, D], dtype)
@@ -288,7 +287,14 @@ def _gqa_dense_causal_ws_kernel(
 
             cv = by // groups
             q0 = bx * block_M
-            eff = T.min(T.ceildiv(Skv, block_N), T.ceildiv(q0 + block_M + co, block_N))
+            causal_offset = T.alloc_var("int32", init=seq_len_kv - seq_len_q)
+            eff = T.alloc_var(
+                "int32",
+                init=T.min(
+                    T.ceildiv(seq_len_kv, block_N),
+                    T.ceildiv(q0 + block_M + causal_offset, block_N),
+                ),
+            )
             tx = T.get_thread_binding()
 
             if tx >= 256:  # ================= producer =================
@@ -345,8 +351,8 @@ def _gqa_dense_causal_ws_kernel(
                 T.named_barrier_arrive(nxt_bar, NMMA)
                 T.wait_wgmma(0)
                 T.mbarrier_arrive(kfree[0])
-                if q0 + r0 + co < block_N - 1:
-                    mask_limit = q0 + r0 + co
+                if q0 + r0 + causal_offset < block_N - 1:
+                    mask_limit = q0 + r0 + causal_offset
                     for i, j in T.Parallel(half, block_N):
                         acc_s[i, j] = T.if_then_else(
                             mask_limit + i >= j, acc_s[i, j], -T.infinity(accum)
@@ -361,7 +367,10 @@ def _gqa_dense_causal_ws_kernel(
                     logsum[i] = ss[i]
                 T.copy(acc_s, pcast)
 
-                nu = T.max(1, T.min(eff, T.floordiv(q0 + r0 + co + 1, block_N)))
+                nu = T.alloc_var(
+                    "int32",
+                    init=T.max(1, T.min(eff, T.floordiv(q0 + r0 + causal_offset + 1, block_N))),
+                )
                 for k in T.serial(1, nu):
                     sk = k % nsK
                     svp = (k - 1) % nsV
@@ -416,7 +425,7 @@ def _gqa_dense_causal_ws_kernel(
                     T.named_barrier_arrive(nxt_bar, NMMA)
                     T.wait_wgmma(1)
                     T.mbarrier_arrive(kfree[sk])
-                    mask_limit_tail = q0 + r0 + co - k * block_N
+                    mask_limit_tail = q0 + r0 + causal_offset - k * block_N
                     for i, j in T.Parallel(half, block_N):
                         acc_s[i, j] = T.if_then_else(
                             mask_limit_tail + i >= j, acc_s[i, j], -T.infinity(accum)
@@ -480,8 +489,8 @@ def _gqa_dense_causal_ws_kernel(
                 T.named_barrier_arrive(nxt_bar, NMMA)
                 T.wait_wgmma(0)
                 T.mbarrier_arrive(kfree[0])
-                if q0 + r0 + co < block_N - 1:
-                    mask_limit_wg1 = q0 + r0 + co
+                if q0 + r0 + causal_offset < block_N - 1:
+                    mask_limit_wg1 = q0 + r0 + causal_offset
                     for i, j in T.Parallel(half, block_N):
                         acc_s[i, j] = T.if_then_else(
                             mask_limit_wg1 + i >= j, acc_s[i, j], -T.infinity(accum)
@@ -496,7 +505,10 @@ def _gqa_dense_causal_ws_kernel(
                     logsum[i] = ss[i]
                 T.copy(acc_s, pcast)
 
-                nu_wg1 = T.max(1, T.min(eff, T.floordiv(q0 + r0 + co + 1, block_N)))
+                nu_wg1 = T.alloc_var(
+                    "int32",
+                    init=T.max(1, T.min(eff, T.floordiv(q0 + r0 + causal_offset + 1, block_N))),
+                )
                 for k in T.serial(1, nu_wg1):
                     sk = k % nsK
                     svp_wg1 = (k - 1) % nsV
@@ -553,7 +565,7 @@ def _gqa_dense_causal_ws_kernel(
                     T.named_barrier_arrive(nxt_bar, NMMA)
                     T.wait_wgmma(1)
                     T.mbarrier_arrive(kfree[sk])
-                    mask_limit_wg1_tail = q0 + r0 + co - k * block_N
+                    mask_limit_wg1_tail = q0 + r0 + causal_offset - k * block_N
                     for i, j in T.Parallel(half, block_N):
                         acc_s[i, j] = T.if_then_else(
                             mask_limit_wg1_tail + i >= j, acc_s[i, j], -T.infinity(accum)
@@ -621,8 +633,6 @@ class GQADenseCausalWsKernel(Kernel):
             batch,
             heads,
             heads_kv,
-            seq_len_q,
-            seq_len_kv,
             dim,
             dim**-0.5 if sm_scale is None else sm_scale,
             softcap,

--- a/src/tileops/ops/attention/gqa.py
+++ b/src/tileops/ops/attention/gqa.py
@@ -497,12 +497,23 @@ class GroupedQueryAttentionDenseFwdOp(Op):
                 device_index=q.device.index,
             )
 
-        key = (
-            q.dtype,
-            tuple(q.shape),
-            tuple(k.shape),
-            None if rope_cos is None else tuple(rope_cos.shape),
-        )
+        if uses_window or rope_on:
+            # Sliding and RoPE still compile exact sequence lengths. The plain
+            # causal WS kernel accepts its sequence extents at runtime.
+            key = (
+                q.dtype,
+                tuple(q.shape),
+                tuple(k.shape),
+                None if rope_cos is None else tuple(rope_cos.shape),
+            )
+        else:
+            key = (
+                q.dtype,
+                batch,
+                heads,
+                heads_kv,
+                dim,
+            )
         return self.get_or_build_kernel(role, inputs, key=key, build=build)
 
     def forward(

--- a/tests/ops/attention/test_gqa.py
+++ b/tests/ops/attention/test_gqa.py
@@ -169,6 +169,35 @@ def test_gqa_dense_sm90_main_kernel_matches_reference(
     assert isinstance(next(iter(op.iter_kernels())), GQADenseCausalWsKernel)
 
 
+@pytest.mark.smoke
+@pytest.mark.parametrize("batch", [1, 2])
+def test_gqa_dense_reuses_one_kernel_across_sequence_lengths(batch: int) -> None:
+    if not torch.cuda.is_available() or get_sm_version() != 90:
+        pytest.skip("Dense warp-specialized prefill requires SM90")
+    heads, heads_kv, dim = 8, 2, 128
+    op = GroupedQueryAttentionDenseFwdOp()
+
+    for seq_len_q, seq_len_kv in (
+        (1, 270),
+        (1, 271),
+        (160, 270),
+        (896, 896),
+        (1, 270),
+    ):
+        q = torch.randn(batch, seq_len_q, heads, dim, device="cuda", dtype=torch.float16)
+        k = torch.randn(batch, seq_len_kv, heads_kv, dim, device="cuda", dtype=torch.float16)
+        v = torch.randn_like(k)
+        output = op(q, k, v)
+        torch.testing.assert_close(
+            output,
+            _gqa_prefill_ref(q, k, v, heads=heads, heads_kv=heads_kv, is_causal=True),
+            atol=5e-3,
+            rtol=1e-5,
+        )
+
+    assert len(list(op.iter_kernels())) == 1
+
+
 @pytest.mark.parametrize("use_rope", [False, True])
 @pytest.mark.smoke
 def test_gqa_dense_sm90_sliding_window_kernel_matches_reference(use_rope: bool) -> None:


### PR DESCRIPTION
## Summary

- make `Sq` and `Skv` runtime TileLang extents in the H200 dense causal WS kernel
- derive the launch grid, KV loop bounds, causal offset, and tail masks from runtime lengths
- remove exact sequence lengths from the builtin Op cache key so one compiled kernel serves decode and prefill lengths
- add a B=1/B=2 correctness and cache-reuse regression test

This follows the Dense GQA and RoPE implementation merged in #2052.

## Validation

On a clock-locked H200 (SM 1500 MHz):

- 8 targeted Dense GQA tests passed, including FP16/BF16, RoPE, sliding window, B=1/B=2, decode-length and prefill-length inputs
- one Op handled `(Sq, Skv)` values from `(1, 270)` through `(896, 896)` with one builtin kernel cache entry
- `ruff`, `compileall`, and `git diff --check` passed after rebasing onto current `main`

## CUPTI A/B

| `(Sq, Skv)` | Exact-shape kernel | Dynamic-length kernel | Change |
|---|---:|---:|---:|
| `(1, 270)` | 8.832 us | 9.184 us | +4.0% |
| `(1, 271)` | 8.768 us | 9.120 us | +4.0% |
| `(160, 270)` | 9.248 us | 9.663 us | +4.5% |
| `(161, 271)` | 9.344 us | 9.664 us | +3.4% |
| `(896, 896)` | 17.440 us | 17.632 us | +1.1% |

The representative five-shape sequence reduces builtin kernel entries from 5 to 1 and avoids an observed 13-28 seconds of JIT compilation for each new exact shape. RoPE preprocessing and the sliding-window kernel remain exact-shape specializations in this PR.