### PR TITLE
[Perf][foundry][Pool] Give the 1d pool kernels a window they read once

### DIFF
--- a/src/tileops/kernels/pool/avg_pool1d.py
+++ b/src/tileops/kernels/pool/avg_pool1d.py
@@ -7,7 +7,7 @@ import tilelang.language as T
 import torch
 
 from tileops.kernels.kernel_base import Kernel
-from tileops.kernels.pool.common import pool_output_dim
+from tileops.kernels.pool.common import fits_static_shared, pool_output_dim
 
 __all__ = ["AvgPool1dKernel", "AvgPool1dSpatialKernel"]
 
@@ -26,75 +26,79 @@ def _avg_pool1d_kernel(
 ):
     accum_dtype = "float"
     out_l = pool_output_dim(l_in, kernel_l, stride_l, pad_l, ceil_mode)
-    total_output = n * c_in * out_l
+    rows = n * c_in
+    total = rows * out_l
+    window_inside = pad_l == 0 and (out_l - 1) * stride_l + kernel_l <= l_in
+    # Otherwise a window can overhang, and the divisor comes from its own extent.
+    whole_window_divides = window_inside or (count_include_pad and not ceil_mode)
 
     @tilelang.jit(out_idx=[1], compile_flags=["-O3", "-DENABLE_BF16"])
     def _avg_pool1d_func(block_m: int, threads: int):
+        tile_full = total % block_m == 0
+        # Neighbouring outputs read windows `stride_l` apart, so a warp's taps span
+        # several lines; a block holding a whole row reads it once instead.
+        stage_row = fits_static_shared(l_in, dtype)
+
+        @T.macro
+        def _mean_window(src, src_row, ol, out, out_row):
+            """Store the mean of one window of ``src[src_row]``.
+
+            ``src`` is indexed with a leading axis so the staged tile and ``x`` are
+            read the same way.
+            """
+            start = ol * stride_l - pad_l
+            total_val = T.alloc_var(T.float32)
+            total_val = T.cast(0.0, accum_dtype)
+            for k in T.serial(kernel_l):
+                il = start + k
+                if window_inside:
+                    total_val += T.cast(src[src_row, il], accum_dtype)
+                else:
+                    # A select, not a branch, so every thread walks the same window.
+                    # The clamp only keeps the discarded read in range.
+                    total_val += T.if_then_else(
+                        (il >= 0) and (il < l_in),
+                        T.cast(src[src_row, T.max(0, T.min(il, l_in - 1))], accum_dtype),
+                        T.cast(0.0, accum_dtype),
+                    )
+            if whole_window_divides:
+                divisor = T.cast(kernel_l, accum_dtype)
+            elif count_include_pad:
+                divisor = T.cast(
+                    T.max(T.min(start + kernel_l, l_in + pad_l) - T.max(start, -pad_l), 1),
+                    accum_dtype,
+                )
+            else:
+                divisor = T.cast(
+                    T.max(T.min(start + kernel_l, l_in) - T.max(start, 0), 1),
+                    accum_dtype,
+                )
+            out[out_row, ol] = T.cast(total_val / divisor, dtype)
+
         @T.prim_func
         def _avg_pool1d_main(
-            x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
-            out: T.Tensor((n, c_in, out_l), dtype),  # type: ignore
+            x: T.Tensor((rows, l_in), dtype),  # type: ignore
+            out: T.Tensor((rows, out_l), dtype),  # type: ignore
         ):
-            with T.Kernel(T.ceildiv(total_output, block_m), threads=threads) as bx:
-                T.use_swizzle(10)
-                tile_out_start = bx * block_m
-                tile_out_end = tile_out_start + block_m - 1
-                tile_ol_start = tile_out_start % out_l
-                tile_ol_end = tile_out_end % out_l
-                tile_same_row = tile_out_start // out_l == tile_out_end // out_l
-                tile_input_start = tile_ol_start * stride_l - pad_l
-                tile_input_end = tile_ol_end * stride_l + kernel_l - 1 - pad_l
-                tile_spatial_full = (
-                    tile_same_row & (tile_input_start >= 0) & (tile_input_end < l_in)
-                )
-                for i in T.Parallel(block_m):
-                    out_idx = bx * block_m + i
-                    if out_idx < total_output:
-                        ol = out_idx % out_l
-                        nc_idx = out_idx // out_l
-                        c_idx = nc_idx % c_in
-                        batch = nc_idx // c_in
-
-                        sum_val = T.alloc_var(T.float32)
-                        sum_val = T.cast(0.0, accum_dtype)
-
-                        if tile_spatial_full:
-                            for kw in T.serial(kernel_l):
-                                il = ol * stride_l + kw - pad_l
-                                sum_val += T.cast(x[batch, c_idx, il], accum_dtype)
-                            out[batch, c_idx, ol] = T.cast(
-                                sum_val / T.cast(kernel_l, accum_dtype),
-                                dtype,
-                            )
-                        else:
-                            for kw in T.serial(kernel_l):
-                                il = ol * stride_l + kw - pad_l
-                                if il >= 0 and il < l_in:
-                                    sum_val += T.cast(x[batch, c_idx, il], accum_dtype)
-
-                            window_start = ol * stride_l - pad_l
-                            window_end = window_start + kernel_l
-                            valid_start = T.max(window_start, 0)
-                            valid_end = T.min(window_end, l_in)
-                            valid_count = T.max(valid_end - valid_start, 0)
-                            padded_start = T.max(window_start, -pad_l)
-                            padded_end = T.min(window_end, l_in + pad_l)
-                            padded_count = T.max(padded_end - padded_start, 0)
-                            divisor = T.max(
-                                T.if_then_else(count_include_pad, padded_count, valid_count),
-                                1,
-                            )
-                            out[batch, c_idx, ol] = T.cast(
-                                sum_val / T.cast(divisor, accum_dtype),
-                                dtype,
-                            )
+            grid = rows if stage_row else T.ceildiv(total, block_m)
+            with T.Kernel(grid, threads=threads) as bx:
+                if stage_row:
+                    tile = T.alloc_shared((1, l_in), dtype)
+                    T.copy(x[bx, 0:l_in], tile[0, 0:l_in])
+                    for ol in T.Parallel(out_l):
+                        _mean_window(tile, 0, ol, out, bx)
+                else:
+                    for i in T.Parallel(block_m):
+                        idx = bx * block_m + i
+                        if tile_full or idx < total:
+                            row = idx // out_l
+                            _mean_window(x, row, idx % out_l, out, row)
 
         return _avg_pool1d_main
 
     return _avg_pool1d_func
 
 
-@functools.lru_cache(maxsize=64)
 def _avg_pool1d_spatial_kernel(
     n: int,
     c_in: int,
@@ -104,81 +108,12 @@ def _avg_pool1d_spatial_kernel(
     pad_l: int,
     dtype: str = "float16",
 ):
-    accum_dtype = "float"
-    out_l = pool_output_dim(l_in, kernel_l, stride_l, pad_l, False)
-    total_output = n * c_in * out_l
+    """Zero-padded, floor-mode 1d average pooling.
 
-    @tilelang.jit(out_idx=[1], compile_flags=["-O3", "-DENABLE_BF16"])
-    def _avg_pool1d_spatial_func(block_m: int, threads: int):
-        @T.prim_func
-        def _avg_pool1d_spatial_main(
-            x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
-            out: T.Tensor((n, c_in, out_l), dtype),  # type: ignore
-        ):
-            with T.Kernel(T.ceildiv(total_output, block_m), threads=threads) as bx:
-                T.use_swizzle(10)
-                tile_out_start = bx * block_m
-                tile_out_end = tile_out_start + block_m - 1
-                tile_ol_start = tile_out_start % out_l
-                tile_ol_end = tile_out_end % out_l
-                tile_same_row = tile_out_start // out_l == tile_out_end // out_l
-                tile_input_start = tile_ol_start * stride_l - pad_l
-                tile_input_end = tile_ol_end * stride_l + kernel_l - 1 - pad_l
-                tile_spatial_full = (
-                    tile_same_row & (tile_input_start >= 0) & (tile_input_end < l_in)
-                )
-                for i in T.Parallel(block_m):
-                    out_idx = bx * block_m + i
-                    if out_idx < total_output:
-                        ol = out_idx % out_l
-                        nc_idx = out_idx // out_l
-                        c_idx = nc_idx % c_in
-                        batch = nc_idx // c_in
-
-                        sum_val = T.alloc_var(T.float32)
-                        sum_val = T.cast(0.0, accum_dtype)
-
-                        if tile_spatial_full:
-                            for kw in T.serial(kernel_l):
-                                il = ol * stride_l + kw - pad_l
-                                sum_val += T.cast(x[batch, c_idx, il], accum_dtype)
-                        else:
-                            for kw in T.serial(kernel_l):
-                                il = ol * stride_l + kw - pad_l
-                                if il >= 0 and il < l_in:
-                                    sum_val += T.cast(x[batch, c_idx, il], accum_dtype)
-
-                        out[batch, c_idx, ol] = T.cast(
-                            sum_val / T.cast(kernel_l, accum_dtype),
-                            dtype,
-                        )
-
-        return _avg_pool1d_spatial_main
-
-    return _avg_pool1d_spatial_func
-
-
-def _launch_avg_pool1d_spatial(
-    n: int,
-    c_in: int,
-    l_in: int,
-    kernel_l: int,
-    stride_l: int,
-    pad_l: int,
-    dtype: str,
-    block_m: int,
-    threads: int,
-    x: torch.Tensor,
-) -> torch.Tensor:
-    return _avg_pool1d_spatial_kernel(
-        n,
-        c_in,
-        l_in,
-        kernel_l,
-        stride_l,
-        pad_l,
-        dtype,
-    )(block_m, threads)(x)
+    Every window then spans the full kernel once the padding is counted, which is
+    what ``_avg_pool1d_kernel`` emits for these two flags.
+    """
+    return _avg_pool1d_kernel(n, c_in, l_in, kernel_l, stride_l, pad_l, False, True, dtype)
 
 
 def _launch_avg_pool1d(
@@ -195,7 +130,8 @@ def _launch_avg_pool1d(
     threads: int,
     x: torch.Tensor,
 ) -> torch.Tensor:
-    return _avg_pool1d_kernel(
+    out_l = pool_output_dim(l_in, kernel_l, stride_l, pad_l, ceil_mode)
+    kernel = _avg_pool1d_kernel(
         n,
         c_in,
         l_in,
@@ -205,7 +141,26 @@ def _launch_avg_pool1d(
         ceil_mode,
         count_include_pad,
         dtype,
-    )(block_m, threads)(x)
+    )(block_m, threads)
+
+    return kernel(x.contiguous().view(n * c_in, l_in)).view(n, c_in, out_l)
+
+
+def _launch_avg_pool1d_spatial(
+    n: int,
+    c_in: int,
+    l_in: int,
+    kernel_l: int,
+    stride_l: int,
+    pad_l: int,
+    dtype: str,
+    block_m: int,
+    threads: int,
+    x: torch.Tensor,
+) -> torch.Tensor:
+    return _launch_avg_pool1d(
+        n, c_in, l_in, kernel_l, stride_l, pad_l, False, True, dtype, block_m, threads, x
+    )
 
 
 class AvgPool1dSpatialKernel(Kernel):

--- a/src/tileops/kernels/pool/max_pool1d.py
+++ b/src/tileops/kernels/pool/max_pool1d.py
@@ -12,25 +12,30 @@ from tileops.kernels.pool.common import fits_static_shared, pool_output_dim
 __all__ = ["MaxPool1dKernel", "MaxPool1dWithIndicesKernel"]
 
 
-# One warp's width. At or below it a warp spans more than one (batch, channel)
-# row, so neighbouring threads read global memory `l_in` elements apart.
-_STAGE_MAX_OUT_L = 32
-# Pad the shared row off a whole number of banks, or the staged rows collide.
-# The width is measured, on an H200; re-measure it on other hardware.
-_STAGE_ROW_PAD = 8
+def _stage_rows(
+    block_m: int, out_l: int, c_in: int, l_in: int, dtype: str
+) -> Optional[Tuple[int, int]]:
+    """Rows of one image a block stages, and the pad between them, or None.
 
+    None means the block reads global instead, which every shape does unless its
+    outputs form whole rows of one image and those rows fit in shared memory.
+    """
+    # A warp's width. At or below it a warp spans more than one (batch, channel)
+    # row, so neighbouring threads read global memory `l_in` elements apart.
+    max_out_l = 32
+    # Pad the shared row off a whole number of banks, or the staged rows collide.
+    # The width is measured, on an H200; re-measure it on other hardware.
+    row_pad = 8
 
-def _stage_rows(block_m: int, out_l: int, c_in: int, l_in: int, dtype: str) -> Optional[int]:
-    """Rows of one image a block stages in shared memory, or None to read global."""
-    if out_l > _STAGE_MAX_OUT_L or block_m % out_l:
+    if out_l > max_out_l or block_m % out_l:
         return None
     rows = block_m // out_l
     # Dividing c_in leaves no ragged last block, so the staged body needs no test.
     if rows > c_in or c_in % rows:
         return None
-    if not fits_static_shared(rows * (l_in + _STAGE_ROW_PAD), dtype):
+    if not fits_static_shared(rows * (l_in + row_pad), dtype):
         return None
-    return rows
+    return rows, row_pad
 
 
 @functools.lru_cache(maxsize=32)
@@ -48,32 +53,59 @@ def _max_pool1d_kernel(
     accum_dtype = "float"
     out_l = pool_output_dim(l_in, kernel_w, stride_w, pad_w, ceil_mode, dilation_w)
     total_output = n * c_in * out_l
+    always_in_bounds = pad_w == 0 and (out_l - 1) * stride_w + (kernel_w - 1) * dilation_w < l_in
 
     @tilelang.jit(out_idx=[1], compile_flags=["-O3", "-DENABLE_BF16"])
     def _max_pool1d_func(block_m: int, threads: int):
-        stage_rows = _stage_rows(block_m, out_l, c_in, l_in, dtype)
+        staged = _stage_rows(block_m, out_l, c_in, l_in, dtype)
 
         @T.macro
-        def _reduce_window(src, src_c, src_row, ow, out, out_c, out_row):
-            """Store the max over one window of ``src[src_c, src_row]``."""
+        def _reduce_window_global(src, src_c, src_row, ow, out, out_c, out_row):
+            """Store the max over one window, for taps that come from global.
+
+            ``src`` is indexed with a leading axis so the staged tile and ``x`` are
+            read the same way.
+
+            NaN enters ``max_val`` and never leaves: a later value fails
+            ``val > NaN``, which is how PyTorch propagates it. Spending a select per
+            tap to save the accumulator's register is the trade a scan that waits on
+            memory wants.
+            """
+            max_val = T.alloc_var(T.float32)
+            max_val = T.cast(float("-inf"), accum_dtype)
+            for kw in T.serial(kernel_w):
+                iw = ow * stride_w - pad_w + kw * dilation_w
+                if always_in_bounds or (iw >= 0 and iw < l_in):
+                    val = T.cast(src[src_c, src_row, iw], accum_dtype)
+                    max_val = T.if_then_else(T.isnan(val) or (val > max_val), val, max_val)
+
+            out[out_c, out_row, ow] = T.cast(max_val, dtype)
+
+        @T.macro
+        def _reduce_window_shared(src, src_c, src_row, ow, out, out_c, out_row):
+            """Store the max over one window, for taps that come from shared.
+
+            ``src`` is indexed with a leading axis so the staged tile and ``x`` are
+            read the same way.
+
+            Resident taps make the scan arithmetic-bound, which wants the opposite
+            trade: ``T.max`` drops NaN, so NaN rides in an accumulator instead of
+            costing a select per tap.
+            """
             max_val = T.alloc_var(T.float32)
             has_nan = T.alloc_var(T.bool)
             max_val = T.cast(float("-inf"), accum_dtype)
             has_nan = False
             for kw in T.serial(kernel_w):
                 iw = ow * stride_w - pad_w + kw * dilation_w
-                if iw >= 0 and iw < l_in:
+                if always_in_bounds or (iw >= 0 and iw < l_in):
                     val = T.cast(src[src_c, src_row, iw], accum_dtype)
-                    if T.isnan(val):
-                        has_nan = True
+                    has_nan = has_nan | T.isnan(val)
                     max_val = T.max(max_val, val)
 
-            result = T.if_then_else(
-                has_nan,
-                T.cast(float("nan"), accum_dtype),
-                max_val,
+            out[out_c, out_row, ow] = T.cast(
+                T.if_then_else(has_nan, T.cast(float("nan"), accum_dtype), max_val), dtype
             )
-            out[out_c, out_row, ow] = T.cast(result, dtype)
 
         @T.prim_func
         def _max_pool1d_main(
@@ -81,33 +113,25 @@ def _max_pool1d_kernel(
             out: T.Tensor((n, c_in, out_l), dtype),  # type: ignore
         ):
             with T.Kernel(T.ceildiv(total_output, block_m), threads=threads) as bx:
-                for i in T.Parallel(block_m):
-                    out_idx = bx * block_m + i
-                    if out_idx < total_output:
-                        ow = out_idx % out_l
-                        channel_batch_idx = out_idx // out_l
-                        c_idx = channel_batch_idx % c_in
-                        batch = channel_batch_idx // c_in
-                        _reduce_window(x, batch, c_idx, ow, out, batch, c_idx)
-
-        if stage_rows is not None:
-            # Leading axis of 1 so the macro indexes the tile and x alike.
-            @T.prim_func
-            def _max_pool1d_staged_main(
-                x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
-                out: T.Tensor((n, c_in, out_l), dtype),  # type: ignore
-            ):
-                with T.Kernel(T.ceildiv(total_output, block_m), threads=threads) as bx:
-                    tile = T.alloc_shared((1, stage_rows, l_in + _STAGE_ROW_PAD), dtype)
+                if staged is None:
+                    for i in T.Parallel(block_m):
+                        out_idx = bx * block_m + i
+                        if out_idx < total_output:
+                            ow = out_idx % out_l
+                            channel_batch_idx = out_idx // out_l
+                            c_idx = channel_batch_idx % c_in
+                            batch = channel_batch_idx // c_in
+                            _reduce_window_global(x, batch, c_idx, ow, out, batch, c_idx)
+                else:
+                    stage_rows, row_pad = staged
+                    tile = T.alloc_shared((1, stage_rows, l_in + row_pad), dtype)
                     batch = bx * stage_rows // c_in
                     c_base = bx * stage_rows % c_in
                     T.copy(x[batch, c_base : c_base + stage_rows, 0:l_in], tile[0, :, 0:l_in])
                     for i in T.Parallel(block_m):
                         ow = i % out_l
                         row = i // out_l
-                        _reduce_window(tile, 0, row, ow, out, batch, c_base + row)
-
-            return _max_pool1d_staged_main
+                        _reduce_window_shared(tile, 0, row, ow, out, batch, c_base + row)
 
         return _max_pool1d_main
 
@@ -256,7 +280,7 @@ def _max_pool1d_with_indices_kernel(
 
     @tilelang.jit(out_idx=[1, 2], compile_flags=["-O3", "-DENABLE_BF16"])
     def _max_pool1d_with_indices_func(block_m: int, threads: int):
-        stage_rows = _stage_rows(block_m, out_l, c_in, l_in, dtype)
+        staged = _stage_rows(block_m, out_l, c_in, l_in, dtype)
 
         @T.macro
         def _reduce_window(src, src_c, src_row, ow, out, indices, out_c, out_row):
@@ -320,25 +344,18 @@ def _max_pool1d_with_indices_kernel(
             indices: T.Tensor((n, c_in, out_l), "int64"),  # type: ignore
         ):
             with T.Kernel(T.ceildiv(total_output, block_m), threads=threads) as bx:
-                for i in T.Parallel(block_m):
-                    out_idx = bx * block_m + i
-                    if out_idx < total_output:
-                        ow = out_idx % out_l
-                        channel_batch_idx = out_idx // out_l
-                        c_idx = channel_batch_idx % c_in
-                        batch = channel_batch_idx // c_in
-                        _reduce_window(x, batch, c_idx, ow, out, indices, batch, c_idx)
-
-        if stage_rows is not None:
-            # Leading axis of 1 so the macro indexes the tile and x alike.
-            @T.prim_func
-            def _max_pool1d_with_indices_staged_main(
-                x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
-                out: T.Tensor((n, c_in, out_l), dtype),  # type: ignore
-                indices: T.Tensor((n, c_in, out_l), "int64"),  # type: ignore
-            ):
-                with T.Kernel(T.ceildiv(total_output, block_m), threads=threads) as bx:
-                    tile = T.alloc_shared((1, stage_rows, l_in + _STAGE_ROW_PAD), dtype)
+                if staged is None:
+                    for i in T.Parallel(block_m):
+                        out_idx = bx * block_m + i
+                        if out_idx < total_output:
+                            ow = out_idx % out_l
+                            channel_batch_idx = out_idx // out_l
+                            c_idx = channel_batch_idx % c_in
+                            batch = channel_batch_idx // c_in
+                            _reduce_window(x, batch, c_idx, ow, out, indices, batch, c_idx)
+                else:
+                    stage_rows, row_pad = staged
+                    tile = T.alloc_shared((1, stage_rows, l_in + row_pad), dtype)
                     batch = bx * stage_rows // c_in
                     c_base = bx * stage_rows % c_in
                     T.copy(x[batch, c_base : c_base + stage_rows, 0:l_in], tile[0, :, 0:l_in])
@@ -346,8 +363,6 @@ def _max_pool1d_with_indices_kernel(
                         ow = i % out_l
                         row = i // out_l
                         _reduce_window(tile, 0, row, ow, out, indices, batch, c_base + row)
-
-            return _max_pool1d_with_indices_staged_main
 
         return _max_pool1d_with_indices_main
 


### PR DESCRIPTION
Supersedes #2066 and #2067, which applied the same changes to two sibling kernels.

## Problems

- Both 1d pool kernels compute a per-tap bounds test that is a compile-time truth
  for any shape with no padding and no ceil overshoot.
- `avg_pool1d` decomposes a flat output index into `(batch, channel, position)`
  when only the row and the position are used, and reads each input element
  `kernel_l / stride_l` times. Neighbouring outputs read windows `stride_l` apart,
  so a warp's taps span several lines to use part of each.

## Changes

- The bounds test comes from the shape. `max_pool1d`'s with-indices path already had
  this from #2063; its value-only path did not, and `avg_pool1d` had neither.
- `avg_pool1d` addresses `(rows, l_in)`, and a block holds a whole input row in
  shared memory when it fits, reading the windows from there. The test is
  `fits_static_shared` from `pool/common.py`; no new constant. `max_pool1d` keeps
  three-axis addressing: its staged launch copies
  `x[batch, c_base : c_base + rows, 0:l_in]`, which the flattened view cannot name.
- `max_pool1d`'s value-only launches take different NaN forms. Where the taps come
  from global the scan waits on memory, so one select per tap buys back the
  register a NaN accumulator holds; where they come from shared it is
  arithmetic-bound and the accumulator is cheaper. Measured: applied to both, the
  select form took `ecg-cnn-dilated` to 1.03x and `textcnn-global` to 0.85x.
- Each kernel reads its window through one `T.macro`, and each builder emits one
  `T.prim_func` whose staged and direct bodies are chosen at trace time.

Dropped from #2067: the `block_k` lane split and its two constants. It fires on one
manifest row, `textcnn-global`, where it ties the shared staging #2064 already
merged -- 3.50 us against 3.60 us -- so keeping the merged path costs one fewer
config dimension and drops a hard-coded SM count.

## Performance

H200 SXM, one idle device, `benchmarks/ops/bench_pool.py`, CUPTI device-busy time,
against `main`. A B A B in one sitting, each round from its own empty
`TILELANG_CACHE_DIR`.

| workload | op | dtype | before | after | speedup | vs baseline |
| --- | --- | --- | ---: | ---: | ---: | --- |
| audio-downsample | AvgPool1d | float16 | 5.5 us | 3.8 us | 1.45x | 0.67x -> 0.97x |
| ceil | AvgPool1d | bfloat16 | 3.0 us | 2.1 us | 1.43x | 0.67x -> 0.91x |
| ecg-cnn-dilated | MaxPool1d | bfloat16 | 7.8 us | 6.7 us | 1.16x | 0.87x -> **1.01x** |
| long-temporal | AvgPool1d | float16 | 19.0 us | 17.3 us | 1.10x | 0.85x -> 0.93x |

Baselines are `torch.compile`. The kernel time is the slowest this branch measured
and the baseline the fastest `torch.compile` measured, over two independent
two-round sittings. That pairing matters: `torch.compile` is bimodal on two of these
rows, reading 2.00 or 2.80 us for `ceil` and 3.70 or 5.20 us for `audio-downsample`,
in runs of `main` and of this branch alike. This branch sits between the two modes,
so a single sitting can read either 0.91x or 1.33x for `ceil`. The table takes the
mode that favours `torch.compile`.

The other 41 rows move by -0.30 us summed and at most +0.30 us on any one of them.

## Result And Limitations

- Four rows change and every one is faster. `ecg-cnn-dilated` crosses its baseline;
  the other three close to 0.91x - 0.97x from 0.67x - 0.85x.
- 274 `tests/ops/test_pool.py` and `tests/ops/test_mean_pooling.py` cases pass; no
  test node added or removed. Values are bit-identical to PyTorch across float16 and
  bfloat16 for random NaN, dilation with padding, and an all-`-inf` window.
- The value-only global read now also agrees with PyTorch on a signed-zero tie,
  which `main` does not. The staged read still reduces with `T.max` and does not.
  That divergence is older and family-wide; #2082 has the reproducer and the cost of
  fixing it.

`long-temporal` is the row left open. Its rows are 64 KB in fp16, so a block cannot
hold one, and four ways of staging a chunk instead were built and measured:

| | time | TB/s |
| --- | ---: | ---: |
| flat, one thread per output, reading global (what this ships) | 17.60 us | 2.33 |
| chunk staged, copy extent computed at runtime | 23.23 us | 1.76 |
| chunk staged, static extent, copy start clamped into the row | 44.54 us | 0.92 |
| chunk staged, affine copy start, first and last chunk on global | 18.24 us | 2.25 |
| *a bulk copy alone, no window arithmetic and no boundary* | *13.57 us* | *3.02* |

The last line is why the others were built. A static-extent `T.copy` whose source
start is a plain `block_index * constant` moves this row at 3.02 TB/s, past the
2.55 TB/s `torch.compile` reaches. It cannot be made into a pooling kernel: the
start has to step back `pad_l` for the first chunk and the last runs past the row,
and clamping the start or branching on the block index each cost more than the copy
saves. One `T.max` on the start alone takes the same kernel from 13.31 to 38.05 us,
because `T.copy` stops lowering to a bulk transfer. That is #2079, with a
self-contained reproducer; if it is fixed, this row is worth revisiting.

So neither the 8.5 us DRAM roofline nor 3.02 TB/s is the yardstick here. A probe
moving exactly this traffic with the same scalar access the kernel has runs at
17.41 us, slower than the kernel.
