### PR TITLE
[Perf][foundry][Norm] Cut a BatchNorm channel into fewer pieces on the split path

### DIFF
--- a/src/tileops/kernels/norm/batch_norm.py
+++ b/src/tileops/kernels/norm/batch_norm.py
@@ -623,9 +623,13 @@ class BatchNormFwdTrainKernel(Kernel):
 
     # The thresholds below are measured crossovers, not derived bounds.
 
-    # Blocks the split path aims for, as a multiple of the channel count. Above
-    # this the runtime is flat.
-    _SPLIT_TARGET_BLOCKS = 1024
+    # Channel counts below this take the split path: above it, one block per
+    # channel already fills the device and the split has nothing to add.
+    _SPLIT_MAX_C = 1024
+
+    # Blocks the split path aims for. A grid this size still covers the device
+    # several times over, and the longer piece each block walks reads faster.
+    _SPLIT_TARGET_BLOCKS = 512
 
     # Per-channel length above which one block per channel is too narrow a grid,
     # whatever the tile size, and the split path takes over.
@@ -707,7 +711,7 @@ class BatchNormFwdTrainKernel(Kernel):
         wide = cls._wide_launch(L, S, dtype)
         if wide is not None:
             return "wide", wide
-        if C < cls._SPLIT_TARGET_BLOCKS and L >= cls._SPLIT_MIN_L:
+        if C < cls._SPLIT_MAX_C and L >= cls._SPLIT_MIN_L:
             return "split", max(1, min(L, -(-cls._SPLIT_TARGET_BLOCKS // C)))
         return "tiled", None
 

--- a/src/tileops/kernels/norm/batch_norm.py
+++ b/src/tileops/kernels/norm/batch_norm.py
@@ -147,9 +147,9 @@ def _batch_norm_fwd_train_kernel(
                     # Persistent path has exactly one tile, so a pipelined loop
                     # cannot overlap producer/consumer work.
                     for _i, j in T.Parallel(1, block_l):
-                        x_shared[j] = x[(j // S) * plane + bc * S + j % S]
-                    for _i, j in T.Parallel(1, block_l):
-                        xval = T.cast(x_shared[j], accum_dtype)
+                        v = x[(j // S) * plane + bc * S + j % S]
+                        x_shared[j] = v
+                        xval = T.cast(v, accum_dtype)
                         xsum_frag[_i, j] += xval
                         xsq_frag[_i, j] += xval * xval
                 else:


### PR DESCRIPTION
## Summary

- Cut a BatchNorm channel into 4 pieces instead of 8 on the split path: the piece a block walks doubles while the grid still covers the device several times over.
- Give the split path's admission bound its own name, so lowering the block target cannot also decide which shapes the path accepts.

## TileFoundry Description

```python
@module(entry="bn_stats", target=CudaTarget("nvidia.h200_sxm"),
        topologies=(Topology("cta", C * SPLITS), Topology("thread", 256)))
class SplitStats:
    @func
    def bn_stats(x: Tensor[(C, L), "f16"]):
        with Mesh(("cta",), (C, SPLITS), ("c", "part")) as cta:
            with Mesh(("thread",), (256,), ("t",)) as m:
                piece = tf.reshape(x, (C, SPLITS, L // SPLITS))
                held = tf.reshard(
                    piece, (C @ cta.c, SPLITS @ cta.part, (L // SPLITS) @ m.t), "rmem")
                v = tf.cast(held, "f32")
                return (tf.reduce(v, (-1,), True, ReduceKind.SUM),
                        tf.reduce(tf.square(v), (-1,), True, ReduceKind.SUM))
```

Training BatchNorm cannot read its input once: the channel statistics must exist before
anything is scaled, and at 2.1 GB the tensor cannot stay resident between the two phases.
So the operator makes three passes over memory, and what is left to tune is how the first
one is placed. `analyze` reports the stats pass `bound-by=memory`, and measurement says the
placement, not the arithmetic, decides it: at 8 pieces the sums read 3.26 TB/s and at 2
they read 3.51 TB/s.

## Performance

Operator: `BatchNormFwdOp`

| Environment | Value |
| --- | --- |
| image | ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-afcebed1-foundry-dev |
| digest | sha256:fe87c536154ad2ce3bffa4ff97e28fbfde7fcf6598d9d87c3f3dcc4ee9e44b5c |
| gpu | NVIDIA H200, one card for both sides |
| driver | 595.71.05 |
| cuda | 13.2 |
| torch | 2.13.0+cu132 |
| tilelang | 0.1.11+cu132.gitafcebed1 |
| timer | native CUPTI |

Method: the merge base and this branch ran `benchmarks/ops/bench_batch_norm.py` back to back
in one window on one card, best of two runs each, L2 cleared per iteration. The window
matters: the same unmodified commit measured 2.8 us early in a session and 3.1 us hours later
on the same card. The rows run untuned, so what they measure is the default this PR changes.

Ratio in comparator columns: implementation / candidate. &#x1F7E2; > 1 means the candidate is
faster; &#x1F534; <= 1 means it is not.

| Workload | Path | Candidate (ms) | Incumbent<br>/ candidate | torch-compile<br>/ candidate |
| --- | --- | ---: | ---: | ---: |
| resnet50-fc | whole | 0.0015 | 0.0015<br>&#x1F534;&nbsp;1.000x | 0.0017<br>&#x1F7E2;&nbsp;1.133x |
| resnet50-stage1 | wide | 0.0026 | 0.0026<br>&#x1F534;&nbsp;1.000x | 0.0039<br>&#x1F7E2;&nbsp;1.500x |
| resnet50-stage2 | wide | 0.0024 | 0.0024<br>&#x1F534;&nbsp;1.000x | 0.0030<br>&#x1F7E2;&nbsp;1.250x |
| resnet50-stage3 | wide | 0.0033 | 0.0033<br>&#x1F534;&nbsp;1.000x | 0.0041<br>&#x1F7E2;&nbsp;1.242x |
| large-spatial | split | 0.8065 | **0.8567<br>&#x1F7E2;&nbsp;1.062x** | 1.0162<br>&#x1F7E2;&nbsp;1.260x |

`BatchNormBwdOp` shares the benchmark file and is unchanged: 0.984x to 1.007x against the
incumbent on all five rows, 1.013x to 1.762x ahead of torch-native-batch-norm.

## Result And Limitations

**SOTA on every row, and near the traffic the operator cannot avoid.**

- The speedup is the smaller split count broadly, not only the longer walk each block makes: halving the pieces also halves the partial statistics written and read back, and the merge that sums them.
- `large-spatial` moves 3.22 GB across its three passes in 806 us, which is 3.99 TB/s. A read-write pair of the same tensor measures 4.31 TB/s on this card, so the operator runs at 93% of what streaming reaches. Its apply pass alone measures 4.30 TB/s, which is that ceiling.
- The remaining 7% is the stats pass, which reads at 3.5 TB/s where a read-write pass reaches 4.31. A rewrite of it that loads vectors and carries several accumulators was tried and is both slower and wrong, so it is not here: TileLang's fragment model does not accept the explicit per-thread indexing it needs.
- Raising the stats pass from 3.5 TB/s to the 4.3 TB/s the map pass reaches would save 55 to 60 us, a single-digit percent, not another step of this size.
- The other four rows do not use the split path and do not move. They are 1.13x to 1.42x ahead of torch-compile and between 1.07x and 1.35x of a read-write pass of the same bytes.
- Three DRAM passes is a property of the operator, not of this implementation: no statistic is known until the whole channel is read, and at 2.1 GB nothing survives in cache between the phases. Quoting a two-pass roofline against this row overstates the gap by 1.7x.
- One constant used to answer two questions: how many pieces a channel is cut into, and which channel counts the split path accepts at all. Lowering it would have dropped 512 to 1023 channels off the path, and a long channel length there has no tiled config to fall back to -- `_tiled_configs` raises unless the length divides by 512, 256, 128, 64, 32 or 16. That is a build failure, not a slower kernel, so the admission bound now has its own name and keeps 1024. Path selection was checked unchanged at C of 1, 3, 128, 511, 512, 513, 1023 and 1024.
- A first version of this change also replaced the split path's tuning, which times the sums kernel alone even though the split count the sums prefer is not the one the operator prefers. It is not here: it measured 806.6 us against 807.1 us without it, so it bought nothing, and deferring the tuning to the first call left `kernel.config` reporting an untuned config until then. The tuning defect is real and is left to its own change.

## Test

`tests/ops/test_batch_norm.py`, `tests/ops/test_norm_ops.py`: 27 passed. Test node delta: 0.
