### PR TITLE
[Perf][foundry][Pool] Read a 1d max-pool window once per output thread

### DIFF
--- a/src/tileops/kernels/pool/max_pool1d.py
+++ b/src/tileops/kernels/pool/max_pool1d.py
@@ -11,6 +11,15 @@ from tileops.kernels.pool.common import pool_output_dim
 
 __all__ = ["MaxPool1dKernel", "MaxPool1dWithIndicesKernel"]
 
+# A window shorter than this has too few positions to fill even one lane group,
+# and the cross-lane reduction costs more than the serial run it replaces.
+_MIN_SPLIT_WINDOW = 8
+
+# Output positions below which a launch cannot fill the device from the output
+# axis alone: 132 SMs at 2048 resident threads is the widest device this kernel
+# is built for.
+_SMALL_LAUNCH = 132 * 2048
+
 
 @functools.lru_cache(maxsize=32)
 def _max_pool1d_kernel(
@@ -26,42 +35,92 @@ def _max_pool1d_kernel(
 ):
     accum_dtype = "float"
     out_l = pool_output_dim(l_in, kernel_w, stride_w, pad_w, ceil_mode, dilation_w)
-    total_output = n * c_in * out_l
+    rows = n * c_in
+    total = rows * out_l
+    # With no padding and no ceil overshoot every window lies inside its row, so
+    # the per-tap bounds test is a compile-time truth and drops out.
+    window_inside = pad_w == 0 and (out_l - 1) * stride_w + (kernel_w - 1) * dilation_w < l_in
 
     @tilelang.jit(out_idx=[1], compile_flags=["-O3", "-DENABLE_BF16"])
-    def _max_pool1d_func(block_m: int, threads: int):
+    def _max_pool1d_func(block_m: int, block_k: int, threads: int):
+        rounds = -(-kernel_w // block_k)
+        lanes_cover_window = rounds * block_k == kernel_w
+        tile_full = total % block_m == 0
+
+        def safe(col):
+            """*col* as an index that is always in range, clamping only when it
+            can leave the row. The clamped value is read under a predicate that
+            already discarded it, so which position it names does not matter."""
+            return col if window_inside else T.max(0, T.min(col, l_in - 1))
+
         @T.prim_func
         def _max_pool1d_main(
-            x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
-            out: T.Tensor((n, c_in, out_l), dtype),  # type: ignore
+            x: T.Tensor((rows, l_in), dtype),  # type: ignore
+            out: T.Tensor((rows, out_l), dtype),  # type: ignore
         ):
-            with T.Kernel(T.ceildiv(total_output, block_m), threads=threads) as bx:
-                for i in T.Parallel(block_m):
-                    out_idx = bx * block_m + i
-                    if out_idx < total_output:
-                        ow = out_idx % out_l
-                        channel_batch_idx = out_idx // out_l
-                        c_idx = channel_batch_idx % c_in
-                        batch = channel_batch_idx // c_in
-
-                        max_val = T.alloc_var(T.float32)
-                        has_nan = T.alloc_var(T.bool)
-                        max_val = T.cast(float("-inf"), accum_dtype)
-                        has_nan = False
-                        for kw in T.serial(kernel_w):
-                            iw = ow * stride_w - pad_w + kw * dilation_w
-                            if iw >= 0 and iw < l_in:
-                                val = T.cast(x[batch, c_idx, iw], accum_dtype)
-                                if T.isnan(val):
-                                    has_nan = True
-                                max_val = T.max(max_val, val)
-
-                        result = T.if_then_else(
-                            has_nan,
-                            T.cast(float("nan"), accum_dtype),
-                            max_val,
-                        )
-                        out[batch, c_idx, ow] = T.cast(result, dtype)
+            with T.Kernel(T.ceildiv(total, block_m), threads=threads) as tile:
+                if block_k == 1:
+                    for i in T.Parallel(block_m):
+                        idx = tile * block_m + i
+                        if tile_full or idx < total:
+                            ow = idx % out_l
+                            row = idx // out_l
+                            first = ow * stride_w - pad_w
+                            run = T.alloc_var(T.float32)
+                            run = -T.infinity(accum_dtype)
+                            for k in T.serial(kernel_w):
+                                col = first + k * dilation_w
+                                if window_inside or ((col >= 0) and (col < l_in)):
+                                    v = T.cast(x[row, safe(col)], accum_dtype)
+                                    # NaN enters `run` and never leaves: a later
+                                    # value fails `v > NaN`, which is how PyTorch
+                                    # propagates it.
+                                    run = T.if_then_else(T.isnan(v) or (v > run), v, run)
+                            out[row, ow] = T.cast(run, dtype)
+                else:
+                    # Window positions run across lanes and finish with a cross-lane
+                    # max. Cross-lane max drops NaN, so a lane's NaN travels beside
+                    # its value as a flag and is put back after the reduction.
+                    part = T.alloc_fragment((block_m, block_k), accum_dtype)
+                    nan_part = T.alloc_fragment((block_m, block_k), accum_dtype)
+                    best = T.alloc_fragment((block_m,), accum_dtype)
+                    nan_seen = T.alloc_fragment((block_m,), accum_dtype)
+                    for i, lane in T.Parallel(block_m, block_k):
+                        idx = tile * block_m + i
+                        run = T.alloc_var(T.float32)
+                        flag = T.alloc_var(T.float32)
+                        run = -T.infinity(accum_dtype)
+                        flag = 0.0
+                        if tile_full or idx < total:
+                            ow = idx % out_l
+                            row = idx // out_l
+                            first = ow * stride_w - pad_w
+                            for r in T.serial(rounds):
+                                # A lane takes one contiguous run of window
+                                # positions, so a warp's taps stay a contiguous
+                                # stretch of the row on every round.
+                                k = lane * rounds + r
+                                if lanes_cover_window or k < kernel_w:
+                                    col = first + k * dilation_w
+                                    if window_inside or ((col >= 0) and (col < l_in)):
+                                        v = T.cast(x[row, safe(col)], accum_dtype)
+                                        flag = T.max(flag, T.if_then_else(T.isnan(v), 1.0, 0.0))
+                                        run = T.if_then_else(v > run, v, run)
+                        part[i, lane] = run
+                        nan_part[i, lane] = flag
+                    T.reduce_max(part, best, dim=1, clear=True)
+                    T.reduce_max(nan_part, nan_seen, dim=1, clear=True)
+                    for i in T.Parallel(block_m):
+                        idx = tile * block_m + i
+                        if tile_full or idx < total:
+                            out[idx // out_l, idx % out_l] = T.cast(
+                                T.if_then_else(
+                                    nan_seen[i] > 0.0,
+                                    T.cast(float("nan"), accum_dtype),
+                                    best[i],
+                                ),
+                                dtype,
+                            )
 
         return _max_pool1d_main
 
@@ -78,11 +137,11 @@ def _launch_max_pool1d(
     dilation_w: int,
     ceil_mode: bool,
     dtype: str,
-    block_m: int,
-    threads: int,
+    config: dict,
     x: torch.Tensor,
 ) -> torch.Tensor:
-    return _max_pool1d_kernel(
+    out_l = pool_output_dim(l_in, kernel_w, stride_w, pad_w, ceil_mode, dilation_w)
+    kernel = _max_pool1d_kernel(
         n,
         c_in,
         l_in,
@@ -92,15 +151,19 @@ def _launch_max_pool1d(
         dilation_w,
         ceil_mode,
         dtype,
-    )(block_m, threads)(x)
+    )(**config)
+    # The kernel addresses one row per (batch, channel) pair, so the two leading
+    # extents are folded away on the way in and restored on the way out.
+    return kernel(x.reshape(n * c_in, l_in)).view(n, c_in, out_l)
 
 
 class _MaxPool1dKernelBase(Kernel):
     """Shared construction and dispatch for the 1d max-pool kernels.
 
     Concrete kernels supply ``_build`` and ``_dispatch``; everything else —
-    parameter capture, output extents, config and launch — is identical
-    between the value-only and with-indices variants.
+    parameter capture, output extents, and launch — is identical between the
+    value-only and with-indices variants. Each declares its own config space,
+    because the two schedule the window differently.
     """
 
     _build: ClassVar[Callable[..., Any]]
@@ -150,20 +213,6 @@ class _MaxPool1dKernelBase(Kernel):
         )
         self.init_config(config, tune)
 
-    @property
-    def default_config(self) -> dict:
-        return {
-            "block_m": 256,
-            "threads": 256,
-        }
-
-    @property
-    def autotune_configs(self) -> list[dict]:
-        return [
-            {"block_m": block_m, "threads": threads}
-            for block_m, threads in itertools.product([128, 256, 512], [128, 256, 512])
-        ]
-
     def forward(self, x: torch.Tensor) -> Any:
         self._require_cuda(x=x)
         return type(self)._dispatch(
@@ -176,16 +225,60 @@ class _MaxPool1dKernelBase(Kernel):
             self.dilation_w,
             self.ceil_mode,
             self.dtype_str,
-            self.config["block_m"],
-            self.config["threads"],
+            dict(self.config),
             x,
         )
 
 
 class MaxPool1dKernel(_MaxPool1dKernelBase):
-    """Max pooling forward kernel (return_indices=False)."""
+    """Max pooling forward kernel (return_indices=False).
+
+    One thread owns one output position and folds its window into a register,
+    so an output is written once and the window never leaves the thread.
+
+    ``block_k`` spreads the window itself across lanes and finishes with a
+    cross-lane max. Global pooling — a window as long as the row, one output
+    per row — has no output positions to spread over threads, and is the shape
+    that needs it.
+    """
 
     _build = staticmethod(_max_pool1d_kernel)
+
+    def _splits_window(self) -> bool:
+        """Whether the default config should spread the window over lanes.
+
+        A split trades window positions for output positions, so it wants a
+        window long enough to fill lanes and a launch with too few output
+        positions to fill the device without them. Both families stay in the
+        tuning space whenever the window is long enough to divide, so this
+        decides only where an untuned build starts.
+        """
+        return self.kernel_w >= _MIN_SPLIT_WINDOW and (
+            self.n * self.c_in * self.out_l < _SMALL_LAUNCH
+        )
+
+    @property
+    def default_config(self) -> dict:
+        if self._splits_window():
+            return {
+                "block_m": 32,
+                "block_k": min(16, self.kernel_w),
+                "threads": 512,
+            }
+        return {"block_m": 512, "block_k": 1, "threads": 128}
+
+    @property
+    def autotune_configs(self) -> list[dict]:
+        space = list(itertools.product((256, 512, 1024), (1,), (128, 256)))
+        if self.kernel_w >= _MIN_SPLIT_WINDOW:
+            space += itertools.product((16, 32, 64), (8, 16, 32), (256, 512))
+        configs = [
+            {"block_m": block_m, "block_k": block_k, "threads": threads}
+            for block_m, block_k, threads in space
+            if block_k <= self.kernel_w and threads <= block_m * block_k <= 8192
+        ]
+        return configs or [self.default_config]
+
     _dispatch = staticmethod(_launch_max_pool1d)
 
 
@@ -298,8 +391,7 @@ def _launch_max_pool1d_with_indices(
     dilation_w: int,
     ceil_mode: bool,
     dtype: str,
-    block_m: int,
-    threads: int,
+    config: dict,
     x: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     return _max_pool1d_with_indices_kernel(
@@ -312,7 +404,7 @@ def _launch_max_pool1d_with_indices(
         dilation_w,
         ceil_mode,
         dtype,
-    )(block_m, threads)(x)
+    )(**config)(x)
 
 
 class MaxPool1dWithIndicesKernel(_MaxPool1dKernelBase):
@@ -320,3 +412,14 @@ class MaxPool1dWithIndicesKernel(_MaxPool1dKernelBase):
 
     _build = staticmethod(_max_pool1d_with_indices_kernel)
     _dispatch = staticmethod(_launch_max_pool1d_with_indices)
+
+    @property
+    def default_config(self) -> dict:
+        return {"block_m": 256, "threads": 256}
+
+    @property
+    def autotune_configs(self) -> list[dict]:
+        return [
+            {"block_m": block_m, "threads": threads}
+            for block_m, threads in itertools.product([128, 256, 512], [128, 256, 512])
+        ]


### PR DESCRIPTION
## Summary

- Rewrite the `MaxPool1dFwdOp` forward kernel as one flat pass over output positions: a thread owns one output, folds its window into a register, and reads its taps under a compile-time bounds claim rather than a per-element branch.
- Add `block_k`, which spreads window positions across lanes and finishes with a cross-lane max, for global pooling — a window as long as the row leaves no output positions to spread over threads.
- Carry the window's NaN beside its value in the lane path, because a cross-lane max drops it.

## TileFoundry Description

```python
@module(
    entry="max_pool1d",
    target=CudaTarget("nvidia.h200_sxm"),
    topologies=(Topology("cta", 132),),
)
class MaxPool1d:
    @func
    def max_pool1d(x: Tensor[(N, C, L_IN), "f16"]) -> Tensor[(N, C, L_OUT), "f16"]:
        left = tf.full_like(x[:, :, 0:PAD], value=NEG_INF)
        right = tf.full_like(x[:, :, 0:OVERHANG], value=NEG_INF)
        padded = tf.concat([left, x, right], axis=2)
        taps = tf.stack(
            [
                padded[:, :, k * DILATION : k * DILATION + (L_OUT - 1) * STRIDE + 1 : STRIDE]
                for k in range(KERNEL)
            ],
            axis=-1,
        )
        return tf.reduce(taps, axes=(-1,), keepdim=False, kind="max")
```

`tilefoundry check` holds the delivered kernel to that program, run by the evaluator, on
every primary manifest workload: `--fn equal` reports 0 mismatched elements for
`f16[32,80,1365]`, `f16[64,256,1]` and `bf16[16,128,1023]`.

`tilefoundry analyze` prices the description at `bound-by=memory` on all three, which is
what the schedule below is written against. The description states the semantics, not the
placement: it materializes the stacked window, so its `ideal-ns` is the cost of an unfused
program and not the floor the kernel is read against. That floor is measured below.

## Performance

Operator: `MaxPool1dFwdOp`

| Environment | Value |
| --- | --- |
| image | ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-afcebed1-foundry-dev |
| digest | sha256:fe87c536154ad2ce3bffa4ff97e28fbfde7fcf6598d9d87c3f3dcc4ee9e44b5c |
| gpu | NVIDIA H200 |
| driver | 595.71.05 |
| cuda | 13.2 |
| torch | 2.13.0+cu132 |
| tilelang | 0.1.11+cu132.gitafcebed1 |
| tilefoundry | 0.1.dev131+g2306bf050 |
| timer | native CUPTI |

Method: candidate, incumbent and both torch baselines ran in one process on common inputs.
Each TileLang implementation was searched over its own config space and is reported at its
best; each was checked against `torch.nn.functional.max_pool1d` before timing, then timed by
`bench_kernel` through CUPTI, which clears L2 before every iteration. Compilation and tuning
were excluded; CUPTI failure was fail-closed.

Ratio in comparator columns: implementation / candidate. &#x1F7E2; > 1 means the candidate is
faster; &#x1F534; <= 1 means it is not.

| Workload | N | C | L | Params | Dtype | Candidate (ms) | TileOPs incumbent (ms)<br>/ candidate | #2064 staged (ms)<br>/ candidate | torch-compile (ms)<br>/ candidate | torch-ref (ms)<br>/ candidate |
| --- | ---: | ---: | ---: | --- | --- | ---: | ---: | ---: | ---: | ---: |
| sincnet-speaker-local | 32 | 80 | 4096 | k3 s3 | float16 | 0.010784 | 0.010720<br>&#x1F534;&nbsp;0.9941x | 0.010721<br>&#x1F534;&nbsp;0.9942x | 0.010656<br>&#x1F534;&nbsp;0.9881x | **0.038752<br>&#x1F7E2;&nbsp;3.5935x** |
| textcnn-global | 64 | 256 | 128 | k128 s1 | float16 | 0.003392 | **0.010624<br>&#x1F7E2;&nbsp;3.1321x** | **0.003584<br>&#x1F7E2;&nbsp;1.0566x** | 0.003360<br>&#x1F534;&nbsp;0.9906x | **0.020672<br>&#x1F7E2;&nbsp;6.0943x** |
| ecg-cnn-dilated | 16 | 128 | 2048 | k5 s2 p2 d2 ceil | bfloat16 | 0.006752 | **0.007872<br>&#x1F7E2;&nbsp;1.1659x** | **0.007872<br>&#x1F7E2;&nbsp;1.1659x** | **0.006912<br>&#x1F7E2;&nbsp;1.0237x** | **0.027200<br>&#x1F7E2;&nbsp;4.0284x** |
| geometric mean |  |  |  |  |  | 0.006392 | **0.009588<br>&#x1F7E2;&nbsp;1.5000x** | **0.007074<br>&#x1F7E2;&nbsp;1.1067x** | 0.006389<br>&#x1F534;&nbsp;0.9995x | **0.027554<br>&#x1F7E2;&nbsp;4.3106x** |

## Result And Limitations

**improvement without SOTA**

- Classification is improvement without SOTA. The candidate is 3.1321x the incumbent on the
  global-pooling workload and 1.1659x on the dilated one, and is ahead of torch-compile on
  the dilated one. On the other two it neither gains nor loses: 0.9906x and 0.9881x
  torch-compile, inside the run-to-run spread.

### Overlap with #2064

#2064 rewrites the same file. Its answer to `textcnn-global` is to stage whole rows of one
image in shared memory; this PR's is to spread the window across lanes and reduce, with no
shared memory and no staging preconditions. The two cannot both land as written, and the
table above times both against this branch in one process, each at its own best config.

| | this PR | #2064 | serves |
| --- | ---: | ---: | --- |
| sincnet-speaker-local | 0.010784 | 0.010721 | both, unchanged from main |
| textcnn-global | 0.003392 | 0.003584 | both |
| ecg-cnn-dilated | 0.006752 | 0.007872 | this PR only; #2064 leaves it at main |

#2064's `max_pool1d` path needs `out_l <= 32`, `block_m % out_l == 0` and `c_in % rows == 0`
to engage, plus a shared row pad tuned to a bank count. This PR's window split needs a window
of 8 positions or more and is otherwise unconditional. The recommendation is that #2064 keeps
its `adaptive_max_pool2d` half, which this PR does not touch, and drops `max_pool1d.py`.

### The rest of the gap

- A load-only twin — same grid, same input stream, one tap instead of the window — runs
  `sincnet-speaker-local` in 9.54us against the candidate's 10.78us, and `ecg-cnn-dilated` in
  5.44us against 6.75us. The residue is the per-tap load, not the access pattern: the twin
  already moves every byte the full kernel does.
- Five other schedules were measured and rejected on that basis. Shared-memory staging of the
  input span: 10.66us / 8.16us (sincnet / ecg). The same with 16-byte-aligned spans: 10.90us
  on ecg. A three-dimensional grid without staging: 11.42us / 7.58us. One thread owning V
  consecutive outputs with `T.vectorized` loads: 11.71us at V=4 and 16.06us at V=8 on sincnet.
- `block_k` splits the window only where the tuner is offered the choice — windows of 8
  positions or more. Below that a cross-lane reduction costs more than the serial run it
  replaces. Both families stay in the tuning space whenever the window can divide, so the
  choice is measured rather than assumed.
- NaN propagation cannot use plain `fmax`: `fmax` returns the non-NaN operand. Folding the
  test into the update costs about 5% against a NaN-unaware `fmax` on `ecg-cnn-dilated`
  (6.66us against 6.30us), measured. The arithmetic alternative — accumulating `v - v` beside
  the maximum — is 5% faster and wrong: the compiler folds `v - v` to zero.
- The 4.8 TB/s HBM figure the target publishes is not reachable under this measurement. A
  same-shape elementwise copy, timed the same way, reaches 3.49 TB/s at 41.9 MB and 2.22 TB/s
  at 8.4 MB; the L2 clear before every iteration is part of what the kernel is timed against.
- 261 `tests/ops/test_pool.py` cases pass, unchanged in count.
