### PR TITLE
[Perf][foundry][Pool] Take the branches and the 64-bit index out of the max-pool window

### DIFF
--- a/src/tileops/kernels/constants.py
+++ b/src/tileops/kernels/constants.py
@@ -6,6 +6,9 @@ VECTOR_ACCESS_BYTES: int = 16
 # Address range the shared-memory banks cover before repeating: 32 banks of 4 bytes.
 SHARED_BANK_SPAN_BYTES: int = 128
 
+# Shared memory one block may take without opting in to the dynamic allocation.
+STATIC_SHARED_BYTES: int = 48 * 1024
+
 # log2(e), to fold exp(x) into the single-instruction exp2(x * LOG2E).
 LOG2E: float = 1.4426950408889634
 

--- a/src/tileops/kernels/pool/adaptive_max_pool2d.py
+++ b/src/tileops/kernels/pool/adaptive_max_pool2d.py
@@ -1,13 +1,35 @@
 import functools
-from typing import Tuple
+from typing import Optional, Tuple
 
 import tilelang
 import tilelang.language as T
 import torch
 
-from .common import AdaptivePool2dKernelBase, adaptive_bin, max_adaptive_bin_extent
+from .common import (
+    AdaptivePool2dKernelBase,
+    adaptive_bin,
+    fits_static_shared,
+    max_adaptive_bin_extent,
+)
 
 __all__ = ["AdaptiveMaxPool2dKernel", "AdaptiveMaxPool2dWithIndicesKernel"]
+
+
+def _stage_planes(
+    block_m: int, out_h: int, out_w: int, c_in: int, h_in: int, w_in: int, dtype: str
+) -> Optional[int]:
+    """(batch, channel) planes a block stages in shared, or None to read global.
+
+    Neighbouring outputs read bins that start ``w_in // out_w`` apart. A block
+    holding whole planes reads each plane once instead.
+    """
+    planes = max(1, block_m // (out_h * out_w))
+    # Dividing c_in keeps every block inside one image, so the copy is one slice.
+    if planes > c_in or c_in % planes:
+        return None
+    if not fits_static_shared(planes * h_in * w_in, dtype):
+        return None
+    return planes
 
 
 @functools.lru_cache(maxsize=32)
@@ -115,10 +137,56 @@ def _adaptive_max_pool2d_with_indices_kernel(
 
     @tilelang.jit(out_idx=[1, 2], compile_flags=["-O3", "-DENABLE_BF16"])
     def _adaptive_max_pool2d_with_indices_func(block_m: int, threads: int):
+        stage_planes = _stage_planes(block_m, out_h, out_w, c_in, h_in, w_in, dtype)
         # The flat index spans one h_in * w_in plane. Carrying it as int32
         # keeps the div/mod the compiler sinks into the update path off the
         # 64-bit path; the stored index stays int64 to match PyTorch.
         idx_dtype = "int32" if h_in * w_in < 2**31 else "int64"
+
+        @T.macro
+        def _reduce_bin(src, src_c, src_p, oh, ow, out, indices, out_c, out_p):
+            """Store the max and its index over one adaptive bin of ``src[src_c, src_p]``."""
+            ih_start, ih_end = adaptive_bin(oh, h_in, out_h)
+            iw_start, iw_end = adaptive_bin(ow, w_in, out_w)
+
+            max_val = T.alloc_var(T.float32)
+            has_nan = T.alloc_var(T.bool)
+            max_idx = T.alloc_var(idx_dtype)
+            nan_idx = T.alloc_var(idx_dtype)
+            first_valid = T.alloc_var(T.bool)
+            max_val = T.cast(float("-inf"), accum_dtype)
+            has_nan = False
+            max_idx = T.cast(0, idx_dtype)
+            nan_idx = T.cast(0, idx_dtype)
+            first_valid = True
+            # Static-bound loops (TileLang rejects dynamic T.serial
+            # bounds); guard skips lanes outside this output's bin.
+            for kh in T.serial(max_kh):
+                for kw in T.serial(max_kw):
+                    if ih_start + kh < ih_end and iw_start + kw < iw_end:
+                        ih = ih_start + kh
+                        iw = iw_start + kw
+                        val = T.cast(src[src_c, src_p, ih, iw], accum_dtype)
+                        flat_idx = T.cast(ih * w_in + iw, idx_dtype)
+                        is_nan = T.isnan(val)
+                        has_nan = has_nan | is_nan
+                        # PyTorch records the last NaN visited in a window.
+                        nan_idx = T.if_then_else(is_nan, flat_idx, nan_idx)
+                        # first_valid: an all--inf window still takes its first element.
+                        take = (not is_nan) and (first_valid or val > max_val)
+                        max_val = T.if_then_else(take, val, max_val)
+                        max_idx = T.if_then_else(take, flat_idx, max_idx)
+                        first_valid = first_valid and is_nan
+
+            result = T.if_then_else(
+                has_nan,
+                T.cast(float("nan"), accum_dtype),
+                max_val,
+            )
+            out[out_c, out_p, oh, ow] = T.cast(result, dtype)
+            indices[out_c, out_p, oh, ow] = T.cast(
+                T.if_then_else(has_nan, nan_idx, max_idx), "int64"
+            )
 
         @T.prim_func
         def _adaptive_max_pool2d_with_indices_main(
@@ -136,52 +204,32 @@ def _adaptive_max_pool2d_with_indices_kernel(
                         channel_batch_idx = spatial_idx // out_h
                         c_idx = channel_batch_idx % c_in
                         batch = channel_batch_idx // c_in
+                        _reduce_bin(x, batch, c_idx, oh, ow, out, indices, batch, c_idx)
 
-                        ih_start, ih_end = adaptive_bin(oh, h_in, out_h)
-                        iw_start, iw_end = adaptive_bin(ow, w_in, out_w)
+        if stage_planes is not None:
+            # Leading axis of 1 so the macro indexes the tile and x alike.
+            @T.prim_func
+            def _adaptive_max_pool2d_with_indices_staged_main(
+                x: T.Tensor((n, c_in, h_in, w_in), dtype),  # type: ignore
+                out: T.Tensor((n, c_in, out_h, out_w), dtype),  # type: ignore
+                indices: T.Tensor((n, c_in, out_h, out_w), "int64"),  # type: ignore
+            ):
+                with T.Kernel(T.ceildiv(n * c_in, stage_planes), threads=threads) as bx:
+                    tile = T.alloc_shared((1, stage_planes, h_in, w_in), dtype)
+                    batch = bx * stage_planes // c_in
+                    c_base = bx * stage_planes % c_in
+                    T.copy(
+                        x[batch, c_base : c_base + stage_planes, 0:h_in, 0:w_in],
+                        tile[0, :, 0:h_in, 0:w_in],
+                    )
+                    for i in T.Parallel(stage_planes * out_h * out_w):
+                        ow = i % out_w
+                        spatial_idx = i // out_w
+                        oh = spatial_idx % out_h
+                        plane = spatial_idx // out_h
+                        _reduce_bin(tile, 0, plane, oh, ow, out, indices, batch, c_base + plane)
 
-                        max_val = T.alloc_var(T.float32)
-                        has_nan = T.alloc_var(T.bool)
-                        max_idx = T.alloc_var(idx_dtype)
-                        nan_idx = T.alloc_var(idx_dtype)
-                        first_valid = T.alloc_var(T.bool)
-                        max_val = T.cast(float("-inf"), accum_dtype)
-                        has_nan = False
-                        max_idx = T.cast(0, idx_dtype)
-                        nan_idx = T.cast(0, idx_dtype)
-                        first_valid = True
-                        # Static-bound loops (TileLang rejects dynamic T.serial
-                        # bounds); guard skips lanes outside this output's bin.
-                        for kh in T.serial(max_kh):
-                            for kw in T.serial(max_kw):
-                                if ih_start + kh < ih_end and iw_start + kw < iw_end:
-                                    ih = ih_start + kh
-                                    iw = iw_start + kw
-                                    val = T.cast(x[batch, c_idx, ih, iw], accum_dtype)
-                                    flat_idx = T.cast(ih * w_in + iw, idx_dtype)
-                                    is_nan = T.isnan(val)
-                                    if is_nan:
-                                        # PyTorch records the last NaN visited in
-                                        # a pooling window.
-                                        nan_idx = flat_idx
-                                        has_nan = True
-                                    elif first_valid:
-                                        max_val = val
-                                        max_idx = flat_idx
-                                        first_valid = False
-                                    elif val > max_val:
-                                        max_val = val
-                                        max_idx = flat_idx
-
-                        result = T.if_then_else(
-                            has_nan,
-                            T.cast(float("nan"), accum_dtype),
-                            max_val,
-                        )
-                        out[batch, c_idx, oh, ow] = T.cast(result, dtype)
-                        indices[batch, c_idx, oh, ow] = T.cast(
-                            T.if_then_else(has_nan, nan_idx, max_idx), "int64"
-                        )
+            return _adaptive_max_pool2d_with_indices_staged_main
 
         return _adaptive_max_pool2d_with_indices_main
 

--- a/src/tileops/kernels/pool/common.py
+++ b/src/tileops/kernels/pool/common.py
@@ -3,7 +3,22 @@ from typing import Any, Callable, ClassVar, Optional
 
 import torch
 
+from tileops.kernels.constants import STATIC_SHARED_BYTES
 from tileops.kernels.kernel_base import Kernel
+
+
+def fits_static_shared(elements: int, dtype: str) -> bool:
+    """Whether a tile of *elements* fits the shared memory a block gets by default.
+
+    Args:
+        elements: Elements the tile holds.
+        dtype: TileLang name of the element type.
+
+    Returns:
+        True when the tile fits :data:`STATIC_SHARED_BYTES`.
+    """
+    itemsize = 4 if dtype in ("float", "float32") else 2
+    return elements * itemsize <= STATIC_SHARED_BYTES
 
 
 def pool_output_dim(

--- a/src/tileops/kernels/pool/max_pool1d.py
+++ b/src/tileops/kernels/pool/max_pool1d.py
@@ -7,9 +7,30 @@ import tilelang.language as T
 import torch
 
 from tileops.kernels.kernel_base import Kernel
-from tileops.kernels.pool.common import pool_output_dim
+from tileops.kernels.pool.common import fits_static_shared, pool_output_dim
 
 __all__ = ["MaxPool1dKernel", "MaxPool1dWithIndicesKernel"]
+
+
+# One warp's width. At or below it a warp spans more than one (batch, channel)
+# row, so neighbouring threads read global memory `l_in` elements apart.
+_STAGE_MAX_OUT_L = 32
+# Pad the shared row off a whole number of banks, or the staged rows collide.
+# The width is measured, on an H200; re-measure it on other hardware.
+_STAGE_ROW_PAD = 8
+
+
+def _stage_rows(block_m: int, out_l: int, c_in: int, l_in: int, dtype: str) -> Optional[int]:
+    """Rows of one image a block stages in shared memory, or None to read global."""
+    if out_l > _STAGE_MAX_OUT_L or block_m % out_l:
+        return None
+    rows = block_m // out_l
+    # Dividing c_in leaves no ragged last block, so the staged body needs no test.
+    if rows > c_in or c_in % rows:
+        return None
+    if not fits_static_shared(rows * (l_in + _STAGE_ROW_PAD), dtype):
+        return None
+    return rows
 
 
 @functools.lru_cache(maxsize=32)
@@ -30,6 +51,30 @@ def _max_pool1d_kernel(
 
     @tilelang.jit(out_idx=[1], compile_flags=["-O3", "-DENABLE_BF16"])
     def _max_pool1d_func(block_m: int, threads: int):
+        stage_rows = _stage_rows(block_m, out_l, c_in, l_in, dtype)
+
+        @T.macro
+        def _reduce_window(src, src_c, src_row, ow, out, out_c, out_row):
+            """Store the max over one window of ``src[src_c, src_row]``."""
+            max_val = T.alloc_var(T.float32)
+            has_nan = T.alloc_var(T.bool)
+            max_val = T.cast(float("-inf"), accum_dtype)
+            has_nan = False
+            for kw in T.serial(kernel_w):
+                iw = ow * stride_w - pad_w + kw * dilation_w
+                if iw >= 0 and iw < l_in:
+                    val = T.cast(src[src_c, src_row, iw], accum_dtype)
+                    if T.isnan(val):
+                        has_nan = True
+                    max_val = T.max(max_val, val)
+
+            result = T.if_then_else(
+                has_nan,
+                T.cast(float("nan"), accum_dtype),
+                max_val,
+            )
+            out[out_c, out_row, ow] = T.cast(result, dtype)
+
         @T.prim_func
         def _max_pool1d_main(
             x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
@@ -43,25 +88,26 @@ def _max_pool1d_kernel(
                         channel_batch_idx = out_idx // out_l
                         c_idx = channel_batch_idx % c_in
                         batch = channel_batch_idx // c_in
+                        _reduce_window(x, batch, c_idx, ow, out, batch, c_idx)
 
-                        max_val = T.alloc_var(T.float32)
-                        has_nan = T.alloc_var(T.bool)
-                        max_val = T.cast(float("-inf"), accum_dtype)
-                        has_nan = False
-                        for kw in T.serial(kernel_w):
-                            iw = ow * stride_w - pad_w + kw * dilation_w
-                            if iw >= 0 and iw < l_in:
-                                val = T.cast(x[batch, c_idx, iw], accum_dtype)
-                                if T.isnan(val):
-                                    has_nan = True
-                                max_val = T.max(max_val, val)
+        if stage_rows is not None:
+            # Leading axis of 1 so the macro indexes the tile and x alike.
+            @T.prim_func
+            def _max_pool1d_staged_main(
+                x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
+                out: T.Tensor((n, c_in, out_l), dtype),  # type: ignore
+            ):
+                with T.Kernel(T.ceildiv(total_output, block_m), threads=threads) as bx:
+                    tile = T.alloc_shared((1, stage_rows, l_in + _STAGE_ROW_PAD), dtype)
+                    batch = bx * stage_rows // c_in
+                    c_base = bx * stage_rows % c_in
+                    T.copy(x[batch, c_base : c_base + stage_rows, 0:l_in], tile[0, :, 0:l_in])
+                    for i in T.Parallel(block_m):
+                        ow = i % out_l
+                        row = i // out_l
+                        _reduce_window(tile, 0, row, ow, out, batch, c_base + row)
 
-                        result = T.if_then_else(
-                            has_nan,
-                            T.cast(float("nan"), accum_dtype),
-                            max_val,
-                        )
-                        out[batch, c_idx, ow] = T.cast(result, dtype)
+            return _max_pool1d_staged_main
 
         return _max_pool1d_main
 
@@ -210,6 +256,63 @@ def _max_pool1d_with_indices_kernel(
 
     @tilelang.jit(out_idx=[1, 2], compile_flags=["-O3", "-DENABLE_BF16"])
     def _max_pool1d_with_indices_func(block_m: int, threads: int):
+        stage_rows = _stage_rows(block_m, out_l, c_in, l_in, dtype)
+
+        @T.macro
+        def _reduce_window(src, src_c, src_row, ow, out, indices, out_c, out_row):
+            """Store the max and its index over one window of ``src[src_c, src_row]``."""
+            max_val = T.alloc_var(T.float32)
+            has_nan = T.alloc_var(T.bool)
+            max_idx = T.alloc_var(T.int32)
+            nan_idx = T.alloc_var(T.int32)
+            first_valid = T.alloc_var(T.bool)
+            # Loop-invariant window corner, materialized so it is not
+            # re-inlined into every window element.
+            iw0 = T.alloc_var(T.int32)
+            max_val = T.cast(float("-inf"), accum_dtype)
+            has_nan = False
+            first_valid = True
+            iw0 = ow * stride_w - pad_w
+            if always_in_bounds:
+                # Window element 0 is in bounds here, so its flat index is
+                # the correct seed: an all--inf window reports the first
+                # position, matching PyTorch, and first_valid is unneeded.
+                max_idx = iw0
+                nan_idx = iw0
+            else:
+                max_idx = 0
+                nan_idx = 0
+            for kw in T.serial(kernel_w):
+                iw = iw0 + kw * dilation_w
+                if always_in_bounds:
+                    val = T.cast(src[src_c, src_row, iw], accum_dtype)
+                    is_nan = T.isnan(val)
+                    # Branch-free update. Strict > keeps the first
+                    # maximum; NaN never touches max_val/max_idx and
+                    # records the last NaN visited, matching PyTorch.
+                    take = (not is_nan) and (val > max_val)
+                    max_val = T.if_then_else(take, val, max_val)
+                    max_idx = T.if_then_else(take, iw, max_idx)
+                    nan_idx = T.if_then_else(is_nan, iw, nan_idx)
+                    has_nan = has_nan or is_nan
+                elif iw >= 0 and iw < l_in:
+                    val = T.cast(src[src_c, src_row, iw], accum_dtype)
+                    is_nan = T.isnan(val)
+                    take = (not is_nan) and (first_valid or (val > max_val))
+                    max_val = T.if_then_else(take, val, max_val)
+                    max_idx = T.if_then_else(take, iw, max_idx)
+                    first_valid = first_valid and is_nan
+                    nan_idx = T.if_then_else(is_nan, iw, nan_idx)
+                    has_nan = has_nan or is_nan
+
+            result = T.if_then_else(
+                has_nan,
+                T.cast(float("nan"), accum_dtype),
+                max_val,
+            )
+            out[out_c, out_row, ow] = T.cast(result, dtype)
+            indices[out_c, out_row, ow] = T.cast(T.if_then_else(has_nan, nan_idx, max_idx), "int64")
+
         @T.prim_func
         def _max_pool1d_with_indices_main(
             x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
@@ -224,64 +327,27 @@ def _max_pool1d_with_indices_kernel(
                         channel_batch_idx = out_idx // out_l
                         c_idx = channel_batch_idx % c_in
                         batch = channel_batch_idx // c_in
-                        max_val = T.alloc_var(T.float32)
-                        has_nan = T.alloc_var(T.bool)
-                        max_idx = T.alloc_var(T.int32)
-                        nan_idx = T.alloc_var(T.int32)
-                        first_valid = T.alloc_var(T.bool)
-                        # Loop-invariant window corner, materialized so it is not
-                        # re-inlined into every window element.
-                        iw0 = T.alloc_var(T.int32)
-                        max_val = T.cast(float("-inf"), accum_dtype)
-                        has_nan = False
-                        first_valid = True
-                        iw0 = ow * stride_w - pad_w
-                        if always_in_bounds:
-                            # Window element 0 is in bounds here, so its flat index is
-                            # the correct seed: an all--inf window reports the first
-                            # position, matching PyTorch, and first_valid is unneeded.
-                            max_idx = iw0
-                            nan_idx = iw0
-                        else:
-                            max_idx = 0
-                            nan_idx = 0
-                        for kw in T.serial(kernel_w):
-                            iw = iw0 + kw * dilation_w
-                            if always_in_bounds:
-                                val = T.cast(x[batch, c_idx, iw], accum_dtype)
-                                is_nan = T.isnan(val)
-                                # Branch-free update. Strict > keeps the first
-                                # maximum; NaN never touches max_val/max_idx and
-                                # records the last NaN visited, matching PyTorch.
-                                take = (not is_nan) and (val > max_val)
-                                max_val = T.if_then_else(take, val, max_val)
-                                max_idx = T.if_then_else(take, iw, max_idx)
-                                nan_idx = T.if_then_else(is_nan, iw, nan_idx)
-                                has_nan = has_nan or is_nan
-                            elif iw >= 0 and iw < l_in:
-                                val = T.cast(x[batch, c_idx, iw], accum_dtype)
-                                is_nan = T.isnan(val)
-                                take = (not is_nan) and (first_valid or (val > max_val))
-                                max_val = T.if_then_else(take, val, max_val)
-                                max_idx = T.if_then_else(take, iw, max_idx)
-                                first_valid = first_valid and is_nan
-                                nan_idx = T.if_then_else(is_nan, iw, nan_idx)
-                                has_nan = has_nan or is_nan
+                        _reduce_window(x, batch, c_idx, ow, out, indices, batch, c_idx)
 
-                        result = T.if_then_else(
-                            has_nan,
-                            T.cast(float("nan"), accum_dtype),
-                            max_val,
-                        )
-                        out[batch, c_idx, ow] = T.cast(result, dtype)
-                        indices[batch, c_idx, ow] = T.cast(
-                            T.if_then_else(
-                                has_nan,
-                                nan_idx,
-                                max_idx,
-                            ),
-                            "int64",
-                        )
+        if stage_rows is not None:
+            # Leading axis of 1 so the macro indexes the tile and x alike.
+            @T.prim_func
+            def _max_pool1d_with_indices_staged_main(
+                x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
+                out: T.Tensor((n, c_in, out_l), dtype),  # type: ignore
+                indices: T.Tensor((n, c_in, out_l), "int64"),  # type: ignore
+            ):
+                with T.Kernel(T.ceildiv(total_output, block_m), threads=threads) as bx:
+                    tile = T.alloc_shared((1, stage_rows, l_in + _STAGE_ROW_PAD), dtype)
+                    batch = bx * stage_rows // c_in
+                    c_base = bx * stage_rows % c_in
+                    T.copy(x[batch, c_base : c_base + stage_rows, 0:l_in], tile[0, :, 0:l_in])
+                    for i in T.Parallel(block_m):
+                        ow = i % out_l
+                        row = i // out_l
+                        _reduce_window(tile, 0, row, ow, out, indices, batch, c_base + row)
+
+            return _max_pool1d_with_indices_staged_main
 
         return _max_pool1d_with_indices_main
 

--- a/tests/ops/test_pool.py
+++ b/tests/ops/test_pool.py
@@ -1012,6 +1012,22 @@ _MAX_POOL1D_PARAMS = [
         marks=pytest.mark.full,
         id="full-ceil-k5-s3-p2-bf16",
     ),
+    # Short output: sends max_pool1d down the shared-memory staged read.
+    pytest.param(
+        2,
+        32,
+        64,
+        (8,),
+        (8,),
+        (0,),
+        (1,),
+        False,
+        torch.float16,
+        False,
+        True,
+        marks=pytest.mark.full,
+        id="full-staged-short-output-fp16",
+    ),
 ]
 
 


### PR DESCRIPTION
Rebased on #2063, which landed the branch-free window scan and the int32 running
index for `max_pool1d/2d/3d`. Those two ideas overlapped with this PR and #2063's
version is the better one — it also drops the per-element bounds check statically.
The 2d and 3d files are therefore no longer touched here. What is left is the part
#2063 does not cover: two shapes whose cost is not the window scan at all.

## Problems

- `max_pool1d` with `out_l == 1` gives each thread one whole input row. Neighbouring
  threads then address global memory `l_in` elements apart, so a warp's 32 loads
  touch 32 different lines and use one element of each.
- `adaptive_max_pool2d` has the same shape of problem one dimension up: neighbouring
  outputs read bins that start `w_in // out_w` apart, and the `nondiv-7x7` row gives
  the device only 6272 outputs to spread over 132 SMs. It ran at 0.93x of
  `torch.adaptive_max_pool2d`, the one row in the family below its baseline.
- `adaptive_max_pool2d`'s window scan is still the three-way branch #2063 removed
  from the other three kernels.

## Changes

- A `max_pool1d` block whose outputs form whole rows of one image copies those rows
  into shared memory once and scans from there. `_stage_rows` states the condition
  and returns `None` for every shape that does not meet it.
- An `adaptive_max_pool2d` block holds whole `(batch, channel)` planes the same way.
  `_stage_planes` derives the plane count from `block_m`, so autotuning already
  searches it and no config key is added.
- `adaptive_max_pool2d`'s scan becomes selects driven by one predicate, as #2063 did
  elsewhere. The last NaN in a window still wins and an all-`-inf` window still takes
  its first element.
- Each kernel reads its window through one `T.macro`, so the staged and direct
  launches differ only in what they pass it rather than carrying the scan twice.
- The shared-memory budget both predicates test against is `STATIC_SHARED_BYTES` in
  `kernels/constants.py`, beside `SHARED_BANK_SPAN_BYTES`, and the test itself is
  `fits_static_shared` in `pool/common.py`. Neither kernel file carries its own copy.

## Performance

H200 SXM, one idle device, `benchmarks/ops/bench_pool.py`, CUPTI device-busy time,
against `main` at #2063. Both sides alternated A B A B in one sitting, each round
from its own empty `TILELANG_CACHE_DIR`; each tag takes the minimum over its rounds.

| workload | op | dtype | before | after | speedup | vs fastest baseline |
| --- | --- | --- | ---: | ---: | ---: | --- |
| global-1x1 | AdaptiveMaxPool2dIndices | float16 | 11.8 us | 2.9 us | 4.07x | 0.55x -> **2.21x** (torch-compile) |
| textcnn-global | MaxPool1d | float16 | 10.8 us | 3.6 us | 3.00x | 0.36x -> **1.03x** (torch-compile) |
| textcnn-global | MaxPool1dIndices | float16 | 11.8 us | 4.3 us | 2.74x | 0.42x -> **1.12x** (torch-compile) |
| nondiv-7x7 | AdaptiveMaxPool2dIndices | bfloat16 | 13.5 us | 5.4 us | 2.50x | 0.73x -> **1.83x** (torch-ref) |
| spp-6x6 | AdaptiveMaxPool2dIndices | float16 | 12.9 us | 7.4 us | 1.74x | 0.94x -> **1.62x** (torch-ref) |

Both ratios come from the same pair of runs: each side is read against the fastest
baseline that run measured for the row, taking the minimum over its rounds.

The `torch.compile` baseline for `textcnn-global` is not stable across processes: a
byte-identical call measured 4.90, 5.31, 6.59 and 11.49 us in different sittings,
inductor emitting one kernel in some and another in others, and the two rounds
behind this table read it at 6.69 and 4.80 us. The table takes the minimum, which
is the harder number for this PR. Read those two rows as clearing the baseline
rather than as a precise 1.12x and 1.03x.

The other 42 rows move by -0.30 us summed and at most +0.30 us on any one of them.

## Result And Limitations

- Five rows change and every one is faster. All five were below the fastest baseline
  for their shape and all five are now above it.
- 262 `tests/ops/test_pool.py` cases pass. The file gains one node (261 -> 262): no
  existing 1d parameter has an output short enough to reach the staged read.
- Values and indices are bit-identical to PyTorch across float16, bfloat16 and
  float32 for random NaN, dilation with padding, a window holding nothing but
  `-inf`, and a non-dividing adaptive output.

`textcnn-global` is finished, and the DRAM roofline is the wrong yardstick for
saying so. Measured on this device:

| | time |
| --- | ---: |
| traffic / 4.8 TB/s | 0.87 us |
| empty kernel, 132 blocks | 0.77 us |
| pure streaming read of the same 4.19 MB, one max per thread | 3.34 us (1.25 TB/s) |
| this kernel, value-only | 3.42 us |

(all four in one harness; the benchmark reads this row at 3.6 us)

A 4.19 MB read does not reach the part's peak bandwidth — that rate needs a much
larger transfer to amortize. The kernel is within 2% of what any kernel reading this
array can do, and staging the tile costs 3.04 us of the 3.42 us by itself: the whole
window scan adds 0.38 us. Splitting one window across several threads and reducing
was built and measured, and gains 14% in isolation but nothing here, because the
copy already bounds the kernel. A column-major shared layout was also measured, at
11 us, and rejected.

Two 1d rows stay below their baseline, and both were chased. Their outputs are
1365 and 1023 long, so neighbouring threads already share a row and the staged read
declines them.

`sincnet-speaker-local` (0.96x with indices, 0.98x without) is finished. A probe
doing its exact traffic and nothing else -- read each input element once, write the
values and the int64 indices, no window arithmetic -- runs at 16.10 us with indices
and 11.62 us without. The kernel, in that same harness, runs at 16.45 and 10.88: it
is at the bound within a couple of percent, and `always_in_bounds` already fires on
it since its padding is zero.

`ecg-cnn-dilated` (0.84x, 0.88x) has real headroom -- 12.70 us against a 7.94 us
probe -- and four things were built and measured against it, none of which helped:

| | value-only | with indices |
| --- | ---: | ---: |
| main | 8.26 us | 13.57 us |
| a runtime per-output interior test, the dynamic form of `always_in_bounds` | 11.78 us | 15.30 us |

(measured in one harness against one another; the benchmark's own numbers for these
rows are 7.80 and 12.70 us). A `(row, tile)` grid removing the `% out_l` and
`// out_l` per output measured 14.72 us against 14.34 us for the flat grid, and
staging the tile's input segment in shared measured 19.87 us. The gap is not the
strided read and not the addressing: with `p=2` the window scan itself costs about
2.6 us over the traffic in both variants, and no arrangement tried moved it.
