### PR TITLE
[Perf][foundry][Pool] Fold the 1d average-pool window into one output thread

### DIFF
--- a/src/tileops/kernels/pool/avg_pool1d.py
+++ b/src/tileops/kernels/pool/avg_pool1d.py
@@ -26,75 +26,75 @@ def _avg_pool1d_kernel(
 ):
     accum_dtype = "float"
     out_l = pool_output_dim(l_in, kernel_l, stride_l, pad_l, ceil_mode)
-    total_output = n * c_in * out_l
+    rows = n * c_in
+    total = rows * out_l
+    # With no padding and no ceil overshoot every window lies inside its row, so
+    # the per-tap bounds test is a compile-time truth and drops out.
+    window_inside = pad_l == 0 and (out_l - 1) * stride_l + kernel_l <= l_in
+    # Without ceil mode the last window ends at l_in + pad_l at the furthest, so
+    # counting the padding gives the whole window for every output. Ceil mode can
+    # push a window past that, and not counting the padding shortens the windows
+    # that overhang, so both take the divisor from the window's own extent.
+    whole_window_divides = window_inside or (count_include_pad and not ceil_mode)
 
     @tilelang.jit(out_idx=[1], compile_flags=["-O3", "-DENABLE_BF16"])
     def _avg_pool1d_func(block_m: int, threads: int):
+        tile_full = total % block_m == 0
+
+        def safe(il):
+            """*il* as an index that is always in range, clamping only when it can
+            leave the row. The clamped value is read under a predicate that already
+            discarded it, so which position it names does not matter."""
+            return il if window_inside else T.max(0, T.min(il, l_in - 1))
+
         @T.prim_func
         def _avg_pool1d_main(
-            x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
-            out: T.Tensor((n, c_in, out_l), dtype),  # type: ignore
+            x: T.Tensor((rows, l_in), dtype),  # type: ignore
+            out: T.Tensor((rows, out_l), dtype),  # type: ignore
         ):
-            with T.Kernel(T.ceildiv(total_output, block_m), threads=threads) as bx:
-                T.use_swizzle(10)
-                tile_out_start = bx * block_m
-                tile_out_end = tile_out_start + block_m - 1
-                tile_ol_start = tile_out_start % out_l
-                tile_ol_end = tile_out_end % out_l
-                tile_same_row = tile_out_start // out_l == tile_out_end // out_l
-                tile_input_start = tile_ol_start * stride_l - pad_l
-                tile_input_end = tile_ol_end * stride_l + kernel_l - 1 - pad_l
-                tile_spatial_full = (
-                    tile_same_row & (tile_input_start >= 0) & (tile_input_end < l_in)
-                )
+            with T.Kernel(T.ceildiv(total, block_m), threads=threads) as tile:
                 for i in T.Parallel(block_m):
-                    out_idx = bx * block_m + i
-                    if out_idx < total_output:
-                        ol = out_idx % out_l
-                        nc_idx = out_idx // out_l
-                        c_idx = nc_idx % c_in
-                        batch = nc_idx // c_in
-
-                        sum_val = T.alloc_var(T.float32)
-                        sum_val = T.cast(0.0, accum_dtype)
-
-                        if tile_spatial_full:
-                            for kw in T.serial(kernel_l):
-                                il = ol * stride_l + kw - pad_l
-                                sum_val += T.cast(x[batch, c_idx, il], accum_dtype)
-                            out[batch, c_idx, ol] = T.cast(
-                                sum_val / T.cast(kernel_l, accum_dtype),
-                                dtype,
+                    idx = tile * block_m + i
+                    if tile_full or idx < total:
+                        ol = idx % out_l
+                        row = idx // out_l
+                        start = ol * stride_l - pad_l
+                        total_val = T.alloc_var(T.float32)
+                        total_val = T.cast(0.0, accum_dtype)
+                        for k in T.serial(kernel_l):
+                            il = start + k
+                            if window_inside:
+                                total_val += T.cast(x[row, il], accum_dtype)
+                            else:
+                                # A position outside the row contributes zero to
+                                # the sum, so the tap is a select rather than a
+                                # branch and every thread walks the same window.
+                                total_val += T.if_then_else(
+                                    (il >= 0) and (il < l_in),
+                                    T.cast(x[row, safe(il)], accum_dtype),
+                                    T.cast(0.0, accum_dtype),
+                                )
+                        if whole_window_divides:
+                            divisor = T.cast(kernel_l, accum_dtype)
+                        elif count_include_pad:
+                            divisor = T.cast(
+                                T.max(
+                                    T.min(start + kernel_l, l_in + pad_l) - T.max(start, -pad_l), 1
+                                ),
+                                accum_dtype,
                             )
                         else:
-                            for kw in T.serial(kernel_l):
-                                il = ol * stride_l + kw - pad_l
-                                if il >= 0 and il < l_in:
-                                    sum_val += T.cast(x[batch, c_idx, il], accum_dtype)
-
-                            window_start = ol * stride_l - pad_l
-                            window_end = window_start + kernel_l
-                            valid_start = T.max(window_start, 0)
-                            valid_end = T.min(window_end, l_in)
-                            valid_count = T.max(valid_end - valid_start, 0)
-                            padded_start = T.max(window_start, -pad_l)
-                            padded_end = T.min(window_end, l_in + pad_l)
-                            padded_count = T.max(padded_end - padded_start, 0)
-                            divisor = T.max(
-                                T.if_then_else(count_include_pad, padded_count, valid_count),
-                                1,
+                            divisor = T.cast(
+                                T.max(T.min(start + kernel_l, l_in) - T.max(start, 0), 1),
+                                accum_dtype,
                             )
-                            out[batch, c_idx, ol] = T.cast(
-                                sum_val / T.cast(divisor, accum_dtype),
-                                dtype,
-                            )
+                        out[row, ol] = T.cast(total_val / divisor, dtype)
 
         return _avg_pool1d_main
 
     return _avg_pool1d_func
 
 
-@functools.lru_cache(maxsize=64)
 def _avg_pool1d_spatial_kernel(
     n: int,
     c_in: int,
@@ -104,81 +104,13 @@ def _avg_pool1d_spatial_kernel(
     pad_l: int,
     dtype: str = "float16",
 ):
-    accum_dtype = "float"
-    out_l = pool_output_dim(l_in, kernel_l, stride_l, pad_l, False)
-    total_output = n * c_in * out_l
+    """Zero-padded, floor-mode 1d average pooling.
 
-    @tilelang.jit(out_idx=[1], compile_flags=["-O3", "-DENABLE_BF16"])
-    def _avg_pool1d_spatial_func(block_m: int, threads: int):
-        @T.prim_func
-        def _avg_pool1d_spatial_main(
-            x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
-            out: T.Tensor((n, c_in, out_l), dtype),  # type: ignore
-        ):
-            with T.Kernel(T.ceildiv(total_output, block_m), threads=threads) as bx:
-                T.use_swizzle(10)
-                tile_out_start = bx * block_m
-                tile_out_end = tile_out_start + block_m - 1
-                tile_ol_start = tile_out_start % out_l
-                tile_ol_end = tile_out_end % out_l
-                tile_same_row = tile_out_start // out_l == tile_out_end // out_l
-                tile_input_start = tile_ol_start * stride_l - pad_l
-                tile_input_end = tile_ol_end * stride_l + kernel_l - 1 - pad_l
-                tile_spatial_full = (
-                    tile_same_row & (tile_input_start >= 0) & (tile_input_end < l_in)
-                )
-                for i in T.Parallel(block_m):
-                    out_idx = bx * block_m + i
-                    if out_idx < total_output:
-                        ol = out_idx % out_l
-                        nc_idx = out_idx // out_l
-                        c_idx = nc_idx % c_in
-                        batch = nc_idx // c_in
-
-                        sum_val = T.alloc_var(T.float32)
-                        sum_val = T.cast(0.0, accum_dtype)
-
-                        if tile_spatial_full:
-                            for kw in T.serial(kernel_l):
-                                il = ol * stride_l + kw - pad_l
-                                sum_val += T.cast(x[batch, c_idx, il], accum_dtype)
-                        else:
-                            for kw in T.serial(kernel_l):
-                                il = ol * stride_l + kw - pad_l
-                                if il >= 0 and il < l_in:
-                                    sum_val += T.cast(x[batch, c_idx, il], accum_dtype)
-
-                        out[batch, c_idx, ol] = T.cast(
-                            sum_val / T.cast(kernel_l, accum_dtype),
-                            dtype,
-                        )
-
-        return _avg_pool1d_spatial_main
-
-    return _avg_pool1d_spatial_func
-
-
-def _launch_avg_pool1d_spatial(
-    n: int,
-    c_in: int,
-    l_in: int,
-    kernel_l: int,
-    stride_l: int,
-    pad_l: int,
-    dtype: str,
-    block_m: int,
-    threads: int,
-    x: torch.Tensor,
-) -> torch.Tensor:
-    return _avg_pool1d_spatial_kernel(
-        n,
-        c_in,
-        l_in,
-        kernel_l,
-        stride_l,
-        pad_l,
-        dtype,
-    )(block_m, threads)(x)
+    Every window then spans the full kernel once the padding is counted, which is
+    what ``_avg_pool1d_kernel`` emits for ``ceil_mode=False`` and
+    ``count_include_pad=True``.
+    """
+    return _avg_pool1d_kernel(n, c_in, l_in, kernel_l, stride_l, pad_l, False, True, dtype)
 
 
 def _launch_avg_pool1d(
@@ -195,7 +127,8 @@ def _launch_avg_pool1d(
     threads: int,
     x: torch.Tensor,
 ) -> torch.Tensor:
-    return _avg_pool1d_kernel(
+    out_l = pool_output_dim(l_in, kernel_l, stride_l, pad_l, ceil_mode)
+    kernel = _avg_pool1d_kernel(
         n,
         c_in,
         l_in,
@@ -205,7 +138,27 @@ def _launch_avg_pool1d(
         ceil_mode,
         count_include_pad,
         dtype,
-    )(block_m, threads)(x)
+    )(block_m, threads)
+    # The kernel addresses one row per (batch, channel) pair, so the two leading
+    # extents are folded away on the way in and restored on the way out.
+    return kernel(x.reshape(n * c_in, l_in)).view(n, c_in, out_l)
+
+
+def _launch_avg_pool1d_spatial(
+    n: int,
+    c_in: int,
+    l_in: int,
+    kernel_l: int,
+    stride_l: int,
+    pad_l: int,
+    dtype: str,
+    block_m: int,
+    threads: int,
+    x: torch.Tensor,
+) -> torch.Tensor:
+    return _launch_avg_pool1d(
+        n, c_in, l_in, kernel_l, stride_l, pad_l, False, True, dtype, block_m, threads, x
+    )
 
 
 class AvgPool1dSpatialKernel(Kernel):


### PR DESCRIPTION
## Summary

- Rewrite the `AvgPool1dFwdOp` forward kernel as one flat pass over output positions: a thread owns one output, accumulates its window in a register, and reads its taps under a compile-time bounds claim rather than a per-element branch.
- Decide the divisor when the kernel is built. Without ceil mode a floor-mode window's padded extent is the whole kernel for every output, so counting the padding makes the divisor a constant.
- Let `AvgPool1dSpatialKernel` delegate to the general kernel rather than carry a second copy of the scan: it serves exactly the region the general kernel emits for `ceil_mode=False, count_include_pad=True`.

## TileFoundry Description

```python
@module(
    entry="avg_pool1d",
    target=CudaTarget("nvidia.h200_sxm"),
    topologies=(Topology("cta", 132),),
)
class AvgPool1d:
    @func
    def avg_pool1d(x: Tensor[(N, C, L_IN), "f16"]) -> Tensor[(N, C, L_OUT), "f16"]:
        edge = tf.full_like(x[:, :, 0:PAD], value=0.0)
        padded = tf.concat([edge, x, edge], axis=2)
        taps = tf.stack(
            [padded[:, :, k : k + (L_OUT - 1) * STRIDE + 1 : STRIDE] for k in range(KERNEL)],
            axis=-1,
        )
        return tf.reduce(taps, axes=(-1,), keepdim=False, kind="mean")
```

`count_include_pad=False` makes the divisor the number of real input positions the window
covers, so the same window runs over a mask of ones and the two sums are divided:

```python
        total = tf.reduce(tf.cast(taps, dtype="f32"), axes=(-1,), keepdim=False, kind="sum")
        live_taps = tf.stack([live_padded[:, :, k : k + 2047 : 2] for k in range(4)], axis=-1)
        count = tf.reduce(tf.cast(live_taps, dtype="f32"), axes=(-1,), keepdim=False, kind="sum")
        return tf.cast(total / count, dtype="bf16")
```

`tilefoundry check` holds the delivered kernel to those programs, run by the evaluator, on
every primary manifest workload: `--fn allclose --atol 1e-3 --rtol 1e-3` reports
`max_violation 0` for `f16[4,128,2048]`, `f16[2,256,8000]` and `bf16[2,128,1024]`.

## Performance

Operator: `AvgPool1dFwdOp`

| Environment | Value |
| --- | --- |
| image | ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-afcebed1-foundry-dev |
| digest | sha256:fe87c536154ad2ce3bffa4ff97e28fbfde7fcf6598d9d87c3f3dcc4ee9e44b5c |
| gpu | NVIDIA H200 |
| driver | 595.71.05 |
| cuda | 13.2 |
| torch | 2.13.0+cu132 |
| tilelang | 0.1.11+cu132.gitafcebed1 |
| tilefoundry | 0.1.dev131+g2306bf050 |
| timer | native CUPTI |

Method: candidate, incumbent and both torch baselines ran in one process on common inputs.
Each TileLang implementation was searched over its own config space and is reported at its
best; each was checked against `torch.nn.functional.avg_pool1d` before timing, then timed by
`bench_kernel` through CUPTI, which clears L2 before every iteration. Compilation and tuning
were excluded; CUPTI failure was fail-closed.

Ratio in comparator columns: implementation / candidate. &#x1F7E2; > 1 means the candidate is
faster; &#x1F534; <= 1 means it is not.

| Workload | N | C | L | Params | Dtype | Candidate (ms) | TileOPs incumbent (ms)<br>/ candidate | torch-compile (ms)<br>/ candidate | torch-ref (ms)<br>/ candidate |
| --- | ---: | ---: | ---: | --- | --- | ---: | ---: | ---: | ---: |
| audio-downsample | 4 | 128 | 4096 | k3 s2 p1 | float16 | 0.004576 | **0.005504<br>&#x1F7E2;&nbsp;1.2028x** | **0.005248<br>&#x1F7E2;&nbsp;1.1469x** | **0.012000<br>&#x1F7E2;&nbsp;2.6224x** |
| long-temporal | 2 | 256 | 32000 | k5 s4 p2 | float16 | 0.017281 | **0.019072<br>&#x1F7E2;&nbsp;1.1036x** | **0.020097<br>&#x1F7E2;&nbsp;1.1629x** | **0.045792<br>&#x1F7E2;&nbsp;2.6499x** |
| ceil | 2 | 128 | 2048 | k4 s2 p1 ceil cip=False | bfloat16 | 0.002176 | **0.003008<br>&#x1F7E2;&nbsp;1.3824x** | **0.002784<br>&#x1F7E2;&nbsp;1.2794x** | **0.004288<br>&#x1F7E2;&nbsp;1.9706x** |
| geometric mean |  |  |  |  |  | 0.005788 | **0.006999<br>&#x1F7E2;&nbsp;1.2092x** | **0.007058<br>&#x1F7E2;&nbsp;1.2194x** | **0.014487<br>&#x1F7E2;&nbsp;2.5029x** |

## Result And Limitations

**SOTA**

- Classification is SOTA on this device: the candidate is ahead of every comparator on every
  primary workload, by 1.10x to 1.38x against the incumbent and 1.15x to 1.28x against
  torch-compile.
- What is left is one division per output, and that is measured rather than inferred. The
  same kernel with the division replaced by an addition of the same divisor — everything
  else held fixed — runs 3.841us / 16.480us / 1.953us against 4.481us / 17.408us / 2.208us
  in table order.
- A load-only twin — same grid, same input stream, the same tap count, no divisor — runs
  3.840us / 15.745us / 1.952us. Two of the three land on the no-division kernel, so on
  `audio-downsample` and `ceil` the division is the whole residue over the memory stream.
  `long-temporal` keeps 0.6us beyond it, in the per-tap select.
- The division is kept. `total / k` and `total * (1 / k)` differ by up to one fp32 ulp for a
  divisor that is not a power of two, and PyTorch divides; buying 5% to 14% with a deviation
  from the reference is not a trade this op should make silently.
- Three guard strategies were measured. A per-tap branch: 4.640us / 17.728us / 2.240us. The
  per-tap select this PR ships: 4.512us / 17.280us / 2.176us. A per-CTA predicate over an
  unguarded body: 4.640us / 17.313us / 2.272us.
- 261 `tests/ops/test_pool.py` cases pass, unchanged in count.
