### PR TITLE
[Perf][Pool] Rework with-indices max-pool argmax and addressing (1D/2D/3D)

### DIFF
--- a/src/tileops/kernels/pool/max_pool1d.py
+++ b/src/tileops/kernels/pool/max_pool1d.py
@@ -204,6 +204,9 @@ def _max_pool1d_with_indices_kernel(
     accum_dtype = "float"
     out_l = pool_output_dim(l_in, kernel_w, stride_w, pad_w, ceil_mode, dilation_w)
     total_output = n * c_in * out_l
+    # Static specialization: with zero padding and no ceil overshoot every window
+    # lies fully inside the input, so the per-element bounds check can be dropped.
+    always_in_bounds = pad_w == 0 and (out_l - 1) * stride_w + (kernel_w - 1) * dilation_w < l_in
 
     @tilelang.jit(out_idx=[1, 2], compile_flags=["-O3", "-DENABLE_BF16"])
     def _max_pool1d_with_indices_func(block_m: int, threads: int):
@@ -221,35 +224,49 @@ def _max_pool1d_with_indices_kernel(
                         channel_batch_idx = out_idx // out_l
                         c_idx = channel_batch_idx % c_in
                         batch = channel_batch_idx // c_in
-
                         max_val = T.alloc_var(T.float32)
                         has_nan = T.alloc_var(T.bool)
-                        max_idx = T.alloc_var(T.int64)
-                        nan_idx = T.alloc_var(T.int64)
+                        max_idx = T.alloc_var(T.int32)
+                        nan_idx = T.alloc_var(T.int32)
                         first_valid = T.alloc_var(T.bool)
+                        # Loop-invariant window corner, materialized so it is not
+                        # re-inlined into every window element.
+                        iw0 = T.alloc_var(T.int32)
                         max_val = T.cast(float("-inf"), accum_dtype)
                         has_nan = False
-                        max_idx = T.cast(0, "int64")
-                        nan_idx = T.cast(0, "int64")
                         first_valid = True
+                        iw0 = ow * stride_w - pad_w
+                        if always_in_bounds:
+                            # Window element 0 is in bounds here, so its flat index is
+                            # the correct seed: an all--inf window reports the first
+                            # position, matching PyTorch, and first_valid is unneeded.
+                            max_idx = iw0
+                            nan_idx = iw0
+                        else:
+                            max_idx = 0
+                            nan_idx = 0
                         for kw in T.serial(kernel_w):
-                            iw = ow * stride_w - pad_w + kw * dilation_w
-                            if iw >= 0 and iw < l_in:
+                            iw = iw0 + kw * dilation_w
+                            if always_in_bounds:
                                 val = T.cast(x[batch, c_idx, iw], accum_dtype)
-                                flat_idx = T.cast(iw, "int64")
                                 is_nan = T.isnan(val)
-                                if is_nan:
-                                    # PyTorch records the last NaN visited in
-                                    # a pooling window.
-                                    nan_idx = flat_idx
-                                    has_nan = True
-                                elif first_valid:
-                                    max_val = val
-                                    max_idx = flat_idx
-                                    first_valid = False
-                                elif val > max_val:
-                                    max_val = val
-                                    max_idx = flat_idx
+                                # Branch-free update. Strict > keeps the first
+                                # maximum; NaN never touches max_val/max_idx and
+                                # records the last NaN visited, matching PyTorch.
+                                take = (not is_nan) and (val > max_val)
+                                max_val = T.if_then_else(take, val, max_val)
+                                max_idx = T.if_then_else(take, iw, max_idx)
+                                nan_idx = T.if_then_else(is_nan, iw, nan_idx)
+                                has_nan = has_nan or is_nan
+                            elif iw >= 0 and iw < l_in:
+                                val = T.cast(x[batch, c_idx, iw], accum_dtype)
+                                is_nan = T.isnan(val)
+                                take = (not is_nan) and (first_valid or (val > max_val))
+                                max_val = T.if_then_else(take, val, max_val)
+                                max_idx = T.if_then_else(take, iw, max_idx)
+                                first_valid = first_valid and is_nan
+                                nan_idx = T.if_then_else(is_nan, iw, nan_idx)
+                                has_nan = has_nan or is_nan
 
                         result = T.if_then_else(
                             has_nan,
@@ -257,10 +274,13 @@ def _max_pool1d_with_indices_kernel(
                             max_val,
                         )
                         out[batch, c_idx, ow] = T.cast(result, dtype)
-                        indices[batch, c_idx, ow] = T.if_then_else(
-                            has_nan,
-                            nan_idx,
-                            max_idx,
+                        indices[batch, c_idx, ow] = T.cast(
+                            T.if_then_else(
+                                has_nan,
+                                nan_idx,
+                                max_idx,
+                            ),
+                            "int64",
                         )
 
         return _max_pool1d_with_indices_main

--- a/src/tileops/kernels/pool/max_pool2d.py
+++ b/src/tileops/kernels/pool/max_pool2d.py
@@ -249,7 +249,16 @@ def _max_pool2d_with_indices_kernel(
     accum_dtype = "float"
     out_h = pool_output_dim(h_in, kernel_h, stride_h, pad_h, ceil_mode, dilation_h)
     out_w = pool_output_dim(w_in, kernel_w, stride_w, pad_w, ceil_mode, dilation_w)
-    total_output = n * c_in * out_h * out_w
+    spatial_output = out_h * out_w
+    total_output = n * c_in * spatial_output
+    # Static specialization: with zero padding and no ceil overshoot every window
+    # lies fully inside the input, so the per-element bounds check can be dropped.
+    always_in_bounds = (
+        pad_h == 0
+        and pad_w == 0
+        and (out_h - 1) * stride_h + (kernel_h - 1) * dilation_h < h_in
+        and (out_w - 1) * stride_w + (kernel_w - 1) * dilation_w < w_in
+    )
 
     @tilelang.jit(out_idx=[1, 2], compile_flags=["-O3", "-DENABLE_BF16"])
     def _max_pool2d_with_indices_func(block_m: int, threads: int):
@@ -272,34 +281,60 @@ def _max_pool2d_with_indices_kernel(
 
                         max_val = T.alloc_var(T.float32)
                         has_nan = T.alloc_var(T.bool)
-                        max_idx = T.alloc_var(T.int64)
-                        nan_idx = T.alloc_var(T.int64)
+                        max_idx = T.alloc_var(T.int32)
+                        nan_idx = T.alloc_var(T.int32)
                         first_valid = T.alloc_var(T.bool)
+                        # Loop-invariant window corner and flat base, materialized so the
+                        # decode is not re-inlined into every window element.
+                        ih0 = T.alloc_var(T.int32)
+                        iw0 = T.alloc_var(T.int32)
+                        base_flat = T.alloc_var(T.int32)
                         max_val = T.cast(float("-inf"), accum_dtype)
                         has_nan = False
-                        max_idx = T.cast(0, "int64")
-                        nan_idx = T.cast(0, "int64")
                         first_valid = True
+                        ih0 = oh * stride_h - pad_h
+                        iw0 = ow * stride_w - pad_w
+                        base_flat = ih0 * w_in + iw0
+                        if always_in_bounds:
+                            # Window element (0, 0) is in bounds here, so its flat
+                            # index is the correct seed: an all--inf window reports the
+                            # first position, matching PyTorch, and first_valid is
+                            # unneeded.
+                            max_idx = base_flat
+                            nan_idx = base_flat
+                        else:
+                            max_idx = 0
+                            nan_idx = 0
                         for kh in T.serial(kernel_h):
                             for kw in T.serial(kernel_w):
-                                ih = oh * stride_h - pad_h + kh * dilation_h
-                                iw = ow * stride_w - pad_w + kw * dilation_w
-                                if ih >= 0 and ih < h_in and iw >= 0 and iw < w_in:
+                                ih = ih0 + kh * dilation_h
+                                iw = iw0 + kw * dilation_w
+                                if always_in_bounds:
                                     val = T.cast(x[batch, c_idx, ih, iw], accum_dtype)
-                                    flat_idx = T.cast(ih * w_in + iw, "int64")
+                                    flat_idx = (
+                                        base_flat + kh * (dilation_h * w_in) + (kw * dilation_w)
+                                    )
                                     is_nan = T.isnan(val)
-                                    if is_nan:
-                                        # PyTorch records the last NaN visited in
-                                        # a pooling window.
-                                        nan_idx = flat_idx
-                                        has_nan = True
-                                    elif first_valid:
-                                        max_val = val
-                                        max_idx = flat_idx
-                                        first_valid = False
-                                    elif val > max_val:
-                                        max_val = val
-                                        max_idx = flat_idx
+                                    # Branch-free update. Strict > keeps the first
+                                    # maximum; NaN never touches max_val/max_idx and
+                                    # records the last NaN visited, matching PyTorch.
+                                    take = (not is_nan) and (val > max_val)
+                                    max_val = T.if_then_else(take, val, max_val)
+                                    max_idx = T.if_then_else(take, flat_idx, max_idx)
+                                    nan_idx = T.if_then_else(is_nan, flat_idx, nan_idx)
+                                    has_nan = has_nan or is_nan
+                                elif ih >= 0 and ih < h_in and iw >= 0 and iw < w_in:
+                                    val = T.cast(x[batch, c_idx, ih, iw], accum_dtype)
+                                    flat_idx = (
+                                        base_flat + kh * (dilation_h * w_in) + (kw * dilation_w)
+                                    )
+                                    is_nan = T.isnan(val)
+                                    take = (not is_nan) and (first_valid or (val > max_val))
+                                    max_val = T.if_then_else(take, val, max_val)
+                                    max_idx = T.if_then_else(take, flat_idx, max_idx)
+                                    first_valid = first_valid and is_nan
+                                    nan_idx = T.if_then_else(is_nan, flat_idx, nan_idx)
+                                    has_nan = has_nan or is_nan
 
                         result = T.if_then_else(
                             has_nan,
@@ -307,10 +342,13 @@ def _max_pool2d_with_indices_kernel(
                             max_val,
                         )
                         out[batch, c_idx, oh, ow] = T.cast(result, dtype)
-                        indices[batch, c_idx, oh, ow] = T.if_then_else(
-                            has_nan,
-                            nan_idx,
-                            max_idx,
+                        indices[batch, c_idx, oh, ow] = T.cast(
+                            T.if_then_else(
+                                has_nan,
+                                nan_idx,
+                                max_idx,
+                            ),
+                            "int64",
                         )
 
         return _max_pool2d_with_indices_main

--- a/src/tileops/kernels/pool/max_pool3d.py
+++ b/src/tileops/kernels/pool/max_pool3d.py
@@ -304,7 +304,18 @@ def _max_pool3d_with_indices_kernel(
     out_d = pool_output_dim(d_in, kernel_d, stride_d, pad_d, ceil_mode, dilation_d)
     out_h = pool_output_dim(h_in, kernel_h, stride_h, pad_h, ceil_mode, dilation_h)
     out_w = pool_output_dim(w_in, kernel_w, stride_w, pad_w, ceil_mode, dilation_w)
-    total_output = n * c_in * out_d * out_h * out_w
+    spatial_output = out_d * out_h * out_w
+    total_output = n * c_in * spatial_output
+    # Static specialization: with zero padding and no ceil overshoot every window
+    # lies fully inside the input, so the per-element bounds check can be dropped.
+    always_in_bounds = (
+        pad_d == 0
+        and pad_h == 0
+        and pad_w == 0
+        and (out_d - 1) * stride_d + (kernel_d - 1) * dilation_d < d_in
+        and (out_h - 1) * stride_h + (kernel_h - 1) * dilation_h < h_in
+        and (out_w - 1) * stride_w + (kernel_w - 1) * dilation_w < w_in
+    )
 
     @tilelang.jit(out_idx=[1, 2], compile_flags=["-O3", "-DENABLE_BF16"])
     def _max_pool3d_with_indices_func(block_m: int, threads: int):
@@ -329,21 +340,55 @@ def _max_pool3d_with_indices_kernel(
 
                         max_val = T.alloc_var(T.float32)
                         has_nan = T.alloc_var(T.bool)
-                        max_idx = T.alloc_var(T.int64)
-                        nan_idx = T.alloc_var(T.int64)
+                        max_idx = T.alloc_var(T.int32)
+                        nan_idx = T.alloc_var(T.int32)
                         first_valid = T.alloc_var(T.bool)
+                        # Loop-invariant window corner and flat base, materialized so the
+                        # decode is not re-inlined into every window element.
+                        id0 = T.alloc_var(T.int32)
+                        ih0 = T.alloc_var(T.int32)
+                        iw0 = T.alloc_var(T.int32)
+                        base_flat = T.alloc_var(T.int32)
                         max_val = T.cast(float("-inf"), accum_dtype)
                         has_nan = False
-                        max_idx = T.cast(0, "int64")
-                        nan_idx = T.cast(0, "int64")
                         first_valid = True
+                        id0 = od * stride_d - pad_d
+                        ih0 = oh * stride_h - pad_h
+                        iw0 = ow * stride_w - pad_w
+                        base_flat = (id0 * h_in + ih0) * w_in + iw0
+                        if always_in_bounds:
+                            # Window element (0, 0, 0) is in bounds here, so its flat
+                            # index is the correct seed: an all--inf window reports the
+                            # first position, matching PyTorch, and first_valid is
+                            # unneeded.
+                            max_idx = base_flat
+                            nan_idx = base_flat
+                        else:
+                            max_idx = 0
+                            nan_idx = 0
                         for kd in T.serial(kernel_d):
                             for kh in T.serial(kernel_h):
                                 for kw in T.serial(kernel_w):
-                                    id_ = od * stride_d - pad_d + kd * dilation_d
-                                    ih = oh * stride_h - pad_h + kh * dilation_h
-                                    iw = ow * stride_w - pad_w + kw * dilation_w
-                                    if (
+                                    id_ = id0 + kd * dilation_d
+                                    ih = ih0 + kh * dilation_h
+                                    iw = iw0 + kw * dilation_w
+                                    if always_in_bounds:
+                                        val = T.cast(x[batch, c_idx, id_, ih, iw], accum_dtype)
+                                        flat_idx = base_flat + (
+                                            kd * (dilation_d * h_in * w_in)
+                                            + kh * (dilation_h * w_in)
+                                            + kw * dilation_w
+                                        )
+                                        is_nan = T.isnan(val)
+                                        # Branch-free update. Strict > keeps the first
+                                        # maximum; NaN never touches max_val/max_idx and
+                                        # records the last NaN visited, matching PyTorch.
+                                        take = (not is_nan) and (val > max_val)
+                                        max_val = T.if_then_else(take, val, max_val)
+                                        max_idx = T.if_then_else(take, flat_idx, max_idx)
+                                        nan_idx = T.if_then_else(is_nan, flat_idx, nan_idx)
+                                        has_nan = has_nan or is_nan
+                                    elif (
                                         id_ >= 0
                                         and id_ < d_in
                                         and ih >= 0
@@ -352,20 +397,18 @@ def _max_pool3d_with_indices_kernel(
                                         and iw < w_in
                                     ):
                                         val = T.cast(x[batch, c_idx, id_, ih, iw], accum_dtype)
-                                        flat_idx = T.cast((id_ * h_in + ih) * w_in + iw, "int64")
+                                        flat_idx = base_flat + (
+                                            kd * (dilation_d * h_in * w_in)
+                                            + kh * (dilation_h * w_in)
+                                            + kw * dilation_w
+                                        )
                                         is_nan = T.isnan(val)
-                                        if is_nan:
-                                            # PyTorch records the last NaN visited in
-                                            # a pooling window.
-                                            nan_idx = flat_idx
-                                            has_nan = True
-                                        elif first_valid:
-                                            max_val = val
-                                            max_idx = flat_idx
-                                            first_valid = False
-                                        elif val > max_val:
-                                            max_val = val
-                                            max_idx = flat_idx
+                                        take = (not is_nan) and (first_valid or (val > max_val))
+                                        max_val = T.if_then_else(take, val, max_val)
+                                        max_idx = T.if_then_else(take, flat_idx, max_idx)
+                                        first_valid = first_valid and is_nan
+                                        nan_idx = T.if_then_else(is_nan, flat_idx, nan_idx)
+                                        has_nan = has_nan or is_nan
 
                         result = T.if_then_else(
                             has_nan,
@@ -373,10 +416,13 @@ def _max_pool3d_with_indices_kernel(
                             max_val,
                         )
                         out[batch, c_idx, od, oh, ow] = T.cast(result, dtype)
-                        indices[batch, c_idx, od, oh, ow] = T.if_then_else(
-                            has_nan,
-                            nan_idx,
-                            max_idx,
+                        indices[batch, c_idx, od, oh, ow] = T.cast(
+                            T.if_then_else(
+                                has_nan,
+                                nan_idx,
+                                max_idx,
+                            ),
+                            "int64",
                         )
 
         return _max_pool3d_with_indices_main


### PR DESCRIPTION
Closes #2059

## Summary

The with-indices max-pool kernels recomputed the flat-index decode with software-emulated int64
div/mod per window element on each of three argmax branch paths, and TileLang auto-predicated
every load. On the nightly H200 benchmark, `MaxPool3dIndicesFwd` W1/W2 lagged torch-compile at
0.43× / 0.55×; the 1D/2D variants lagged on every workload (0.39×–0.82×).

Four changes, applied to `_max_pool{1,2,3}d_with_indices_kernel` — no new kernels, no Op-layer
or public-API changes:

1. **Addressing rewrite**: materialize the loop-invariant window corner and flat base with
   `T.alloc_var`; the inner loop degrades to int32 multiply-adds with compile-time constants;
   the int64 cast happens once at the final store.
2. **Branch-free argmax**: `T.if_then_else` predicated selects — strict `>` keeps the first
   maximum, NaN records the last one visited; semantically equivalent to PyTorch.
3. **Static bounds-check elimination**: compile-time `always_in_bounds` (zero padding, no ceil
   overshoot) drops the per-element bounds check; other shapes keep the checked path unchanged.
4. **Sentinel seeding on the in-bounds path**: `max_idx`/`nan_idx` seeded with the window
   corner's flat index, dropping `first_valid`; an all-`-inf` window still reports the first
   position.

A **3D grid** `(spatial, C, N)` was evaluated and rejected: ≤3% on benchmark shapes, but a
pathological 3× regression on tiny-spatial shapes (`textcnn-global`: `out_l=1` leaves 255/256
threads idle per block).

Other negative results kept as evidence: explicit TIR `if` instead of TileLang's
auto-predication (+32% slower), flat-1D self-computed addressing (+40%), window-position
deferred resolution (+6%), wider autotune space (no better config).

## Measurement (H200, CUPTI device-busy medians, `git archive HEAD` snapshot as baseline)

| workload | baseline | this PR | speedup | ratio vs torch-compile |
| --- | --- | --- | --- | --- |
| 3D c3d-pool1-f16 | 0.3041 ms | 0.1397 ms | 2.18× | 0.42× → **0.92×** |
| 3D c3d-pool2-f16 | 0.0625 ms | 0.0315 ms | 1.98× | 0.52× → **1.04×** |
| 3D medicalnet-stem-bf16 | 0.3280 ms | 0.2462 ms | 1.33× | 6.2× → 8.3× |
| 2D alexnet-ceil (f16/bf16/f32) | 0.0237 ms | 0.0161–0.0163 ms | 1.45–1.47× | 0.73–0.81× → **1.08–1.20×** |
| 2D resnet-stem (f16/bf16/f32) | 0.107–0.109 ms | 0.083–0.104 ms | 1.05–1.29× | 0.63–0.67× → 0.66–0.86× |
| 2D vgg-block (f16/bf16/f32) | 0.0194 ms | 0.0120–0.0140 ms | 1.39–1.62× | 0.54–0.67× → 0.87–0.93× |
| 1D ecg-cnn-dilated-bf16 | 0.0208 ms | 0.0155 ms | 1.34× | 0.64× → 0.86× |
| 1D sincnet-speaker-local-f16 | 0.0217 ms | 0.0185 ms | 1.17× | 0.73× → 0.86× |
| 1D textcnn-global-f16 | 0.0192 ms | 0.0150 ms | 1.28× | 0.40× → 0.51× |

Adaptive-max-pool workloads (untouched kernels in the same bench file): 1.00×, no collateral.

## Test

- `tests/ops/test_pool.py`: **261 passed** — all ranks, value-only and indices variants, NaN /
  all-`-inf` / tied-maxima / padding special values, all dtypes.
- Full benchmark selectors `max_pool{1,2,3}d_indices_bench` (15 workloads): all pass, no
  regression.
