### PR TITLE
[Refactor][Elementwise] Drop the unreachable fp8 paths and collapse the parametric kernel builders

### DIFF
--- a/benchmarks/ops/bench_independent_elementwise.py
+++ b/benchmarks/ops/bench_independent_elementwise.py
@@ -11,7 +11,6 @@ from typing import Optional
 
 import pytest
 import torch
-import torch.nn.functional as F
 
 from benchmarks.baselines import TORCH_COMPILE_TAG, compiled_reference
 from benchmarks.benchmark_base import (
@@ -23,15 +22,9 @@ from tileops.manifest import load_workloads
 from tileops.ops.elementwise import (
     AlibiFwdOp,
     ClampFwdOp,
-    ClampScalarFwdOp,
-    EluFwdOp,
-    LeakyReluFwdOp,
-    MaskedFillScalarFwdOp,
     SinusoidalFwdOp,
 )
 from workloads.elementwise import (
-    Fp8MaskedFillBenchCase,
-    Fp8UnaryBenchCase,
     TensorClampBenchCase,
     _GenerativeWorkload,
 )
@@ -189,118 +182,4 @@ def test_sinusoidal_bench(seq_len: int, d_model: int, dtype: torch.dtype) -> Non
             "torch-ref": baseline_fn,
             TORCH_COMPILE_TAG: compiled_reference(baseline_fn),
         }
-    )
-
-
-# fp8 benchmarks: representative independent ops with e4m3fn / e5m2
-# Baseline: PyTorch fp16-compute-then-cast (no native fp8 elementwise in PyTorch)
-
-_FP8_DTYPES = (torch.float8_e4m3fn, torch.float8_e5m2)
-_UNSUPPORTED_FP8_SKIP = pytest.mark.skip(
-    reason=(
-        "TileOPs elementwise ops currently reject fp8 dtypes; "
-        "benchmark is kept as an explicit unsupported case"
-    )
-)
-
-
-_FP8_UNARY_OPS = {
-    "leaky_relu": (LeakyReluFwdOp, lambda x: F.leaky_relu(x, 0.01), {}),
-    "elu": (EluFwdOp, lambda x: F.elu(x, 1.0), {}),
-    "clamp": (ClampScalarFwdOp, lambda x: torch.clamp(x, -0.5, 0.5), {"min": -0.5, "max": 0.5}),
-}
-
-
-def _fp8_unary_params():
-    """Both fp8 dtypes per op (e5m2 takes the non-saturating cast path);
-    shape swept on one op, since all three share one kernel."""
-    ref_shape = _UNARY_SHAPES[0]
-    params = []
-    for op_name in ("leaky_relu", "elu", "clamp"):
-        for dtype in _FP8_DTYPES:
-            mark = pytest.mark.smoke if dtype == torch.float8_e4m3fn else pytest.mark.full
-            params.append(
-                pytest.param(op_name, ref_shape, dtype, marks=[mark, _UNSUPPORTED_FP8_SKIP])
-            )
-    for shape in _UNARY_SHAPES[1:]:
-        params.append(
-            pytest.param(
-                "leaky_relu",
-                shape,
-                torch.float8_e4m3fn,
-                marks=[pytest.mark.full, _UNSUPPORTED_FP8_SKIP],
-            )
-        )
-    return params
-
-
-class Fp8UnaryIndependentBenchFixture(FixtureBase):
-    PARAMS = [("op_name, shape, dtype", _fp8_unary_params())]
-
-
-@Fp8UnaryIndependentBenchFixture
-def test_fp8_unary_independent_bench(op_name: str, shape: tuple, dtype: torch.dtype) -> None:
-    op_cls, baseline_fn, extra_kwargs = _FP8_UNARY_OPS[op_name]
-    test = Fp8UnaryBenchCase(shape, dtype)
-    inputs = test.gen_inputs()
-
-    op = op_cls(**extra_kwargs)
-    bm = ManifestBenchmark(op, test)
-
-    # Baseline: PyTorch fp16 compute then cast back to fp8
-    def baseline(x):
-        return baseline_fn(x.to(torch.float16)).to(dtype)
-
-    bm.compare(
-        {
-            "tileops": op,
-            "torch-ref": baseline,
-            TORCH_COMPILE_TAG: compiled_reference(baseline),
-        },
-        *inputs,
-    )
-
-
-# fp8 masked_fill (a selection op — fp8 passes through)
-
-
-def _fp8_selection_params():
-    """Both fp8 dtypes per op at the reference shape; the selection kernels are
-    shape-agnostic beyond total element count."""
-    ref_shape = _UNARY_SHAPES[0]
-    # ``where`` is absent: WhereFwdOp declares no fp8, so its case could only
-    # time torch against nothing.
-    params = []
-    for dtype in _FP8_DTYPES:
-        marks = [
-            pytest.mark.smoke if dtype == torch.float8_e4m3fn else pytest.mark.full,
-            _UNSUPPORTED_FP8_SKIP,
-        ]
-        params.append(pytest.param("masked_fill", ref_shape, dtype, marks=marks))
-    return params
-
-
-class Fp8SelectionBenchFixture(FixtureBase):
-    PARAMS = [("op_name, shape, dtype", _fp8_selection_params())]
-
-
-@Fp8SelectionBenchFixture
-def test_fp8_selection_bench(op_name: str, shape: tuple, dtype: torch.dtype) -> None:
-    test = Fp8MaskedFillBenchCase(shape, dtype)
-    x, mask = test.gen_inputs()
-
-    op = MaskedFillScalarFwdOp(value=-100.0)
-    bm = ManifestBenchmark(op, test)
-
-    def baseline(x, mask):
-        return x.to(torch.float16).masked_fill(mask, -100.0).to(dtype)
-
-    bm.compare(
-        {
-            "tileops": op,
-            "torch-ref": baseline,
-            TORCH_COMPILE_TAG: compiled_reference(baseline),
-        },
-        x,
-        mask,
     )

--- a/scripts/lint/workload_names_lint.py
+++ b/scripts/lint/workload_names_lint.py
@@ -26,7 +26,6 @@ BENCH_DIR = REPO_ROOT / "benchmarks" / "ops"
 # Files written before the rule. Name their cases and delete the line.
 EXEMPT = {
     "benchmarks/ops/bench_binary_elementwise.py",
-    "benchmarks/ops/bench_independent_elementwise.py",
     "benchmarks/ops/bench_moe_shared_fused_moe.py",
 }
 

--- a/src/tileops/kernels/elementwise/_base.py
+++ b/src/tileops/kernels/elementwise/_base.py
@@ -34,7 +34,6 @@ from ._op_body import (
     register_op_func,
 )
 from ._policy import (
-    _DEFAULT_THREADS,
     choose_binary_strategy,
     choose_unary_strategy,
     default_launch_config,
@@ -513,10 +512,6 @@ class _Uint8StorageUnaryKernel(UnaryKernel):
     DEFAULT_STRATEGY = "register_copy"
     SUPPORTED_DTYPES = (torch.uint8,)
 
-    @property
-    def default_config(self) -> dict:
-        return {"strategy": self.strategy, "threads": _DEFAULT_THREADS, "num_per_thread": 16}
-
     def forward(self, x):
         as_bool = x.dtype == torch.bool
         if as_bool:
@@ -530,10 +525,6 @@ class _Uint8StorageBinaryKernel(BinaryKernel):
 
     DEFAULT_STRATEGY = "explicit_parallel"
     SUPPORTED_DTYPES = (torch.uint8,)
-
-    @property
-    def default_config(self) -> dict:
-        return {"strategy": self.strategy, "threads": _DEFAULT_THREADS, "num_per_thread": 16}
 
     def forward(self, a, b):
         as_bool = a.dtype == torch.bool

--- a/src/tileops/kernels/elementwise/_base.py
+++ b/src/tileops/kernels/elementwise/_base.py
@@ -9,6 +9,8 @@ from tileops.kernels.kernel_base import Kernel
 
 from ._broadcast import (
     BroadcastPlan,
+    _broadcast_target,
+    _expand_flat,
     _flat,
     _is_contiguous_same_shape,
     coalesce_broadcast_dims,
@@ -25,16 +27,14 @@ from ._builders import (
     _make_unary_explicit,
     _make_unary_regcopy,
 )
-from ._dtype import _BITWISE_DTYPES, _FLOAT_DTYPES, _LOGICAL_DTYPES, _is_fp8
+from ._dtype import _BITWISE_DTYPES, _FLOAT_DTYPES, _LOGICAL_DTYPES
 from ._op_body import (
     _store_binary_bool_as_int8,
     _store_unary_bool_as_int8,
-    _wrap_fp8_accumulation,
     register_op_func,
 )
 from ._policy import (
     _DEFAULT_THREADS,
-    _get_fp8_output_dtypes,
     choose_binary_strategy,
     choose_unary_strategy,
     default_launch_config,
@@ -48,7 +48,8 @@ __all__ = [
     "FloatUnaryKernel",
     "FusedGatedKernel",
     "LogicalUnaryKernel",
-    "ParametricUnaryKernel",
+    "MultiInputElementwiseKernel",
+    "ScalarParamUnaryKernel",
     "UnaryKernel",
 ]
 
@@ -65,26 +66,14 @@ class _ElementwiseKernel(Kernel):
     MIN_NUM_PER_THREAD: int = 4
     # Input dtypes admitted; ``None`` admits every dtype the builder handles.
     SUPPORTED_DTYPES = None
+    # Thread count this family launches with, or ``None`` to take the strategy's.
+    DEFAULT_THREADS: int | None = None
     # Whether bool results are stored through an int8 buffer.
     _bool_via_int8: bool = False
-    # Dtype the result is cast back to when the kernel writes a wider one.
-    _fp8_output_dtype = None
 
     # Extent of the row a broadcast block walks, or ``None`` where blocks are not
     # cut from rows. Only the binary families lay a grid out that way.
     row_broadcast_inner: int | None = None
-
-    @property
-    def stage_broadcast(self) -> bool:
-        """Whether a broadcast block reads and writes through fragments.
-
-        A body TileLang cannot vectorise -- a predicate, whose ``boolx<N>`` has no
-        CUDA type -- drags the loads and stores to its own width when they share
-        its loop. Staging keeps the copies wide, at the cost of a round trip
-        through registers. A body that scalarises for another reason overrides
-        this.
-        """
-        return self.output_dtype == torch.bool
 
     def _validate_supported_dtype(self, dtype) -> None:
         if self.SUPPORTED_DTYPES is None or dtype in self.SUPPORTED_DTYPES:
@@ -93,11 +82,7 @@ class _ElementwiseKernel(Kernel):
         raise ValueError(f"{type(self).__name__} only supports dtypes [{supported}], got {dtype}")
 
     def _restore_output_dtype(self, result):
-        if self._bool_via_int8:
-            result = result.view(torch.bool)
-        if self._fp8_output_dtype is not None:
-            result = result.to(self._fp8_output_dtype)
-        return result
+        return result.view(torch.bool) if self._bool_via_int8 else result
 
 
 class _StrategyKernel(_ElementwiseKernel):
@@ -117,6 +102,7 @@ class _StrategyKernel(_ElementwiseKernel):
             bytes_per_thread=self.BYTES_PER_THREAD,
             min_num_per_thread=self.MIN_NUM_PER_THREAD,
             row_broadcast_inner=self.row_broadcast_inner,
+            default_threads=self.DEFAULT_THREADS,
         )
 
     @property
@@ -185,7 +171,6 @@ class UnaryKernel(_StrategyKernel):
             bool_storage=True,
         )
         self.output_dtype = self.output_plan.logical_dtype
-        self._fp8_output_dtype = self.output_plan.post_cast_dtype
         self._bool_via_int8 = self.output_plan.bool_via_int8
         self.kernel = self._build_kernel(self.strategy)
         self.init_config(config, tune)
@@ -195,13 +180,19 @@ class UnaryKernel(_StrategyKernel):
         name = self._op_func_name()
         if self._bool_via_int8:
             return name, _store_unary_bool_as_int8(self.op_func)
-        if self.OUTPUT_DTYPE is not None:
-            return name, self.op_func
-        return name, _wrap_fp8_accumulation(self.op_func, self.dtype, self.dtype_str, arity=1)
+        return name, self.op_func
 
     def _op_func_name(self) -> str:
-        """Name every input that changes the op body: see ``register_op_func``."""
-        return f"{type(self).__qualname__}|{self.dtype_str}|{self.output_dtype_str}|{self.strategy}"
+        """Name every input that changes the op body: see ``register_op_func``.
+
+        Module included: ``_OP_FUNCS`` is one dict for the whole package, and two
+        classes sharing a qualname would otherwise overwrite each other's body.
+        """
+        cls = type(self)
+        return (
+            f"{cls.__module__}.{cls.__qualname__}"
+            f"|{self.dtype_str}|{self.output_dtype_str}|{self.strategy}"
+        )
 
     def _build_kernel(self, strategy):
         cfg = self.default_config
@@ -320,19 +311,28 @@ class BinaryKernel(_StrategyKernel):
             bool_storage=True,
         )
         self.output_dtype = self.output_plan.logical_dtype
-        self._fp8_output_dtype = self.output_plan.post_cast_dtype
         self._bool_via_int8 = self.output_plan.bool_via_int8
         self.kernel = self._build_kernel(self.strategy)
         self.init_config(config, tune)
+
+    @property
+    def stage_broadcast(self) -> bool:
+        """Whether a broadcast block reads and writes through fragments.
+
+        A body TileLang cannot vectorise -- a predicate, whose ``boolx<N>`` has no
+        CUDA type -- drags the loads and stores to its own width when they share
+        its loop. Staging keeps the copies wide, at the cost of a round trip
+        through registers. A body that scalarises for another reason overrides
+        this.
+        """
+        return self.output_dtype == torch.bool
 
     def _get_effective_op_func(self):
         """The op body this kernel builds with, and the name that identifies it."""
         name = self._op_func_name()
         if self._bool_via_int8:
             return name, _store_binary_bool_as_int8(self.op_func)
-        if self.OUTPUT_DTYPE is not None:
-            return name, self.op_func
-        return name, _wrap_fp8_accumulation(self.op_func, self.dtype, self.dtype_str, arity=2)
+        return name, self.op_func
 
     def _op_func_name(self) -> str:
         cls = type(self)
@@ -347,7 +347,7 @@ class BinaryKernel(_StrategyKernel):
         )
         kernel_output_dtype = (
             self.output_plan.kernel_output_dtype
-            if self.OUTPUT_DTYPE is not None or self._bool_via_int8 or self._fp8_output_dtype
+            if self.OUTPUT_DTYPE is not None or self._bool_via_int8
             else None
         )
         if strategy == "direct":
@@ -432,12 +432,7 @@ class FusedGatedKernel(_StrategyKernel):
             raise ValueError(
                 f"Unknown strategy '{self.strategy}', expected one of {self.STRATEGIES}"
             )
-        self.output_plan = elementwise_output_plan(dtype)
-        self.output_dtype = self.output_plan.logical_dtype
-        self._fp8_output_dtype = self.output_plan.post_cast_dtype
-        self._kernel_output_dtype = (
-            self.output_plan.kernel_output_dtype if self.output_plan.post_cast_dtype else None
-        )
+        self.output_dtype = dtype
         self.kernel = self._build_kernel(self.strategy)
         self.init_config(config, tune)
 
@@ -450,7 +445,7 @@ class FusedGatedKernel(_StrategyKernel):
 
         cls = type(self)
         name = f"{cls.__module__}.{cls.__qualname__}|{self.dtype_str}|{self.strategy}"
-        return name, _wrap_fp8_accumulation(fused_op, self.dtype, self.dtype_str, arity=2)
+        return name, fused_op
 
     def _build_kernel(self, strategy):
         cfg = self.default_config
@@ -462,7 +457,6 @@ class FusedGatedKernel(_StrategyKernel):
                 self.dtype_str,
                 effective_op,
                 threads=cfg["threads"],
-                output_dtype=self._kernel_output_dtype,
             )
         elif strategy == "explicit_parallel":
             return _make_fused_gated_explicit(
@@ -472,7 +466,6 @@ class FusedGatedKernel(_StrategyKernel):
                 effective_op,
                 cfg["threads"],
                 cfg["num_per_thread"],
-                output_dtype=self._kernel_output_dtype,
             )
         else:
             raise ValueError(f"Unknown strategy: {strategy}")
@@ -631,93 +624,101 @@ class _AlphaScaledBinaryKernel(BinaryKernel):
 
     def _get_effective_op_func(self):
         """Inject the alpha-baked op_func into the parent build pipeline."""
-        op_func = self._alpha_op_func()
-        name = f"{self._op_func_name()}|alpha={self._alpha!r}"
-        if self.OUTPUT_DTYPE is not None:
-            return name, op_func
-        return name, _wrap_fp8_accumulation(op_func, self.dtype, self.dtype_str, arity=2)
+        return f"{self._op_func_name()}|alpha={self._alpha!r}", self._alpha_op_func()
 
 
-class ParametricUnaryKernel(_ElementwiseKernel):
-    """Shared base for independent parametric elementwise kernels.
+class ScalarParamUnaryKernel(UnaryKernel):
+    """A unary kernel whose op body is built from construction-time scalars.
 
-    Subclasses must define:
-    - ``_builder_fn``: a ``@staticmethod`` returning the ``@lru_cache``-d
-      builder function (e.g. ``_make_leaky_relu_kernel``).
-    - ``_builder_args(self) -> tuple``: positional args for the builder
-      *between* ``N_total`` and the common ``output_dtype, is_fp8, threads,
-      npt`` suffix.
+    The scalars are bound into the body rather than passed to the PrimFunc, so
+    every distinct value is its own specialization. Subclasses implement
+    ``_make_op_func`` and ``_param_key``; ``op_func`` is never called.
 
-    Optional overrides:
-    - ``_DEFAULT_THREADS``: class-level default thread count (default 256).
-    - ``_NPT_FP8``: npt when dtype is fp8 but not fp32 (default 16).
-    - ``_NPT_NON_FP32``: npt for non-fp32, non-fp8 (default 8).
-    - ``_skip_fp8_output``: set to ``True`` if the kernel should *not*
-      use ``_get_fp8_output_dtypes`` (e.g. Where, which is a pure selection
-      op). When True, ``_fp8_output_dtype`` is ``None``.
+    Only ``register_copy`` is offered. The wider strategy axis ``UnaryKernel``
+    carries has never been measured for these bodies.
+    """
+
+    SUPPORTED_DTYPES = _FLOAT_DTYPES
+    STRATEGIES = ["register_copy"]
+    DEFAULT_STRATEGY = "register_copy"
+    DEFAULT_THREADS = 256
+
+    def _make_op_func(self):
+        """Return the op body for this specialization's scalars."""
+        raise NotImplementedError
+
+    def _param_key(self) -> str:
+        """Return the scalar values, spelled out for the op body's name."""
+        raise NotImplementedError
+
+    @staticmethod
+    def op_func(x):
+        raise NotImplementedError(
+            "ScalarParamUnaryKernel builds its body from construction parameters; "
+            "use the kernel through __init__ instead of calling op_func."
+        )
+
+    def _get_effective_op_func(self):
+        return f"{self._op_func_name()}|{self._param_key()}", self._make_op_func()
+
+
+class MultiInputElementwiseKernel(_ElementwiseKernel):
+    """Several inputs broadcast to one shape, read as fragments, one output.
+
+    Subclasses define ``_builder_fn`` (the ``@lru_cache``-d builder) and
+    ``_builder_args`` (its positional arguments after ``N_total`` and the dtype
+    string), and describe their forward arguments in ``INPUTS`` as
+    ``(name, kind)`` pairs in PrimFunc parameter order:
+
+    =========== =============================================================
+    ``tile``    broadcast to the output shape and flattened
+    ``mask``    the same, reinterpreted as uint8 -- this backend has no
+                vectorised bool
+    ``value``   a 0-dim scalar reshaped to a length-one buffer
+    =========== =============================================================
+
+    An argument the call leaves as ``None`` names no PrimFunc parameter, which
+    is how an optional bound drops out of the signature.
     """
 
     supported_archs: list[int] = [80, 86, 89, 90]
     SUPPORTED_DTYPES = _FLOAT_DTYPES
+    DEFAULT_THREADS = 256
+    INPUTS: tuple = ()
 
-    _DEFAULT_THREADS: int = 256
-    _NPT_FP8: int = 16
-    _NPT_NON_FP32: int = 8
-    _skip_fp8_output: bool = False
+    # Elements per thread for a dtype narrower than float32. A float32 thread
+    # takes four, which is one vector.
+    NPT_NON_FP32: int = 8
 
     def __init__(self, N_total, dtype, config=None, tune=False):
         super().__init__()
         self._validate_supported_dtype(dtype)
         self.N_total = N_total
         self.dtype = dtype
-        if self._skip_fp8_output:
-            self._fp8_output_dtype = None
-        else:
-            self._fp8_output_dtype, self.output_dtype = _get_fp8_output_dtypes(dtype)
-        self._post_init_params()
+        self.output_dtype = dtype
         cfg = self.default_config
-        builder_kwargs = {
-            "is_fp8": _is_fp8(dtype),
-            "threads": cfg["threads"],
-            "npt": cfg["num_per_thread"],
-        }
-        if not self._skip_fp8_output:
-            builder_kwargs["output_dtype"] = self.dtype_to_str(self.output_dtype)
         self.kernel = self._builder_fn()(
-            *self._builder_positional_args(),
-            **builder_kwargs,
+            self.N_total,
+            self.dtype_str,
+            *self._builder_args(),
+            threads=cfg["threads"],
+            npt=cfg["num_per_thread"],
         )
         self.init_config(config, tune)
 
     @staticmethod
     def _builder_fn():
-        """Return the @lru_cache builder function for this kernel."""
+        """Return the ``@lru_cache``-d builder function for this kernel."""
         raise NotImplementedError
 
-    def _builder_positional_args(self) -> tuple:
-        """Return all positional args for the builder function.
-
-        Default: ``(N_total, dtype_str, *_builder_args())``.
-        Override if the builder has a different parameter order (e.g. PReLU).
-        """
-        return (self.N_total, self.dtype_str, *self._builder_args())
-
     def _builder_args(self) -> tuple:
-        """Return op-specific positional args (after N_total, dtype_str)."""
+        """Return the builder's positional args after ``N_total`` and the dtype."""
         return ()
-
-    def _post_init_params(self):
-        """Hook called after fp8 output dtypes are set, before kernel build."""
 
     @property
     def default_config(self):
-        if self.dtype == torch.float32:
-            npt = 4
-        elif _is_fp8(self.dtype):
-            npt = self._NPT_FP8
-        else:
-            npt = self._NPT_NON_FP32
-        return {"threads": self._DEFAULT_THREADS, "num_per_thread": npt}
+        npt = 4 if self.dtype == torch.float32 else self.NPT_NON_FP32
+        return {"threads": self.DEFAULT_THREADS, "num_per_thread": npt}
 
     @property
     def autotune_configs(self) -> list[dict]:
@@ -728,7 +729,27 @@ class ParametricUnaryKernel(_ElementwiseKernel):
         cfg = self.config
         self._compiled_fn = self.kernel(cfg["threads"], cfg["num_per_thread"])
 
-    def forward(self, x):
-        self._require_cuda(x=x)
-        result = self._compiled_fn(_flat(x))
-        return self._restore_output_dtype(result).reshape(x.shape)
+    def _run(self, **tensors):
+        """Broadcast the named inputs together, run, and restore the call's shape.
+
+        The first ``tile`` input carries the semantic dtype: a bool one is
+        computed in uint8 storage, and the result is viewed back to bool.
+        """
+        self._require_cuda(**tensors)
+        present = [(name, kind) for name, kind in self.INPUTS if tensors.get(name) is not None]
+        out_shape = _broadcast_target(*(tensors[n] for n, kind in present if kind != "value"))
+        as_bool = tensors[next(n for n, kind in present if kind == "tile")].dtype == torch.bool
+
+        args = []
+        for name, kind in present:
+            tensor = tensors[name]
+            if kind == "value":
+                tensor = tensor.contiguous().reshape(1)
+                args.append(tensor.view(torch.uint8) if as_bool else tensor)
+                continue
+            if kind == "mask" or as_bool:
+                tensor = tensor.view(torch.uint8)
+            args.append(_expand_flat(tensor, out_shape))
+
+        result = self._compiled_fn(*args).reshape(out_shape)
+        return result.view(torch.bool) if as_bool else result

--- a/src/tileops/kernels/elementwise/_base.py
+++ b/src/tileops/kernels/elementwise/_base.py
@@ -634,8 +634,8 @@ class ScalarParamUnaryKernel(UnaryKernel):
     every distinct value is its own specialization. Subclasses implement
     ``_make_op_func`` and ``_param_key``; ``op_func`` is never called.
 
-    Only ``register_copy`` is offered. The wider strategy axis ``UnaryKernel``
-    carries has never been measured for these bodies.
+    Only ``register_copy`` is offered; a ``config`` naming another strategy
+    raises.
     """
 
     SUPPORTED_DTYPES = _FLOAT_DTYPES
@@ -677,8 +677,7 @@ class MultiInputElementwiseKernel(_ElementwiseKernel):
     ``value``   a 0-dim scalar reshaped to a length-one buffer
     =========== =============================================================
 
-    An argument the call leaves as ``None`` names no PrimFunc parameter, which
-    is how an optional bound drops out of the signature.
+    An argument the call leaves as ``None`` names no PrimFunc parameter.
     """
 
     supported_archs: list[int] = [80, 86, 89, 90]

--- a/src/tileops/kernels/elementwise/_builders.py
+++ b/src/tileops/kernels/elementwise/_builders.py
@@ -569,16 +569,15 @@ def _make_binary_explicit(
 
 
 @functools.lru_cache(maxsize=32)
-def _make_fused_gated_direct(M, N, dtype, op_name, threads=256, output_dtype=None):
+def _make_fused_gated_direct(M, N, dtype, op_name, threads=256):
     """FusedGated direct: 1 element per thread."""
-    out_dtype = output_dtype or dtype
 
     @tilelang.jit(out_idx=[1])
     def kernel(threads_arg):
         op_func = op_func_for(op_name)
 
         @T.prim_func
-        def main(x: T.Tensor((M, 2 * N), dtype), y: T.Tensor((M, N), out_dtype)):
+        def main(x: T.Tensor((M, 2 * N), dtype), y: T.Tensor((M, N), dtype)):
             with T.Kernel(T.ceildiv(N, threads_arg), M, threads=threads_arg) as (bx, by):
                 for i in T.Parallel(threads_arg):
                     col = bx * threads_arg + i
@@ -592,11 +591,8 @@ def _make_fused_gated_direct(M, N, dtype, op_name, threads=256, output_dtype=Non
 
 
 @functools.lru_cache(maxsize=32)
-def _make_fused_gated_explicit(
-    M, N, dtype, op_name, threads=256, num_per_thread=8, output_dtype=None
-):
+def _make_fused_gated_explicit(M, N, dtype, op_name, threads=256, num_per_thread=8):
     """FusedGated explicit_parallel: N elements per thread."""
-    out_dtype = output_dtype or dtype
 
     @tilelang.jit(out_idx=[1])
     def kernel(threads_arg, npt_arg):
@@ -604,7 +600,7 @@ def _make_fused_gated_explicit(
         block_N = threads_arg * npt_arg
 
         @T.prim_func
-        def main(x: T.Tensor((M, 2 * N), dtype), y: T.Tensor((M, N), out_dtype)):
+        def main(x: T.Tensor((M, 2 * N), dtype), y: T.Tensor((M, N), dtype)):
             with T.Kernel(T.ceildiv(N, block_N), M, threads=threads_arg) as (bx, by):
                 for i, j in T.Parallel(threads_arg, npt_arg):
                     col = (bx * threads_arg + i) * npt_arg + j

--- a/src/tileops/kernels/elementwise/_dtype.py
+++ b/src/tileops/kernels/elementwise/_dtype.py
@@ -24,8 +24,7 @@ _BITWISE_DTYPES = (
 )
 
 
-# The dtypes every elementwise kernel refuses. No kernel here declares one in
-# ``SUPPORTED_DTYPES``, so this is a rejection list, not a code path.
+# The dtypes every elementwise kernel refuses.
 _FP8_DTYPES = (
     torch.float8_e4m3fn,
     torch.float8_e5m2,

--- a/src/tileops/kernels/elementwise/_dtype.py
+++ b/src/tileops/kernels/elementwise/_dtype.py
@@ -24,6 +24,8 @@ _BITWISE_DTYPES = (
 )
 
 
+# The dtypes every elementwise kernel refuses. No kernel here declares one in
+# ``SUPPORTED_DTYPES``, so this is a rejection list, not a code path.
 _FP8_DTYPES = (
     torch.float8_e4m3fn,
     torch.float8_e5m2,
@@ -50,24 +52,9 @@ _BINARY_FULL_DTYPES = _BITWISE_DTYPES + (
 _BINARY_NO_BOOL_DTYPES = tuple(dt for dt in _BINARY_FULL_DTYPES if dt is not torch.bool)
 
 
-def _is_fp8(dtype: torch.dtype) -> bool:
-    """Check if a torch dtype is an fp8 variant."""
-    return dtype in _FP8_DTYPES
-
-
 def _torch_dtype_nbytes(dtype: torch.dtype) -> int:
     """Return the byte width of a torch dtype."""
     return torch.empty(0, dtype=dtype).element_size()
-
-
-def _fp8_needs_nonsaturating_cast(dtype: torch.dtype) -> bool:
-    """Return True if the fp8 format supports Inf/NaN and needs non-saturating output."""
-    return dtype == torch.float8_e5m2
-
-
-def _fp8_accum_dtype_str() -> str:
-    """Return the TileLang dtype string used for fp8 intermediate accumulation."""
-    return "float16"
 
 
 def _clamp_to_dtype_range(value, dtype: torch.dtype):
@@ -91,7 +78,5 @@ def _clamp_to_dtype_range(value, dtype: torch.dtype):
         return fvalue
     finfo = torch.finfo(dtype)
     if math.isinf(fvalue):
-        if dtype in _FP8_DTYPES and not _fp8_needs_nonsaturating_cast(dtype):
-            return finfo.max if fvalue > 0 else finfo.min
         return fvalue
     return max(finfo.min, min(finfo.max, fvalue))

--- a/src/tileops/kernels/elementwise/_op_body.py
+++ b/src/tileops/kernels/elementwise/_op_body.py
@@ -8,12 +8,7 @@ from typing import Callable
 
 import tilelang.language as T
 
-from ._dtype import (
-    BOOL_STORAGE_DTYPE,
-    _fp8_accum_dtype_str,
-    _fp8_needs_nonsaturating_cast,
-    _is_fp8,
-)
+from ._dtype import BOOL_STORAGE_DTYPE
 
 __all__ = ["op_func_for", "register_op_func"]
 
@@ -62,29 +57,3 @@ def _store_unary_bool_as_int8(op_func):
 
 def _store_binary_bool_as_int8(op_func):
     return _store_bool_as_int8(op_func, arity=2)
-
-
-def _wrap_fp8_accumulation(base_op, dtype, dtype_str, arity=1):
-    if not _is_fp8(dtype):
-        return base_op
-
-    accum = _fp8_accum_dtype_str()
-    if _fp8_needs_nonsaturating_cast(dtype):
-        if arity == 1:
-
-            def fp8_accum_op(x):
-                return base_op(T.cast(x, accum))
-        else:
-
-            def fp8_accum_op(a, b):
-                return base_op(T.cast(a, accum), T.cast(b, accum))
-    elif arity == 1:
-
-        def fp8_accum_op(x):
-            return T.Cast(dtype_str, base_op(T.cast(x, accum)))
-    else:
-
-        def fp8_accum_op(a, b):
-            return T.Cast(dtype_str, base_op(T.cast(a, accum), T.cast(b, accum)))
-
-    return fp8_accum_op

--- a/src/tileops/kernels/elementwise/_policy.py
+++ b/src/tileops/kernels/elementwise/_policy.py
@@ -8,13 +8,7 @@ import torch
 from tileops.kernels.kernel_base import Kernel
 
 from ._broadcast import row_tile_leaves_tail
-from ._dtype import (
-    BOOL_STORAGE_DTYPE,
-    _fp8_accum_dtype_str,
-    _fp8_needs_nonsaturating_cast,
-    _is_fp8,
-    _torch_dtype_nbytes,
-)
+from ._dtype import BOOL_STORAGE_DTYPE, _torch_dtype_nbytes
 
 _AUTOTUNE_THREADS = (128, 256, 512)
 _DEFAULT_THREADS = 128
@@ -24,7 +18,6 @@ _MIN_NUM_PER_THREAD = 4
 _BOOL_OUTPUT_MAX_NPT = 4
 _MAX_THREADS = 1024
 _TARGET_BLOCKS = 256
-_FP8_NPT = 16
 
 
 def default_launch_config(
@@ -37,6 +30,7 @@ def default_launch_config(
     bytes_per_thread: int = _BYTES_PER_THREAD,
     min_num_per_thread: int = _MIN_NUM_PER_THREAD,
     row_broadcast_inner: int | None = None,
+    default_threads: int | None = None,
 ) -> dict:
     """Return the default launch config for one elementwise specialization.
 
@@ -44,14 +38,13 @@ def default_launch_config(
     how few elements the shrink below leaves it; see
     ``_ElementwiseKernel.BYTES_PER_THREAD`` and ``MIN_NUM_PER_THREAD``.
     *row_broadcast_inner* is the row extent a broadcast block walks, or
-    ``None``; see ``_tail_dominated``.
+    ``None``; see ``_tail_dominated``. *default_threads* replaces the
+    strategy's thread count; see ``_ElementwiseKernel.DEFAULT_THREADS``.
     """
     # A direct block covers ``threads`` elements where a vectorized one covers
     # ``threads * num_per_thread``: the elements per block, not the thread count,
     # are what has to stay wide enough to keep the memory pipe busy.
-    threads = _DIRECT_THREADS if strategy == "direct" else _DEFAULT_THREADS
-    if _is_fp8(input_dtype):
-        return {"strategy": strategy, "threads": threads, "num_per_thread": _FP8_NPT}
+    threads = default_threads or (_DIRECT_THREADS if strategy == "direct" else _DEFAULT_THREADS)
 
     elem_bytes = _torch_dtype_nbytes(input_dtype)
     npt = max(_MIN_NUM_PER_THREAD, bytes_per_thread // elem_bytes)
@@ -109,23 +102,17 @@ def elementwise_autotune_configs(
     # and the sweep would time one kernel three times over.
     if strategy == "direct":
         return [{"threads": t} for t in _AUTOTUNE_THREADS]
-    if _is_fp8(dtype):
-        npts = (_FP8_NPT, _FP8_NPT * 2)
-    else:
-        default = max(_MIN_NUM_PER_THREAD, bytes_per_thread // _torch_dtype_nbytes(dtype))
-        npts = tuple(
-            sorted(
-                {min_num_per_thread, max(min_num_per_thread, default // 2), default, default * 2}
-            )
-        )
+    default = max(_MIN_NUM_PER_THREAD, bytes_per_thread // _torch_dtype_nbytes(dtype))
+    npts = tuple(
+        sorted({min_num_per_thread, max(min_num_per_thread, default // 2), default, default * 2})
+    )
     return [{"threads": t, "num_per_thread": n} for t in _AUTOTUNE_THREADS for n in npts]
 
 
 @dataclass(frozen=True)
 class ElementwiseOutputPlan:
     logical_dtype: torch.dtype
-    kernel_output_dtype: str | None
-    post_cast_dtype: torch.dtype | None = None
+    kernel_output_dtype: str
     bool_via_int8: bool = False
 
 
@@ -136,26 +123,15 @@ def elementwise_output_plan(
     strategy: str | None = None,
     bool_storage: bool = False,
 ) -> ElementwiseOutputPlan:
-    post_cast_dtype = None
+    """Return the dtype the kernel writes, and the dtype the caller sees."""
     logical_dtype = declared_output_dtype or input_dtype
-    if (
-        declared_output_dtype is None
-        and _is_fp8(input_dtype)
-        and _fp8_needs_nonsaturating_cast(input_dtype)
-    ):
-        logical_dtype, post_cast_dtype = torch.float16, input_dtype
-
     # Every strategy but `direct` can store the result through an int8 buffer, and
     # wants to: a bool store lowers to one byte per lane, where int8 vectorises.
     bool_via_int8 = bool_storage and declared_output_dtype == torch.bool and strategy != "direct"
-    if bool_via_int8:
-        kernel_output_dtype = BOOL_STORAGE_DTYPE
-    elif post_cast_dtype is not None:
-        kernel_output_dtype = _fp8_accum_dtype_str()
-    else:
-        kernel_output_dtype = Kernel.dtype_to_str(logical_dtype)
-
-    return ElementwiseOutputPlan(logical_dtype, kernel_output_dtype, post_cast_dtype, bool_via_int8)
+    kernel_output_dtype = (
+        BOOL_STORAGE_DTYPE if bool_via_int8 else Kernel.dtype_to_str(logical_dtype)
+    )
+    return ElementwiseOutputPlan(logical_dtype, kernel_output_dtype, bool_via_int8)
 
 
 def _bool_output_needs_scalar(
@@ -167,12 +143,6 @@ def _bool_output_needs_scalar(
         torch.int8,
         torch.int16,
     )
-
-
-def _get_fp8_output_dtypes(dtype: torch.dtype):
-    if _is_fp8(dtype) and _fp8_needs_nonsaturating_cast(dtype):
-        return dtype, torch.float16
-    return None, dtype
 
 
 def _validate_strategy(requested: str | None, strategies: list[str]) -> None:
@@ -210,8 +180,6 @@ def choose_unary_strategy(
     if _bool_output_needs_scalar(input_dtype, declared_output_dtype):
         _warn_direct_override(requested, "UnaryKernel", input_dtype)
         return "direct"
-    if requested is None and _is_fp8(input_dtype):
-        return "explicit_parallel"
     return requested or default_strategy
 
 

--- a/src/tileops/kernels/elementwise/activations.py
+++ b/src/tileops/kernels/elementwise/activations.py
@@ -270,10 +270,8 @@ class HardtanhFwdKernel(ScalarParamUnaryKernel):
 def _make_softplus_kernel(N, dtype, beta, threshold, threads=256, npt=8):
     """Build softplus: y = log(1 + exp(x*beta))/beta if x*beta <= threshold else x.
 
-    Written out rather than bound through ``ScalarParamUnaryKernel``: the
-    statement binding ``softplus`` lifts the exponential and the logarithm out
-    of the guard, which an op body returning one expression cannot do, and a
-    float16 row is 1.2% slower with them inside it.
+    Binding ``softplus`` as a statement lifts the exponential and the logarithm
+    out of the guard. float16 rows are 1.2% slower with them inside it.
     """
 
     @tilelang.jit(out_idx=[1])

--- a/src/tileops/kernels/elementwise/activations.py
+++ b/src/tileops/kernels/elementwise/activations.py
@@ -11,9 +11,10 @@ from ._base import (
     _FLOAT_DTYPES,
     FloatUnaryKernel,
     FusedGatedKernel,
-    ParametricUnaryKernel,
+    MultiInputElementwiseKernel,
+    ScalarParamUnaryKernel,
 )
-from ._dtype import _fp8_accum_dtype_str, log_for_output_precision
+from ._dtype import log_for_output_precision
 from ._erf import erf
 
 __all__ = [
@@ -198,206 +199,51 @@ class SeluFwdKernel(FloatUnaryKernel):
         return scale * T.if_then_else(x32 > zero, x32, alpha * (T.exp(x32) - one))
 
 
-@functools.lru_cache(maxsize=32)
-def _make_leaky_relu_kernel(
-    N, dtype, negative_slope, output_dtype=None, is_fp8=False, threads=256, npt=8
-):
-    """Build leaky_relu kernel: y = x if x > 0 else negative_slope * x.
-
-    For non-fp8 dtypes, uses register_copy strategy: fragment load -> compute
-    -> fragment store for coalesced memory access.
-
-    For fp8 dtypes, uses explicit_parallel with fp16 accumulation (register_copy
-    is unreliable for 8-bit fragments).
-    """
-    out_dtype = output_dtype or dtype
-
-    if is_fp8:
-        accum = _fp8_accum_dtype_str()
-
-        @tilelang.jit(out_idx=[1])
-        def kernel(threads_arg, npt_arg):
-            block_size = threads_arg * npt_arg
-
-            @T.prim_func
-            def main(x: T.Tensor((N,), dtype), y: T.Tensor((N,), out_dtype)):
-                with T.Kernel(T.ceildiv(N, block_size), threads=threads_arg) as bx:
-                    for i, j in T.Parallel(threads_arg, npt_arg):
-                        idx = (bx * threads_arg + i) * npt_arg + j
-                        if idx < N:
-                            val = x[idx]
-                            v = T.cast(val, accum)
-                            zero = T.cast(0, accum)
-                            slope = T.cast(negative_slope, accum)
-                            result = T.if_then_else(v > zero, v, slope * v)
-                            y[idx] = T.Cast(out_dtype, result)
-
-            return main
-    else:
-
-        @tilelang.jit(out_idx=[1])
-        def kernel(threads_arg, npt_arg):
-            block_size = threads_arg * npt_arg
-
-            @T.prim_func
-            def main(x: T.Tensor((N,), dtype), y: T.Tensor((N,), dtype)):
-                with T.Kernel(T.ceildiv(N, block_size), threads=threads_arg) as bx:
-                    x_reg = T.alloc_fragment((block_size,), dtype)
-                    y_reg = T.alloc_fragment((block_size,), dtype)
-                    T.copy(x[bx * block_size : (bx + 1) * block_size], x_reg)
-                    for i, j in T.Parallel(threads_arg, npt_arg):
-                        val = x_reg[i * npt_arg + j]
-                        zero = T.cast(0, val.dtype)
-                        slope = T.cast(negative_slope, val.dtype)
-                        y_reg[i * npt_arg + j] = T.if_then_else(val > zero, val, slope * val)
-                    T.copy(y_reg, y[bx * block_size : (bx + 1) * block_size])
-
-            return main
-
-    return kernel
-
-
-class LeakyReluFwdKernel(ParametricUnaryKernel):
+class LeakyReluFwdKernel(ScalarParamUnaryKernel):
     """Leaky ReLU: y = x if x > 0 else negative_slope * x."""
 
     def __init__(self, N_total, dtype, negative_slope=0.01, config=None, tune=False):
         self.negative_slope = negative_slope
         super().__init__(N_total, dtype, config=config, tune=tune)
 
-    @staticmethod
-    def _builder_fn():
-        return _make_leaky_relu_kernel
+    def _param_key(self):
+        return f"negative_slope={self.negative_slope!r}"
 
-    def _builder_args(self):
-        return (self.negative_slope,)
+    def _make_op_func(self):
+        negative_slope = self.negative_slope
 
+        def op_func(x):
+            zero = T.cast(0, x.dtype)
+            slope = T.cast(negative_slope, x.dtype)
+            return T.if_then_else(x > zero, x, slope * x)
 
-@functools.lru_cache(maxsize=32)
-def _make_elu_kernel(N, dtype, alpha, output_dtype=None, is_fp8=False, threads=256, npt=8):
-    """Build ELU kernel: y = x if x > 0 else alpha * (exp(x) - 1)."""
-    out_dtype = output_dtype or dtype
-
-    if is_fp8:
-
-        @tilelang.jit(out_idx=[1])
-        def kernel(threads_arg, npt_arg):
-            block_size = threads_arg * npt_arg
-
-            @T.prim_func
-            def main(x: T.Tensor((N,), dtype), y: T.Tensor((N,), out_dtype)):
-                with T.Kernel(T.ceildiv(N, block_size), threads=threads_arg) as bx:
-                    for i, j in T.Parallel(threads_arg, npt_arg):
-                        idx = (bx * threads_arg + i) * npt_arg + j
-                        if idx < N:
-                            val = x[idx]
-                            zero = T.cast(0, "float32")
-                            a = T.cast(alpha, "float32")
-                            one = T.cast(1.0, "float32")
-                            v32 = T.cast(val, "float32")
-                            y[idx] = T.if_then_else(
-                                v32 > zero,
-                                T.Cast(out_dtype, v32),
-                                T.Cast(out_dtype, a * (T.exp(v32) - one)),
-                            )
-
-            return main
-    else:
-
-        @tilelang.jit(out_idx=[1])
-        def kernel(threads_arg, npt_arg):
-            block_size = threads_arg * npt_arg
-
-            @T.prim_func
-            def main(x: T.Tensor((N,), dtype), y: T.Tensor((N,), dtype)):
-                with T.Kernel(T.ceildiv(N, block_size), threads=threads_arg) as bx:
-                    x_reg = T.alloc_fragment((block_size,), dtype)
-                    y_reg = T.alloc_fragment((block_size,), dtype)
-                    T.copy(x[bx * block_size : (bx + 1) * block_size], x_reg)
-                    for i, j in T.Parallel(threads_arg, npt_arg):
-                        val = x_reg[i * npt_arg + j]
-                        zero = T.cast(0, "float32")
-                        a = T.cast(alpha, "float32")
-                        one = T.cast(1.0, "float32")
-                        v32 = T.cast(val, "float32")
-                        y_reg[i * npt_arg + j] = T.if_then_else(
-                            v32 > zero,
-                            val,
-                            T.Cast(val.dtype, a * (T.exp(v32) - one)),
-                        )
-                    T.copy(y_reg, y[bx * block_size : (bx + 1) * block_size])
-
-            return main
-
-    return kernel
+        return op_func
 
 
-class EluFwdKernel(ParametricUnaryKernel):
+class EluFwdKernel(ScalarParamUnaryKernel):
     """ELU: y = x if x > 0 else alpha * (exp(x) - 1)."""
 
     def __init__(self, N_total, dtype, alpha=1.0, config=None, tune=False):
         self.alpha = alpha
         super().__init__(N_total, dtype, config=config, tune=tune)
 
-    @staticmethod
-    def _builder_fn():
-        return _make_elu_kernel
+    def _param_key(self):
+        return f"alpha={self.alpha!r}"
 
-    def _builder_args(self):
-        return (self.alpha,)
+    def _make_op_func(self):
+        alpha = self.alpha
 
+        def op_func(x):
+            zero = T.cast(0, "float32")
+            one = T.cast(1.0, "float32")
+            a = T.cast(alpha, "float32")
+            wide = T.cast(x, "float32")
+            return T.if_then_else(wide > zero, x, T.Cast(x.dtype, a * (T.exp(wide) - one)))
 
-@functools.lru_cache(maxsize=32)
-def _make_hardtanh_kernel(
-    N, dtype, min_val, max_val, output_dtype=None, is_fp8=False, threads=256, npt=8
-):
-    """Build hardtanh kernel: y = clamp(x, min_val, max_val)."""
-    out_dtype = output_dtype or dtype
-
-    if is_fp8:
-
-        @tilelang.jit(out_idx=[1])
-        def kernel(threads_arg, npt_arg):
-            block_size = threads_arg * npt_arg
-
-            @T.prim_func
-            def main(x: T.Tensor((N,), dtype), y: T.Tensor((N,), out_dtype)):
-                with T.Kernel(T.ceildiv(N, block_size), threads=threads_arg) as bx:
-                    for i, j in T.Parallel(threads_arg, npt_arg):
-                        idx = (bx * threads_arg + i) * npt_arg + j
-                        if idx < N:
-                            val = x[idx]
-                            lo = T.cast(min_val, "float32")
-                            hi = T.cast(max_val, "float32")
-                            v32 = T.cast(val, "float32")
-                            y[idx] = T.Cast(out_dtype, T.min(T.max(v32, lo), hi))
-
-            return main
-    else:
-
-        @tilelang.jit(out_idx=[1])
-        def kernel(threads_arg, npt_arg):
-            block_size = threads_arg * npt_arg
-
-            @T.prim_func
-            def main(x: T.Tensor((N,), dtype), y: T.Tensor((N,), dtype)):
-                with T.Kernel(T.ceildiv(N, block_size), threads=threads_arg) as bx:
-                    x_reg = T.alloc_fragment((block_size,), dtype)
-                    y_reg = T.alloc_fragment((block_size,), dtype)
-                    T.copy(x[bx * block_size : (bx + 1) * block_size], x_reg)
-                    for i, j in T.Parallel(threads_arg, npt_arg):
-                        val = x_reg[i * npt_arg + j]
-                        lo = T.cast(min_val, "float32")
-                        hi = T.cast(max_val, "float32")
-                        v32 = T.cast(val, "float32")
-                        y_reg[i * npt_arg + j] = T.Cast(val.dtype, T.min(T.max(v32, lo), hi))
-                    T.copy(y_reg, y[bx * block_size : (bx + 1) * block_size])
-
-            return main
-
-    return kernel
+        return op_func
 
 
-class HardtanhFwdKernel(ParametricUnaryKernel):
+class HardtanhFwdKernel(ScalarParamUnaryKernel):
     """Hardtanh: y = clamp(x, min_val, max_val)."""
 
     def __init__(self, N_total, dtype, min_val=-1.0, max_val=1.0, config=None, tune=False):
@@ -405,79 +251,65 @@ class HardtanhFwdKernel(ParametricUnaryKernel):
         self.max_val = max_val
         super().__init__(N_total, dtype, config=config, tune=tune)
 
-    @staticmethod
-    def _builder_fn():
-        return _make_hardtanh_kernel
+    def _param_key(self):
+        return f"min_val={self.min_val!r}|max_val={self.max_val!r}"
 
-    def _builder_args(self):
-        return (self.min_val, self.max_val)
+    def _make_op_func(self):
+        min_val, max_val = self.min_val, self.max_val
+
+        def op_func(x):
+            lo = T.cast(min_val, "float32")
+            hi = T.cast(max_val, "float32")
+            wide = T.cast(x, "float32")
+            return T.Cast(x.dtype, T.min(T.max(wide, lo), hi))
+
+        return op_func
 
 
 @functools.lru_cache(maxsize=32)
-def _make_softplus_kernel(
-    N, dtype, beta, threshold, output_dtype=None, is_fp8=False, threads=256, npt=8
-):
-    """Build softplus kernel: y = log(1 + exp(x*beta))/beta if x*beta <= threshold else x."""
-    out_dtype = output_dtype or dtype
+def _make_softplus_kernel(N, dtype, beta, threshold, threads=256, npt=8):
+    """Build softplus: y = log(1 + exp(x*beta))/beta if x*beta <= threshold else x.
 
-    if is_fp8:
+    Written out rather than bound through ``ScalarParamUnaryKernel``: the
+    statement binding ``softplus`` lifts the exponential and the logarithm out
+    of the guard, which an op body returning one expression cannot do, and a
+    float16 row is 1.2% slower with them inside it.
+    """
 
-        @tilelang.jit(out_idx=[1])
-        def kernel(threads_arg, npt_arg):
-            block_size = threads_arg * npt_arg
+    @tilelang.jit(out_idx=[1])
+    def kernel(threads_arg, npt_arg):
+        block_size = threads_arg * npt_arg
 
-            @T.prim_func
-            def main(x: T.Tensor((N,), dtype), y: T.Tensor((N,), out_dtype)):
-                with T.Kernel(T.ceildiv(N, block_size), threads=threads_arg) as bx:
-                    for i, j in T.Parallel(threads_arg, npt_arg):
-                        idx = (bx * threads_arg + i) * npt_arg + j
-                        if idx < N:
-                            val = x[idx]
-                            v32 = T.cast(val, "float32")
-                            b = T.cast(beta, "float32")
-                            t = T.cast(threshold, "float32")
-                            one = T.cast(1.0, "float32")
-                            scaled = v32 * b
-                            sp = log_for_output_precision(val, one + T.exp(scaled)) / b
-                            y[idx] = T.if_then_else(
-                                scaled > t, T.Cast(out_dtype, v32), T.Cast(out_dtype, sp)
-                            )
+        @T.prim_func
+        def main(x: T.Tensor((N,), dtype), y: T.Tensor((N,), dtype)):
+            with T.Kernel(T.ceildiv(N, block_size), threads=threads_arg) as bx:
+                x_reg = T.alloc_fragment((block_size,), dtype)
+                y_reg = T.alloc_fragment((block_size,), dtype)
+                T.copy(x[bx * block_size : (bx + 1) * block_size], x_reg)
+                for i, j in T.Parallel(threads_arg, npt_arg):
+                    val = x_reg[i * npt_arg + j]
+                    v32 = T.cast(val, "float32")
+                    b = T.cast(beta, "float32")
+                    t = T.cast(threshold, "float32")
+                    one = T.cast(1.0, "float32")
+                    scaled = v32 * b
+                    softplus = log_for_output_precision(val, one + T.exp(scaled)) / b
+                    y_reg[i * npt_arg + j] = T.if_then_else(
+                        scaled > t,
+                        val,
+                        T.Cast(val.dtype, softplus),
+                    )
+                T.copy(y_reg, y[bx * block_size : (bx + 1) * block_size])
 
-            return main
-    else:
-
-        @tilelang.jit(out_idx=[1])
-        def kernel(threads_arg, npt_arg):
-            block_size = threads_arg * npt_arg
-
-            @T.prim_func
-            def main(x: T.Tensor((N,), dtype), y: T.Tensor((N,), dtype)):
-                with T.Kernel(T.ceildiv(N, block_size), threads=threads_arg) as bx:
-                    x_reg = T.alloc_fragment((block_size,), dtype)
-                    y_reg = T.alloc_fragment((block_size,), dtype)
-                    T.copy(x[bx * block_size : (bx + 1) * block_size], x_reg)
-                    for i, j in T.Parallel(threads_arg, npt_arg):
-                        val = x_reg[i * npt_arg + j]
-                        v32 = T.cast(val, "float32")
-                        b = T.cast(beta, "float32")
-                        t = T.cast(threshold, "float32")
-                        one = T.cast(1.0, "float32")
-                        scaled = v32 * b
-                        sp = log_for_output_precision(val, one + T.exp(scaled)) / b
-                        y_reg[i * npt_arg + j] = T.if_then_else(
-                            scaled > t,
-                            val,
-                            T.Cast(val.dtype, sp),
-                        )
-                    T.copy(y_reg, y[bx * block_size : (bx + 1) * block_size])
-
-            return main
+        return main
 
     return kernel
 
 
-class SoftplusFwdKernel(ParametricUnaryKernel):
+class SoftplusFwdKernel(MultiInputElementwiseKernel):
     """Softplus: y = log(1 + exp(x*beta))/beta if x*beta <= threshold else x."""
+
+    INPUTS = (("x", "tile"),)
 
     def __init__(self, N_total, dtype, beta=1.0, threshold=20.0, config=None, tune=False):
         self.beta = beta
@@ -490,6 +322,9 @@ class SoftplusFwdKernel(ParametricUnaryKernel):
 
     def _builder_args(self):
         return (self.beta, self.threshold)
+
+    def forward(self, x):
+        return self._run(x=x)
 
 
 class SiluAndMulFwdKernel(FusedGatedKernel):

--- a/src/tileops/kernels/elementwise/alibi.py
+++ b/src/tileops/kernels/elementwise/alibi.py
@@ -8,11 +8,7 @@ import torch
 
 from tileops.kernels.kernel_base import Kernel
 
-from ._base import (
-    _FLOAT_DTYPES,
-    _get_fp8_output_dtypes,
-    _is_fp8,
-)
+from ._dtype import _FLOAT_DTYPES
 
 __all__ = [
     "AlibiFwdKernel",
@@ -89,12 +85,12 @@ class AlibiFwdKernel(Kernel):
         self.seq_len = seq_len
         self.num_heads = num_heads
         self.dtype = dtype
-        self._fp8_output_dtype, self.output_dtype = _get_fp8_output_dtypes(dtype)
+        self.output_dtype = dtype
         cfg = self.default_config
         self.kernel = _make_alibi_kernel(
             seq_len,
             num_heads,
-            self.dtype_to_str(self.output_dtype),
+            self.dtype_str,
             cfg["threads"],
             cfg["num_per_thread"],
         )
@@ -102,8 +98,7 @@ class AlibiFwdKernel(Kernel):
 
     @property
     def default_config(self):
-        npt = 4 if self.dtype == torch.float32 else (16 if _is_fp8(self.dtype) else 8)
-        return {"threads": 256, "num_per_thread": npt}
+        return {"threads": 256, "num_per_thread": 4 if self.dtype == torch.float32 else 8}
 
     def init_config(self, config=None, tune=False):
         """Override to cache the compiled kernel function after config is set."""

--- a/src/tileops/kernels/elementwise/arithmetic.py
+++ b/src/tileops/kernels/elementwise/arithmetic.py
@@ -10,18 +10,10 @@ import tvm.tirx as tirx
 from ._base import (
     _FLOAT_DTYPES,
     BinaryKernel,
-    ParametricUnaryKernel,
+    MultiInputElementwiseKernel,
     _AlphaScaledBinaryKernel,
-    _make_binary_direct,
-    _make_binary_explicit,
-    _make_binary_register_copy,
 )
-from ._broadcast import BroadcastPlan, _broadcast_target, _expand_flat, register_broadcast_plan
-from ._dtype import _BINARY_FULL_DTYPES, _BINARY_NO_BOOL_DTYPES, _fp8_accum_dtype_str
-from ._op_body import (
-    _wrap_fp8_accumulation,
-    register_op_func,
-)
+from ._dtype import _BINARY_FULL_DTYPES, _BINARY_NO_BOOL_DTYPES
 
 __all__ = [
     "AddFwdKernel",
@@ -209,7 +201,7 @@ class LerpFwdKernel(BinaryKernel):
     """Element-wise lerp: y = a + weight * (b - a).
 
     PyTorch lerp is ternary (a, b, weight). Here weight is a compile-time
-    constant passed at kernel construction, keeping the binary kernel template.
+    constant bound at kernel construction, keeping the binary kernel template.
 
     Args:
         weight: Scalar interpolation weight (default 0.5). Keyword-only so the
@@ -220,74 +212,22 @@ class LerpFwdKernel(BinaryKernel):
 
     @staticmethod
     def op_func(a, b):
-        raise NotImplementedError("Use _make_lerp_op_func(weight) instead")
+        raise NotImplementedError(
+            "LerpFwdKernel builds its body from weight; use the kernel through "
+            "__init__ instead of calling op_func."
+        )
 
     def __init__(self, a_shape, b_shape, dtype, config=None, tune=False, *, weight=0.5):
         self._weight = weight
         super().__init__(a_shape, b_shape, dtype, config=config, tune=tune)
 
-    def _build_kernel(self, strategy):
-        """Override to inject compile-time weight into op_func."""
-        w = self._weight
+    def _get_effective_op_func(self):
+        weight = self._weight
 
         def lerp_func(a, b):
-            return a + T.cast(w, a.dtype) * (b - a)
+            return a + T.cast(weight, a.dtype) * (b - a)
 
-        effective_op = register_op_func(
-            f"{self._op_func_name()}|weight={w!r}",
-            _wrap_fp8_accumulation(
-                lerp_func,
-                self.dtype,
-                self.dtype_str,
-                arity=2,
-            ),
-        )
-        plan = register_broadcast_plan(
-            BroadcastPlan(self.coalesced_shape, self.a_strides, self.b_strides)
-        )
-
-        # For e5m2: kernel output is fp16 (non-saturating path)
-        kernel_output_dtype = (
-            self.dtype_to_str(self.OUTPUT_DTYPE) if self.OUTPUT_DTYPE is not None else None
-        )
-        if self._fp8_output_dtype is not None:
-            kernel_output_dtype = _fp8_accum_dtype_str()
-
-        cfg = self.default_config
-        if strategy == "direct":
-            return _make_binary_direct(
-                self.N_total,
-                self.dtype_str,
-                effective_op,
-                plan,
-                self.a_numel,
-                self.b_numel,
-                output_dtype=kernel_output_dtype,
-                threads=cfg["threads"],
-            )
-        elif strategy == "explicit_parallel":
-            return _make_binary_explicit(
-                self.N_total,
-                self.dtype_str,
-                effective_op,
-                plan,
-                self.a_numel,
-                self.b_numel,
-                output_dtype=kernel_output_dtype,
-                threads=cfg["threads"],
-                num_per_thread=cfg["num_per_thread"],
-            )
-        elif strategy == "register_copy":
-            return _make_binary_register_copy(
-                self.N_total,
-                self.dtype_str,
-                effective_op,
-                output_dtype=kernel_output_dtype,
-                threads=cfg["threads"],
-                num_per_thread=cfg["num_per_thread"],
-            )
-        else:
-            raise ValueError(f"Unknown strategy: {strategy}")
+        return f"{self._op_func_name()}|weight={weight!r}", lerp_func
 
 
 def _is_float_dtype_str(dtype_str: str) -> bool:
@@ -422,22 +362,16 @@ class MinimumFwdKernel(BinaryKernel):
 
 
 @functools.lru_cache(maxsize=32)
-def _make_lerp_tensor_kernel(N, dtype, output_dtype=None, is_fp8=False, threads=256, npt=8):
+def _make_lerp_tensor_kernel(N, dtype, threads=256, npt=8):
     """Build Tensor-weight lerp kernel: out = a + weight * (b - a).
 
     ``LerpTensorFwdKernel.forward`` broadcasts ``input`` / ``end`` / ``weight``
-        to the output shape and flattens them, so this PrimFunc sees three
-        contiguous 1-D tensors of size ``N``. Computation is performed in the input dtype for fp16 /
-        bfloat16 / float32 (the only dtypes the manifest declares); the fp8
-        path is unreachable here because the kernel's ``SUPPORTED_DTYPES``
-        excludes fp8.
+    to the output shape and flattens them, so this PrimFunc sees three
+    contiguous 1-D tensors of size ``N``, and computes in the input dtype.
 
-        Uses the register-fragment load -> compute -> fragment store strategy
-        (matches the non-fp8 ``_make_where_kernel`` layout) so all three
-        inputs and the output share the same vectorized memory access path.
+    All three inputs move through register fragments so they share one
+    vectorized access path; the result is written back into ``a``'s fragment.
     """
-    del is_fp8  # fp8 is not in the manifest contract for this op
-    out_dtype = output_dtype or dtype
 
     @tilelang.jit(out_idx=[3])
     def kernel(threads_arg, npt_arg):
@@ -448,7 +382,7 @@ def _make_lerp_tensor_kernel(N, dtype, output_dtype=None, is_fp8=False, threads=
             a: T.Tensor((N,), dtype),
             b: T.Tensor((N,), dtype),
             w: T.Tensor((N,), dtype),
-            out: T.Tensor((N,), out_dtype),
+            out: T.Tensor((N,), dtype),
         ):
             with T.Kernel(T.ceildiv(N, block_size), threads=threads_arg) as bx:
                 a_reg = T.alloc_fragment((block_size,), dtype)
@@ -467,33 +401,22 @@ def _make_lerp_tensor_kernel(N, dtype, output_dtype=None, is_fp8=False, threads=
     return kernel
 
 
-class LerpTensorFwdKernel(ParametricUnaryKernel):
+class LerpTensorFwdKernel(MultiInputElementwiseKernel):
     """Tensor-weight lerp: out = input + weight * (end - input).
 
-        Implements the Tensor-weight overload of ``torch.lerp`` —
-        ``torch.lerp(input, end, weight: Tensor)`` — where all three operands
-    are float tensors of the same dtype, broadcast together and flattened
-        by ``forward``.
-
-        Manifest declares ``float16 | bfloat16 | float32``; fp8 is rejected
-        at construction. ``forward`` takes the manifest shapes and broadcasts
-        them to ``N_total`` itself.
+    Implements the Tensor-weight overload of ``torch.lerp`` --
+    ``torch.lerp(input, end, weight: Tensor)`` -- where all three operands are
+    float tensors of the same dtype, broadcast together and flattened by
+    ``forward``.
     """
 
     SUPPORTED_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
-    _DEFAULT_THREADS = 512
-    _skip_fp8_output = True
+    DEFAULT_THREADS = 512
+    INPUTS = (("a", "tile"), ("b", "tile"), ("w", "tile"))
 
     @staticmethod
     def _builder_fn():
         return _make_lerp_tensor_kernel
 
     def forward(self, a, b, w):
-        self._require_cuda(a=a, b=b, w=w)
-        out_shape = _broadcast_target(a, b, w)
-        result = self._compiled_fn(
-            _expand_flat(a, out_shape),
-            _expand_flat(b, out_shape),
-            _expand_flat(w, out_shape),
-        )
-        return result.reshape(out_shape)
+        return self._run(a=a, b=b, w=w)

--- a/src/tileops/kernels/elementwise/arithmetic.py
+++ b/src/tileops/kernels/elementwise/arithmetic.py
@@ -234,11 +234,10 @@ def _is_float_dtype_str(dtype_str: str) -> bool:
     """Return True for floating-point TileLang dtype strings.
 
     TileLang IR exposes operand dtypes only as strings (``"float16"``,
-    ``"bfloat16"``, ``"float32"``, ``"float8_e4m3fn"`` ...), so prefix
-    matching is the established convention for float detection inside
-    ``op_func`` kernel bodies. All TileLang float dtype names start
-    with ``"float"`` or ``"bfloat"``; integer / bool dtype names
-    (``"int*"``, ``"uint*"``, ``"bool"``) do not.
+    ``"bfloat16"``, ``"float32"``), so prefix matching is the established
+    convention for float detection inside ``op_func`` kernel bodies. All
+    TileLang float dtype names start with ``"float"`` or ``"bfloat"``;
+    integer / bool dtype names (``"int*"``, ``"uint*"``, ``"bool"``) do not.
     """
     return dtype_str.startswith(("float", "bfloat"))
 

--- a/src/tileops/kernels/elementwise/clamp.py
+++ b/src/tileops/kernels/elementwise/clamp.py
@@ -6,9 +6,9 @@ import tilelang
 import tilelang.language as T
 
 from ._base import (
-    ParametricUnaryKernel,
+    MultiInputElementwiseKernel,
+    ScalarParamUnaryKernel,
 )
-from ._broadcast import _broadcast_target, _expand_flat
 
 __all__ = [
     "ClampFwdKernel",
@@ -16,221 +16,50 @@ __all__ = [
 ]
 
 
-@functools.lru_cache(maxsize=32)
-def _make_clamp_kernel(
-    N,
-    dtype,
-    has_min,
-    has_max,
-    min_val,
-    max_val,
-    output_dtype=None,
-    is_fp8=False,
-    threads=256,
-    npt=8,
-):
-    """Build clamp kernel: y = clamp(x, min_val, max_val) with optional bounds.
+class ClampFwdKernel(ScalarParamUnaryKernel):
+    """Clamp: y = clamp(x, min, max) with optional bounds.
 
-    For non-fp8 dtypes, uses register_copy strategy: fragment load -> compute
-    -> fragment store for coalesced memory access.  Computes in fp32 then
-    casts back to preserve precision.
+    Computes in float32 and casts back at the store, so a half input keeps the
+    precision of the comparison. A bound the caller omitted is not applied.
     """
-    out_dtype = output_dtype or dtype
-
-    if is_fp8:
-
-        @tilelang.jit(out_idx=[1])
-        def kernel(threads_arg, npt_arg):
-            block_size = threads_arg * npt_arg
-
-            @T.prim_func
-            def main(x: T.Tensor((N,), dtype), y: T.Tensor((N,), out_dtype)):
-                with T.Kernel(T.ceildiv(N, block_size), threads=threads_arg) as bx:
-                    for i, j in T.Parallel(threads_arg, npt_arg):
-                        idx = (bx * threads_arg + i) * npt_arg + j
-                        if idx < N:
-                            v32 = T.cast(x[idx], "float32")
-                            if has_min:
-                                lo = T.cast(min_val, "float32")
-                                v32 = T.max(v32, lo)
-                            if has_max:
-                                hi = T.cast(max_val, "float32")
-                                v32 = T.min(v32, hi)
-                            y[idx] = T.Cast(out_dtype, v32)
-
-            return main
-    else:
-
-        @tilelang.jit(out_idx=[1])
-        def kernel(threads_arg, npt_arg):
-            block_size = threads_arg * npt_arg
-
-            @T.prim_func
-            def main(x: T.Tensor((N,), dtype), y: T.Tensor((N,), dtype)):
-                with T.Kernel(T.ceildiv(N, block_size), threads=threads_arg) as bx:
-                    x_reg = T.alloc_fragment((block_size,), dtype)
-                    y_reg = T.alloc_fragment((block_size,), dtype)
-                    T.copy(x[bx * block_size : (bx + 1) * block_size], x_reg)
-                    for i, j in T.Parallel(threads_arg, npt_arg):
-                        val = x_reg[i * npt_arg + j]
-                        v32 = T.cast(val, "float32")
-                        if has_min:
-                            lo = T.cast(min_val, "float32")
-                            v32 = T.max(v32, lo)
-                        if has_max:
-                            hi = T.cast(max_val, "float32")
-                            v32 = T.min(v32, hi)
-                        y_reg[i * npt_arg + j] = T.Cast(val.dtype, v32)
-                    T.copy(y_reg, y[bx * block_size : (bx + 1) * block_size])
-
-            return main
-
-    return kernel
-
-
-class ClampFwdKernel(ParametricUnaryKernel):
-    """Clamp: y = clamp(x, min, max) with optional bounds."""
 
     def __init__(self, N_total, dtype, min_val=None, max_val=None, config=None, tune=False):
         self.min_val = min_val
         self.max_val = max_val
         super().__init__(N_total, dtype, config=config, tune=tune)
 
-    @staticmethod
-    def _builder_fn():
-        return _make_clamp_kernel
+    def _param_key(self):
+        return f"min_val={self.min_val!r}|max_val={self.max_val!r}"
 
-    def _builder_args(self):
-        return (
-            self.min_val is not None,
-            self.max_val is not None,
-            self.min_val if self.min_val is not None else 0.0,
-            self.max_val if self.max_val is not None else 0.0,
-        )
+    def _make_op_func(self):
+        min_val, max_val = self.min_val, self.max_val
+
+        def op_func(x):
+            wide = T.cast(x, "float32")
+            if min_val is not None:
+                wide = T.max(wide, T.cast(min_val, "float32"))
+            if max_val is not None:
+                wide = T.min(wide, T.cast(max_val, "float32"))
+            return T.Cast(x.dtype, wide)
+
+        return op_func
 
 
 @functools.lru_cache(maxsize=32)
-def _make_clamp_tensor_kernel(
-    N, dtype, has_min, has_max, output_dtype=None, is_fp8=False, threads=256, npt=8
-):
-    """Build Tensor-bound clamp kernel.
+def _make_clamp_tensor_kernel(N, dtype, has_min, has_max, threads=256, npt=8):
+    """Build the Tensor-bound clamp kernel: ``y = clamp(x, lo, hi)``.
 
-    Inputs (all flat, length N, broadcast and flattened by
-        ``ClampTensorFwdKernel.forward``):
-            x: data tensor.
-            lo: lower-bound tensor (only present when ``has_min``).
-            hi: upper-bound tensor (only present when ``has_max``).
+    Inputs are flat and of length *N*; ``ClampTensorFwdKernel.forward``
+    broadcasts them. ``has_min`` / ``has_max`` select the three forms the
+    Tensor clamp, clamp_min and clamp_max ops take. One bound and the other
+    read the same two-operand PrimFunc, which one being decided here.
 
-        Output:
-            y: clamp result, same dtype as ``output_dtype`` (or ``dtype``).
-
-        For fp8 the cast/compute uses fp32 to preserve precision; for non-fp8
-        the kernel uses register_copy with fp32 accumulation.
-
-        NaN semantics: matches ``torch.clamp`` / ``torch.clamp_min`` /
-        ``torch.clamp_max``. If ``x``, ``lo``, or ``hi`` is NaN at a position,
-        the output at that position is NaN. ``T.max`` / ``T.min`` on CUDA do
-        not propagate NaN by themselves (they return the non-NaN operand), so
-        we add explicit ``isnan`` guards in fp32 -- mirroring the pattern used
-        by ``MaximumFwdKernel`` / ``MinimumFwdKernel``.
+    The result is written back into ``x``'s fragment, so the third data-typed
+    fragment a separate output would need is never allocated.
     """
     if not (has_min or has_max):
-        raise ValueError(
-            "_make_clamp_tensor_kernel requires has_min or has_max to be True",
-        )
-    out_dtype = output_dtype or dtype
+        raise ValueError("_make_clamp_tensor_kernel requires has_min or has_max to be True")
 
-    if is_fp8:
-        if has_min and has_max:
-
-            @tilelang.jit(out_idx=[3])
-            def kernel(threads_arg, npt_arg):
-                block_size = threads_arg * npt_arg
-
-                @T.prim_func
-                def main(
-                    x: T.Tensor((N,), dtype),
-                    lo: T.Tensor((N,), dtype),
-                    hi: T.Tensor((N,), dtype),
-                    y: T.Tensor((N,), out_dtype),
-                ):
-                    with T.Kernel(T.ceildiv(N, block_size), threads=threads_arg) as bx:
-                        for i, j in T.Parallel(threads_arg, npt_arg):
-                            idx = (bx * threads_arg + i) * npt_arg + j
-                            if idx < N:
-                                x32 = T.cast(x[idx], "float32")
-                                lo32 = T.cast(lo[idx], "float32")
-                                hi32 = T.cast(hi[idx], "float32")
-                                r = T.max(x32, lo32)
-                                r = T.min(r, hi32)
-                                # NaN propagation (PyTorch semantics):
-                                # if any of x/lo/hi is NaN -> output NaN.
-                                r = T.if_then_else(T.isnan(hi32), hi32, r)
-                                r = T.if_then_else(T.isnan(lo32), lo32, r)
-                                r = T.if_then_else(T.isnan(x32), x32, r)
-                                y[idx] = T.Cast(out_dtype, r)
-
-                return main
-
-            return kernel
-        if has_min:
-
-            @tilelang.jit(out_idx=[2])
-            def kernel(threads_arg, npt_arg):
-                block_size = threads_arg * npt_arg
-
-                @T.prim_func
-                def main(
-                    x: T.Tensor((N,), dtype),
-                    lo: T.Tensor((N,), dtype),
-                    y: T.Tensor((N,), out_dtype),
-                ):
-                    with T.Kernel(T.ceildiv(N, block_size), threads=threads_arg) as bx:
-                        for i, j in T.Parallel(threads_arg, npt_arg):
-                            idx = (bx * threads_arg + i) * npt_arg + j
-                            if idx < N:
-                                x32 = T.cast(x[idx], "float32")
-                                lo32 = T.cast(lo[idx], "float32")
-                                r = T.max(x32, lo32)
-                                # NaN propagation (PyTorch clamp_min):
-                                # if x or lo is NaN -> output NaN.
-                                r = T.if_then_else(T.isnan(lo32), lo32, r)
-                                r = T.if_then_else(T.isnan(x32), x32, r)
-                                y[idx] = T.Cast(out_dtype, r)
-
-                return main
-
-            return kernel
-
-        # has_max only
-        @tilelang.jit(out_idx=[2])
-        def kernel(threads_arg, npt_arg):
-            block_size = threads_arg * npt_arg
-
-            @T.prim_func
-            def main(
-                x: T.Tensor((N,), dtype),
-                hi: T.Tensor((N,), dtype),
-                y: T.Tensor((N,), out_dtype),
-            ):
-                with T.Kernel(T.ceildiv(N, block_size), threads=threads_arg) as bx:
-                    for i, j in T.Parallel(threads_arg, npt_arg):
-                        idx = (bx * threads_arg + i) * npt_arg + j
-                        if idx < N:
-                            x32 = T.cast(x[idx], "float32")
-                            hi32 = T.cast(hi[idx], "float32")
-                            r = T.min(x32, hi32)
-                            # NaN propagation (PyTorch clamp_max):
-                            # if x or hi is NaN -> output NaN.
-                            r = T.if_then_else(T.isnan(hi32), hi32, r)
-                            r = T.if_then_else(T.isnan(x32), x32, r)
-                            y[idx] = T.Cast(out_dtype, r)
-
-            return main
-
-        return kernel
-
-    # non-fp8 path (register_copy)
     if has_min and has_max:
 
         @tilelang.jit(out_idx=[3])
@@ -256,10 +85,10 @@ def _make_clamp_tensor_kernel(
                         x32 = T.cast(x_reg[k], "float32")
                         lo32 = T.cast(lo_reg[k], "float32")
                         hi32 = T.cast(hi_reg[k], "float32")
-                        r = T.max(x32, lo32)
-                        r = T.min(r, hi32)
-                        # NaN propagation (PyTorch clamp):
-                        # if any of x/lo/hi is NaN -> output NaN.
+                        r = T.min(T.max(x32, lo32), hi32)
+                        # fmaxf / fminf return their non-NaN operand; torch
+                        # returns NaN. Put it back, after both bounds, so a
+                        # bound's NaN is not clamped away by the other.
                         r = T.if_then_else(T.isnan(hi32), hi32, r)
                         r = T.if_then_else(T.isnan(lo32), lo32, r)
                         r = T.if_then_else(T.isnan(x32), x32, r)
@@ -269,40 +98,9 @@ def _make_clamp_tensor_kernel(
             return main
 
         return kernel
-    if has_min:
 
-        @tilelang.jit(out_idx=[2])
-        def kernel(threads_arg, npt_arg):
-            block_size = threads_arg * npt_arg
+    take_max = bool(has_min)
 
-            @T.prim_func
-            def main(
-                x: T.Tensor((N,), dtype),
-                lo: T.Tensor((N,), dtype),
-                y: T.Tensor((N,), dtype),
-            ):
-                with T.Kernel(T.ceildiv(N, block_size), threads=threads_arg) as bx:
-                    x_reg = T.alloc_fragment((block_size,), dtype)
-                    lo_reg = T.alloc_fragment((block_size,), dtype)
-                    T.copy(x[bx * block_size : (bx + 1) * block_size], x_reg)
-                    T.copy(lo[bx * block_size : (bx + 1) * block_size], lo_reg)
-                    for i, j in T.Parallel(threads_arg, npt_arg):
-                        k = i * npt_arg + j
-                        x32 = T.cast(x_reg[k], "float32")
-                        lo32 = T.cast(lo_reg[k], "float32")
-                        r = T.max(x32, lo32)
-                        # NaN propagation (PyTorch clamp_min):
-                        # if x or lo is NaN -> output NaN.
-                        r = T.if_then_else(T.isnan(lo32), lo32, r)
-                        r = T.if_then_else(T.isnan(x32), x32, r)
-                        x_reg[k] = T.Cast(dtype, r)
-                    T.copy(x_reg, y[bx * block_size : (bx + 1) * block_size])
-
-            return main
-
-        return kernel
-
-    # has_max only
     @tilelang.jit(out_idx=[2])
     def kernel(threads_arg, npt_arg):
         block_size = threads_arg * npt_arg
@@ -310,22 +108,21 @@ def _make_clamp_tensor_kernel(
         @T.prim_func
         def main(
             x: T.Tensor((N,), dtype),
-            hi: T.Tensor((N,), dtype),
+            bound: T.Tensor((N,), dtype),
             y: T.Tensor((N,), dtype),
         ):
             with T.Kernel(T.ceildiv(N, block_size), threads=threads_arg) as bx:
                 x_reg = T.alloc_fragment((block_size,), dtype)
-                hi_reg = T.alloc_fragment((block_size,), dtype)
+                bound_reg = T.alloc_fragment((block_size,), dtype)
                 T.copy(x[bx * block_size : (bx + 1) * block_size], x_reg)
-                T.copy(hi[bx * block_size : (bx + 1) * block_size], hi_reg)
+                T.copy(bound[bx * block_size : (bx + 1) * block_size], bound_reg)
                 for i, j in T.Parallel(threads_arg, npt_arg):
                     k = i * npt_arg + j
                     x32 = T.cast(x_reg[k], "float32")
-                    hi32 = T.cast(hi_reg[k], "float32")
-                    r = T.min(x32, hi32)
-                    # NaN propagation (PyTorch clamp_max):
-                    # if x or hi is NaN -> output NaN.
-                    r = T.if_then_else(T.isnan(hi32), hi32, r)
+                    b32 = T.cast(bound_reg[k], "float32")
+                    r = T.max(x32, b32) if take_max else T.min(x32, b32)
+                    # fmaxf / fminf return their non-NaN operand; torch returns NaN.
+                    r = T.if_then_else(T.isnan(b32), b32, r)
                     r = T.if_then_else(T.isnan(x32), x32, r)
                     x_reg[k] = T.Cast(dtype, r)
                 T.copy(x_reg, y[bx * block_size : (bx + 1) * block_size])
@@ -335,25 +132,30 @@ def _make_clamp_tensor_kernel(
     return kernel
 
 
-class ClampTensorFwdKernel(ParametricUnaryKernel):
-    """Tensor-bound clamp kernel.
+class ClampTensorFwdKernel(MultiInputElementwiseKernel):
+    """Tensor-bound clamp: ``y = clamp(x, lo, hi)``.
 
-    Computes ``y = clamp(x, lo, hi)``. ``forward`` takes the manifest shapes,
-        broadcasts ``input`` / ``min`` / ``max`` to the output shape and flattens
-        them; the PrimFunc works on length ``N_total``. ``has_min`` / ``has_max``
-        select between the three forms used by the Tensor clamp, clamp_min, and
-        clamp_max ops.
+    ``has_min`` / ``has_max`` select between the three forms used by the Tensor
+    clamp, clamp_min and clamp_max ops; the bound a form omits is not a
+    PrimFunc parameter.
+
+    NaN semantics match ``torch.clamp`` / ``torch.clamp_min`` /
+    ``torch.clamp_max``: a NaN in ``x``, ``lo`` or ``hi`` makes the output NaN
+    at that position.
     """
 
-    _DEFAULT_THREADS = 512
+    DEFAULT_THREADS = 512
 
     def __init__(self, N_total, dtype, has_min, has_max, config=None, tune=False):
         if not (has_min or has_max):
-            raise ValueError(
-                "ClampTensorFwdKernel requires has_min or has_max to be True",
-            )
+            raise ValueError("ClampTensorFwdKernel requires has_min or has_max to be True")
         self.has_min = bool(has_min)
         self.has_max = bool(has_max)
+        self.INPUTS = (
+            ("x", "tile"),
+            *((("lo", "tile"),) if self.has_min else ()),
+            *((("hi", "tile"),) if self.has_max else ()),
+        )
         super().__init__(N_total, dtype, config=config, tune=tune)
 
     @staticmethod
@@ -364,17 +166,4 @@ class ClampTensorFwdKernel(ParametricUnaryKernel):
         return (self.has_min, self.has_max)
 
     def forward(self, x, lo=None, hi=None):
-        self._require_cuda(x=x, lo=lo, hi=hi)
-        out_shape = _broadcast_target(x, lo, hi)
-        x_flat = _expand_flat(x, out_shape)
-        if self.has_min and self.has_max:
-            result = self._compiled_fn(
-                x_flat, _expand_flat(lo, out_shape), _expand_flat(hi, out_shape)
-            )
-        elif self.has_min:
-            result = self._compiled_fn(x_flat, _expand_flat(lo, out_shape))
-        else:
-            result = self._compiled_fn(x_flat, _expand_flat(hi, out_shape))
-        if self._fp8_output_dtype is not None:
-            result = result.to(self._fp8_output_dtype)
-        return result.reshape(out_shape)
+        return self._run(x=x, lo=lo, hi=hi)

--- a/src/tileops/kernels/elementwise/clamp.py
+++ b/src/tileops/kernels/elementwise/clamp.py
@@ -51,11 +51,10 @@ def _make_clamp_tensor_kernel(N, dtype, has_min, has_max, threads=256, npt=8):
 
     Inputs are flat and of length *N*; ``ClampTensorFwdKernel.forward``
     broadcasts them. ``has_min`` / ``has_max`` select the three forms the
-    Tensor clamp, clamp_min and clamp_max ops take. One bound and the other
-    read the same two-operand PrimFunc, which one being decided here.
+    Tensor clamp, clamp_min and clamp_max ops take.
 
-    The result is written back into ``x``'s fragment, so the third data-typed
-    fragment a separate output would need is never allocated.
+    The result is written back into ``x``'s fragment rather than a third
+    data-typed one.
     """
     if not (has_min or has_max):
         raise ValueError("_make_clamp_tensor_kernel requires has_min or has_max to be True")
@@ -86,9 +85,9 @@ def _make_clamp_tensor_kernel(N, dtype, has_min, has_max, threads=256, npt=8):
                         lo32 = T.cast(lo_reg[k], "float32")
                         hi32 = T.cast(hi_reg[k], "float32")
                         r = T.min(T.max(x32, lo32), hi32)
-                        # fmaxf / fminf return their non-NaN operand; torch
-                        # returns NaN. Put it back, after both bounds, so a
-                        # bound's NaN is not clamped away by the other.
+                        # fmaxf / fminf return their non-NaN operand where torch
+                        # returns NaN. Restored after both bounds, so one bound's
+                        # NaN is not clamped away by the other.
                         r = T.if_then_else(T.isnan(hi32), hi32, r)
                         r = T.if_then_else(T.isnan(lo32), lo32, r)
                         r = T.if_then_else(T.isnan(x32), x32, r)

--- a/src/tileops/kernels/elementwise/masked_fill.py
+++ b/src/tileops/kernels/elementwise/masked_fill.py
@@ -26,8 +26,8 @@ def _make_masked_fill_kernel(N, dtype, fill_value, threads=256, npt=8):
     Each uint8 element is 0 or 1; the kernel loads it into a register fragment
     and unpacks per-element with a != 0 comparison.
 
-    The result is written back into ``x``'s register fragment, so the third
-    data-typed fragment a separate output would need is never allocated.
+    The result is written back into ``x``'s register fragment rather than a
+    third data-typed one.
     """
 
     @tilelang.jit(out_idx=[2])

--- a/src/tileops/kernels/elementwise/masked_fill.py
+++ b/src/tileops/kernels/elementwise/masked_fill.py
@@ -4,100 +4,63 @@ import functools
 
 import tilelang
 import tilelang.language as T
-import torch
 
-from ._base import (
-    _BITWISE_DTYPES,
-    _FLOAT_DTYPES,
-    ParametricUnaryKernel,
-)
-from ._broadcast import _broadcast_target, _expand_flat
-from ._dtype import _clamp_to_dtype_range
+from ._base import MultiInputElementwiseKernel
+from ._dtype import _BITWISE_DTYPES, _FLOAT_DTYPES, _clamp_to_dtype_range
 
 __all__ = [
     "MaskedFillFwdKernel",
     "MaskedFillTensorValueFwdKernel",
 ]
 
+# uint8/intN + fp16/bf16/fp32. bool operands arrive in uint8 storage.
+_MASKED_FILL_DTYPES = _BITWISE_DTYPES[1:] + _FLOAT_DTYPES
+
 
 @functools.lru_cache(maxsize=32)
-def _make_masked_fill_kernel(
-    N, dtype, fill_value, output_dtype=None, is_fp8=False, threads=256, npt=8
-):
+def _make_masked_fill_kernel(N, dtype, fill_value, threads=256, npt=8):
     """Build masked_fill kernel: out = mask ? fill_value : x.
 
     ``MaskedFillFwdKernel.forward`` packs the bool mask as uint8 so that T.copy
-        can perform vectorized loads (TileLang does not vectorize bool tensors).
-        Each uint8 element is 0 or 1; the kernel loads it into a register
-        fragment and unpacks per-element with a != 0 comparison.
+    can perform vectorized loads (TileLang does not vectorize bool tensors).
+    Each uint8 element is 0 or 1; the kernel loads it into a register fragment
+    and unpacks per-element with a != 0 comparison.
 
-        For non-fp8 dtypes, writes the result back into the x register fragment
-        (in-place) to reduce register pressure and avoid a third data-typed
-        fragment allocation.
-
-        For e5m2, the PrimFunc outputs fp16 so ``forward`` can do a
-        non-saturating cast to e5m2.
+    The result is written back into ``x``'s register fragment, so the third
+    data-typed fragment a separate output would need is never allocated.
     """
-    out_dtype = output_dtype or dtype
 
-    if is_fp8:
+    @tilelang.jit(out_idx=[2])
+    def kernel(threads_arg, npt_arg):
+        block_size = threads_arg * npt_arg
 
-        @tilelang.jit(out_idx=[2])
-        def kernel(threads_arg, npt_arg):
-            block_size = threads_arg * npt_arg
+        @T.prim_func
+        def main(
+            x: T.Tensor((N,), dtype),
+            mask: T.Tensor((N,), "uint8"),
+            out: T.Tensor((N,), dtype),
+        ):
+            with T.Kernel(T.ceildiv(N, block_size), threads=threads_arg) as bx:
+                m_reg = T.alloc_fragment((block_size,), "uint8")
+                x_reg = T.alloc_fragment((block_size,), dtype)
+                T.copy(mask[bx * block_size : (bx + 1) * block_size], m_reg)
+                T.copy(x[bx * block_size : (bx + 1) * block_size], x_reg)
+                for i, j in T.Parallel(threads_arg, npt_arg):
+                    k = i * npt_arg + j
+                    fv = T.cast(fill_value, dtype)
+                    x_reg[k] = T.if_then_else(
+                        m_reg[k] != T.cast(0, "uint8"),
+                        fv,
+                        x_reg[k],
+                    )
+                T.copy(x_reg, out[bx * block_size : (bx + 1) * block_size])
 
-            @T.prim_func
-            def main(
-                x: T.Tensor((N,), dtype),
-                mask: T.Tensor((N,), "uint8"),
-                out: T.Tensor((N,), out_dtype),
-            ):
-                with T.Kernel(T.ceildiv(N, block_size), threads=threads_arg) as bx:
-                    for i, j in T.Parallel(threads_arg, npt_arg):
-                        idx = (bx * threads_arg + i) * npt_arg + j
-                        if idx < N:
-                            fv = T.cast(fill_value, out_dtype)
-                            x_val = T.Cast(out_dtype, x[idx])
-                            out[idx] = T.if_then_else(
-                                mask[idx] != T.cast(0, "uint8"),
-                                fv,
-                                x_val,
-                            )
-
-            return main
-    else:
-
-        @tilelang.jit(out_idx=[2])
-        def kernel(threads_arg, npt_arg):
-            block_size = threads_arg * npt_arg
-
-            @T.prim_func
-            def main(
-                x: T.Tensor((N,), dtype),
-                mask: T.Tensor((N,), "uint8"),
-                out: T.Tensor((N,), dtype),
-            ):
-                with T.Kernel(T.ceildiv(N, block_size), threads=threads_arg) as bx:
-                    m_reg = T.alloc_fragment((block_size,), "uint8")
-                    x_reg = T.alloc_fragment((block_size,), dtype)
-                    T.copy(mask[bx * block_size : (bx + 1) * block_size], m_reg)
-                    T.copy(x[bx * block_size : (bx + 1) * block_size], x_reg)
-                    for i, j in T.Parallel(threads_arg, npt_arg):
-                        k = i * npt_arg + j
-                        fv = T.cast(fill_value, dtype)
-                        x_reg[k] = T.if_then_else(
-                            m_reg[k] != T.cast(0, "uint8"),
-                            fv,
-                            x_reg[k],
-                        )
-                    T.copy(x_reg, out[bx * block_size : (bx + 1) * block_size])
-
-            return main
+        return main
 
     return kernel
 
 
-class MaskedFillFwdKernel(ParametricUnaryKernel):
+class MaskedFillFwdKernel(MultiInputElementwiseKernel):
     """MaskedFill: out = mask ? fill_value : x.
 
     Supports the PyTorch ``Tensor.masked_fill(mask, value: Number)`` dtype
@@ -106,15 +69,13 @@ class MaskedFillFwdKernel(ParametricUnaryKernel):
     rather than part of the op's semantics.
     """
 
-    _DEFAULT_THREADS = 512
-    SUPPORTED_DTYPES = _BITWISE_DTYPES[1:] + _FLOAT_DTYPES  # uint8/intN + fp16/bf16/fp32
+    DEFAULT_THREADS = 512
+    SUPPORTED_DTYPES = _MASKED_FILL_DTYPES
+    INPUTS = (("x", "tile"), ("mask", "mask"))
 
     def __init__(self, N_total, dtype, fill_value, config=None, tune=False):
-        self._raw_fill_value = fill_value
+        self.fill_value = _clamp_to_dtype_range(fill_value, dtype)
         super().__init__(N_total, dtype, config=config, tune=tune)
-
-    def _post_init_params(self):
-        self.fill_value = _clamp_to_dtype_range(self._raw_fill_value, self.output_dtype)
 
     @staticmethod
     def _builder_fn():
@@ -124,65 +85,17 @@ class MaskedFillFwdKernel(ParametricUnaryKernel):
         return (self.fill_value,)
 
     def forward(self, x, mask):
-        self._require_cuda(x=x, mask=mask)
-        out_shape = _broadcast_target(x, mask)
-        as_bool = x.dtype == torch.bool
-        if as_bool:
-            x = x.view(torch.uint8)
-        if mask.dtype == torch.bool:
-            mask = mask.view(torch.uint8)
-        result = self._compiled_fn(
-            _expand_flat(x, out_shape), _expand_flat(mask, out_shape)
-        ).reshape(out_shape)
-        return result.view(torch.bool) if as_bool else result
+        return self._run(x=x, mask=mask)
 
 
 @functools.lru_cache(maxsize=32)
-def _make_masked_fill_tensor_value_kernel(
-    N, dtype, output_dtype=None, is_fp8=False, threads=256, npt=8
-):
+def _make_masked_fill_tensor_value_kernel(N, dtype, threads=256, npt=8):
     """Build masked_fill kernel with a 0-dim Tensor fill value.
 
-    Inputs (all flat, length N, broadcast and flattened by
-        ``MaskedFillTensorValueFwdKernel.forward``):
-            x: data tensor (length N).
-            mask: bool mask packed as uint8 (length N).
-            value: scalar fill value carried as a length-1 tensor (``forward``
-                reshapes the 0-dim Tensor to $[1]$).
-
-        Output:
-            out: ``out[i] = value[0] if mask[i] else x[i]``.
+    Inputs are flat and of length *N*, except ``value``, which carries the
+    0-dim scalar in a length-one buffer. It is read once before the element
+    loop, not per element. The result is written back into ``x``'s fragment.
     """
-    out_dtype = output_dtype or dtype
-
-    if is_fp8:
-
-        @tilelang.jit(out_idx=[3])
-        def kernel(threads_arg, npt_arg):
-            block_size = threads_arg * npt_arg
-
-            @T.prim_func
-            def main(
-                x: T.Tensor((N,), dtype),
-                mask: T.Tensor((N,), "uint8"),
-                value: T.Tensor((1,), dtype),
-                out: T.Tensor((N,), out_dtype),
-            ):
-                with T.Kernel(T.ceildiv(N, block_size), threads=threads_arg) as bx:
-                    fv = T.Cast(out_dtype, value[0])
-                    for i, j in T.Parallel(threads_arg, npt_arg):
-                        idx = (bx * threads_arg + i) * npt_arg + j
-                        if idx < N:
-                            x_val = T.Cast(out_dtype, x[idx])
-                            out[idx] = T.if_then_else(
-                                mask[idx] != T.cast(0, "uint8"),
-                                fv,
-                                x_val,
-                            )
-
-            return main
-
-        return kernel
 
     @tilelang.jit(out_idx=[3])
     def kernel(threads_arg, npt_arg):
@@ -215,39 +128,21 @@ def _make_masked_fill_tensor_value_kernel(
     return kernel
 
 
-class MaskedFillTensorValueFwdKernel(ParametricUnaryKernel):
+class MaskedFillTensorValueFwdKernel(MultiInputElementwiseKernel):
     """MaskedFill kernel with 0-dim Tensor fill value.
 
-    Computes ``out = mask ? value : x``. ``forward`` broadcasts ``input`` and
-        ``mask`` to the output shape, flattens them, packs the mask as uint8, and
-        reshapes the 0-dim ``value`` to a length-1 tensor; the PrimFunc works on
-        length ``N_total``. Bool storage is
-        reinterpreted as uint8 here, being this backend's requirement rather than
-        part of the op's semantics.
+    Computes ``out = mask ? value : x``. Bool storage is reinterpreted as uint8
+    here, being this backend's requirement rather than part of the op's
+    semantics.
     """
 
-    _DEFAULT_THREADS = 512
-    SUPPORTED_DTYPES = _BITWISE_DTYPES[1:] + _FLOAT_DTYPES  # uint8/intN + fp16/bf16/fp32
+    DEFAULT_THREADS = 512
+    SUPPORTED_DTYPES = _MASKED_FILL_DTYPES
+    INPUTS = (("x", "tile"), ("mask", "mask"), ("value", "value"))
 
     @staticmethod
     def _builder_fn():
         return _make_masked_fill_tensor_value_kernel
 
     def forward(self, x, mask, value):
-        self._require_cuda(x=x, mask=mask, value=value)
-        out_shape = _broadcast_target(x, mask)
-        as_bool = x.dtype == torch.bool
-        if as_bool:
-            x = x.view(torch.uint8)
-        # A 0-d scalar is the semantic form; this kernel reads it from a
-        # length-one buffer.
-        value = value.contiguous().reshape(1)
-        if as_bool:
-            value = value.view(torch.uint8)
-        if mask.dtype == torch.bool:
-            mask = mask.view(torch.uint8)
-        result = self._compiled_fn(_expand_flat(x, out_shape), _expand_flat(mask, out_shape), value)
-        if self._fp8_output_dtype is not None:
-            result = result.to(self._fp8_output_dtype)
-        result = result.reshape(out_shape)
-        return result.view(torch.bool) if as_bool else result
+        return self._run(x=x, mask=mask, value=value)

--- a/src/tileops/kernels/elementwise/nan_to_num.py
+++ b/src/tileops/kernels/elementwise/nan_to_num.py
@@ -1,16 +1,9 @@
 """The nan_to_num kernel."""
 
-import functools
-
-import tilelang
 import tilelang.language as T
 import torch
 
-from tileops.utils import str2dtype
-
-from ._base import (
-    ParametricUnaryKernel,
-)
+from ._base import ScalarParamUnaryKernel
 from ._dtype import _clamp_to_dtype_range
 
 __all__ = [
@@ -18,118 +11,50 @@ __all__ = [
 ]
 
 
-@functools.lru_cache(maxsize=32)
-def _make_nan_to_num_kernel(
-    N, dtype, nan_val, posinf_val, neginf_val, output_dtype=None, is_fp8=False, threads=256, npt=8
-):
-    """Build nan_to_num kernel: replace NaN, +Inf, -Inf with given values.
-
-    For non-fp8 dtypes, uses register_copy strategy: fragment load -> compute
-    -> fragment store for coalesced memory access.
-    """
-    out_dtype = output_dtype or dtype
-    # A clamp replaces the infinity tests only when the replacements are the
-    # dtype's own ends; otherwise it would move finite values too.
-    _info = torch.finfo(str2dtype[dtype]) if dtype in str2dtype else None
-    clamps = bool(_info is not None and posinf_val == _info.max and neginf_val == _info.min)
-
-    if is_fp8:
-
-        @tilelang.jit(out_idx=[1])
-        def kernel(threads_arg, npt_arg):
-            block_size = threads_arg * npt_arg
-
-            @T.prim_func
-            def main(x: T.Tensor((N,), dtype), y: T.Tensor((N,), out_dtype)):
-                with T.Kernel(T.ceildiv(N, block_size), threads=threads_arg) as bx:
-                    for i, j in T.Parallel(threads_arg, npt_arg):
-                        idx = (bx * threads_arg + i) * npt_arg + j
-                        if idx < N:
-                            val = x[idx]
-                            v32 = T.cast(val, "float32")
-                            nan_r = T.cast(nan_val, out_dtype)
-                            pos_r = T.cast(posinf_val, out_dtype)
-                            neg_r = T.cast(neginf_val, out_dtype)
-                            pass_through = T.Cast(out_dtype, v32)
-                            result = T.if_then_else(
-                                T.isnan(v32),
-                                nan_r,
-                                T.if_then_else(
-                                    T.isinf(v32),
-                                    T.if_then_else(v32 > T.cast(0, "float32"), pos_r, neg_r),
-                                    pass_through,
-                                ),
-                            )
-                            y[idx] = result
-
-            return main
-    else:
-
-        @tilelang.jit(out_idx=[1])
-        def kernel(threads_arg, npt_arg):
-            block_size = threads_arg * npt_arg
-
-            @T.prim_func
-            def main(x: T.Tensor((N,), dtype), y: T.Tensor((N,), dtype)):
-                with T.Kernel(T.ceildiv(N, block_size), threads=threads_arg) as bx:
-                    x_reg = T.alloc_fragment((block_size,), dtype)
-                    y_reg = T.alloc_fragment((block_size,), dtype)
-                    T.copy(x[bx * block_size : (bx + 1) * block_size], x_reg)
-                    for i, j in T.Parallel(threads_arg, npt_arg):
-                        k = i * npt_arg + j
-                        val = x_reg[k]
-                        v32 = T.cast(val, "float32")
-                        nan_r = T.cast(nan_val, val.dtype)
-                        pos_r = T.cast(posinf_val, val.dtype)
-                        neg_r = T.cast(neginf_val, val.dtype)
-                        if clamps:
-                            y_reg[k] = T.if_then_else(
-                                T.isnan(v32),
-                                nan_r,
-                                T.cast(
-                                    T.min(
-                                        T.max(v32, T.cast(neginf_val, "float32")),
-                                        T.cast(posinf_val, "float32"),
-                                    ),
-                                    val.dtype,
-                                ),
-                            )
-                        else:
-                            y_reg[k] = T.if_then_else(
-                                T.isnan(v32),
-                                nan_r,
-                                T.if_then_else(
-                                    T.isinf(v32),
-                                    T.if_then_else(v32 > T.cast(0, "float32"), pos_r, neg_r),
-                                    val,
-                                ),
-                            )
-                    T.copy(y_reg, y[bx * block_size : (bx + 1) * block_size])
-
-            return main
-
-    return kernel
-
-
-class NanToNumFwdKernel(ParametricUnaryKernel):
+class NanToNumFwdKernel(ScalarParamUnaryKernel):
     """NanToNum: replace NaN, +Inf, -Inf with specified values."""
 
     def __init__(
         self, N_total, dtype, nan_val=0.0, posinf_val=1e4, neginf_val=-1e4, config=None, tune=False
     ):
-        self._raw_nan_val = nan_val
-        self._raw_posinf_val = posinf_val
-        self._raw_neginf_val = neginf_val
+        self.nan_val = _clamp_to_dtype_range(nan_val, dtype)
+        self.posinf_val = _clamp_to_dtype_range(posinf_val, dtype)
+        self.neginf_val = _clamp_to_dtype_range(neginf_val, dtype)
         super().__init__(N_total, dtype, config=config, tune=tune)
 
-    def _post_init_params(self):
-        self.nan_val = _clamp_to_dtype_range(self._raw_nan_val, self.output_dtype)
-        self.posinf_val = _clamp_to_dtype_range(self._raw_posinf_val, self.output_dtype)
-        self.neginf_val = _clamp_to_dtype_range(self._raw_neginf_val, self.output_dtype)
+    def _param_key(self):
+        return f"nan={self.nan_val!r}|posinf={self.posinf_val!r}|neginf={self.neginf_val!r}"
 
-    @staticmethod
-    def _builder_fn():
-        return _make_nan_to_num_kernel
+    def _make_op_func(self):
+        nan_val, posinf_val, neginf_val = self.nan_val, self.posinf_val, self.neginf_val
+        # A clamp replaces the infinity tests only when the replacements are the
+        # dtype's own ends; otherwise it would move finite values too.
+        info = torch.finfo(self.dtype)
+        clamps = posinf_val == info.max and neginf_val == info.min
 
-    def _builder_args(self):
-        return (self.nan_val, self.posinf_val, self.neginf_val)
+        def op_func(x):
+            wide = T.cast(x, "float32")
+            nan_r = T.cast(nan_val, x.dtype)
+            if clamps:
+                bounded = T.min(
+                    T.max(wide, T.cast(neginf_val, "float32")),
+                    T.cast(posinf_val, "float32"),
+                )
+                return T.if_then_else(T.isnan(wide), nan_r, T.cast(bounded, x.dtype))
+            pos_r = T.cast(posinf_val, x.dtype)
+            neg_r = T.cast(neginf_val, x.dtype)
+            # ``|x| == inf`` rather than ``T.isinf(x)``: the NaN case is already
+            # taken, and ``isinf`` lowers to that comparison plus a NaN test
+            # this branch has no argument for.
+            infinite = T.abs(wide) == T.cast(float("inf"), "float32")
+            return T.if_then_else(
+                T.isnan(wide),
+                nan_r,
+                T.if_then_else(
+                    infinite,
+                    T.if_then_else(wide > T.cast(0, "float32"), pos_r, neg_r),
+                    x,
+                ),
+            )
+
+        return op_func

--- a/src/tileops/kernels/elementwise/nan_to_num.py
+++ b/src/tileops/kernels/elementwise/nan_to_num.py
@@ -43,9 +43,8 @@ class NanToNumFwdKernel(ScalarParamUnaryKernel):
                 return T.if_then_else(T.isnan(wide), nan_r, T.cast(bounded, x.dtype))
             pos_r = T.cast(posinf_val, x.dtype)
             neg_r = T.cast(neginf_val, x.dtype)
-            # ``|x| == inf`` rather than ``T.isinf(x)``: the NaN case is already
-            # taken, and ``isinf`` lowers to that comparison plus a NaN test
-            # this branch has no argument for.
+            # ``T.isinf`` lowers to this comparison plus a NaN test, which the
+            # branch above has already taken.
             infinite = T.abs(wide) == T.cast(float("inf"), "float32")
             return T.if_then_else(
                 T.isnan(wide),

--- a/src/tileops/kernels/elementwise/prelu.py
+++ b/src/tileops/kernels/elementwise/prelu.py
@@ -5,11 +5,7 @@ import functools
 import tilelang
 import tilelang.language as T
 
-from ._base import (
-    ParametricUnaryKernel,
-    _flat,
-)
-from ._dtype import _fp8_accum_dtype_str
+from ._base import MultiInputElementwiseKernel, _flat
 
 __all__ = [
     "PreluFwdKernel",
@@ -17,81 +13,47 @@ __all__ = [
 
 
 @functools.lru_cache(maxsize=32)
-def _make_prelu_kernel(
-    N, C, inner_size, dtype, output_dtype=None, is_fp8=False, threads=256, npt=8
-):
+def _make_prelu_kernel(N, dtype, C, inner_size, threads=256, npt=8):
     """Build PReLU kernel: y = x if x > 0 else weight[channel] * x.
 
     Weight is per-channel. Channel index follows PyTorch convention:
     for flat index ``idx``, channel = (idx // inner_size) % C, where
     ``inner_size`` is the product of all dimensions after the channel dim.
 
-    For non-fp8 dtypes, uses register_copy strategy for input/output to
-    improve memory coalescing for the main data path.
+    Input and output move through register fragments; the weight is gathered
+    per element, since its length is C rather than N.
     """
-    out_dtype = output_dtype or dtype
 
-    if is_fp8:
-        accum = _fp8_accum_dtype_str()
+    @tilelang.jit(out_idx=[2])
+    def kernel(threads_arg, npt_arg):
+        block_size = threads_arg * npt_arg
 
-        @tilelang.jit(out_idx=[2])
-        def kernel(threads_arg, npt_arg):
-            block_size = threads_arg * npt_arg
+        @T.prim_func
+        def main(
+            x: T.Tensor((N,), dtype),
+            weight: T.Tensor((C,), dtype),
+            y: T.Tensor((N,), dtype),
+        ):
+            with T.Kernel(T.ceildiv(N, block_size), threads=threads_arg) as bx:
+                x_reg = T.alloc_fragment((block_size,), dtype)
+                y_reg = T.alloc_fragment((block_size,), dtype)
+                T.copy(x[bx * block_size : (bx + 1) * block_size], x_reg)
+                for i, j in T.Parallel(threads_arg, npt_arg):
+                    k = i * npt_arg + j
+                    idx = bx * block_size + k
+                    val = x_reg[k]
+                    ch = (idx // inner_size) % C
+                    w = weight[ch]
+                    zero = T.cast(0, val.dtype)
+                    y_reg[k] = T.if_then_else(val > zero, val, w * val)
+                T.copy(y_reg, y[bx * block_size : (bx + 1) * block_size])
 
-            @T.prim_func
-            def main(
-                x: T.Tensor((N,), dtype),
-                weight: T.Tensor((C,), dtype),
-                y: T.Tensor((N,), out_dtype),
-            ):
-                with T.Kernel(T.ceildiv(N, block_size), threads=threads_arg) as bx:
-                    for i, j in T.Parallel(threads_arg, npt_arg):
-                        k = i * npt_arg + j
-                        idx = bx * block_size + k
-                        if idx < N:
-                            val = x[idx]
-                            ch = (idx // inner_size) % C
-                            w = weight[ch]
-                            v = T.cast(val, accum)
-                            wf = T.cast(w, accum)
-                            zero = T.cast(0, accum)
-                            y[idx] = T.if_then_else(
-                                v > zero, T.Cast(out_dtype, v), T.Cast(out_dtype, wf * v)
-                            )
-
-            return main
-    else:
-
-        @tilelang.jit(out_idx=[2])
-        def kernel(threads_arg, npt_arg):
-            block_size = threads_arg * npt_arg
-
-            @T.prim_func
-            def main(
-                x: T.Tensor((N,), dtype),
-                weight: T.Tensor((C,), dtype),
-                y: T.Tensor((N,), dtype),
-            ):
-                with T.Kernel(T.ceildiv(N, block_size), threads=threads_arg) as bx:
-                    x_reg = T.alloc_fragment((block_size,), dtype)
-                    y_reg = T.alloc_fragment((block_size,), dtype)
-                    T.copy(x[bx * block_size : (bx + 1) * block_size], x_reg)
-                    for i, j in T.Parallel(threads_arg, npt_arg):
-                        k = i * npt_arg + j
-                        idx = bx * block_size + k
-                        val = x_reg[k]
-                        ch = (idx // inner_size) % C
-                        w = weight[ch]
-                        zero = T.cast(0, val.dtype)
-                        y_reg[k] = T.if_then_else(val > zero, val, w * val)
-                    T.copy(y_reg, y[bx * block_size : (bx + 1) * block_size])
-
-            return main
+        return main
 
     return kernel
 
 
-class PreluFwdKernel(ParametricUnaryKernel):
+class PreluFwdKernel(MultiInputElementwiseKernel):
     """PReLU: y = x if x > 0 else weight[channel] * x."""
 
     def __init__(self, N_total, C, inner_size, dtype, config=None, tune=False):
@@ -103,9 +65,14 @@ class PreluFwdKernel(ParametricUnaryKernel):
     def _builder_fn():
         return _make_prelu_kernel
 
-    def _builder_positional_args(self):
-        return (self.N_total, self.C, self.inner_size, self.dtype_str)
+    def _builder_args(self):
+        return (self.C, self.inner_size)
 
     def forward(self, x, weight):
+        """Run the kernel.
+
+        ``weight`` is per-channel, not per element, so it is passed flat rather
+        than broadcast against ``x``; ``_run`` does not apply.
+        """
         self._require_cuda(x=x, weight=weight)
         return self._compiled_fn(_flat(x), _flat(weight)).reshape(x.shape)

--- a/src/tileops/kernels/elementwise/prelu.py
+++ b/src/tileops/kernels/elementwise/prelu.py
@@ -72,7 +72,7 @@ class PreluFwdKernel(MultiInputElementwiseKernel):
         """Run the kernel.
 
         ``weight`` is per-channel, not per element, so it is passed flat rather
-        than broadcast against ``x``; ``_run`` does not apply.
+        than broadcast against ``x``.
         """
         self._require_cuda(x=x, weight=weight)
         return self._compiled_fn(_flat(x), _flat(weight)).reshape(x.shape)

--- a/src/tileops/kernels/elementwise/sinusoidal.py
+++ b/src/tileops/kernels/elementwise/sinusoidal.py
@@ -7,10 +7,7 @@ import tilelang.language as T
 
 from tileops.kernels.kernel_base import Kernel
 
-from ._base import (
-    _FLOAT_DTYPES,
-    _get_fp8_output_dtypes,
-)
+from ._dtype import _FLOAT_DTYPES
 
 __all__ = [
     "SinusoidalFwdKernel",
@@ -102,10 +99,8 @@ class SinusoidalFwdKernel(Kernel):
         self.seq_len = seq_len
         self.d_model = d_model
         self.dtype = dtype
-        self._fp8_output_dtype, self.output_dtype = _get_fp8_output_dtypes(dtype)
-        self.kernel = _make_sinusoidal_kernel(
-            seq_len, d_model, self.dtype_to_str(self.output_dtype)
-        )
+        self.output_dtype = dtype
+        self.kernel = _make_sinusoidal_kernel(seq_len, d_model, self.dtype_str)
         self.init_config(config, tune)
 
     @property

--- a/src/tileops/kernels/elementwise/where.py
+++ b/src/tileops/kernels/elementwise/where.py
@@ -4,12 +4,8 @@ import functools
 
 import tilelang
 import tilelang.language as T
-import torch
 
-from ._base import (
-    ParametricUnaryKernel,
-)
-from ._broadcast import _broadcast_target, _expand_flat
+from ._base import MultiInputElementwiseKernel
 
 __all__ = [
     "WhereFwdKernel",
@@ -17,97 +13,59 @@ __all__ = [
 
 
 @functools.lru_cache(maxsize=32)
-def _make_where_kernel(N, dtype, is_fp8=False, threads=256, npt=8):
+def _make_where_kernel(N, dtype, threads=256, npt=8):
     """Build where kernel: out = cond ? x : y.
 
     ``WhereFwdKernel.forward`` packs the bool condition as uint8 so that T.copy
-        can perform vectorized loads (TileLang does not vectorize bool tensors).
-        Each uint8 element is 0 or 1; the kernel loads it into a register
-        fragment and unpacks per-element with a != 0 comparison.
+    can perform vectorized loads (TileLang does not vectorize bool tensors).
+    Each uint8 element is 0 or 1; the kernel loads it into a register fragment
+    and unpacks per-element with a != 0 comparison.
 
-        For non-fp8 dtypes, writes the result back into the x register fragment
-        (in-place) to reduce register pressure and avoid a fourth data-typed
-        fragment allocation.
+    The result is written back into ``x``'s register fragment, so the fourth
+    data-typed fragment a separate output would need is never allocated.
     """
 
-    if is_fp8:
+    @tilelang.jit(out_idx=[3])
+    def kernel(threads_arg, npt_arg):
+        block_size = threads_arg * npt_arg
 
-        @tilelang.jit(out_idx=[3])
-        def kernel(threads_arg, npt_arg):
-            block_size = threads_arg * npt_arg
+        @T.prim_func
+        def main(
+            cond: T.Tensor((N,), "uint8"),
+            x: T.Tensor((N,), dtype),
+            y_in: T.Tensor((N,), dtype),
+            out: T.Tensor((N,), dtype),
+        ):
+            with T.Kernel(T.ceildiv(N, block_size), threads=threads_arg) as bx:
+                c_reg = T.alloc_fragment((block_size,), "uint8")
+                x_reg = T.alloc_fragment((block_size,), dtype)
+                y_reg = T.alloc_fragment((block_size,), dtype)
+                T.copy(cond[bx * block_size : (bx + 1) * block_size], c_reg)
+                T.copy(x[bx * block_size : (bx + 1) * block_size], x_reg)
+                T.copy(y_in[bx * block_size : (bx + 1) * block_size], y_reg)
+                for i, j in T.Parallel(threads_arg, npt_arg):
+                    k = i * npt_arg + j
+                    x_reg[k] = T.if_then_else(
+                        c_reg[k] != T.cast(0, "uint8"),
+                        x_reg[k],
+                        y_reg[k],
+                    )
+                T.copy(x_reg, out[bx * block_size : (bx + 1) * block_size])
 
-            @T.prim_func
-            def main(
-                cond: T.Tensor((N,), "uint8"),
-                x: T.Tensor((N,), dtype),
-                y_in: T.Tensor((N,), dtype),
-                out: T.Tensor((N,), dtype),
-            ):
-                with T.Kernel(T.ceildiv(N, block_size), threads=threads_arg) as bx:
-                    for i, j in T.Parallel(threads_arg, npt_arg):
-                        idx = (bx * threads_arg + i) * npt_arg + j
-                        if idx < N:
-                            out[idx] = T.if_then_else(
-                                cond[idx] != T.cast(0, "uint8"),
-                                x[idx],
-                                y_in[idx],
-                            )
-
-            return main
-    else:
-
-        @tilelang.jit(out_idx=[3])
-        def kernel(threads_arg, npt_arg):
-            block_size = threads_arg * npt_arg
-
-            @T.prim_func
-            def main(
-                cond: T.Tensor((N,), "uint8"),
-                x: T.Tensor((N,), dtype),
-                y_in: T.Tensor((N,), dtype),
-                out: T.Tensor((N,), dtype),
-            ):
-                with T.Kernel(T.ceildiv(N, block_size), threads=threads_arg) as bx:
-                    c_reg = T.alloc_fragment((block_size,), "uint8")
-                    x_reg = T.alloc_fragment((block_size,), dtype)
-                    y_reg = T.alloc_fragment((block_size,), dtype)
-                    T.copy(cond[bx * block_size : (bx + 1) * block_size], c_reg)
-                    T.copy(x[bx * block_size : (bx + 1) * block_size], x_reg)
-                    T.copy(y_in[bx * block_size : (bx + 1) * block_size], y_reg)
-                    for i, j in T.Parallel(threads_arg, npt_arg):
-                        k = i * npt_arg + j
-                        x_reg[k] = T.if_then_else(
-                            c_reg[k] != T.cast(0, "uint8"),
-                            x_reg[k],
-                            y_reg[k],
-                        )
-                    T.copy(x_reg, out[bx * block_size : (bx + 1) * block_size])
-
-            return main
+        return main
 
     return kernel
 
 
-class WhereFwdKernel(ParametricUnaryKernel):
+class WhereFwdKernel(MultiInputElementwiseKernel):
     """Where: out = cond ? x : y."""
 
-    _DEFAULT_THREADS = 512
-    _skip_fp8_output = True
+    DEFAULT_THREADS = 512
+    INPUTS = (("cond", "mask"), ("x", "tile"), ("y", "tile"))
 
     @staticmethod
     def _builder_fn():
         return _make_where_kernel
 
     def forward(self, cond, x, y):
-        self._require_cuda(cond=cond, x=x, y=y)
-        out_shape = _broadcast_target(cond, x, y)
-        # A bool condition is this backend's uint8 predicate; the caller passes
-        # semantic bool and never names the representation.
-        if cond.dtype == torch.bool:
-            cond = cond.view(torch.uint8)
-        result = self._compiled_fn(
-            _expand_flat(cond, out_shape),
-            _expand_flat(x, out_shape),
-            _expand_flat(y, out_shape),
-        )
-        return result.reshape(out_shape)
+        return self._run(cond=cond, x=x, y=y)

--- a/src/tileops/kernels/elementwise/where.py
+++ b/src/tileops/kernels/elementwise/where.py
@@ -21,8 +21,8 @@ def _make_where_kernel(N, dtype, threads=256, npt=8):
     Each uint8 element is 0 or 1; the kernel loads it into a register fragment
     and unpacks per-element with a != 0 comparison.
 
-    The result is written back into ``x``'s register fragment, so the fourth
-    data-typed fragment a separate output would need is never allocated.
+    The result is written back into ``x``'s register fragment rather than a
+    fourth data-typed one.
     """
 
     @tilelang.jit(out_idx=[3])

--- a/src/tileops/ops/elementwise/_base.py
+++ b/src/tileops/ops/elementwise/_base.py
@@ -58,9 +58,9 @@ def _validate_scalar_param_repr(
 ) -> None:
     """Reject scalar params that cannot be represented in the user dtype.
 
-    Validates against the *user-facing* ``dtype``, not the kernel's fp16
-    intermediate: an fp8 kernel computes in fp16, so a value that only fits in
-    fp16 would surface as ``+/-Inf`` after the fp8 post-cast.
+    Validated against the dtype the caller passes, which is the dtype the result
+    is stored in. A kernel widening an operand for the arithmetic does not widen
+    what the scalar has to fit in.
 
     Integer and bool mirror PyTorch ``Tensor.masked_fill`` coercion:
 

--- a/src/tileops/ops/elementwise/nan_to_num.py
+++ b/src/tileops/ops/elementwise/nan_to_num.py
@@ -35,11 +35,9 @@ class NanToNumFwdOp(_PerDtypeKernels, Op):
             nan: Replacement for NaN (default 0.0).
             posinf: Replacement for +Inf. Manifest default ``None`` resolves
                 to the largest finite value representable in the element type of the
-                call (matches ``torch.nan_to_num``). Explicit values
-                must also be representable in that dtype end-to-end; values
-                that fit only in the kernel's intermediate dtype (e.g. fp16
-                for fp8_e5m2) are rejected so the post-cast cannot resurface
-                them as Inf.
+                call (matches ``torch.nan_to_num``). An explicit value outside
+                that element type's finite range is rejected rather than stored
+                as Inf.
             neginf: Replacement for -Inf. Manifest default ``None`` resolves
                 to the smallest (most negative) finite value representable
                 in the element type of the call.
@@ -63,9 +61,8 @@ class NanToNumFwdOp(_PerDtypeKernels, Op):
 
         A ``None`` bound means "this dtype's largest finite value", so it
         cannot be resolved before the element type is known. Picking
-        ``finfo(dtype).max`` keeps the replacement finite end-to-end and
-        matches ``torch.nan_to_num``; forwarding ``+inf`` would resolve to
-        fp16's 65504.0 and resurface as ``+Inf`` after an e5m2 post-cast.
+        ``finfo(dtype).max`` matches ``torch.nan_to_num``; forwarding ``+inf``
+        would write back the infinity the op was called to replace.
         """
         _validate_scalar_param_repr("nan", self.nan, dtype, self._op_name)
         if self.posinf is None:

--- a/tests/ops/test_elementwise_config_dtype.py
+++ b/tests/ops/test_elementwise_config_dtype.py
@@ -55,6 +55,10 @@ def test_parametric_unary_honours_a_non_default_config(threads: int, npt: int) -
 INDEPENDENT_KERNELS_SIMPLE = [LeakyReluFwdKernel, EluFwdKernel, HardtanhFwdKernel]
 
 
+# Big enough that the grid-filling shrink leaves the dtype-driven width alone.
+_WIDE_N = 1 << 24
+
+
 @pytest.mark.full
 @pytest.mark.parametrize(
     ("dtype", "expected_npt"),
@@ -62,16 +66,18 @@ INDEPENDENT_KERNELS_SIMPLE = [LeakyReluFwdKernel, EluFwdKernel, HardtanhFwdKerne
         (torch.float32, 4),
         (torch.float16, 8),
         (torch.bfloat16, 8),
-        (torch.float8_e4m3fn, 16),
-        (torch.float8_e5m2, 16),
     ],
 )
 @pytest.mark.parametrize("kernel_cls", INDEPENDENT_KERNELS_SIMPLE)
 def test_independent_kernels_use_expected_default_npt(kernel_cls, dtype, expected_npt):
     """Representative independent kernels should preserve dtype-driven npt defaults."""
-    kernel = kernel_cls.__new__(kernel_cls)
-    kernel.dtype = dtype
+    with (
+        patch.object(kernel_cls, "_build_kernel", return_value=None),
+        patch.object(kernel_cls, "init_config"),
+    ):
+        kernel = kernel_cls(_WIDE_N, dtype)
     assert kernel.default_config["num_per_thread"] == expected_npt
+    assert kernel.default_config["threads"] == 256
 
 
 @pytest.mark.full
@@ -81,8 +87,6 @@ def test_independent_kernels_use_expected_default_npt(kernel_cls, dtype, expecte
         (torch.float32, 4),
         (torch.float16, 8),
         (torch.bfloat16, 8),
-        (torch.float8_e4m3fn, 16),
-        (torch.float8_e5m2, 16),
     ],
 )
 def test_prelu_preserves_dtype_driven_default_npt(dtype, expected_npt):


### PR DESCRIPTION
## Problems

- Every fp8 code path in `src/tileops/kernels/elementwise/` is unreachable. `_FLOAT_DTYPES` dropped fp8 in an earlier change, `_validate_supported_dtype` rejects it at construction, and `test_elementwise_fp8.py` walks the whole package asserting no concrete kernel admits it. No elementwise manifest entry declares an fp8 dtype. The codegen behind that rejection was never removed, and three op-layer docstrings still justify themselves by it.
- Six parametric unary kernels each carried a hand-written `@tilelang.jit` builder whose PrimFunc body is the same fragment-load / compute / fragment-store shape as `_make_unary_regcopy`, differing only by a closed-over scalar. `register_op_func` already binds a scalar into an op body — that is how `_AlphaScaledBinaryKernel` binds `alpha`.
- Five multi-input kernels repeat the same `forward`: broadcast the operands, flatten them, view a bool operand as uint8, call, reshape, view back.
- `LerpFwdKernel._build_kernel` copies `BinaryKernel._build_kernel`'s three-way dispatch verbatim to bind a weight, and drops the `stage=` argument in the copy.
- `UnaryKernel._op_func_name` omits `__module__` where `BinaryKernel` includes it, so two unary kernels sharing a qualname would silently overwrite each other's body in the global `_OP_FUNCS`.
- `_Uint8StorageUnaryKernel` and `_Uint8StorageBinaryKernel` each pin `threads=128, num_per_thread=16`, bypassing the shared launch policy that already yields exactly that for uint8.

## Changes

- Delete every fp8 codegen path: 335 lines of `if is_fp8:` PrimFuncs plus `_wrap_fp8_accumulation`, `_get_fp8_output_dtypes`, `_fp8_accum_dtype_str`, `ElementwiseOutputPlan.post_cast_dtype`, `_restore_output_dtype`'s post-cast, `_NPT_FP8`, `_skip_fp8_output` and the `is_fp8` / `output_dtype` builder parameters. `_FP8_DTYPES` stays as the rejection list it is.
- Add `ScalarParamUnaryKernel`: a `UnaryKernel` whose body is built from construction scalars through `register_op_func`, with two hooks (`_make_op_func`, `_param_key`) replacing the eight `ParametricUnaryKernel` carried. `leaky_relu`, `elu`, `hardtanh`, scalar `clamp` and `nan_to_num` move onto it. It declares `STRATEGIES = ["register_copy"]`, so a `config["strategy"]` naming another strategy now raises instead of being silently ignored; no caller passes one.
- `SoftplusFwdKernel` keeps its builder. The statement binding its logarithm lifts the exponential and the logarithm out of the threshold guard; an op body returning one expression cannot, and float16 rows measure 1.2% slower with them inside it.
- Add `MultiInputElementwiseKernel`: describes its arguments in `INPUTS` and drives broadcast, flatten, uint8 mask packing and shape restore once. Tensor-bound `clamp`, both `masked_fill` forms, `where`, tensor-weight `lerp` and `prelu` move onto it. Their PrimFuncs are untouched, each keeping the fragment aliasing and scalar hoisting it was tuned with.
- Collapse `_make_clamp_tensor_kernel` from three PrimFunc variants to two: the min-only and max-only forms are the same two-operand body with `T.max` or `T.min`.
- `LerpFwdKernel` overrides only `_get_effective_op_func`. The unary op-body name carries its module. `stage_broadcast` moves to `BinaryKernel`, its only reader.
- Delete the `default_config` overrides on the two bool-storage bases. For uint8 the shared policy gives the same `threads=128, num_per_thread=16`; the two diverge only below 524288 elements, where the grid-filling shrink lowers the width — and there the kernel is launch-bound (262144 uint8 elements move 512 KiB, a 0.13 us DRAM floor against 1.1-1.3 us measured), so the width decides nothing. Every shipped bool workload keeps the config it had.
- Retire the fp8 rationale three op-layer docstrings still carried; two are rendered on the docs site. The fp8 notes in `WhereFwdOp` and `LerpTensorFwdOp` stay, since they say fp8 is rejected, which is still what happens.
- Cut the comments that record how the code got here rather than what it does. What a reader acts on stays: tensor clamp's NaN-restore ordering, why `T.isinf` became `|x| == inf`, softplus's 1.2%, why the unary op-body name carries its module.
- The fp8 rows of the default-npt test and the permanently skipped fp8 section of the independent-elementwise benchmark go with the code they pinned; that benchmark leaves the workload-name lint's exempt list, every case in it now being named.

| | before | after |
| --- | --- | --- |
| lines in `kernels/elementwise/` | 5077 | 4282 |
| `@T.prim_func` | 42 | 23 |
| hand-written register-copy PrimFunc bodies | 13 | 7 |
| hooks on the parametric base class | 8 | 2 |

## No behaviour or performance change

The generated CUDA of 57 specializations was dumped and compared against the base commit. 35 are byte-identical, including every `where`, `masked_fill`, `lerp`, `prelu`, fused-gated, generative, unary, binary and comparison kernel. The 22 that differ do so by variable naming, one dead node removed from tensor clamp, and the register loop shape the rest of the unary family already ships. Launch configs are unchanged.

Timed with CUDA graphs over 99 shape/dtype cases (H200, 3 runs, per-case median of the minimum-of-9 mean):

| | |
| --- | --- |
| worst case | +0.96% (`clamp_tensor_both` fp16 1024x4096, 5.5 us) |
| best case | -0.29% |
| mean | +0.14% |
| cases above +1% | 0 |

Run-to-run spread at these sizes is about ±1%: one case read +3.15% on the first run and -0.02% / -0.10% on the next two.

Two tuning constants the refactor inherited were swept rather than carried forward on faith. `threads` over {128, 256, 512} for the five migrated kernels across 3 dtypes x 3 shapes: 256 wins 23 of 45 cases and no alternative buys more than 1% except one 2.69% outlier, so 256 stays. The bool-storage width is the deletion above.
