### PR TITLE
[Perf][foundry][Norm] Read an aligned row into registers, and settle InstanceNorm's affine once

### DIFF
--- a/src/tileops/kernels/norm/_config.py
+++ b/src/tileops/kernels/norm/_config.py
@@ -9,10 +9,16 @@ is 5-16x slower yet numerically correct, so no correctness test catches it.
 
 ``select_row_config`` pins ``block_m=1``: with one row per CTA the per-row
 uniformity the reduction needs always holds, so the collapse is impossible for
-any N/threads/dtype -- structural, not a tuned value. ``threads=128`` is the
-measured optimum. ``select_row_configs`` keeps ``block_m`` as a swept autotune
-knob so the kernel interface is not narrowed; configs that collapse lose on their
-measured runtime.
+any N/threads/dtype -- structural, not a tuned value. ``threads=128`` is what it
+pins, because a row padded to the 256-element alignment often divides by nothing
+wider. ``select_row_configs`` keeps ``block_m`` as a swept autotune knob so the
+kernel interface is not narrowed; configs that collapse lose on their measured
+runtime.
+
+A row of a few thousand elements is latency-bound, not instruction-bound: what
+decides it is how many loads one thread has in flight. ``select_row_config_by_width``
+sizes the block from :data:`_TARGET_ELEMENTS_PER_THREAD` for that reason, over widths
+that reach down to one warp for a row short enough to keep a thread's share small.
 """
 
 import tilelang.language as T
@@ -22,6 +28,7 @@ from tileops.kernels.constants import VECTOR_ACCESS_BYTES
 from tileops.kernels.tiling import ALIGNMENT
 
 __all__ = [
+    "CANDIDATE_THREADS_BY_WIDTH",
     "make_row_reduce",
     "row_padding",
     "select_row_config",
@@ -33,10 +40,28 @@ __all__ = [
 # N_padded, or layout inference reports "no available layout". CUDA caps at 1024.
 _CANDIDATE_THREADS = (128, 256, 512, 1024)
 
+# Row width at or below which a block narrower than 128 is offered. Above it a
+# narrow block hands one thread hundreds of elements, and layout inference
+# answers that with the replicated layout this module's docstring describes:
+# a 7200-wide row measures 5.7 us against 3.2 us that way.
+NARROW_ROW = 2048
+
+# The widths a row sized by :data:`_TARGET_ELEMENTS_PER_THREAD` can land on.
+# Separate from :data:`_CANDIDATE_THREADS` so a block narrower than one warp
+# reaches only the kernels that ask for this tuple, and only for a row short
+# enough to keep a thread's share of it small.
+CANDIDATE_THREADS_BY_WIDTH = (32, 64) + _CANDIDATE_THREADS
+
+
+def widths_for_row(n_padded: int) -> tuple:
+    """Block widths a row of *n_padded* elements may be split across."""
+    return CANDIDATE_THREADS_BY_WIDTH if n_padded <= NARROW_ROW else _CANDIDATE_THREADS
+
+
 # block_m values offered to autotune; block_m=1 is always the safe default.
 _CANDIDATE_BLOCK_M = (1, 2, 4, 8)
 
-_DEFAULT_THREADS = 128  # measured optimum; see the module docstring
+_DEFAULT_THREADS = 128  # divides every aligned row; see the module docstring
 
 _ROW_SMEM_BUDGET_BYTES = 48 * 1024
 
@@ -46,8 +71,8 @@ def row_padding(n: int, elem_bytes: int) -> int:
 
     Only a power of two is divided by every entry of :data:`_CANDIDATE_THREADS`;
     the 256-element alignment leaves an odd factor that caps a block at eight
-    warps. Rounding to 1024 instead measured 3% slower (7168 against 8192).
-    Never below :data:`ALIGNMENT`, which the 128-thread default needs.
+    warps, which costs 3% on a row of 7168. Never below :data:`ALIGNMENT`, which
+    the 128-thread default needs.
     """
     pow2 = 1 << (n - 1).bit_length()
     if pow2 * elem_bytes <= _ROW_SMEM_BUDGET_BYTES:
@@ -55,7 +80,9 @@ def row_padding(n: int, elem_bytes: int) -> int:
     return -(-n // ALIGNMENT) * ALIGNMENT
 
 
-# Row elements a thread carries. Measured across the group-norm rows: 32 wins.
+# Row elements a thread carries. Enough of them keep loads in flight to cover the
+# latency the row is bound by: a 1024-wide row split across 128 threads leaves 8
+# each and measures 12% slower than the same row across one warp.
 _TARGET_ELEMENTS_PER_THREAD = 32
 
 
@@ -63,25 +90,30 @@ def select_row_config_by_width(n_padded: int) -> dict:
     """``{block_m, threads}`` for a row reduction, sized by the row itself.
 
     For a row padded to a power of two, which admits every candidate width.
-    ``select_row_config`` pins 128 because the aligned padding often admits
-    nothing wider.
     """
     threads = n_padded // _TARGET_ELEMENTS_PER_THREAD
-    for candidate in sorted(_CANDIDATE_THREADS, reverse=True):
+    for candidate in sorted(widths_for_row(n_padded), reverse=True):
         if candidate <= threads and n_padded % candidate == 0:
             return {"block_m": 1, "threads": candidate}
     return {"block_m": 1, "threads": _DEFAULT_THREADS}
 
 
-def _feasible_threads(n_padded: int, dtype: torch.dtype = torch.float16) -> list[int]:
+def _feasible_threads(
+    n_padded: int, dtype: torch.dtype = torch.float16, widths: tuple = _CANDIDATE_THREADS
+) -> list[int]:
     """Thread counts that divide the row and keep loads 128-bit vectorizable.
 
     128-bit needs ``16 // element_size`` elements per thread (8 for fp16/bf16,
     4 for fp32). If no candidate meets that floor (small rows), fall back to any
     thread count that divides the row so the autotune space is never empty.
+
+    Args:
+        n_padded: Padded row width.
+        dtype: Element type the row is stored in.
+        widths: Block widths to draw from.
     """
     min_elements = VECTOR_ACCESS_BYTES // torch.tensor([], dtype=dtype).element_size()
-    candidates = [t for t in _CANDIDATE_THREADS if n_padded % t == 0]
+    candidates = [t for t in widths if n_padded % t == 0]
     vectorizable = [t for t in candidates if n_padded // t >= min_elements]
     return vectorizable or candidates
 
@@ -96,16 +128,27 @@ def select_row_config() -> dict:
 
 
 def select_row_configs(
-    n_padded: int, dtype: torch.dtype = torch.float16, num_buffers: int = 1
+    n_padded: int,
+    dtype: torch.dtype = torch.float16,
+    num_buffers: int = 1,
+    widths: tuple = _CANDIDATE_THREADS,
 ) -> list[dict]:
     """Autotune space: block_m x usable thread counts, default always included.
 
     block_m is swept (not pinned) so the interface is preserved; configs that
     collapse are rejected by the autotuner's own measured runtime. block_m is
     capped by the 48 KB shared-memory budget for ``num_buffers`` row-sized
-    buffers, and the default is always a member so the list is never empty.
+    buffers, which bounds the kernels that stage a row block in shared memory;
+    for one that holds the block in registers the cap is simply not the binding
+    limit. The default is always a member so the list is never empty.
+
+    Args:
+        n_padded: Padded row width.
+        dtype: Element type the row is stored in.
+        num_buffers: Row-sized shared buffers the kernel holds live at once.
+        widths: Block widths to draw from.
     """
-    threads = _feasible_threads(n_padded, dtype)
+    threads = _feasible_threads(n_padded, dtype, widths)
     smem_per_row = n_padded * torch.tensor([], dtype=dtype).element_size()
     max_block_m = (48 * 1024) // (num_buffers * smem_per_row)
     configs = [
@@ -124,9 +167,8 @@ def make_row_reduce(block_m, n, n_padded, eps):
     """Create the macro reducing a loaded fp32 row block to mean and rstd.
 
     Consumes ``x_f32`` and overwrites it with the centered squares. The load
-    stays at the call sites: pulling it in here makes TileLang insert a
-    ``__syncthreads()`` between the global-to-shared and shared-to-register
-    copies, which measures 2% slower on an aligned row.
+    stays at the call sites, which read the row block in the dtype the tensor
+    holds and keep it for the output pass.
 
     Args:
         block_m: Rows per block.

--- a/src/tileops/kernels/norm/_config.py
+++ b/src/tileops/kernels/norm/_config.py
@@ -42,8 +42,7 @@ _CANDIDATE_THREADS = (128, 256, 512, 1024)
 
 # Row width at or below which a block narrower than 128 is offered. Above it a
 # narrow block hands one thread hundreds of elements, and layout inference
-# answers that with the replicated layout this module's docstring describes:
-# a 7200-wide row measures 5.7 us against 3.2 us that way.
+# answers that with the replicated layout this module's docstring describes.
 NARROW_ROW = 2048
 
 # The widths a row sized by :data:`_TARGET_ELEMENTS_PER_THREAD` can land on.
@@ -80,9 +79,8 @@ def row_padding(n: int, elem_bytes: int) -> int:
     return -(-n // ALIGNMENT) * ALIGNMENT
 
 
-# Row elements a thread carries. Enough of them keep loads in flight to cover the
-# latency the row is bound by: a 1024-wide row split across 128 threads leaves 8
-# each and measures 12% slower than the same row across one warp.
+# Row elements a thread carries. Enough of them keep loads in flight to cover
+# the latency the row is bound by.
 _TARGET_ELEMENTS_PER_THREAD = 32
 
 

--- a/src/tileops/kernels/norm/group_norm.py
+++ b/src/tileops/kernels/norm/group_norm.py
@@ -34,10 +34,12 @@ import torch
 from tileops.kernels.kernel_base import Kernel
 
 from ._config import (
+    NARROW_ROW,
     make_row_reduce,
     row_padding,
     select_row_config_by_width,
     select_row_configs,
+    widths_for_row,
 )
 
 __all__ = ["GroupNormKernel", "GroupNormNoAffineKernel"]
@@ -89,6 +91,15 @@ def _group_norm_kernel(M, D, eps, dtype, num_groups, channels_per_group):
     def _func(block_m, threads):
         # A non-aligned D would read and write columns >= D unless masked.
         masked = D_padded != D
+        # One channel owns the whole row exactly when a group holds one channel.
+        row_constant_affine = channels_per_group == 1
+        # A row short enough that its fragment leaves the register file room goes
+        # straight from global memory into it. A wider one reads faster staged
+        # through shared: at 8192 elements the direct read measures 3.8 us
+        # against 3.2 us, and a narrow block on top of it 5.7 us.
+        register_direct = D_padded <= NARROW_ROW
+        # A tail row block runs past the end unless every index is guarded.
+        guarded = masked or M % block_m != 0
         row_reduce = make_row_reduce(block_m, D, D_padded, eps)
 
         @T.prim_func
@@ -105,8 +116,25 @@ def _group_norm_kernel(M, D, eps, dtype, num_groups, channels_per_group):
                 acc = T.alloc_fragment((block_m,), "float32")
                 mean_val = T.alloc_fragment((block_m,), "float32")
                 rstd = T.alloc_fragment((block_m,), "float32")
+                if row_constant_affine:
+                    scale = T.alloc_fragment((block_m,), "float32")
+                    bias_row = T.alloc_fragment((block_m,), "float32")
 
-                if masked:
+                if register_direct and guarded:
+                    for i, j in T.Parallel(block_m, D_padded):
+                        x_local[i, j] = T.if_then_else(
+                            T.And(pid_m * block_m + i < M, j < D),
+                            x[pid_m * block_m + i, j],
+                            T.cast(0.0, dtype),
+                        )
+                    for i, j in T.Parallel(block_m, D_padded):
+                        x_f32[i, j] = T.cast(x_local[i, j], "float32")
+                elif register_direct:
+                    for i, j in T.Parallel(block_m, D_padded):
+                        x_local[i, j] = x[pid_m * block_m + i, j]
+                    for i, j in T.Parallel(block_m, D_padded):
+                        x_f32[i, j] = T.cast(x_local[i, j], "float32")
+                elif masked:
                     # Keep the input in shared memory for the output pass.
                     for i, j in T.Parallel(block_m, D_padded):
                         shared_buf[i, j] = T.if_then_else(
@@ -124,7 +152,33 @@ def _group_norm_kernel(M, D, eps, dtype, num_groups, channels_per_group):
                 row_reduce(x_f32, acc, mean_val, rstd)
 
                 # --- Output: y = (x - mean) * rstd * weight[c] + bias[c] ---
-                if masked:
+                if row_constant_affine:
+                    # A group of one channel gives the whole row one weight and
+                    # one bias, so the channel derivation and the two gathers
+                    # leave the element loop. Centering stays in it: a shift term
+                    # folding it in would subtract two large products, losing a
+                    # row whose mean dwarfs its residuals.
+                    for i in T.Parallel(block_m):
+                        c = (pid_m * block_m + i) % num_groups
+                        scale[i] = rstd[i] * T.cast(weight[c], "float32")
+                        bias_row[i] = T.cast(bias[c], "float32")
+                    for i, j in T.Parallel(block_m, D_padded):
+                        if (not guarded) or T.And(pid_m * block_m + i < M, j < D):
+                            y[pid_m * block_m + i, j] = T.cast(
+                                (
+                                    T.cast(
+                                        shared_buf[i, j]
+                                        if (masked and not register_direct)
+                                        else x_local[i, j],
+                                        "float32",
+                                    )
+                                    - mean_val[i]
+                                )
+                                * scale[i]
+                                + bias_row[i],
+                                dtype,
+                            )
+                elif masked:
                     for i, j in T.Parallel(block_m, D_padded):
                         if T.And(pid_m * block_m + i < M, j < D):
                             c = _channel_of(
@@ -135,7 +189,11 @@ def _group_norm_kernel(M, D, eps, dtype, num_groups, channels_per_group):
                                 spatial_size,
                             )
                             y[pid_m * block_m + i, j] = (
-                                T.cast(shared_buf[i, j], "float32") - mean_val[i]
+                                T.cast(
+                                    x_local[i, j] if register_direct else shared_buf[i, j],
+                                    "float32",
+                                )
+                                - mean_val[i]
                             ) * rstd[i] * T.cast(weight[c], "float32") + T.cast(bias[c], "float32")
                 else:
                     # Re-cast from x_local (original dtype) to avoid a second
@@ -216,7 +274,7 @@ class GroupNormKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        return select_row_configs(self.D_padded, self.dtype)
+        return select_row_configs(self.D_padded, self.dtype, widths=widths_for_row(self.D_padded))
 
     def forward(
         self,
@@ -287,6 +345,12 @@ def _group_norm_no_affine_kernel(M, D, eps, dtype):
     def _func(block_m, threads):
         # A non-aligned D would read and write columns >= D unless masked.
         masked = D_padded != D
+        # A row short enough that its fragment leaves the register file room goes
+        # straight from global memory into it; a wider one reads faster staged
+        # through shared.
+        register_direct = D_padded <= NARROW_ROW
+        # A tail row block runs past the end unless every index is guarded.
+        guarded = masked or M % block_m != 0
         row_reduce = make_row_reduce(block_m, D, D_padded, eps)
 
         @T.prim_func
@@ -302,7 +366,21 @@ def _group_norm_no_affine_kernel(M, D, eps, dtype):
                 mean_val = T.alloc_fragment((block_m,), "float32")
                 rstd = T.alloc_fragment((block_m,), "float32")
 
-                if masked:
+                if register_direct and guarded:
+                    for i, j in T.Parallel(block_m, D_padded):
+                        x_local[i, j] = T.if_then_else(
+                            T.And(pid_m * block_m + i < M, j < D),
+                            x[pid_m * block_m + i, j],
+                            T.cast(0.0, dtype),
+                        )
+                    for i, j in T.Parallel(block_m, D_padded):
+                        x_f32[i, j] = T.cast(x_local[i, j], "float32")
+                elif register_direct:
+                    for i, j in T.Parallel(block_m, D_padded):
+                        x_local[i, j] = x[pid_m * block_m + i, j]
+                    for i, j in T.Parallel(block_m, D_padded):
+                        x_f32[i, j] = T.cast(x_local[i, j], "float32")
+                elif masked:
                     # Keep the input in shared memory for the output pass.
                     for i, j in T.Parallel(block_m, D_padded):
                         shared_buf[i, j] = T.if_then_else(
@@ -319,8 +397,22 @@ def _group_norm_no_affine_kernel(M, D, eps, dtype):
 
                 row_reduce(x_f32, acc, mean_val, rstd)
 
-                # No-affine output: y = (x - mean) * rstd
-                if masked:
+                # No-affine output: y = (x - mean) * rstd. The row is read back
+                # from wherever the load left it.
+                if register_direct and guarded:
+                    for i, j in T.Parallel(block_m, D_padded):
+                        if T.And(pid_m * block_m + i < M, j < D):
+                            y[pid_m * block_m + i, j] = T.cast(
+                                (T.cast(x_local[i, j], "float32") - mean_val[i]) * rstd[i],
+                                dtype,
+                            )
+                elif register_direct:
+                    for i, j in T.Parallel(block_m, D_padded):
+                        y[pid_m * block_m + i, j] = T.cast(
+                            (T.cast(x_local[i, j], "float32") - mean_val[i]) * rstd[i],
+                            dtype,
+                        )
+                elif masked:
                     for i, j in T.Parallel(block_m, D_padded):
                         if T.And(pid_m * block_m + i < M, j < D):
                             y[pid_m * block_m + i, j] = T.cast(
@@ -387,7 +479,7 @@ class GroupNormNoAffineKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        return select_row_configs(self.D_padded, self.dtype)
+        return select_row_configs(self.D_padded, self.dtype, widths=widths_for_row(self.D_padded))
 
     def forward(
         self,

--- a/src/tileops/kernels/norm/group_norm.py
+++ b/src/tileops/kernels/norm/group_norm.py
@@ -93,11 +93,11 @@ def _group_norm_kernel(M, D, eps, dtype, num_groups, channels_per_group):
         masked = D_padded != D
         # One channel owns the whole row exactly when a group holds one channel.
         row_constant_affine = channels_per_group == 1
-        # A row short enough that its fragment leaves the register file room goes
-        # straight from global memory into it. A wider one reads faster staged
-        # through shared: at 8192 elements the direct read measures 3.8 us
-        # against 3.2 us, and a narrow block on top of it 5.7 us.
-        register_direct = D_padded <= NARROW_ROW
+        # A row whose width the block divides is read from global memory straight
+        # into the register fragment. A padded row loses the vectorized copy to a
+        # per-element guard, so above NARROW_ROW it stages through shared memory,
+        # the only path that allocates it.
+        register_direct = not masked or D_padded <= NARROW_ROW
         # A tail row block runs past the end unless every index is guarded.
         guarded = masked or M % block_m != 0
         row_reduce = make_row_reduce(block_m, D, D_padded, eps)
@@ -110,7 +110,8 @@ def _group_norm_kernel(M, D, eps, dtype, num_groups, channels_per_group):
             y: T.Tensor[(M, D), dtype],
         ):
             with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
-                shared_buf = T.alloc_shared((block_m, D_padded), dtype)
+                if not register_direct:
+                    shared_buf = T.alloc_shared((block_m, D_padded), dtype)
                 x_local = T.alloc_fragment((block_m, D_padded), dtype)
                 x_f32 = T.alloc_fragment((block_m, D_padded), "float32")
                 acc = T.alloc_fragment((block_m,), "float32")
@@ -122,20 +123,22 @@ def _group_norm_kernel(M, D, eps, dtype, num_groups, channels_per_group):
 
                 if register_direct and guarded:
                     for i, j in T.Parallel(block_m, D_padded):
-                        x_local[i, j] = T.if_then_else(
+                        v = T.if_then_else(
                             T.And(pid_m * block_m + i < M, j < D),
                             x[pid_m * block_m + i, j],
                             T.cast(0.0, dtype),
                         )
-                    for i, j in T.Parallel(block_m, D_padded):
-                        x_f32[i, j] = T.cast(x_local[i, j], "float32")
+                        x_local[i, j] = v
+                        x_f32[i, j] = T.cast(v, "float32")
                 elif register_direct:
                     for i, j in T.Parallel(block_m, D_padded):
-                        x_local[i, j] = x[pid_m * block_m + i, j]
-                    for i, j in T.Parallel(block_m, D_padded):
-                        x_f32[i, j] = T.cast(x_local[i, j], "float32")
-                elif masked:
-                    # Keep the input in shared memory for the output pass.
+                        v = x[pid_m * block_m + i, j]
+                        x_local[i, j] = v
+                        x_f32[i, j] = T.cast(v, "float32")
+                else:
+                    # A padded wide row keeps its input in shared memory for the
+                    # output pass: the reduction overwrites the fp32 copy with
+                    # the centered squares.
                     for i, j in T.Parallel(block_m, D_padded):
                         shared_buf[i, j] = T.if_then_else(
                             T.And(pid_m * block_m + i < M, j < D),
@@ -143,11 +146,6 @@ def _group_norm_kernel(M, D, eps, dtype, num_groups, channels_per_group):
                             T.cast(0.0, dtype),
                         )
                         x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
-                else:
-                    T.copy(x[pid_m * block_m, 0], shared_buf)
-                    T.copy(shared_buf, x_local)
-                    for i, j in T.Parallel(block_m, D_padded):
-                        x_f32[i, j] = T.cast(x_local[i, j], "float32")
 
                 row_reduce(x_f32, acc, mean_val, rstd)
 
@@ -155,9 +153,8 @@ def _group_norm_kernel(M, D, eps, dtype, num_groups, channels_per_group):
                 if row_constant_affine:
                     # A group of one channel gives the whole row one weight and
                     # one bias, so the channel derivation and the two gathers
-                    # leave the element loop. Centering stays in it: a shift term
-                    # folding it in would subtract two large products, losing a
-                    # row whose mean dwarfs its residuals.
+                    # leave the element loop. Centering stays in it: folding it
+                    # into a shift term subtracts two large products.
                     for i in T.Parallel(block_m):
                         c = (pid_m * block_m + i) % num_groups
                         scale[i] = rstd[i] * T.cast(weight[c], "float32")
@@ -167,9 +164,7 @@ def _group_norm_kernel(M, D, eps, dtype, num_groups, channels_per_group):
                             y[pid_m * block_m + i, j] = T.cast(
                                 (
                                     T.cast(
-                                        shared_buf[i, j]
-                                        if (masked and not register_direct)
-                                        else x_local[i, j],
+                                        x_local[i, j] if register_direct else shared_buf[i, j],
                                         "float32",
                                     )
                                     - mean_val[i]
@@ -178,7 +173,7 @@ def _group_norm_kernel(M, D, eps, dtype, num_groups, channels_per_group):
                                 + bias_row[i],
                                 dtype,
                             )
-                elif masked:
+                elif guarded:
                     for i, j in T.Parallel(block_m, D_padded):
                         if T.And(pid_m * block_m + i < M, j < D):
                             c = _channel_of(
@@ -196,8 +191,6 @@ def _group_norm_kernel(M, D, eps, dtype, num_groups, channels_per_group):
                                 - mean_val[i]
                             ) * rstd[i] * T.cast(weight[c], "float32") + T.cast(bias[c], "float32")
                 else:
-                    # Re-cast from x_local (original dtype) to avoid a second
-                    # fp32 buffer.
                     for i, j in T.Parallel(block_m, D_padded):
                         c = _channel_of(
                             pid_m * block_m + i,
@@ -206,11 +199,9 @@ def _group_norm_kernel(M, D, eps, dtype, num_groups, channels_per_group):
                             channels_per_group,
                             spatial_size,
                         )
-                        x_local[i, j] = (T.cast(x_local[i, j], "float32") - mean_val[i]) * rstd[
-                            i
-                        ] * T.cast(weight[c], "float32") + T.cast(bias[c], "float32")
-                    T.copy(x_local, shared_buf)
-                    T.copy(shared_buf, y[pid_m * block_m, 0])
+                        y[pid_m * block_m + i, j] = (
+                            T.cast(x_local[i, j], "float32") - mean_val[i]
+                        ) * rstd[i] * T.cast(weight[c], "float32") + T.cast(bias[c], "float32")
 
         return main
 
@@ -345,10 +336,9 @@ def _group_norm_no_affine_kernel(M, D, eps, dtype):
     def _func(block_m, threads):
         # A non-aligned D would read and write columns >= D unless masked.
         masked = D_padded != D
-        # A row short enough that its fragment leaves the register file room goes
-        # straight from global memory into it; a wider one reads faster staged
-        # through shared.
-        register_direct = D_padded <= NARROW_ROW
+        # A row whose width the block divides is read straight into the register
+        # fragment; a padded one only while it is narrow.
+        register_direct = not masked or D_padded <= NARROW_ROW
         # A tail row block runs past the end unless every index is guarded.
         guarded = masked or M % block_m != 0
         row_reduce = make_row_reduce(block_m, D, D_padded, eps)
@@ -359,7 +349,8 @@ def _group_norm_no_affine_kernel(M, D, eps, dtype):
             y: T.Tensor[(M, D), dtype],
         ):
             with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
-                shared_buf = T.alloc_shared((block_m, D_padded), dtype)
+                if not register_direct:
+                    shared_buf = T.alloc_shared((block_m, D_padded), dtype)
                 x_local = T.alloc_fragment((block_m, D_padded), dtype)
                 x_f32 = T.alloc_fragment((block_m, D_padded), "float32")
                 acc = T.alloc_fragment((block_m,), "float32")
@@ -368,20 +359,22 @@ def _group_norm_no_affine_kernel(M, D, eps, dtype):
 
                 if register_direct and guarded:
                     for i, j in T.Parallel(block_m, D_padded):
-                        x_local[i, j] = T.if_then_else(
+                        v = T.if_then_else(
                             T.And(pid_m * block_m + i < M, j < D),
                             x[pid_m * block_m + i, j],
                             T.cast(0.0, dtype),
                         )
-                    for i, j in T.Parallel(block_m, D_padded):
-                        x_f32[i, j] = T.cast(x_local[i, j], "float32")
+                        x_local[i, j] = v
+                        x_f32[i, j] = T.cast(v, "float32")
                 elif register_direct:
                     for i, j in T.Parallel(block_m, D_padded):
-                        x_local[i, j] = x[pid_m * block_m + i, j]
-                    for i, j in T.Parallel(block_m, D_padded):
-                        x_f32[i, j] = T.cast(x_local[i, j], "float32")
-                elif masked:
-                    # Keep the input in shared memory for the output pass.
+                        v = x[pid_m * block_m + i, j]
+                        x_local[i, j] = v
+                        x_f32[i, j] = T.cast(v, "float32")
+                else:
+                    # A padded wide row keeps its input in shared memory for the
+                    # output pass: the reduction overwrites the fp32 copy with
+                    # the centered squares.
                     for i, j in T.Parallel(block_m, D_padded):
                         shared_buf[i, j] = T.if_then_else(
                             T.And(pid_m * block_m + i < M, j < D),
@@ -389,44 +382,30 @@ def _group_norm_no_affine_kernel(M, D, eps, dtype):
                             T.cast(0.0, dtype),
                         )
                         x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
-                else:
-                    T.copy(x[pid_m * block_m, 0], shared_buf)
-                    T.copy(shared_buf, x_local)
-                    for i, j in T.Parallel(block_m, D_padded):
-                        x_f32[i, j] = T.cast(x_local[i, j], "float32")
 
                 row_reduce(x_f32, acc, mean_val, rstd)
 
-                # No-affine output: y = (x - mean) * rstd. The row is read back
-                # from wherever the load left it.
-                if register_direct and guarded:
+                # No-affine output: y = (x - mean) * rstd.
+                if guarded:
                     for i, j in T.Parallel(block_m, D_padded):
                         if T.And(pid_m * block_m + i < M, j < D):
                             y[pid_m * block_m + i, j] = T.cast(
-                                (T.cast(x_local[i, j], "float32") - mean_val[i]) * rstd[i],
+                                (
+                                    T.cast(
+                                        x_local[i, j] if register_direct else shared_buf[i, j],
+                                        "float32",
+                                    )
+                                    - mean_val[i]
+                                )
+                                * rstd[i],
                                 dtype,
                             )
-                elif register_direct:
+                else:
                     for i, j in T.Parallel(block_m, D_padded):
                         y[pid_m * block_m + i, j] = T.cast(
                             (T.cast(x_local[i, j], "float32") - mean_val[i]) * rstd[i],
                             dtype,
                         )
-                elif masked:
-                    for i, j in T.Parallel(block_m, D_padded):
-                        if T.And(pid_m * block_m + i < M, j < D):
-                            y[pid_m * block_m + i, j] = T.cast(
-                                (T.cast(shared_buf[i, j], "float32") - mean_val[i]) * rstd[i],
-                                dtype,
-                            )
-                else:
-                    for i, j in T.Parallel(block_m, D_padded):
-                        x_local[i, j] = T.cast(
-                            (T.cast(x_local[i, j], "float32") - mean_val[i]) * rstd[i],
-                            dtype,
-                        )
-                    T.copy(x_local, shared_buf)
-                    T.copy(shared_buf, y[pid_m * block_m, 0])
 
         return main
 


### PR DESCRIPTION
## Summary

- Read a row whose width the block divides from global memory straight into the register fragment, with the fp32 conversion fused into the same traversal. Only a padded row wider than 2048 elements still stages through shared memory.
- Allocate the shared buffer only on that staged path, and write the output straight to global memory instead of staging it through the same buffer.
- Settle InstanceNorm's row affine once per row: a group of one channel gives the whole row one weight and one bias, so the channel derivation and both gathers leave the element loop.
- Let a row of at most 2048 elements take a block of one or two warps. The widths a row could land on started at 128, so a 1024-wide row reached nothing narrower and fell back to a block leaving each thread 8 elements.
- Guard the row direction on the aligned path. The staged store it replaces was a `T.copy` of a whole `block_m` tile into `y[pid_m * block_m, 0]`, which runs past the last row when `M % block_m != 0`.

## TileFoundry Description

```python
@module(entry="instance_norm", target=CudaTarget("nvidia.h200_sxm"),
        topologies=(Topology("cta", M), Topology("thread", 128)))
class RowPass:
    @func
    def instance_norm(x: Tensor[(M, D), "f16"], weight: ConstTensor[(1, C), "f16"],
                      bias: ConstTensor[(1, C), "f16"]):
        with Mesh(("cta",), (M,), ("row",)) as cta:
            with Mesh(("thread",), (128,), ("t",)) as m:
                held = tf.reshard(x, (M @ cta.row, D @ m.t), "rmem")
                rows = tf.cast(held, "f32")
                mean = tf.reduce(rows, (-1,), True, ReduceKind.MEAN)
                centered = rows - mean
                var = tf.reduce(tf.square(centered), (-1,), True, ReduceKind.MEAN)
                return tf.reshard(tf.cast(centered * tf.rsqrt(var + EPS), "f16"), (M, D), "gmem")
```

`tilefoundry analyze` prices the image-affine row at `ideal-ns=437` for the read and 437 for
the write, `bound-by=memory`, and reports every stage between them as register traffic. The
affine gather and the shared-memory staging this PR removes are two of those stages.

## Performance

Operators: `InstanceNormFwdOp`, `GroupNormFwdOp` (they share one row kernel)

| Environment | Value |
| --- | --- |
| image | ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-afcebed1-foundry-dev |
| digest | sha256:fe87c536154ad2ce3bffa4ff97e28fbfde7fcf6598d9d87c3f3dcc4ee9e44b5c |
| gpu | NVIDIA H200, one card for both sides |
| driver | 595.71.05 |
| cuda | 13.2 |
| torch | 2.13.0+cu132 |
| tilelang | 0.1.11+cu132.gitafcebed1 |
| timer | native CUPTI |

Method: the merge base and this branch ran `bench_instance_norm.py` and `bench_group_norm.py`
back to back in one window on one card, best of two runs each, L2 cleared per iteration. The
window matters: the same unmodified commit measured 2.8 us early in a session and 3.1 us
hours later on the same card, a drift of 1.03x to 1.11x that is larger than what is being
measured here. The table below is one such window; two earlier windows reproduce every figure
in it to within one displayed digit on 15 of 16 rows.

Ratio in comparator columns: implementation / candidate. &#x1F7E2; > 1 means the candidate is
faster.

### InstanceNormFwdOp

| Workload | Dtype | Candidate (us) | Merge base<br>/ candidate | Best comparator<br>/ candidate |
| --- | --- | ---: | ---: | ---: |
| image-affine | float16 | 2.8 | **3.1<br>&#x1F7E2;&nbsp;1.107x** | torch-compile 2.8<br>&#x1F7E2;&nbsp;1.000x |
| image-affine | bfloat16 | 2.8 | **3.1<br>&#x1F7E2;&nbsp;1.107x** | torch-compile 2.8<br>&#x1F7E2;&nbsp;1.000x |
| wider-channel-affine | float16 | 2.8 | **3.1<br>&#x1F7E2;&nbsp;1.107x** | torch-compile 2.7<br>&#x1F534;&nbsp;0.964x |
| tail-spatial-affine | float16 | 2.3 | **2.4<br>&#x1F7E2;&nbsp;1.043x** | torch-compile 2.2<br>&#x1F534;&nbsp;0.957x |
| image | float16 | 2.7 | **3.0<br>&#x1F7E2;&nbsp;1.111x** | torch-compile 2.7<br>&#x1F7E2;&nbsp;1.000x |
| image | bfloat16 | 2.8 | **3.0<br>&#x1F7E2;&nbsp;1.071x** | torch-compile 2.7<br>&#x1F534;&nbsp;0.964x |
| wider-channel | float16 | 2.7 | **3.0<br>&#x1F7E2;&nbsp;1.111x** | torch-compile 2.6<br>&#x1F534;&nbsp;0.963x |
| tail-spatial | float16 | 2.1 | **2.3<br>&#x1F7E2;&nbsp;1.095x** | torch-compile 2.1<br>&#x1F7E2;&nbsp;1.000x |

### GroupNormFwdOp

| Workload | Dtype | Candidate (us) | Merge base<br>/ candidate | Best comparator<br>/ candidate |
| --- | --- | ---: | ---: | ---: |
| image-g32-affine | float16 | 3.1 | **3.3<br>&#x1F7E2;&nbsp;1.065x** | flaggems 3.7<br>&#x1F7E2;&nbsp;1.194x |
| image-g32-affine | bfloat16 | 3.1 | **3.3<br>&#x1F7E2;&nbsp;1.065x** | flaggems 3.7<br>&#x1F7E2;&nbsp;1.194x |
| wider-channel-g32-affine | float16 | 3.4 | 3.4<br>1.000x | flaggems 3.7<br>&#x1F7E2;&nbsp;1.088x |
| tail-spatial-g16-affine | float16 | 3.5 | 3.5<br>1.000x | flaggems 3.6<br>&#x1F7E2;&nbsp;1.029x |
| image-g32 | float16 | 2.9 | **3.2<br>&#x1F7E2;&nbsp;1.103x** | flaggems 3.3<br>&#x1F7E2;&nbsp;1.138x |
| image-g32 | bfloat16 | 2.9 | **3.2<br>&#x1F7E2;&nbsp;1.103x** | flaggems 3.3<br>&#x1F7E2;&nbsp;1.138x |
| wider-channel-g32 | float16 | 3.0 | 3.0<br>1.000x | flaggems 3.2<br>&#x1F7E2;&nbsp;1.067x |
| tail-spatial-g16 | float16 | 2.8 | 2.8<br>1.000x | flaggems 3.2<br>&#x1F7E2;&nbsp;1.143x |

The four GroupNorm rows that move are the ones whose padded width is a power of two, 4096
elements: those now read into registers. The other four pad 6272 and 7200 elements up to
8192, stay masked and stay on the shared-memory path.

## Result And Limitations

- GroupNorm leads its fastest comparator on 8 of 8 rows, 1.029x to 1.194x. InstanceNorm ties or leads torch-compile on 5 of 8 and trails on 3, 0.957x to 0.964x.
- Those three rows are 2.3 us to 2.8 us against a 2.560 us kernel that reads the row, reduces it whole and writes it back with no normalization arithmetic. What is left is 4% of a figure a repeated measurement moves by up to 4.3%.
- Both bounds are the same 2048 elements and both are measured. A padded row above it loses the vectorized copy to a per-element guard and reads 5.7 us against 3.2 us on a 7200-wide row, and a block of one warp on such a row sends layout inference to the replicated layout this module's docstring describes.
- Row width picks the path and the guard is chosen inside it. Ordering them the other way sends a padded narrow row down the shared-memory path, which is what an earlier version of this change did.
- Placement was checked against TileFoundry and rejected: it prices four rows to a block at 1748 ns against 6992 ns for one row to a block, on a waves count of 2 against 8. Measured, more rows per block is slower at every width tried, and a hand-written warp-per-row kernel runs 3.008 us to 3.040 us against 2.816 us, unchanged as the block count falls from 1024 to 128. Waves are not what these rows wait on.
- The rows this PR moves are 2.1 us to 3.5 us, where a benchmark row and a repeated measurement of it differ by up to 4.3%. The gains above are best-of-two against a same-window baseline; a single pair of runs would not resolve them.
