### PR TITLE
[Refactor][Reduction] Delete the unused macro factories and share the tile_n sweep

### DIFF
--- a/src/tileops/kernels/reduction/__init__.py
+++ b/src/tileops/kernels/reduction/__init__.py
@@ -1,18 +1,14 @@
 # Copyright (c) Tile-AI. All rights reserved.
-"""Reduction kernel primitives and shared utilities.
+"""Reduction kernels, one module per sub-category.
 
-This package provides the foundational building blocks (macros, constants,
-and utility functions) used by all reduction sub-category kernels.
+The row layout, launch planning and shared-memory arithmetic every one of them
+builds on are in ``_primitives``.
 """
 
 from ._primitives import (
     DEFAULT_ALIGNMENT,
     SHARED_MEMORY_BUDGET_BYTES,
     align_up,
-    make_cumulative_scan,
-    make_reduce_epilogue,
-    make_softmax_epilogue,
-    make_welford_update,
 )
 from .argreduce import ArgreduceKernel
 from .cumulative import CumulativeKernel
@@ -20,9 +16,6 @@ from .logical_reduce import LogicalReduceEdgeFusedKernel, LogicalReduceKernel
 from .logsumexp import LogSumExpKernel
 from .reduce import ReduceKernel
 from .softmax import SoftmaxKernel
-
-# Placeholder imports for reduction kernels.
-# Each sub-category PR uncomments its own lines.
 from .vector_norm import VectorNormKernel
 
 __all__: list[str] = [
@@ -37,8 +30,4 @@ __all__: list[str] = [
     "SoftmaxKernel",
     "VectorNormKernel",
     "align_up",
-    "make_cumulative_scan",
-    "make_reduce_epilogue",
-    "make_softmax_epilogue",
-    "make_welford_update",
 ]

--- a/src/tileops/kernels/reduction/__init__.py
+++ b/src/tileops/kernels/reduction/__init__.py
@@ -1,9 +1,5 @@
 # Copyright (c) Tile-AI. All rights reserved.
-"""Reduction kernels, one module per sub-category.
-
-The row layout, launch planning and shared-memory arithmetic every one of them
-builds on are in ``_primitives``.
-"""
+"""Reduction kernels, one module per sub-category."""
 
 from ._primitives import (
     DEFAULT_ALIGNMENT,

--- a/src/tileops/kernels/reduction/_primitives.py
+++ b/src/tileops/kernels/reduction/_primitives.py
@@ -1,8 +1,8 @@
 """Shared reduction primitives for reduction kernels.
 
-Provides reusable utility functions, constants, and T.macro factories
-used across all reduction sub-category kernels (sum, max, softmax,
-variance, prefix-scan, etc.), plus the row layout every one of them wants.
+Launch planning, shared-memory arithmetic and the row layout the reduction
+kernels build on, plus the engine that reduces an ``(A, B)`` buffer down its
+rows.
 
 A reduction kernel reduces the trailing axis of a 2-D ``(M, N)`` buffer, while an op
 declares an arbitrary-rank tensor and the axes to reduce; the permute and flatten between
@@ -23,6 +23,7 @@ import torch
 
 from tileops.kernels.constants import SHARED_BANK_SPAN_BYTES, VECTOR_ACCESS_BYTES
 from tileops.kernels.tiling import ALIGNMENT, align_up
+from tileops.utils import device_busy_of
 
 __all__ = [
     "AUTOTUNE_THREADS",
@@ -42,11 +43,7 @@ __all__ = [
     "device_smem_budget",
     "edge_axis_plan",
     "edge_axis_split",
-    "make_cumulative_scan",
-    "make_reduce_epilogue",
-    "make_softmax_epilogue",
-    "make_welford_update",
-    "reduce_column_alignment",
+    "identity_for",
     "reduce_down_rows",
     "restore_reduced",
     "restore_same_shape",
@@ -83,6 +80,22 @@ def ceildiv_int(x: int, y: int) -> int:
     return -(-x // y)
 
 
+def identity_for(op_kind: str) -> float:
+    """The value a masked lane contributes, leaving the reduction unchanged.
+
+    Covers every op_kind the reduction kernels mask for: a product and an
+    ``all`` take one, the extrema take the infinity they cannot beat, and the
+    additive kinds take zero.
+    """
+    if op_kind in ("prod", "all"):
+        return 1.0
+    if op_kind == "amin":
+        return float("inf")
+    if op_kind == "amax":
+        return float("-inf")
+    return 0.0
+
+
 def torch_dtype_nbytes(dtype: torch.dtype | str) -> int:
     """Return element size for a torch dtype object or dtype-name string."""
     if isinstance(dtype, str):
@@ -103,10 +116,15 @@ def reduce_column_alignment(elem_bytes: int, threads: int) -> int:
 class BlockConfigPlanner:
     """Derives ``block_m`` / ``threads`` / ``tile_n`` for a row-wise reduction.
 
-    Every reduction kernel that maps one row per ``block_m`` slot makes the same
-    three decisions -- whether a row fits in shared memory, which config to run
-    untuned, and which candidates to offer the autotuner.  Derived here once so
-    the kernels cannot answer them differently.
+    Answers three questions for a kernel that maps one row per ``block_m`` slot:
+    whether a row fits in shared memory, which config to run untuned, and which
+    candidates to offer the autotuner.
+
+    ``autotune_configs`` here serves the kernels that sweep by calling forward
+    through ``tune_by_forward``, where a candidate costs one call. A kernel that
+    bakes ``tile_n`` into the PrimFunc pays a recompilation per distinct value
+    and sweeps a narrower list of its own; see `RowTiledAutotuneMixin`. The two
+    lists differ at every width, so they are not interchangeable.
 
     Args:
         num_buffers: ``(block_m, tile_n)`` shared buffers alive at once.
@@ -495,12 +513,6 @@ def compute_tile_n(
     return tile_n_max
 
 
-# Supported op_kind values for each macro factory
-_REDUCE_KINDS = {"sum", "max", "min"}
-_SOFTMAX_KINDS = {"softmax", "log_softmax"}
-_SCAN_KINDS = {"sum", "prod"}
-
-
 def tune_by_forward(
     kernel,
     *probe_inputs,
@@ -554,214 +566,6 @@ def tune_by_forward(
 
     kernel.config = best_config
     print(f"Best config: {kernel.config}")
-
-
-def make_reduce_epilogue(op_kind: str):
-    """Create a post-reduce processing T.macro.
-
-    The returned macro applies a final element-wise transformation to the
-    reduced result depending on *op_kind*.
-
-    Supported op_kind values: ``"sum"``, ``"max"``, ``"min"``.
-
-    Args:
-        op_kind: The reduction operation kind.
-
-    Returns:
-        A ``T.macro`` that performs the post-reduce epilogue step.
-        The macro signature is ``epilogue(result, output)`` where both
-        are 1-D fragments of the same shape.
-
-    Raises:
-        ValueError: If *op_kind* is not supported.
-    """
-    if op_kind not in _REDUCE_KINDS:
-        raise ValueError(
-            f"Unsupported op_kind '{op_kind}' for reduce epilogue. "
-            f"Expected one of {sorted(_REDUCE_KINDS)}."
-        )
-
-    # Every reduce kind shares one epilogue: a copy of the reduced fragment.
-    @T.macro
-    def epilogue(result, output):
-        T.copy(result, output)
-
-    return epilogue
-
-
-def make_welford_update(block_m: int, N_padded: int):
-    """Create a single-pass Welford mean+variance update T.macro.
-
-    Uses a two-phase approach that is safe under ``T.Parallel``:
-      1. **Parallel phase**: compute per-row sum and sum-of-squares via
-         ``T.reduce_sum`` (hardware-accelerated, no data races).
-      2. **Per-row phase**: derive mean and M2 from the aggregated sums
-         using the standard Welford combination formula.
-
-    This avoids the race condition inherent in naively updating shared
-    accumulators (mean, m2, count) inside a ``T.Parallel`` loop.
-
-    Args:
-        block_m: Number of rows per thread block.
-        N_padded: Padded hidden dimension (aligned to DEFAULT_ALIGNMENT).
-
-    Returns:
-        A ``T.macro`` with signature
-        ``welford_update(x, mean, m2, count)`` where:
-
-        - *x*: input fragment ``(block_m, N_padded)`` in fp32.
-        - *mean*: running mean ``(block_m,)`` in fp32 (updated in-place).
-        - *m2*: running M2 ``(block_m,)`` in fp32 (updated in-place).
-        - *count*: running element count ``(block_m,)`` in fp32 (updated).
-    """
-
-    @T.macro
-    def welford_update(x, mean, m2, count):
-        # Phase 1: parallel reduction -- safe because T.reduce_sum handles
-        # the intra-row reduction internally without user-level races.
-        row_sum = T.alloc_fragment((block_m,), "float32")
-        sq_diff = T.alloc_fragment((block_m, N_padded), "float32")
-        row_sq_sum = T.alloc_fragment((block_m,), "float32")
-
-        T.reduce_sum(x, row_sum, dim=1)
-
-        # Phase 2: per-row combination (no j dimension, no race).
-        batch_mean = T.alloc_fragment((block_m,), "float32")
-        new_count = T.alloc_fragment((block_m,), "float32")
-        new_mean = T.alloc_fragment((block_m,), "float32")
-        for i in T.Parallel(block_m):
-            batch_mean[i] = row_sum[i] / float(N_padded)
-            new_count[i] = count[i] + float(N_padded)
-            new_mean[i] = (mean[i] * count[i] + row_sum[i]) / new_count[i]
-
-        # Compute M2_b = sum((x[j] - batch_mean)^2) -- deviations from
-        # the *batch's own mean*, not the combined mean.  The parallel
-        # Welford merge formula requires this to be correct.
-        for i in T.serial(block_m):
-            for j in T.Parallel(N_padded):
-                dev = x[i, j] - batch_mean[i]
-                sq_diff[i, j] = dev * dev
-        T.reduce_sum(sq_diff, row_sq_sum, dim=1)
-
-        # Combine with existing M2 using parallel Welford merge formula:
-        #   M2_combined = M2_a + M2_b + delta^2 * (n_a * n_b / n_combined)
-        # Here M2_b = row_sq_sum and delta = batch_mean - mean (old).
-        for i in T.Parallel(block_m):
-            delta = batch_mean[i] - mean[i]
-            m2[i] = (
-                m2[i] + row_sq_sum[i] + delta * delta * (count[i] * float(N_padded) / new_count[i])
-            )
-            mean[i] = new_mean[i]
-            count[i] = new_count[i]
-
-    return welford_update
-
-
-def make_softmax_epilogue(op_kind: str):
-    """Create a softmax family post-processing T.macro.
-
-    The returned macro applies the final normalization step for softmax
-    or log-softmax.
-
-    Supported op_kind values: ``"softmax"``, ``"log_softmax"``.
-
-    Args:
-        op_kind: The softmax variant.
-
-    Returns:
-        A ``T.macro`` with signature
-        ``epilogue(row_exp, row_sum, block_rows, block_cols, output)``
-        where:
-
-        - *row_exp*: exponentiated scores ``(block_rows, block_cols)``.
-        - *row_sum*: per-row sums ``(block_rows,)`` in fp32.
-        - *block_rows*: number of rows (compile-time constant).
-        - *block_cols*: number of columns (compile-time constant).
-        - *output*: destination fragment ``(block_rows, block_cols)``.
-
-    Raises:
-        ValueError: If *op_kind* is not supported.
-    """
-    if op_kind not in _SOFTMAX_KINDS:
-        raise ValueError(
-            f"Unsupported op_kind '{op_kind}' for softmax epilogue. "
-            f"Expected one of {sorted(_SOFTMAX_KINDS)}."
-        )
-
-    if op_kind == "softmax":
-
-        @T.macro
-        def epilogue(row_exp, row_sum, block_rows, block_cols, output):
-            """Normalize exponentials: output[i,j] = row_exp[i,j] / row_sum[i]."""
-            for i, j in T.Parallel(block_rows, block_cols):
-                output[i, j] = row_exp[i, j] / row_sum[i]
-
-    else:  # log_softmax
-
-        @T.macro
-        def epilogue(row_exp, row_sum, block_rows, block_cols, output):
-            """Log-normalize: output[i,j] = log(row_exp[i,j] / row_sum[i])."""
-            for i, j in T.Parallel(block_rows, block_cols):
-                output[i, j] = T.log(row_exp[i, j] / row_sum[i])
-
-    return epilogue
-
-
-def make_cumulative_scan(op_kind: str):
-    """Create an inclusive prefix scan T.macro.
-
-    The returned macro performs an inclusive scan (prefix sum or prefix
-    product) along the last dimension using a sequential loop
-    (``T.Serial``) to maintain the correct data dependency chain.
-
-    Supported op_kind values: ``"sum"``, ``"prod"``.
-
-    Args:
-        op_kind: The scan operation kind.
-
-    Returns:
-        A ``T.macro`` with signature
-        ``scan(input_buf, block_rows, block_cols, output_buf)`` where:
-
-        - *input_buf*: source fragment ``(block_rows, block_cols)``.
-        - *block_rows*: number of rows (compile-time constant).
-        - *block_cols*: number of columns (compile-time constant).
-        - *output_buf*: destination fragment ``(block_rows, block_cols)``.
-
-    Raises:
-        ValueError: If *op_kind* is not supported.
-    """
-    if op_kind not in _SCAN_KINDS:
-        raise ValueError(
-            f"Unsupported op_kind '{op_kind}' for cumulative scan. "
-            f"Expected one of {sorted(_SCAN_KINDS)}."
-        )
-
-    if op_kind == "sum":
-
-        @T.macro
-        def scan(input_buf, block_rows, block_cols, output_buf):
-            """Inclusive prefix sum along the last dimension."""
-            # First column is copied as-is.
-            for i in T.Parallel(block_rows):
-                output_buf[i, 0] = input_buf[i, 0]
-            # Sequential scan across columns to maintain dependency.
-            for j in T.Serial(1, block_cols):
-                for i in T.Parallel(block_rows):
-                    output_buf[i, j] = output_buf[i, j - 1] + input_buf[i, j]
-
-    else:  # prod
-
-        @T.macro
-        def scan(input_buf, block_rows, block_cols, output_buf):
-            """Inclusive prefix product along the last dimension."""
-            for i in T.Parallel(block_rows):
-                output_buf[i, 0] = input_buf[i, 0]
-            for j in T.Serial(1, block_cols):
-                for i in T.Parallel(block_rows):
-                    output_buf[i, j] = output_buf[i, j - 1] * input_buf[i, j]
-
-    return scan
 
 
 # The row layout a reduction kernel reduces, and the shape its caller declared.
@@ -829,8 +633,25 @@ class RowTiledAutotuneMixin:
 
     A subclass must set, before autotuning: ``_planner`` (a
     `BlockConfigPlanner`), ``_smem_budget``, ``N_padded``, ``_elem_bytes``,
-    and ``_MAX_TILE_N_CANDIDATES``.
+    ``_MAX_TILE_N_CANDIDATES``, ``_tile_n`` and ``_split_target``, and implement
+    ``_build_row_kernel`` and ``_row_forward``.
     """
+
+    def _build_row_kernel(self, tile_n: int):
+        """Return the JIT kernel this class builds for *tile_n*."""
+        raise NotImplementedError
+
+    def _row_forward(self, x):
+        """Run the row-level entry point, for the split pair's timing."""
+        raise NotImplementedError
+
+    def _sweep_applies(self) -> bool:
+        """Whether the candidate sweep has anything to vary.
+
+        False where the kernel bakes its whole launch shape in at build time,
+        leaving the default config to stand.
+        """
+        return True
 
     def _tile_n_for_block_m(self, block_m: int) -> int:
         """Return tile_n for a given block_m (0 means no tiling needed).
@@ -911,6 +732,73 @@ class RowTiledAutotuneMixin:
         # Cap to avoid excessive compilation time.
         sorted_candidates = sorted(candidates, reverse=True)
         return sorted_candidates[: self._MAX_TILE_N_CANDIDATES]
+
+    def autotune(self, warmup: int = 10, rep: int = 10) -> None:
+        """Sweep the candidates, rebuilding per tile_n, then judge the split pair.
+
+        Configs are grouped by tile_n because each distinct value is a different
+        kernel; every group is swept with its own build and the best latency
+        across groups wins. The split pair has nothing for the sweep to vary, so
+        it is timed against that winner on device kernel time: paths launching
+        different kernel counts are judged by GPU work, not host-launch gaps.
+        """
+        from tilelang.autotuner import autotune as tl_autotune
+
+        from ._split_softmax import split_seg_n
+
+        if not self._sweep_applies():
+            self.config = self.default_config
+            return
+
+        default = self.default_config
+        split_eligible = bool(split_seg_n(self.M, self.N, default["block_m"], self._split_target))
+
+        configs = self.autotune_configs
+        if not configs:
+            self.config = default
+            return
+
+        by_tile_n: dict[int, list[dict]] = {}
+        for cfg in configs:
+            by_tile_n.setdefault(cfg["tile_n"], []).append(
+                {"block_m": cfg["block_m"], "threads": cfg["threads"]}
+            )
+
+        best_time = float("inf")
+        best_config = None
+        for tile_n, group_cfgs in by_tile_n.items():
+            kernel = self._build_row_kernel(tile_n)
+            tunable_params = list(self._autotune_initial_kwargs(kernel, group_cfgs[0]).keys())
+            autotune_kwargs: dict = dict(configs=group_cfgs, warmup=warmup, rep=rep)
+            if tunable_params:
+                autotune_kwargs["do_not_specialize"] = tunable_params
+            if self.autotune_supply_prog is not None:
+                autotune_kwargs["supply_prog"] = self.autotune_supply_prog
+            autotuned = tl_autotune(**autotune_kwargs)(kernel)
+            tuned = self._call_autotuned_kernel(autotuned, kernel, group_cfgs[0])
+            if tuned.latency < best_time:
+                best_time = tuned.latency
+                best_config = {**tuned.config, "tile_n": tile_n}
+
+        if best_config is not None:
+            self.config = best_config
+            if best_config["tile_n"] != self._tile_n:
+                self._tile_n = best_config["tile_n"]
+                self.kernel = self._build_row_kernel(self._tile_n)
+
+        if split_eligible and best_config is not None:
+            device = torch.device(
+                "cuda",
+                self.device_index if self.device_index is not None else torch.cuda.current_device(),
+            )
+            probe = torch.randn(self.M, self.N, dtype=self.dtype, device=device)
+            swept_config = dict(self.config, split=False)
+            self.config = swept_config
+            swept_ms = device_busy_of(lambda: self._row_forward(probe), device)
+            self.config = default
+            split_ms = device_busy_of(lambda: self._row_forward(probe), device)
+            if split_ms > swept_ms:
+                self.config = swept_config
 
     @property
     def autotune_configs(self) -> list[dict]:
@@ -1043,15 +931,6 @@ def _leading_row_splits(reduced: int, kept: int, threads: int) -> int:
     return max(1, min(reduced, ceildiv_int(_LEADING_POLICY.target_blocks, column_blocks)))
 
 
-def _down_rows_identity(op_kind: str) -> float:
-    """The identity element a masked lane contributes."""
-    if op_kind == "amin":
-        return float("inf")
-    if op_kind == "amax":
-        return float("-inf")
-    return 0.0
-
-
 def _make_down_rows_ops(op_kind: str, divisor: float, out_dtype: str, epilogue: str):
     """Create the per-op macros used by the down-rows reduction."""
 
@@ -1165,7 +1044,7 @@ def _down_rows_kernel(
                             val = T.if_then_else(
                                 T.And(row < A, col < B),
                                 T.cast(x[row, col], "float32"),
-                                T.cast(_down_rows_identity(op_kind), "float32"),
+                                T.cast(identity_for(op_kind), "float32"),
                             )
                             combine(acc, j, val)
 

--- a/src/tileops/kernels/reduction/_primitives.py
+++ b/src/tileops/kernels/reduction/_primitives.py
@@ -81,12 +81,7 @@ def ceildiv_int(x: int, y: int) -> int:
 
 
 def identity_for(op_kind: str) -> float:
-    """The value a masked lane contributes, leaving the reduction unchanged.
-
-    Covers every op_kind the reduction kernels mask for: a product and an
-    ``all`` take one, the extrema take the infinity they cannot beat, and the
-    additive kinds take zero.
-    """
+    """The value a masked lane contributes, leaving the reduction unchanged."""
     if op_kind in ("prod", "all"):
         return 1.0
     if op_kind == "amin":
@@ -120,11 +115,9 @@ class BlockConfigPlanner:
     whether a row fits in shared memory, which config to run untuned, and which
     candidates to offer the autotuner.
 
-    ``autotune_configs`` here serves the kernels that sweep by calling forward
-    through ``tune_by_forward``, where a candidate costs one call. A kernel that
-    bakes ``tile_n`` into the PrimFunc pays a recompilation per distinct value
-    and sweeps a narrower list of its own; see `RowTiledAutotuneMixin`. The two
-    lists differ at every width, so they are not interchangeable.
+    ``autotune_configs`` here serves the ``tune_by_forward`` sweeps. A kernel
+    baking ``tile_n`` into the PrimFunc sweeps `RowTiledAutotuneMixin`'s list
+    instead, which differs at every width.
 
     Args:
         num_buffers: ``(block_m, tile_n)`` shared buffers alive at once.
@@ -638,19 +631,12 @@ class RowTiledAutotuneMixin:
     """
 
     def _build_row_kernel(self, tile_n: int):
-        """Return the JIT kernel this class builds for *tile_n*."""
         raise NotImplementedError
 
     def _row_forward(self, x):
-        """Run the row-level entry point, for the split pair's timing."""
         raise NotImplementedError
 
     def _sweep_applies(self) -> bool:
-        """Whether the candidate sweep has anything to vary.
-
-        False where the kernel bakes its whole launch shape in at build time,
-        leaving the default config to stand.
-        """
         return True
 
     def _tile_n_for_block_m(self, block_m: int) -> int:
@@ -736,11 +722,9 @@ class RowTiledAutotuneMixin:
     def autotune(self, warmup: int = 10, rep: int = 10) -> None:
         """Sweep the candidates, rebuilding per tile_n, then judge the split pair.
 
-        Configs are grouped by tile_n because each distinct value is a different
-        kernel; every group is swept with its own build and the best latency
-        across groups wins. The split pair has nothing for the sweep to vary, so
-        it is timed against that winner on device kernel time: paths launching
-        different kernel counts are judged by GPU work, not host-launch gaps.
+        The split pair is timed on device kernel time: paths launching different
+        kernel counts cannot be compared on wall time, which carries the
+        host-launch gaps.
         """
         from tilelang.autotuner import autotune as tl_autotune
 

--- a/src/tileops/kernels/reduction/logical_reduce.py
+++ b/src/tileops/kernels/reduction/logical_reduce.py
@@ -32,6 +32,7 @@ from tileops.kernels.reduction._primitives import (
     device_smem_budget,
     edge_axis_plan,
     edge_axis_split,
+    identity_for,
     reduce_down_rows,
     restore_reduced,
     rows_for_axes,
@@ -93,13 +94,6 @@ def to_logical_storage(x: torch.Tensor) -> torch.Tensor:
     return ((x.real != 0) | (x.imag != 0)).to(torch.float32)
 
 
-def _pad_value_for_op(op_kind: str) -> float:
-    """Return the identity value for masked padding."""
-    if op_kind == "all":
-        return 1.0
-    return 0.0
-
-
 # Logical reduce kernel
 
 
@@ -151,7 +145,7 @@ def _logical_reduce_edge_fused(lead: int, kept: int, trail: int, op_kind: str, d
     """
     trail_padded = align_up(trail, DEFAULT_ALIGNMENT)
     needs_pad = trail_padded != trail
-    pad_val = _pad_value_for_op(op_kind)
+    pad_val = identity_for(op_kind)
     out_dtype = _logical_out_dtype(op_kind, partial=False)
     # any is a max and all is a min over 0/1, so each starts from its identity;
     # a count sums from zero. The column-wise fold starts from the same value a
@@ -231,7 +225,7 @@ def _logical_reduce_kernel(M: int, N: int, op_kind: str, dtype: str, partial: bo
     """
     N_padded = align_up(N, DEFAULT_ALIGNMENT)
     _needs_pad = N_padded != N
-    _pad_val = _pad_value_for_op(op_kind)
+    _pad_val = identity_for(op_kind)
     out_dtype = _logical_out_dtype(op_kind, partial)
 
     @tilelang.jit(out_idx=[1])
@@ -310,7 +304,7 @@ def _logical_reduce_kernel_tiled(
     """
     N_padded = align_up(N, DEFAULT_ALIGNMENT)
     num_tiles = (N_padded + tile_n - 1) // tile_n
-    _pad_val = _pad_value_for_op(op_kind)
+    _pad_val = identity_for(op_kind)
     _past_n = num_tiles * tile_n > N
     out_dtype = _logical_out_dtype(op_kind, partial)
 

--- a/src/tileops/kernels/reduction/logsumexp.py
+++ b/src/tileops/kernels/reduction/logsumexp.py
@@ -49,7 +49,7 @@ from tileops.kernels.reduction._split_softmax import (
     split_seg_n,
     split_target_blocks,
 )
-from tileops.utils import WARP_LANES, device_busy_of
+from tileops.utils import WARP_LANES
 
 # These two kernels bake tile_n in at build time and default to the wider
 # thread block; AUTOTUNE_THREADS still bounds what the sweep explores.
@@ -426,15 +426,6 @@ def _logsumexp_kernel(M: int, N: int, dtype: str, tile_n: int = 0):
     return _logsumexp_kernel_tiled(M, N, dtype, tile_n)
 
 
-def _compute_padded_cols(N: int, tile_n: int) -> int:
-    """Compute the total column count (may exceed N_padded for tiled path)."""
-    N_padded = align_up(N, DEFAULT_ALIGNMENT)
-    if tile_n == 0:
-        return N_padded
-    num_tiles = (N_padded + tile_n - 1) // tile_n
-    return num_tiles * tile_n
-
-
 class LogSumExpKernel(RowTiledAutotuneMixin, Kernel):
     """LogSumExp forward kernel.
 
@@ -604,92 +595,15 @@ class LogSumExpKernel(RowTiledAutotuneMixin, Kernel):
             "split": bool(split_seg_n(self.M, self.N, best_bm, self._split_target)),
         }
 
-    def autotune(self, warmup: int = 10, rep: int = 10) -> None:
-        """Autotune across tile_n candidates by rebuilding the kernel per regime.
+    def _build_row_kernel(self, tile_n: int):
+        return _logsumexp_kernel(self.M, self.N, self.dtype_str, tile_n)
 
-        Groups configs by tile_n, benchmarks each group with its own kernel,
-        and picks the overall best (block_m, threads, tile_n) config.
-        """
-        from tilelang.autotuner import autotune as tl_autotune
+    def _row_forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self._reduce_rows(x)
 
-        # The streaming kernel bakes its launch shape in at build time; there
-        # is nothing for the sweep to vary, so the default config stands.
-        if self._streaming:
-            self.config = self.default_config
-            return
-
-        default = self.default_config
-        split_eligible = bool(split_seg_n(self.M, self.N, default["block_m"], self._split_target))
-
-        configs = self.autotune_configs
-        if not configs:
-            self.config = default
-            return
-
-        # Group configs by tile_n
-        by_tile_n: dict[int, list[dict]] = {}
-        for cfg in configs:
-            tn = cfg["tile_n"]
-            by_tile_n.setdefault(tn, []).append(
-                {"block_m": cfg["block_m"], "threads": cfg["threads"]}
-            )
-
-        best_time = float("inf")
-        best_config = None
-
-        for tile_n, group_cfgs in by_tile_n.items():
-            kernel = _logsumexp_kernel(
-                self.M,
-                self.N,
-                self.dtype_str,
-                tile_n,
-            )
-            autotune_kwargs: dict = dict(
-                configs=group_cfgs,
-                warmup=warmup,
-                rep=rep,
-            )
-            tunable_params = list(self._autotune_initial_kwargs(kernel, group_cfgs[0]).keys())
-            if tunable_params:
-                autotune_kwargs["do_not_specialize"] = tunable_params
-            if self.autotune_supply_prog is not None:
-                autotune_kwargs["supply_prog"] = self.autotune_supply_prog
-            autotuned = tl_autotune(**autotune_kwargs)(kernel)
-            tuned = self._call_autotuned_kernel(autotuned, kernel, group_cfgs[0])
-            latency = tuned.latency
-            if latency < best_time:
-                best_time = latency
-                best_config = {**tuned.config, "tile_n": tile_n}
-
-        if best_config is not None:
-            self.config = best_config
-            # Rebuild kernel for the winning tile_n
-            winning_tile_n = best_config["tile_n"]
-            if winning_tile_n != self._tile_n:
-                self._tile_n = winning_tile_n
-                self.kernel = _logsumexp_kernel(
-                    self.M,
-                    self.N,
-                    self.dtype_str,
-                    self._tile_n,
-                )
-
-        # The split pair has nothing for the sweep to vary, so it is timed
-        # against the sweep's winner on device kernel time: paths launching
-        # different kernel counts are judged by GPU work, not host-launch gaps.
-        if split_eligible and best_config is not None:
-            device = torch.device(
-                "cuda",
-                self.device_index if self.device_index is not None else torch.cuda.current_device(),
-            )
-            probe = torch.randn(self.M, self.N, dtype=self.dtype, device=device)
-            swept_config = dict(self.config, split=False)
-            self.config = swept_config
-            swept_ms = device_busy_of(lambda: self._reduce_rows(probe), device)
-            self.config = default
-            split_ms = device_busy_of(lambda: self._reduce_rows(probe), device)
-            if split_ms > swept_ms:
-                self.config = swept_config
+    def _sweep_applies(self) -> bool:
+        """The streaming kernel bakes its launch shape in; nothing to vary."""
+        return not self._streaming
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Reduce *reduce_axes* of *x*.

--- a/src/tileops/kernels/reduction/reduce.py
+++ b/src/tileops/kernels/reduction/reduce.py
@@ -21,6 +21,7 @@ from tileops.kernels.reduction._primitives import (
     device_smem_budget,
     edge_axis_plan,
     edge_axis_split,
+    identity_for,
     reduce_down_rows,
     restore_reduced,
     rows_for_axes,
@@ -59,18 +60,6 @@ _PROD_POLICY = ProductReducePolicy()
 
 
 # Simple reduce kernel
-
-
-def _pad_value_for_op(op_kind: str) -> float:
-    """Return the identity element for padding columns of the given op."""
-    if op_kind == "prod":
-        return 1.0
-    if op_kind == "amin":
-        return float("inf")
-    if op_kind == "amax":
-        return float("-inf")
-    # sum, mean, std, var, var_mean: zero padding
-    return 0.0
 
 
 _LEADING_AXIS_KINDS = frozenset({"sum", "mean", "amax", "amin"})
@@ -466,7 +455,7 @@ class ReduceKernel(Kernel):
         """
         N_padded = align_up(N, DEFAULT_ALIGNMENT)
         _needs_pad = N_padded != N
-        _pad_val = _pad_value_for_op(op_kind)
+        _pad_val = identity_for(op_kind)
         out_dtype = out_dtype or dtype
 
         @tilelang.jit(out_idx=[1])
@@ -542,7 +531,7 @@ class ReduceKernel(Kernel):
         num_tiles = (N_padded + tile_n - 1) // tile_n
         total_cols = num_tiles * tile_n
         _needs_mask = total_cols > N
-        _pad_val = _pad_value_for_op(op_kind)
+        _pad_val = identity_for(op_kind)
         out_dtype = out_dtype or dtype
 
         @tilelang.jit(out_idx=[1])

--- a/src/tileops/kernels/reduction/softmax.py
+++ b/src/tileops/kernels/reduction/softmax.py
@@ -33,6 +33,7 @@ from tileops.kernels.reduction._primitives import (
     device_smem_budget,
     restore_same_shape,
     rows_for_axes,
+    torch_dtype_nbytes,
 )
 from tileops.kernels.reduction._split_softmax import (
     fused_split_plan,
@@ -41,7 +42,6 @@ from tileops.kernels.reduction._split_softmax import (
     split_seg_n,
     split_target_blocks,
 )
-from tileops.utils import device_busy_of
 
 # These two kernels bake tile_n in at build time and default to the wider
 # thread block; AUTOTUNE_THREADS still bounds what the sweep explores.
@@ -601,20 +601,6 @@ def _softmax_fused_split_kernel(M: int, N: int, op_kind: str, dtype: str, seg_n:
     return _func
 
 
-def _compute_padded_cols(N: int, tile_n: int) -> int:
-    """Compute the total column count (may exceed N_padded for tiled path)."""
-    N_padded = align_up(N, DEFAULT_ALIGNMENT)
-    if tile_n == 0:
-        return N_padded
-    num_tiles = (N_padded + tile_n - 1) // tile_n
-    return num_tiles * tile_n
-
-
-def _elem_bytes(dtype: torch.dtype) -> int:
-    """Return bytes per element for the given dtype."""
-    return torch.tensor([], dtype=dtype).element_size()
-
-
 class SoftmaxKernel(RowTiledAutotuneMixin, Kernel):
     """Softmax / log-softmax forward kernel.
 
@@ -668,7 +654,7 @@ class SoftmaxKernel(RowTiledAutotuneMixin, Kernel):
         self.dtype = dtype
         self.norm_axis = norm_axis
         self.N_padded = align_up(N, DEFAULT_ALIGNMENT)
-        self._elem_bytes = _elem_bytes(dtype)
+        self._elem_bytes = torch_dtype_nbytes(dtype)
         self._smem_budget = device_smem_budget(device_index)
         self._split_target = split_target_blocks(device_index)
         self._planner = BlockConfigPlanner(
@@ -792,88 +778,11 @@ class SoftmaxKernel(RowTiledAutotuneMixin, Kernel):
             "split": bool(split_seg_n(self.M, self.N, best_bm, self._split_target)),
         }
 
-    def autotune(self, warmup: int = 10, rep: int = 10) -> None:
-        """Autotune across tile_n candidates by rebuilding the kernel per regime.
+    def _build_row_kernel(self, tile_n: int):
+        return _softmax_kernel(self.M, self.N, self.op_kind, self.dtype_str, tile_n)
 
-        Groups configs by tile_n, benchmarks each group with its own kernel,
-        and picks the overall best (block_m, threads, tile_n) config.
-        """
-        from tilelang.autotuner import autotune as tl_autotune
-
-        default = self.default_config
-        split_eligible = bool(split_seg_n(self.M, self.N, default["block_m"], self._split_target))
-
-        configs = self.autotune_configs
-        if not configs:
-            self.config = default
-            return
-
-        # Group configs by tile_n
-        by_tile_n: dict[int, list[dict]] = {}
-        for cfg in configs:
-            tn = cfg["tile_n"]
-            by_tile_n.setdefault(tn, []).append(
-                {"block_m": cfg["block_m"], "threads": cfg["threads"]}
-            )
-
-        best_time = float("inf")
-        best_config = None
-
-        for tile_n, group_cfgs in by_tile_n.items():
-            kernel = _softmax_kernel(
-                self.M,
-                self.N,
-                self.op_kind,
-                self.dtype_str,
-                tile_n,
-            )
-            tunable_params = list(self._autotune_initial_kwargs(kernel, group_cfgs[0]).keys())
-            autotune_kwargs: dict = dict(
-                configs=group_cfgs,
-                warmup=warmup,
-                rep=rep,
-            )
-            if tunable_params:
-                autotune_kwargs["do_not_specialize"] = tunable_params
-            if self.autotune_supply_prog is not None:
-                autotune_kwargs["supply_prog"] = self.autotune_supply_prog
-            autotuned = tl_autotune(**autotune_kwargs)(kernel)
-            tuned = self._call_autotuned_kernel(autotuned, kernel, group_cfgs[0])
-            latency = tuned.latency
-            if latency < best_time:
-                best_time = latency
-                best_config = {**tuned.config, "tile_n": tile_n}
-
-        if best_config is not None:
-            self.config = best_config
-            # Rebuild kernel for the winning tile_n
-            winning_tile_n = best_config["tile_n"]
-            if winning_tile_n != self._tile_n:
-                self._tile_n = winning_tile_n
-                self.kernel = _softmax_kernel(
-                    self.M,
-                    self.N,
-                    self.op_kind,
-                    self.dtype_str,
-                    self._tile_n,
-                )
-
-        # The split pair has nothing for the sweep to vary, so it is timed
-        # against the sweep's winner on device kernel time: paths launching
-        # different kernel counts are judged by GPU work, not host-launch gaps.
-        if split_eligible and best_config is not None:
-            device = torch.device(
-                "cuda",
-                self.device_index if self.device_index is not None else torch.cuda.current_device(),
-            )
-            probe = torch.randn(self.M, self.N, dtype=self.dtype, device=device)
-            swept_config = dict(self.config, split=False)
-            self.config = swept_config
-            swept_ms = device_busy_of(lambda: self._normalize_rows(probe), device)
-            self.config = default
-            split_ms = device_busy_of(lambda: self._normalize_rows(probe), device)
-            if split_ms > swept_ms:
-                self.config = swept_config
+    def _row_forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self._normalize_rows(x)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Normalize *x* over *norm_axis*.

--- a/tests/ops/test_reduction_primitives.py
+++ b/tests/ops/test_reduction_primitives.py
@@ -1,9 +1,4 @@
-"""Tests for src/tileops/kernels/reduction/_primitives.py.
-
-Validates the shared reduction primitives: utility functions, constants,
-and T.macro factory functions.  Tests verify both API contracts (callability,
-error handling) and correctness of the generated macro logic.
-"""
+"""Tests for src/tileops/kernels/reduction/_primitives.py."""
 
 import pytest
 
@@ -85,228 +80,6 @@ class TestDefaultAlignment:
         assert isinstance(DEFAULT_ALIGNMENT, int)
 
 
-# make_reduce_epilogue
-
-
-class TestMakeReduceEpilogue:
-    """Tests for make_reduce_epilogue factory."""
-
-    @pytest.mark.smoke
-    def test_reduce_epilogue_returns_callable(self):
-        from tileops.kernels.reduction._primitives import make_reduce_epilogue
-
-        macro = make_reduce_epilogue("sum")
-        assert callable(macro)
-
-    @pytest.mark.smoke
-    def test_reduce_epilogue_all_valid_kinds(self):
-        from tileops.kernels.reduction._primitives import make_reduce_epilogue
-
-        for kind in ("sum", "max", "min"):
-            macro = make_reduce_epilogue(kind)
-            assert callable(macro)
-
-    @pytest.mark.smoke
-    def test_reduce_epilogue_invalid_kind_raises(self):
-        from tileops.kernels.reduction._primitives import make_reduce_epilogue
-
-        with pytest.raises(ValueError, match="Unsupported"):
-            make_reduce_epilogue("invalid_op")
-
-
-# make_welford_update
-
-
-class TestMakeWelfordUpdate:
-    """Tests for make_welford_update factory."""
-
-    @pytest.mark.smoke
-    def test_welford_returns_callable(self):
-        from tileops.kernels.reduction._primitives import make_welford_update
-
-        macro = make_welford_update(block_m=4, N_padded=256)
-        assert callable(macro)
-
-    @pytest.mark.smoke
-    def test_welford_different_shapes(self):
-        from tileops.kernels.reduction._primitives import make_welford_update
-
-        m1 = make_welford_update(block_m=4, N_padded=256)
-        m2 = make_welford_update(block_m=8, N_padded=512)
-        assert m1 is not None
-        assert m2 is not None
-
-    @pytest.mark.smoke
-    def test_welford_uses_reduce_sum(self):
-        """Verify the macro uses T.reduce_sum for parallel-safe reduction."""
-        import inspect
-
-        import tileops.kernels.reduction._primitives as mod
-
-        src = inspect.getsource(mod.make_welford_update)
-        assert "T.reduce_sum" in src, "Welford must use T.reduce_sum for parallel-safe reduction"
-
-    @pytest.mark.smoke
-    def test_welford_no_race_condition(self):
-        """The source must NOT update mean[i] inside a T.Parallel(block_m, N_padded) loop."""
-        import inspect
-
-        import tileops.kernels.reduction._primitives as mod
-
-        src = inspect.getsource(mod.make_welford_update)
-        assert "mean[i] = mean[i] + delta" not in src, "Found racy mean update inside parallel loop"
-
-    @pytest.mark.smoke
-    def test_welford_sq_diff_uses_batch_mean(self):
-        """sq_diff must use batch_mean (batch's own mean), not new_mean (combined mean).
-
-        The parallel Welford merge formula requires M2_b = sum((x[j] - mean_b)^2)
-        where mean_b is the batch's own mean, not the combined mean of old + batch.
-        """
-        import inspect
-
-        import tileops.kernels.reduction._primitives as mod
-
-        src = inspect.getsource(mod.make_welford_update)
-        assert "batch_mean" in src, "Welford must compute batch_mean for M2_b calculation"
-        assert "x[i, j] - batch_mean[i]" in src, "sq_diff must use batch_mean[i], not new_mean[i]"
-        # Ensure sq_diff does NOT use new_mean
-        assert "x[i, j] - new_mean[i]" not in src, (
-            "sq_diff must NOT use new_mean (combined mean) -- causes incorrect variance"
-        )
-
-
-# make_softmax_epilogue
-
-
-class TestMakeSoftmaxEpilogue:
-    """Tests for make_softmax_epilogue factory."""
-
-    @pytest.mark.smoke
-    def test_softmax_epilogue_returns_callable(self):
-        from tileops.kernels.reduction._primitives import make_softmax_epilogue
-
-        macro = make_softmax_epilogue("softmax")
-        assert callable(macro)
-
-    @pytest.mark.smoke
-    def test_log_softmax_epilogue_returns_callable(self):
-        from tileops.kernels.reduction._primitives import make_softmax_epilogue
-
-        macro = make_softmax_epilogue("log_softmax")
-        assert callable(macro)
-
-    @pytest.mark.smoke
-    def test_softmax_epilogue_invalid_kind_raises(self):
-        from tileops.kernels.reduction._primitives import make_softmax_epilogue
-
-        with pytest.raises(ValueError, match="Unsupported"):
-            make_softmax_epilogue("invalid_op")
-
-    @pytest.mark.smoke
-    def test_softmax_epilogue_has_division(self):
-        """Softmax epilogue must normalize by row_sum (division)."""
-        import inspect
-
-        import tileops.kernels.reduction._primitives as mod
-
-        src = inspect.getsource(mod.make_softmax_epilogue)
-        assert "/ row_sum[i]" in src, "Softmax epilogue must divide by row_sum"
-
-    @pytest.mark.smoke
-    def test_log_softmax_epilogue_has_log(self):
-        """Log-softmax epilogue must apply T.log."""
-        import inspect
-
-        import tileops.kernels.reduction._primitives as mod
-
-        src = inspect.getsource(mod.make_softmax_epilogue)
-        assert "T.log" in src, "Log-softmax epilogue must use T.log"
-
-    @pytest.mark.smoke
-    def test_softmax_vs_log_softmax_differ(self):
-        """The two softmax variants must produce different macros."""
-        from tileops.kernels.reduction._primitives import make_softmax_epilogue
-
-        m_soft = make_softmax_epilogue("softmax")
-        m_log = make_softmax_epilogue("log_softmax")
-        assert m_soft is not m_log
-
-
-# make_cumulative_scan
-
-
-class TestMakeCumulativeScan:
-    """Tests for make_cumulative_scan factory."""
-
-    @pytest.mark.smoke
-    def test_cumsum_scan_returns_callable(self):
-        from tileops.kernels.reduction._primitives import make_cumulative_scan
-
-        macro = make_cumulative_scan("sum")
-        assert callable(macro)
-
-    @pytest.mark.smoke
-    def test_cumprod_scan_returns_callable(self):
-        from tileops.kernels.reduction._primitives import make_cumulative_scan
-
-        macro = make_cumulative_scan("prod")
-        assert callable(macro)
-
-    @pytest.mark.smoke
-    def test_cumulative_scan_invalid_kind_raises(self):
-        from tileops.kernels.reduction._primitives import make_cumulative_scan
-
-        with pytest.raises(ValueError, match="Unsupported"):
-            make_cumulative_scan("invalid_op")
-
-    @pytest.mark.smoke
-    def test_cumulative_scan_uses_serial_loop(self):
-        """Cumulative scan must use T.Serial for sequential dependency."""
-        import inspect
-
-        import tileops.kernels.reduction._primitives as mod
-
-        src = inspect.getsource(mod.make_cumulative_scan)
-        assert "T.Serial" in src, "Cumulative scan must use T.Serial for sequential scan"
-
-    @pytest.mark.smoke
-    def test_cumsum_scan_has_addition(self):
-        """Sum scan must accumulate via addition."""
-        import inspect
-
-        import tileops.kernels.reduction._primitives as mod
-
-        src = inspect.getsource(mod.make_cumulative_scan)
-        assert "output_buf[i, j - 1] + input_buf[i, j]" in src, (
-            "Sum scan must add previous output to current input"
-        )
-
-    @pytest.mark.smoke
-    def test_cumprod_scan_has_multiplication(self):
-        """Prod scan must accumulate via multiplication."""
-        import inspect
-
-        import tileops.kernels.reduction._primitives as mod
-
-        src = inspect.getsource(mod.make_cumulative_scan)
-        assert "output_buf[i, j - 1] * input_buf[i, j]" in src, (
-            "Prod scan must multiply previous output by current input"
-        )
-
-    @pytest.mark.smoke
-    def test_cumsum_vs_cumprod_differ(self):
-        """Sum and prod scans must be different macros."""
-        from tileops.kernels.reduction._primitives import make_cumulative_scan
-
-        m_sum = make_cumulative_scan("sum")
-        m_prod = make_cumulative_scan("prod")
-        assert m_sum is not m_prod
-
-
-# __init__.py re-exports
-
-
 class TestInitReExports:
     """Tests for __init__.py re-exports."""
 
@@ -315,34 +88,15 @@ class TestInitReExports:
         import tileops.kernels.reduction as reduction
 
         assert hasattr(reduction, "__all__")
-        expected = [
-            "align_up",
-            "DEFAULT_ALIGNMENT",
-            "make_reduce_epilogue",
-            "make_welford_update",
-            "make_softmax_epilogue",
-            "make_cumulative_scan",
-        ]
-        for name in expected:
+        for name in ("align_up", "DEFAULT_ALIGNMENT"):
             assert name in reduction.__all__, f"{name} missing from __all__"
 
     @pytest.mark.smoke
     def test_kernel_init_imports_work(self):
-        from tileops.kernels.reduction import (
-            DEFAULT_ALIGNMENT,
-            align_up,
-            make_cumulative_scan,
-            make_reduce_epilogue,
-            make_softmax_epilogue,
-            make_welford_update,
-        )
+        from tileops.kernels.reduction import DEFAULT_ALIGNMENT, align_up
 
-        assert align_up is not None
+        assert callable(align_up)
         assert DEFAULT_ALIGNMENT == 256
-        assert callable(make_reduce_epilogue)
-        assert callable(make_welford_update)
-        assert callable(make_softmax_epilogue)
-        assert callable(make_cumulative_scan)
 
     @pytest.mark.smoke
     def test_kernel_init_no_underscore_in_all(self):


### PR DESCRIPTION
## Problems

- Four macro factories in `_primitives.py` — `make_reduce_epilogue`, `make_welford_update`, `make_softmax_epilogue`, `make_cumulative_scan`, 200 lines — have no call site in `src/`. Their only consumer is the test file written for them, whose `TestInitReExports` asserts they stay in the package's `__all__`. The package docstring calls them "the foundational building blocks ... used by all reduction sub-category kernels"; no kernel uses one. `make_reduce_epilogue` validated `op_kind` against `{sum, max, min}` and then returned the same `T.copy` macro for all three.
- `_compute_padded_cols` is defined verbatim in both `softmax.py` and `logsumexp.py` and called from neither. `softmax._elem_bytes` duplicates `_primitives.torch_dtype_nbytes`.
- `SoftmaxKernel.autotune` and `LogSumExpKernel.autotune` are 84 near-identical lines each. Both group candidates by tile_n, sweep each group against its own build, keep the best, rebuild when the winner moved, then time the split pair against that winner on device-busy. They differ in the builder they call, the row-level entry point the split probe times, and one early return.
- Three functions answer "the identity element for this op_kind": `_pad_value_for_op` in `reduce.py`, a different `_pad_value_for_op` in `logical_reduce.py`, and `_down_rows_identity` in `_primitives.py`. Two share a name and disagree in body while covering disjoint op sets.
- `BlockConfigPlanner`'s docstring claims its three decisions are "derived here once so the kernels cannot answer them differently". Softmax and logsumexp answer them through `RowTiledAutotuneMixin` instead.

## Changes

- Delete the four macro factories, the `_REDUCE_KINDS` / `_SOFTMAX_KINDS` / `_SCAN_KINDS` sets that only they validated against, their re-exports, their 220 lines of tests, and the two `TestInitReExports` assertions that pinned them to `__all__`. The package docstring now says what the package holds.
- Delete both dead copies of `_compute_padded_cols`; `softmax` calls `torch_dtype_nbytes`.
- Move the tile_n sweep into `RowTiledAutotuneMixin`, which both classes already inherit, behind three hooks: `_build_row_kernel(tile_n)`, `_row_forward(x)` and `_sweep_applies()`. The last is where logsumexp keeps the streaming kernel — whose launch shape is baked in at build time — out of a sweep with nothing to vary.
- One `identity_for(op_kind)` replaces the three helpers. They agree on every kind they share, so the union has no conflict.
- `BlockConfigPlanner`'s docstring now states the region it serves and points at the other one. **The two are not merged**: their candidate lists differ at every width measured, so merging would change what gets swept.

| | before | after |
| --- | --- | --- |
| lines in `kernels/reduction/` | 7156 | 6830 |
| dead names in the package `__all__` | 4 | 0 |
| implementations of "identity for op_kind" | 3 | 1 |
| duplicated `autotune` bodies | 2 | 0 |

## Why the two candidate generators are not merged

`BlockConfigPlanner.autotune_configs()` serves the kernels that sweep by calling forward through `tune_by_forward`, where a candidate costs one call. `RowTiledAutotuneMixin` serves the two that bake tile_n into the PrimFunc and pay a recompilation per distinct value. Comparing the two over fp16/fp32 × nine widths at the H200 shared-memory budget, they agree on **0 of 18** shapes, and not in one direction:

| N | planner candidates | mixin candidates |
| --- | --- | --- |
| 4096 | 9 | 12 |
| 16384 | 3 | 12 |
| 32768 | 30 | 9 |
| 262144 | 24 | 9 |

Softmax and logsumexp were tuned inside the mixin's space. Adopting the planner's would be a retune, not a refactor, so this PR corrects the claim and leaves the split alone.

## No behaviour change

`default_config`, `config`, `autotune_configs` and the generated CUDA were dumped for 190 kernel specializations — seven kernel classes × two dtypes × five shapes from 1024×256 to 128×131072 — before and after. **Zero fields differ.**

1641 reduction tests pass. The lifted sweep was exercised end to end: `SoftmaxKernel` and `LogSumExpKernel` both tune, rebuild and run; the streaming logsumexp path (512×32768 fp16) takes `_sweep_applies() == False`, keeps `default_config`, and matches `torch.logsumexp` to 3.9e-3.
