### PR TITLE
[Perf][foundry][Norm] Hold the row-norm block in registers from the load through the store

### DIFF
--- a/src/tileops/kernels/norm/fused_add_norm.py
+++ b/src/tileops/kernels/norm/fused_add_norm.py
@@ -8,8 +8,12 @@ memory round-trip compared to separate add + norm.  Both kernels return dual
 outputs ``(y, x + residual)`` so downstream residual connections can reuse the
 pre-norm sum without recomputation.
 
-256-element alignment (512 bytes for fp16/bf16) required by T.copy() shared
-memory instructions.
+The row is held in a register fragment from the load through the store. Shared memory
+is left to the FusedAddRMSNorm path that keeps the pre-norm sum there to stay under the
+register limit on a grid that already fills the device.
+
+256-element alignment (512 bytes for fp16/bf16) required by the T.copy() that fills that
+shared buffer.
 """
 
 import functools
@@ -39,6 +43,9 @@ def _fused_add_layer_norm_kernel(M, N, eps, dtype):
 
     @tilelang.jit(out_idx=[4, 5])
     def _func(block_m, threads):
+        # A tail row block runs past the end unless every index is guarded.
+        row_guard = M % block_m != 0
+
         @T.prim_func
         def main(
             x: T.Tensor[(M, N_padded), dtype],
@@ -49,8 +56,6 @@ def _fused_add_layer_norm_kernel(M, N, eps, dtype):
             residual_out: T.Tensor[(M, N_padded), dtype],
         ):
             with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
-                shared_x = T.alloc_shared((block_m, N_padded), dtype)
-                shared_r = T.alloc_shared((block_m, N_padded), dtype)
                 x_local = T.alloc_fragment((block_m, N_padded), dtype)
                 r_local = T.alloc_fragment((block_m, N_padded), dtype)
                 add_f32 = T.alloc_fragment((block_m, N_padded), "float32")
@@ -58,11 +63,26 @@ def _fused_add_layer_norm_kernel(M, N, eps, dtype):
                 mean_val = T.alloc_fragment((block_m,), "float32")
                 rstd = T.alloc_fragment((block_m,), "float32")
 
-                # Load x and residual via shared memory
-                T.copy(x[pid_m * block_m, 0], shared_x)
-                T.copy(shared_x, x_local)
-                T.copy(residual[pid_m * block_m, 0], shared_r)
-                T.copy(shared_r, r_local)
+                # Both operands are read once and reduced along the row the thread
+                # already owns, so neither has to pass through shared memory.
+                if row_guard:
+                    for i, j in T.Parallel(block_m, N_padded):
+                        x_local[i, j] = T.if_then_else(
+                            pid_m * block_m + i < M,
+                            x[pid_m * block_m + i, j],
+                            T.cast(0.0, dtype),
+                        )
+                    for i, j in T.Parallel(block_m, N_padded):
+                        r_local[i, j] = T.if_then_else(
+                            pid_m * block_m + i < M,
+                            residual[pid_m * block_m + i, j],
+                            T.cast(0.0, dtype),
+                        )
+                else:
+                    for i, j in T.Parallel(block_m, N_padded):
+                        x_local[i, j] = x[pid_m * block_m + i, j]
+                    for i, j in T.Parallel(block_m, N_padded):
+                        r_local[i, j] = residual[pid_m * block_m + i, j]
 
                 # Fused add: compute (x + residual) in fp32
                 for i, j in T.Parallel(block_m, N_padded):
@@ -92,16 +112,19 @@ def _fused_add_layer_norm_kernel(M, N, eps, dtype):
                 # --- Output y: (add - mean) * rstd * weight + bias ---
                 # Re-cast from x_local (which holds the pre-norm sum in native dtype)
                 for i, j in T.Parallel(block_m, N_padded):
-                    r_local[i, j] = (T.cast(x_local[i, j], "float32") - mean_val[i]) * rstd[
-                        i
-                    ] * T.cast(weight[j], "float32") + T.cast(bias[j], "float32")
-
-                T.copy(r_local, shared_x)
-                T.copy(shared_x, y[pid_m * block_m, 0])
+                    if (not row_guard) or pid_m * block_m + i < M:
+                        y[pid_m * block_m + i, j] = T.cast(
+                            (T.cast(x_local[i, j], "float32") - mean_val[i])
+                            * rstd[i]
+                            * T.cast(weight[j], "float32")
+                            + T.cast(bias[j], "float32"),
+                            dtype,
+                        )
 
                 # Write residual_out = x + residual
-                T.copy(x_local, shared_r)
-                T.copy(shared_r, residual_out[pid_m * block_m, 0])
+                for i, j in T.Parallel(block_m, N_padded):
+                    if (not row_guard) or pid_m * block_m + i < M:
+                        residual_out[pid_m * block_m + i, j] = x_local[i, j]
 
         return main
 
@@ -115,8 +138,9 @@ class FusedAddLayerNormKernel(Kernel):
     ``x + residual``.  The residual add is fused into the first load pass
     to save one global memory round-trip.
 
-    Supports SM80+ architectures.  Uses 256-element alignment for shared
-    memory copies.
+    Supports SM80+ architectures.  Uses 256-element alignment for the shared
+    buffer the register-relief path fills; every other path holds the row in a
+    register fragment from the load through the store.
     """
 
     supported_archs: list[int] = [80, 86, 89, 90]
@@ -215,6 +239,8 @@ def _fused_add_rms_norm_kernel(M, N, eps, dtype, sm_count):
         # bfloat16 off the register limit, but only pays when the registers it
         # frees buy resident blocks: a single-row call measured 0.94x.
         sum_in_shared = -(-M // block_m) >= sm_count
+        # A tail row block runs past the end unless every index is guarded.
+        row_guard = M % block_m != 0
 
         @T.prim_func
         def main(
@@ -225,8 +251,9 @@ def _fused_add_rms_norm_kernel(M, N, eps, dtype, sm_count):
             residual_out: T.Tensor[(M, N_padded), dtype],
         ):
             with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
-                shared_x = T.alloc_shared((block_m, N_padded), dtype)
-                shared_r = T.alloc_shared((block_m, N_padded), dtype)
+                if sum_in_shared:
+                    shared_x = T.alloc_shared((block_m, N_padded), dtype)
+                    shared_r = T.alloc_shared((block_m, N_padded), dtype)
                 x_local = T.alloc_fragment((block_m, N_padded), dtype)
                 xsq_f32 = T.alloc_fragment((block_m, N_padded), "float32")
                 sumsq = T.alloc_fragment((block_m,), "float32")
@@ -255,21 +282,34 @@ def _fused_add_rms_norm_kernel(M, N, eps, dtype, sm_count):
                         rrms[i] = T.rsqrt(sumsq[i] / float(N) + eps)
 
                     for i, j in T.Parallel(block_m, N_padded):
-                        x_local[i, j] = (
-                            T.cast(x_local[i, j], "float32")
-                            * rrms[i]
-                            * T.cast(weight[j], "float32")
-                        )
-
-                    T.copy(x_local, shared_r)
-                    T.copy(shared_r, y[pid_m * block_m, 0])
+                        if (not row_guard) or pid_m * block_m + i < M:
+                            y[pid_m * block_m + i, j] = T.cast(
+                                T.cast(x_local[i, j], "float32")
+                                * rrms[i]
+                                * T.cast(weight[j], "float32"),
+                                dtype,
+                            )
                 else:
                     r_local = T.alloc_fragment((block_m, N_padded), dtype)
 
-                    T.copy(x[pid_m * block_m, 0], shared_x)
-                    T.copy(shared_x, x_local)
-                    T.copy(residual[pid_m * block_m, 0], shared_r)
-                    T.copy(shared_r, r_local)
+                    if row_guard:
+                        for i, j in T.Parallel(block_m, N_padded):
+                            x_local[i, j] = T.if_then_else(
+                                pid_m * block_m + i < M,
+                                x[pid_m * block_m + i, j],
+                                T.cast(0.0, dtype),
+                            )
+                        for i, j in T.Parallel(block_m, N_padded):
+                            r_local[i, j] = T.if_then_else(
+                                pid_m * block_m + i < M,
+                                residual[pid_m * block_m + i, j],
+                                T.cast(0.0, dtype),
+                            )
+                    else:
+                        for i, j in T.Parallel(block_m, N_padded):
+                            x_local[i, j] = x[pid_m * block_m + i, j]
+                        for i, j in T.Parallel(block_m, N_padded):
+                            r_local[i, j] = residual[pid_m * block_m + i, j]
 
                     for i, j in T.Parallel(block_m, N_padded):
                         x_local[i, j] = T.cast(x_local[i, j], "float32") + T.cast(
@@ -287,17 +327,17 @@ def _fused_add_rms_norm_kernel(M, N, eps, dtype, sm_count):
                         rrms[i] = T.rsqrt(sumsq[i] / float(N) + eps)
 
                     for i, j in T.Parallel(block_m, N_padded):
-                        r_local[i, j] = (
-                            T.cast(x_local[i, j], "float32")
-                            * rrms[i]
-                            * T.cast(weight[j], "float32")
-                        )
+                        if (not row_guard) or pid_m * block_m + i < M:
+                            y[pid_m * block_m + i, j] = T.cast(
+                                T.cast(x_local[i, j], "float32")
+                                * rrms[i]
+                                * T.cast(weight[j], "float32"),
+                                dtype,
+                            )
 
-                    T.copy(r_local, shared_x)
-                    T.copy(shared_x, y[pid_m * block_m, 0])
-
-                    T.copy(x_local, shared_r)
-                    T.copy(shared_r, residual_out[pid_m * block_m, 0])
+                    for i, j in T.Parallel(block_m, N_padded):
+                        if (not row_guard) or pid_m * block_m + i < M:
+                            residual_out[pid_m * block_m + i, j] = x_local[i, j]
 
         return main
 
@@ -420,8 +460,9 @@ class FusedAddRMSNormKernel(Kernel):
     ``x + residual``.  The residual add is fused into the first load pass
     to save one global memory round-trip.
 
-    Supports SM80+ architectures.  Uses 256-element alignment for shared
-    memory copies.
+    Supports SM80+ architectures.  Uses 256-element alignment for the shared
+    buffer the register-relief path fills; every other path holds the row in a
+    register fragment from the load through the store.
     """
 
     supported_archs: list[int] = [80, 86, 89, 90]

--- a/src/tileops/kernels/norm/layer_norm.py
+++ b/src/tileops/kernels/norm/layer_norm.py
@@ -2,12 +2,15 @@
 
 y = (x - mean(x)) / sqrt(var(x) + eps) * weight + bias
 
-256-element alignment (512 bytes for fp16/bf16) is required by T.copy() shared
-memory instructions. Boundary handling for non-aligned N is performed inside
-the kernel, eliminating host-side padding allocations and copies. Padding zeros
-contribute 0 to the mean reduction; the centered two-pass variance computation
-subtracts their exact contribution to remain numerically stable for large-offset
-inputs.
+The row is held in a register fragment from the load through the store. Shared memory
+is left to the partial reduction, whose threads each walk a strided run of the row and
+so must reach slots the reader does not own.
+
+256-element alignment (512 bytes for fp16/bf16) is required by the T.copy() that fills
+that shared buffer. Boundary handling for non-aligned N is performed inside the kernel,
+eliminating host-side padding allocations and copies. Padding zeros contribute 0 to the
+mean reduction; the centered two-pass variance computation subtracts their exact
+contribution to remain numerically stable for large-offset inputs.
 """
 
 import functools
@@ -37,6 +40,8 @@ def _layer_norm_kernel(M, N, eps, dtype, partial_min_elements, sm_count):
         # A partial per thread trades the fp32 fragment's N/threads registers,
         # which cap the resident warps, for a serial walk of shared memory. Only
         # a grid that oversubscribes the device is paid back for the walk.
+        # A tail row block runs past the end unless every index is guarded.
+        row_guard = M % block_m != 0
         per_thread_partial = (
             -(-M // block_m) > sm_count
             # A thread count that does not divide the row truncates the walk.
@@ -52,7 +57,10 @@ def _layer_norm_kernel(M, N, eps, dtype, partial_min_elements, sm_count):
             y: T.Tensor[(M, N), dtype],
         ):
             with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
-                shared_buf = T.alloc_shared((block_m, N_padded), dtype)
+                # Only the strided walk needs shared memory: a thread can reach
+                # another thread's shared slot and cannot reach its registers.
+                if per_thread_partial:
+                    shared_buf = T.alloc_shared((block_m, N_padded), dtype)
                 x_local = T.alloc_fragment((block_m, N_padded), dtype)
                 reduce_width = threads if per_thread_partial else N_padded
                 x_f32 = T.alloc_fragment((block_m, reduce_width), "float32")
@@ -96,22 +104,27 @@ def _layer_norm_kernel(M, N, eps, dtype, partial_min_elements, sm_count):
                     if not needs_pad:
                         T.copy(shared_buf, x_local)
                 else:
+                    # The fragment holds the row for the output pass while the
+                    # fp32 copy below is reduced and overwritten.
                     if needs_pad:
-                        # Retain the original values in shared memory for the
-                        # output pass while the fp32 fragment is reduced below.
                         for i, j in T.Parallel(block_m, N_padded):
-                            shared_buf[i, j] = T.if_then_else(
+                            x_local[i, j] = T.if_then_else(
                                 T.And(pid_m * block_m + i < M, j < N),
                                 x[pid_m * block_m + i, j],
                                 T.cast(0.0, dtype),
                             )
-                            x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
-                    else:
-                        # Preserve the vectorized copy fast path for aligned N.
-                        T.copy(x[pid_m * block_m, 0], shared_buf)
-                        T.copy(shared_buf, x_local)
+                    elif row_guard:
                         for i, j in T.Parallel(block_m, N_padded):
-                            x_f32[i, j] = T.cast(x_local[i, j], "float32")
+                            x_local[i, j] = T.if_then_else(
+                                pid_m * block_m + i < M,
+                                x[pid_m * block_m + i, j],
+                                T.cast(0.0, dtype),
+                            )
+                    else:
+                        for i, j in T.Parallel(block_m, N_padded):
+                            x_local[i, j] = x[pid_m * block_m + i, j]
+                    for i, j in T.Parallel(block_m, N_padded):
+                        x_f32[i, j] = T.cast(x_local[i, j], "float32")
 
                     T.reduce_sum(x_f32, acc, dim=1)
                     for i in T.Parallel(block_m):
@@ -128,7 +141,9 @@ def _layer_norm_kernel(M, N, eps, dtype, partial_min_elements, sm_count):
                         )
 
                 # --- Output: y = (x - mean) * rstd * weight + bias ---
-                if needs_pad:
+                # A padded row under the partial walk is the one case the fragment
+                # never received: its values are still only in shared memory.
+                if needs_pad and per_thread_partial:
                     # Store only real columns.  Returning the natural shape
                     # avoids allocating and writing an M x N_padded output
                     # merely to slice it in the Op layer.
@@ -137,15 +152,22 @@ def _layer_norm_kernel(M, N, eps, dtype, partial_min_elements, sm_count):
                             y[pid_m * block_m + i, j] = (
                                 T.cast(shared_buf[i, j], "float32") - mean_val[i]
                             ) * rstd[i] * T.cast(weight[j], "float32") + T.cast(bias[j], "float32")
-                else:
-                    # Re-cast from x_local (original dtype) to avoid a second
-                    # fp32 buffer, then retain the vectorized copy fast path.
+                elif needs_pad:
                     for i, j in T.Parallel(block_m, N_padded):
-                        x_local[i, j] = (T.cast(x_local[i, j], "float32") - mean_val[i]) * rstd[
-                            i
-                        ] * T.cast(weight[j], "float32") + T.cast(bias[j], "float32")
-                    T.copy(x_local, shared_buf)
-                    T.copy(shared_buf, y[pid_m * block_m, 0])
+                        if T.And(pid_m * block_m + i < M, j < N):
+                            y[pid_m * block_m + i, j] = (
+                                T.cast(x_local[i, j], "float32") - mean_val[i]
+                            ) * rstd[i] * T.cast(weight[j], "float32") + T.cast(bias[j], "float32")
+                else:
+                    for i, j in T.Parallel(block_m, N_padded):
+                        if (not row_guard) or pid_m * block_m + i < M:
+                            y[pid_m * block_m + i, j] = T.cast(
+                                (T.cast(x_local[i, j], "float32") - mean_val[i])
+                                * rstd[i]
+                                * T.cast(weight[j], "float32")
+                                + T.cast(bias[j], "float32"),
+                                dtype,
+                            )
 
         return main
 
@@ -156,8 +178,8 @@ class LayerNormKernel(Kernel):
     """LayerNorm kernel.
 
     Supports SM80+ architectures. Uses 256-element alignment (512 bytes for
-    fp16/bf16) for shared memory copies. Single shared buffer reused for
-    input load and output store.
+    fp16/bf16) for the shared buffer the partial reduction walks; every other
+    path holds the row in a register fragment from the load through the store.
     """
 
     supported_archs: list[int] = [80, 86, 89, 90]

--- a/src/tileops/kernels/norm/rms_norm.py
+++ b/src/tileops/kernels/norm/rms_norm.py
@@ -2,9 +2,13 @@
 
 y = x * rsqrt(mean(x^2) + eps) * weight
 
-256-element alignment (512 bytes for fp16/bf16) required by T.copy() shared memory
-instructions. Padding zeros don't affect sum of squares; division uses original N
-for correct mean computation.
+The normalized row goes from the register fragment straight to global memory. Only the
+partial reduction reads shared memory, because a thread walking a strided run of the row
+can reach it there and cannot reach another thread's registers.
+
+256-element alignment (512 bytes for fp16/bf16) required by the T.copy() that fills that
+shared buffer. Padding zeros don't affect sum of squares; division uses original N for
+correct mean computation.
 """
 
 import functools
@@ -33,6 +37,8 @@ def _rms_norm_kernel(M, N, eps, dtype, partial_min_elements, sm_count):
         # A partial per thread trades the fp32 fragment's N/threads registers,
         # which cap the resident warps, for a serial walk of shared memory. Only
         # a grid that oversubscribes the device is paid back for the walk.
+        # A tail row block runs past the end unless every index is guarded.
+        row_guard = M % block_m != 0
         per_thread_partial = (
             -(-M // block_m) > sm_count
             # A thread count that does not divide the row truncates the walk.
@@ -47,15 +53,15 @@ def _rms_norm_kernel(M, N, eps, dtype, partial_min_elements, sm_count):
             y: T.Tensor[(M, N_padded), dtype],
         ):
             with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
-                shared_buf = T.alloc_shared((block_m, N_padded), dtype)
                 x_local = T.alloc_fragment((block_m, N_padded), dtype)
                 reduce_width = threads if per_thread_partial else N_padded
                 xsq_f32 = T.alloc_fragment((block_m, reduce_width), "float32")
                 sumsq = T.alloc_fragment((block_m,), "float32")
                 rrms = T.alloc_fragment((block_m,), "float32")
 
-                T.copy(x[pid_m * block_m, 0], shared_buf)
                 if per_thread_partial:
+                    shared_buf = T.alloc_shared((block_m, N_padded), dtype)
+                    T.copy(x[pid_m * block_m, 0], shared_buf)
                     T.clear(xsq_f32)
                     for i, j in T.Parallel(block_m, threads):
                         for k in T.serial(N_padded // threads):
@@ -70,7 +76,16 @@ def _rms_norm_kernel(M, N, eps, dtype, partial_min_elements, sm_count):
 
                     T.copy(shared_buf, x_local)
                 else:
-                    T.copy(shared_buf, x_local)
+                    if row_guard:
+                        for i, j in T.Parallel(block_m, N_padded):
+                            x_local[i, j] = T.if_then_else(
+                                pid_m * block_m + i < M,
+                                x[pid_m * block_m + i, j],
+                                T.cast(0.0, dtype),
+                            )
+                    else:
+                        for i, j in T.Parallel(block_m, N_padded):
+                            x_local[i, j] = x[pid_m * block_m + i, j]
 
                     for i, j in T.Parallel(block_m, N_padded):
                         xsq_f32[i, j] = T.cast(x_local[i, j], "float32") * T.cast(
@@ -83,14 +98,15 @@ def _rms_norm_kernel(M, N, eps, dtype, partial_min_elements, sm_count):
                     for i in T.Parallel(block_m):
                         rrms[i] = T.rsqrt(sumsq[i] / float(N) + eps)
 
-                # y = x * rrms * weight, result stored back in x_local
+                # y = x * rrms * weight, written from the fragment holding the row.
                 for i, j in T.Parallel(block_m, N_padded):
-                    x_local[i, j] = (
-                        T.cast(x_local[i, j], "float32") * rrms[i] * T.cast(weight[j], "float32")
-                    )
-
-                T.copy(x_local, shared_buf)
-                T.copy(shared_buf, y[pid_m * block_m, 0])
+                    if (not row_guard) or pid_m * block_m + i < M:
+                        y[pid_m * block_m + i, j] = T.cast(
+                            T.cast(x_local[i, j], "float32")
+                            * rrms[i]
+                            * T.cast(weight[j], "float32"),
+                            dtype,
+                        )
 
         return main
 
@@ -101,8 +117,8 @@ class RMSNormKernel(Kernel):
     """RMS Norm kernel.
 
     Supports SM80+ architectures. Uses 256-element alignment (512 bytes for
-    fp16/bf16) for shared memory copies. Single shared buffer reused for
-    input load and output store.
+    fp16/bf16) for the shared buffer the partial reduction walks; the row itself
+    is held in a register fragment from the load through the store.
     """
 
     supported_archs: list[int] = [80, 86, 89, 90]


### PR DESCRIPTION
## Summary

- Move the row block between global memory and the register fragment directly in RMSNorm, LayerNorm, FusedAddRMSNorm and FusedAddLayerNorm, instead of staging it through shared memory on both the load and the store.
- Keep shared memory only where a thread reaches a slot it does not own: the strided partial reduction, and the FusedAddRMSNorm path that holds the pre-norm sum there to stay under the register limit.
- Guard the row indexing these loops add wherever a tail row block can exist.

## TileFoundry Description

```python
@module(entry="rms_norm", target=CudaTarget("nvidia.h200_sxm"),
        topologies=(Topology("cta", 1), Topology("thread", 512)))
class OneCta:
    @func
    def rms_norm(x: Tensor[(1, N), "f16"], weight: ConstTensor[(1, N), "f16"]):
        with Mesh(("cta",), (1,), ("tile",)) as _cta:
            with Mesh(("thread",), (512,), ("t",)) as m:
                held = tf.reshard(x, (1, N @ m.t), "rmem")
                scaling = tf.reshard(weight, (1, N @ m.t), "rmem")
                rows = tf.cast(held, "f32")
                mean = tf.reduce(tf.square(rows), (-1,), True, ReduceKind.MEAN)
                normed = rows * tf.rsqrt(mean + EPS)
                return tf.reshard(tf.cast(normed, "f16") * scaling, (1, N), "gmem")
```

`tilefoundry analyze --performance` on the decode shape reports `predicted-ns=2846 waves=1`
against `ideal-ns=21 bound-by=memory`, and that row measured 2848 ns. The same description
with the row cut across 64 blocks predicts 37 ns, which says the decode row is held by its
placement, not its arithmetic. That split needs two launches and costs more than it saves at
16 KB to 64 KB a row, the trade `fused_add_norm.py` already records as `_SPLIT_MIN_ROW_TRAFFIC`.
What is left to remove is the staging.

## Performance

Operators: `RMSNormFwdOp`, `LayerNormFwdOp`, `FusedAddRMSNormFwdOp`, `FusedAddLayerNormFwdOp`

| Environment | Value |
| --- | --- |
| image | ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-afcebed1-foundry-dev |
| digest | sha256:fe87c536154ad2ce3bffa4ff97e28fbfde7fcf6598d9d87c3f3dcc4ee9e44b5c |
| gpu | NVIDIA H200, one card for both sides |
| driver | 595.71.05 |
| cuda | 13.2 |
| torch | 2.13.0+cu132 |
| tilelang | 0.1.11+cu132.gitafcebed1 |
| timer | native CUPTI |

Method: the merge base and this branch ran `benchmarks/ops/bench_norm.py` back to back in one
window on one card, best of two runs each, L2 cleared per iteration. The window matters: the
same unmodified commit measured 2.8 us early in a session and 3.1 us hours later on the same
card, a drift larger than several of the gains below.

Ratio in comparator columns: implementation / candidate. &#x1F7E2; > 1 means the candidate is
faster; &#x1F534; <= 1 means it is not.

### RMSNormFwdOp

| Workload | Candidate (us) | Merge base<br>/ candidate | Best comparator<br>/ candidate |
| --- | ---: | ---: | ---: |
| llama-8b-prefill f16 | 10.1 | **10.8<br>&#x1F7E2;&nbsp;1.069x** | flashinfer 10.4<br>&#x1F7E2;&nbsp;1.030x |
| llama-8b-prefill bf16 | 10.0 | **10.8<br>&#x1F7E2;&nbsp;1.080x** | flashinfer 10.2<br>&#x1F7E2;&nbsp;1.020x |
| llama-8b-decode bf16 | 1.7 | **1.8<br>&#x1F7E2;&nbsp;1.059x** | flashinfer 1.9<br>&#x1F7E2;&nbsp;1.118x |
| llama-70b-prefill f16 | 19.0 | **19.9<br>&#x1F7E2;&nbsp;1.047x** | torch-compile 18.8<br>&#x1F534;&nbsp;0.989x |
| llama-70b-prefill bf16 | 18.9 | **19.6<br>&#x1F7E2;&nbsp;1.037x** | flashinfer 18.7<br>&#x1F534;&nbsp;0.989x |
| llama-70b-decode bf16 | 2.1 | **2.2<br>&#x1F7E2;&nbsp;1.048x** | flashinfer 2.3<br>&#x1F7E2;&nbsp;1.095x |
| llama-405b-prefill f16 | 35.8 | **37.3<br>&#x1F7E2;&nbsp;1.042x** | flashinfer 35.5<br>&#x1F534;&nbsp;0.992x |
| llama-405b-prefill bf16 | 36.1 | **37.5<br>&#x1F7E2;&nbsp;1.039x** | flashinfer 36.5<br>&#x1F7E2;&nbsp;1.011x |
| llama-405b-decode bf16 | 2.8 | **3.1<br>&#x1F7E2;&nbsp;1.107x** | flashinfer 3.0<br>&#x1F7E2;&nbsp;1.071x |

### LayerNormFwdOp

| Workload | Candidate (us) | Merge base<br>/ candidate | Best comparator<br>/ candidate |
| --- | ---: | ---: | ---: |
| llama-8b-prefill f16 | 11.7 | **12.5<br>&#x1F7E2;&nbsp;1.068x** | flaggems 12.2<br>&#x1F7E2;&nbsp;1.043x |
| llama-8b-prefill bf16 | 11.8 | **13.3<br>&#x1F7E2;&nbsp;1.127x** | flaggems 12.6<br>&#x1F7E2;&nbsp;1.068x |
| llama-8b-decode bf16 | 2.0 | **2.4<br>&#x1F7E2;&nbsp;1.200x** | flaggems 2.4<br>&#x1F7E2;&nbsp;1.200x |
| llama-70b-prefill f16 | 21.4 | **22.5<br>&#x1F7E2;&nbsp;1.051x** | flaggems 23.5<br>&#x1F7E2;&nbsp;1.098x |
| llama-70b-prefill bf16 | 22.3 | **22.6<br>&#x1F7E2;&nbsp;1.013x** | flaggems 24.8<br>&#x1F7E2;&nbsp;1.112x |
| llama-70b-decode bf16 | 2.6 | **2.8<br>&#x1F7E2;&nbsp;1.077x** | flashinfer 3.5<br>&#x1F7E2;&nbsp;1.346x |
| llama-405b-prefill f16 | 42.2 | **44.1<br>&#x1F7E2;&nbsp;1.045x** | torch-compile 42.6<br>&#x1F7E2;&nbsp;1.009x |
| llama-405b-prefill bf16 | 42.7 | **44.9<br>&#x1F7E2;&nbsp;1.052x** | torch-compile 44.3<br>&#x1F7E2;&nbsp;1.037x |
| llama-405b-decode bf16 | 3.4 | **3.7<br>&#x1F7E2;&nbsp;1.088x** | torch-compile 4.9<br>&#x1F7E2;&nbsp;1.441x |

### FusedAddRMSNormFwdOp

| Workload | Candidate (us) | Merge base<br>/ candidate | Best comparator<br>/ candidate |
| --- | ---: | ---: | ---: |
| llama-8b-prefill f16 | 18.7 | **18.9<br>&#x1F7E2;&nbsp;1.011x** | vllm 18.3<br>&#x1F534;&nbsp;0.979x |
| llama-8b-prefill bf16 | 18.8 | 18.9<br>&#x1F7E2;&nbsp;1.005x | vllm 18.4<br>&#x1F534;&nbsp;0.979x |
| llama-8b-decode bf16 | 2.0 | **2.4<br>&#x1F7E2;&nbsp;1.200x** | flashinfer 2.0<br>&#x1F7E2;&nbsp;1.000x |
| llama-70b-prefill f16 | 35.5 | 35.8<br>&#x1F7E2;&nbsp;1.008x | vllm 35.0<br>&#x1F534;&nbsp;0.986x |
| llama-70b-prefill bf16 | 35.7 | **36.1<br>&#x1F7E2;&nbsp;1.011x** | flashinfer 35.2<br>&#x1F534;&nbsp;0.986x |
| llama-70b-decode bf16 | 2.6 | **3.0<br>&#x1F7E2;&nbsp;1.154x** | flashinfer 2.5<br>&#x1F534;&nbsp;0.962x |
| llama-405b-prefill f16 | 68.9 | 69.4<br>&#x1F7E2;&nbsp;1.007x | torch-compile 69.3<br>&#x1F7E2;&nbsp;1.006x |
| llama-405b-prefill bf16 | 69.0 | **69.7<br>&#x1F7E2;&nbsp;1.010x** | flashinfer 70.2<br>&#x1F7E2;&nbsp;1.017x |
| llama-405b-decode bf16 | 2.8 | 2.8<br>&#x1F7E2;&nbsp;1.000x | flashinfer 3.7<br>&#x1F7E2;&nbsp;1.321x |

### FusedAddLayerNormFwdOp

| Workload | Candidate (us) | Merge base<br>/ candidate | Best comparator<br>/ candidate |
| --- | ---: | ---: | ---: |
| llama-8b-prefill f16 | 19.4 | **20.3<br>&#x1F7E2;&nbsp;1.046x** | torch-compile 25.4<br>&#x1F7E2;&nbsp;1.309x |
| llama-8b-prefill bf16 | 19.7 | **20.7<br>&#x1F7E2;&nbsp;1.051x** | torch-compile 25.0<br>&#x1F7E2;&nbsp;1.269x |
| llama-8b-decode bf16 | 2.3 | **2.7<br>&#x1F7E2;&nbsp;1.174x** | torch-compile 3.3<br>&#x1F7E2;&nbsp;1.435x |
| llama-70b-prefill f16 | 36.8 | **40.3<br>&#x1F7E2;&nbsp;1.095x** | torch-compile 39.7<br>&#x1F7E2;&nbsp;1.079x |
| llama-70b-prefill bf16 | 38.5 | **42.5<br>&#x1F7E2;&nbsp;1.104x** | torch-compile 40.2<br>&#x1F7E2;&nbsp;1.044x |
| llama-70b-decode bf16 | 3.1 | **3.6<br>&#x1F7E2;&nbsp;1.161x** | torch-compile 5.0<br>&#x1F7E2;&nbsp;1.613x |

## Result And Limitations

**LayerNorm and FusedAddLayerNorm: SOTA on every row. RMSNorm and FusedAddRMSNorm: improvement without SOTA.**

- No row regressed against the merge base. LayerNorm leads its fastest comparator on all 9 rows and FusedAddLayerNorm on all 6; RMSNorm leads 6 of 9 and FusedAddRMSNorm 4 of 9.
- The gain is the generated code as a whole, not only the shared-memory bytes. The change also replaces aligned `T.copy` fast paths with indexed `T.Parallel` loops, which alters instruction shape and occupancy, and `select_row_configs` still bounds `block_m` by a shared-memory budget the direct paths no longer spend.
- The rows that still trail are RMSNorm and FusedAddRMSNorm prefill against vllm and flashinfer, 0.979x to 0.992x. These kernels are not proven at their limit from the code: the non-partial paths still hold a full-row fp32 fragment, which leaves room in register pressure and occupancy. Closing them should start from counters -- achieved bandwidth, instructions per element, registers and occupancy, vector width against the libraries -- not another rewrite by inspection.
- `T.copy` calls this change did not touch keep the bounds behaviour they already had. Two of them read, and one writes, past `M` when `block_m` does not divide it: the `per_thread_partial` loads in RMSNorm and LayerNorm, and the `sum_in_shared` copies and `residual_out` store in FusedAddRMSNorm. Autotune can select `block_m > 1`, so the case is reachable; a poisoned-tail run showed no wrong output, because each row reduces independently and the guarded store drops the tail rows. It is a pre-existing hole and belongs to its own change.
- AdaLayerNorm is left alone. It reuses one shared buffer across four tensors and stages some of them with `cp.async`, so the same change is a different change there, and none of its rows is behind.
- Tail-row correctness for the loops this change adds was checked at M of 7, 130, 1000 and 1023 against `block_m` of 2, 4 and 8, in RMSNorm and LayerNorm, for finite and correct output.

## Test

`tests/ops/test_rms_norm.py`, `test_layer_norm.py`, `test_fused_add_rms_norm.py`, `test_fused_add_layer_norm.py`, `test_normalization_alignment.py`, `test_norm_ops.py`: 95 passed. Test node delta: 0.
