### PR TITLE
[Fix][Norm] Size the fused add+RMSNorm sum from the input device, and refuse a one-value-per-channel training call

### DIFF
--- a/src/tileops/kernels/norm/_config.py
+++ b/src/tileops/kernels/norm/_config.py
@@ -1,4 +1,4 @@
-"""Tile-config selection shared by the row-wise norm kernels.
+"""What the row-wise norm kernels share: tile-config selection and the row reduction.
 
 These kernels hold a ``(block_m, N_padded)`` row block in register fragments and
 reduce along the row. When ``N_padded`` is not a power of two, TileLang's layout
@@ -15,12 +15,19 @@ knob so the kernel interface is not narrowed; configs that collapse lose on thei
 measured runtime.
 """
 
+import tilelang.language as T
 import torch
 
 from tileops.kernels.constants import VECTOR_ACCESS_BYTES
 from tileops.kernels.tiling import ALIGNMENT
 
-__all__ = ["row_padding", "select_row_config_by_width", "select_row_config", "select_row_configs"]
+__all__ = [
+    "make_row_reduce",
+    "row_padding",
+    "select_row_config",
+    "select_row_config_by_width",
+    "select_row_configs",
+]
 
 # Powers of two only (tl::AllReduce is an XOR butterfly) that also divide
 # N_padded, or layout inference reports "no available layout". CUDA caps at 1024.
@@ -79,9 +86,13 @@ def _feasible_threads(n_padded: int, dtype: torch.dtype = torch.float16) -> list
     return vectorizable or candidates
 
 
-def select_row_config(n_padded: int) -> dict:
-    """Structurally collapse-free default ``{block_m, threads}`` for a row reduction."""
-    # N_padded is a multiple of the 256-element alignment, so 128 always divides it.
+def select_row_config() -> dict:
+    """Structurally collapse-free default ``{block_m, threads}`` for a row reduction.
+
+    Takes no width: a row is padded to a multiple of the 256-element alignment,
+    which 128 threads always divide. `select_row_config_by_width` is the sibling
+    that does size itself from the row.
+    """
     return {"block_m": 1, "threads": _DEFAULT_THREADS}
 
 
@@ -104,7 +115,46 @@ def select_row_configs(
         if block_m <= max_block_m
         for t in threads
     ]
-    default = select_row_config(n_padded)
+    default = select_row_config()
     if default not in configs:
         configs.insert(0, default)
     return configs
+
+
+def make_row_reduce(block_m, n, n_padded, eps):
+    """Create the macro reducing a loaded fp32 row block to mean and rstd.
+
+    Consumes ``x_f32`` and overwrites it with the centered squares. The load
+    stays at the call sites: pulling it in here makes TileLang insert a
+    ``__syncthreads()`` between the global-to-shared and shared-to-register
+    copies, which measures 2% slower on an aligned row.
+
+    Args:
+        block_m: Rows per block.
+        n: Row length.
+        n_padded: *n* rounded up to :data:`ALIGNMENT`.
+        eps: Epsilon for numerical stability.
+
+    Returns:
+        A ``@T.macro`` taking ``(x_f32, acc, mean_val, rstd)``.
+    """
+    pad_count = n_padded - n
+
+    @T.macro
+    def row_reduce(x_f32, acc, mean_val, rstd):
+        T.reduce_sum(x_f32, acc, dim=1)
+        for i in T.Parallel(block_m):
+            mean_val[i] = acc[i] / float(n)
+
+        # Rewrite x_f32 in-place with (x - mean)^2. Padded positions (x=0)
+        # contribute mean^2, subtracted back out below.
+        for i, j in T.Parallel(block_m, n_padded):
+            x_f32[i, j] = (x_f32[i, j] - mean_val[i]) * (x_f32[i, j] - mean_val[i])
+
+        T.reduce_sum(x_f32, acc, dim=1)
+        for i in T.Parallel(block_m):
+            rstd[i] = T.rsqrt(
+                (acc[i] - float(pad_count) * mean_val[i] * mean_val[i]) / float(n) + eps
+            )
+
+    return row_reduce

--- a/src/tileops/kernels/norm/_config.py
+++ b/src/tileops/kernels/norm/_config.py
@@ -90,8 +90,7 @@ def select_row_config() -> dict:
     """Structurally collapse-free default ``{block_m, threads}`` for a row reduction.
 
     Takes no width: a row is padded to a multiple of the 256-element alignment,
-    which 128 threads always divide. `select_row_config_by_width` is the sibling
-    that does size itself from the row.
+    which 128 threads always divide.
     """
     return {"block_m": 1, "threads": _DEFAULT_THREADS}
 

--- a/src/tileops/kernels/norm/ada_layer_norm.py
+++ b/src/tileops/kernels/norm/ada_layer_norm.py
@@ -29,7 +29,7 @@ import torch
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.tiling import ALIGNMENT, align_up
 
-from ._config import select_row_config, select_row_configs
+from ._config import make_row_reduce, select_row_config, select_row_configs
 
 __all__ = ["AdaLayerNormKernel"]
 
@@ -51,7 +51,6 @@ def _should_use_cp_async(
 def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False, use_cp_async=False):
     N_padded = align_up(N, ALIGNMENT)
     needs_pad = N_padded != N
-    pad_count = N_padded - N  # number of zero-padded elements per row
     # The async policy guarantees that each source row is a whole number of
     # 4-byte cp.async transactions.
     async_copy_elems = 1 if dtype == "float32" else 2
@@ -75,20 +74,7 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False, use_cp_async=False)
             for i, j in T.Parallel(block_m, N_padded):
                 x_f32[i, j] = T.cast(x_local[i, j], "float32")
 
-        @T.macro
-        def compute_mean_rstd(x_f32, acc, mean_val, rstd):
-            T.reduce_sum(x_f32, acc, dim=1)
-            for i in T.Parallel(block_m):
-                mean_val[i] = acc[i] / float(N)
-
-            for i, j in T.Parallel(block_m, N_padded):
-                x_f32[i, j] = (x_f32[i, j] - mean_val[i]) * (x_f32[i, j] - mean_val[i])
-
-            T.reduce_sum(x_f32, acc, dim=1)
-            for i in T.Parallel(block_m):
-                rstd[i] = T.rsqrt(
-                    (acc[i] - float(pad_count) * mean_val[i] * mean_val[i]) / float(N) + eps
-                )
+        compute_mean_rstd = make_row_reduce(block_m, N, N_padded, eps)
 
         @T.macro
         def prefetch_modulation(src, dst, pid_m):
@@ -270,7 +256,7 @@ class AdaLayerNormKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
-        return select_row_config(self.N_padded)
+        return select_row_config()
 
     @property
     def autotune_configs(self) -> list[dict]:

--- a/src/tileops/kernels/norm/batch_norm.py
+++ b/src/tileops/kernels/norm/batch_norm.py
@@ -659,6 +659,11 @@ class BatchNormFwdTrainKernel(Kernel):
         S: Optional[int] = None,
     ) -> None:
         super().__init__()
+        if L == 1:
+            # Every path folds Bessel's correction, whose divisor is L - 1.
+            raise ValueError(
+                "BatchNormFwdTrainKernel needs more than one value per channel, got L=1"
+            )
         self.C = C
         self.L = L
         self.S = L if S is None else S

--- a/src/tileops/kernels/norm/fused_add_norm.py
+++ b/src/tileops/kernels/norm/fused_add_norm.py
@@ -22,7 +22,7 @@ import torch.nn.functional as F
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.tiling import ALIGNMENT, align_up
-from tileops.utils import get_sm_count
+from tileops.utils import WARP_LANES, get_sm_count
 
 from ._config import select_row_config, select_row_configs
 
@@ -144,7 +144,7 @@ class FusedAddLayerNormKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
-        return select_row_config(self.N_padded)
+        return select_row_config()
 
     @property
     def autotune_configs(self) -> list[dict]:
@@ -206,7 +206,7 @@ class FusedAddLayerNormKernel(Kernel):
 
 
 @functools.lru_cache(maxsize=32)
-def _fused_add_rms_norm_kernel(M, N, eps, dtype):
+def _fused_add_rms_norm_kernel(M, N, eps, dtype, sm_count):
     N_padded = align_up(N, ALIGNMENT)
 
     @tilelang.jit(out_idx=[3, 4])
@@ -214,7 +214,7 @@ def _fused_add_rms_norm_kernel(M, N, eps, dtype):
         # Forming the sum in shared rather than a second row-wide fragment keeps
         # bfloat16 off the register limit, but only pays when the registers it
         # frees buy resident blocks: a single-row call measured 0.94x.
-        sum_in_shared = -(-M // block_m) >= get_sm_count()
+        sum_in_shared = -(-M // block_m) >= sm_count
 
         @T.prim_func
         def main(
@@ -314,8 +314,6 @@ _SPLIT_BLOCKS = 16
 _SPLIT_THREADS = 128
 _SPLIT_PER_THREAD = 8
 
-_WARP_LANES = 32
-
 
 @functools.lru_cache(maxsize=32)
 def _fused_add_rms_norm_split_kernel(N, eps, dtype):
@@ -336,7 +334,7 @@ def _fused_add_rms_norm_split_kernel(N, eps, dtype):
     @tilelang.jit
     def _stats(splits, threads, per):
         chunk = N // splits
-        n_warps = max(threads // _WARP_LANES, 1)
+        n_warps = max(threads // WARP_LANES, 1)
 
         @T.prim_func
         def main(
@@ -367,8 +365,8 @@ def _fused_add_rms_norm_split_kernel(N, eps, dtype):
                 for step in T.serial(5):
                     acc[0] += T.shfl_xor(acc[0], T.shift_left(1, step))
                 warp_totals = T.alloc_shared([n_warps], accum)
-                if tx % _WARP_LANES == 0:
-                    warp_totals[tx // _WARP_LANES] = acc[0]
+                if tx % WARP_LANES == 0:
+                    warp_totals[tx // WARP_LANES] = acc[0]
                 T.sync_threads()
                 if tx == 0:
                     acc[0] = T.cast(0, accum)
@@ -469,7 +467,7 @@ class FusedAddRMSNormKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
-        return select_row_config(self.N_padded)
+        return select_row_config()
 
     @property
     def autotune_configs(self) -> list[dict]:
@@ -517,7 +515,14 @@ class FusedAddRMSNormKernel(Kernel):
             return [y.reshape(original_shape), residual_out.reshape(original_shape)]
 
         # Exposed as ``self.kernel`` because that is what autotune and profiling read.
-        self.kernel = _fused_add_rms_norm_kernel(rows.shape[0], self.N, self.eps, self.dtype_str)
+        self.kernel = _fused_add_rms_norm_kernel(
+            rows.shape[0],
+            self.N,
+            self.eps,
+            self.dtype_str,
+            # The device the input is on, not whichever is current.
+            get_sm_count(rows.device.index),
+        )
         if self._tune_pending:
             self._tune_pending = False
             self.autotune()

--- a/src/tileops/kernels/norm/group_norm.py
+++ b/src/tileops/kernels/norm/group_norm.py
@@ -33,7 +33,12 @@ import torch
 
 from tileops.kernels.kernel_base import Kernel
 
-from ._config import row_padding, select_row_config_by_width, select_row_configs
+from ._config import (
+    make_row_reduce,
+    row_padding,
+    select_row_config_by_width,
+    select_row_configs,
+)
 
 __all__ = ["GroupNormKernel", "GroupNormNoAffineKernel"]
 
@@ -56,45 +61,6 @@ def _channel_of(row, col, num_groups: int, channels_per_group: int, spatial_size
         Index into the length-C weight / bias vectors.
     """
     return (row % num_groups) * channels_per_group + col // spatial_size
-
-
-def _make_row_reduce(block_m, D, D_padded, eps):
-    """Create the macro reducing a loaded fp32 row block to mean and rstd.
-
-    Consumes ``x_f32`` and overwrites it with the centered squares. The load
-    stays at the call sites: pulling it in here makes TileLang insert a
-    ``__syncthreads()`` between the global-to-shared and shared-to-register
-    copies, which measures 2% slower on an aligned row.
-
-    Args:
-        block_m: Rows per block.
-        D: Row length.
-        D_padded: *D* rounded up to :data:`ALIGNMENT`.
-        eps: Epsilon for numerical stability.
-
-    Returns:
-        A ``@T.macro`` taking ``(x_f32, acc, mean_val, rstd)``.
-    """
-    pad_count = D_padded - D
-
-    @T.macro
-    def row_reduce(x_f32, acc, mean_val, rstd):
-        T.reduce_sum(x_f32, acc, dim=1)
-        for i in T.Parallel(block_m):
-            mean_val[i] = acc[i] / float(D)
-
-        # Rewrite x_f32 in-place with (x - mean)^2. Padded positions (x=0)
-        # contribute mean^2, subtracted back out below.
-        for i, j in T.Parallel(block_m, D_padded):
-            x_f32[i, j] = (x_f32[i, j] - mean_val[i]) * (x_f32[i, j] - mean_val[i])
-
-        T.reduce_sum(x_f32, acc, dim=1)
-        for i in T.Parallel(block_m):
-            rstd[i] = T.rsqrt(
-                (acc[i] - float(pad_count) * mean_val[i] * mean_val[i]) / float(D) + eps
-            )
-
-    return row_reduce
 
 
 @functools.lru_cache(maxsize=32)
@@ -123,7 +89,7 @@ def _group_norm_kernel(M, D, eps, dtype, num_groups, channels_per_group):
     def _func(block_m, threads):
         # A non-aligned D would read and write columns >= D unless masked.
         masked = D_padded != D
-        row_reduce = _make_row_reduce(block_m, D, D_padded, eps)
+        row_reduce = make_row_reduce(block_m, D, D_padded, eps)
 
         @T.prim_func
         def main(
@@ -321,7 +287,7 @@ def _group_norm_no_affine_kernel(M, D, eps, dtype):
     def _func(block_m, threads):
         # A non-aligned D would read and write columns >= D unless masked.
         masked = D_padded != D
-        row_reduce = _make_row_reduce(block_m, D, D_padded, eps)
+        row_reduce = make_row_reduce(block_m, D, D_padded, eps)
 
         @T.prim_func
         def main(

--- a/src/tileops/kernels/norm/layer_norm.py
+++ b/src/tileops/kernels/norm/layer_norm.py
@@ -189,7 +189,7 @@ class LayerNormKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
-        return select_row_config(self.N_padded)
+        return select_row_config()
 
     @property
     def autotune_configs(self) -> list[dict]:

--- a/src/tileops/kernels/norm/rms_norm.py
+++ b/src/tileops/kernels/norm/rms_norm.py
@@ -134,7 +134,7 @@ class RMSNormKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
-        return select_row_config(self.N_padded)
+        return select_row_config()
 
     @property
     def autotune_configs(self) -> list[dict]:

--- a/src/tileops/ops/norm/batch_norm.py
+++ b/src/tileops/ops/norm/batch_norm.py
@@ -135,11 +135,10 @@ class BatchNormFwdOp(Op):
             raise ValueError(f"x.dtype must be float32, float16, or bfloat16, got {x.dtype}")
         C = x.shape[1]
         L = x.numel() // C
-        if self.training and L < 2:
+        if self.training and L == 1:
             # Bessel's correction divides by L - 1. torch refuses the same call.
             raise ValueError(
-                f"Expected more than 1 value per channel when training, got input size "
-                f"{tuple(x.shape)}"
+                f"Expected more than 1 value per channel when training, got input size {x.shape}"
             )
         return C, L, x.dtype
 

--- a/src/tileops/ops/norm/batch_norm.py
+++ b/src/tileops/ops/norm/batch_norm.py
@@ -134,7 +134,14 @@ class BatchNormFwdOp(Op):
         if x.dtype not in (torch.float32, torch.float16, torch.bfloat16):
             raise ValueError(f"x.dtype must be float32, float16, or bfloat16, got {x.dtype}")
         C = x.shape[1]
-        return C, x.numel() // C, x.dtype
+        L = x.numel() // C
+        if self.training and L < 2:
+            # Bessel's correction divides by L - 1. torch refuses the same call.
+            raise ValueError(
+                f"Expected more than 1 value per channel when training, got input size "
+                f"{tuple(x.shape)}"
+            )
+        return C, L, x.dtype
 
     @staticmethod
     def _validate_channel_tensor(

--- a/tests/ops/test_batch_norm.py
+++ b/tests/ops/test_batch_norm.py
@@ -194,10 +194,7 @@ def test_training_updates_a_non_contiguous_running_stat() -> None:
 
 @pytest.mark.smoke
 def test_training_rejects_one_value_per_channel() -> None:
-    """Bessel's correction divides by L - 1; torch refuses the same call.
-
-    Inference applies no correction and takes the shape, as torch does.
-    """
+    """Bessel's correction divides by L - 1; torch refuses the same call."""
     C = 4
     x = torch.randn(1, C, 1, 1, device="cuda", dtype=torch.float32)
     weight = torch.ones(C, device="cuda", dtype=torch.float32)

--- a/tests/ops/test_batch_norm.py
+++ b/tests/ops/test_batch_norm.py
@@ -7,10 +7,13 @@ Run:
     conda run -n tileops python -m pytest tests/ops/test_batch_norm.py -vvs
 """
 
+import re
+
 import pytest
 import torch
 
 from tests.test_base import FixtureBase, TestBase
+from tileops.kernels.norm import BatchNormFwdTrainKernel
 from tileops.ops.norm.batch_norm import BatchNormBwdOp, BatchNormFwdOp
 from workloads.normalization import (
     BatchNormBwdWorkload,
@@ -195,6 +198,9 @@ def test_training_updates_a_non_contiguous_running_stat() -> None:
 @pytest.mark.smoke
 def test_training_rejects_one_value_per_channel() -> None:
     """Bessel's correction divides by L - 1; torch refuses the same call."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required for forward call")
+
     C = 4
     x = torch.randn(1, C, 1, 1, device="cuda", dtype=torch.float32)
     weight = torch.ones(C, device="cuda", dtype=torch.float32)
@@ -202,11 +208,24 @@ def test_training_rejects_one_value_per_channel() -> None:
     rm = torch.zeros(C, device="cuda", dtype=torch.float32)
     rv = torch.ones(C, device="cuda", dtype=torch.float32)
 
-    with pytest.raises(ValueError, match="more than 1 value per channel"):
+    torch_message = ""
+    try:
+        torch.nn.functional.batch_norm(x, rm, rv, weight, bias, training=True)
+    except ValueError as exc:
+        torch_message = str(exc)
+    assert torch_message, "torch accepted L=1 in training; the guard's premise is gone"
+
+    with pytest.raises(ValueError, match=re.escape(torch_message)):
         BatchNormFwdOp(training=True)(x, rm, rv, weight, bias)
 
-    y = BatchNormFwdOp(training=False)(x, rm, rv, weight, bias)
+    # The kernel refuses on its own: it is exported, so a caller can reach it directly.
+    with pytest.raises(ValueError, match="more than one value per channel"):
+        BatchNormFwdTrainKernel(C, 1, torch.float32, S=1)
+
+    # Inference applies no correction; torch normalizes the same shape.
+    infer = BatchNormFwdOp(training=False)
+    y = infer(x, rm, rv, weight, bias)
     expected = torch.nn.functional.batch_norm(
-        x, rm, rv, weight, bias, training=False, eps=BatchNormFwdOp(training=False).eps
+        x, rm, rv, weight, bias, training=False, eps=infer.eps
     )
     torch.testing.assert_close(y, expected, atol=1e-3, rtol=1e-3)

--- a/tests/ops/test_batch_norm.py
+++ b/tests/ops/test_batch_norm.py
@@ -190,3 +190,26 @@ def test_training_updates_a_non_contiguous_running_stat() -> None:
     expected_mean = op.momentum * x.float().transpose(0, 1).reshape(C, -1).mean(dim=1)
     torch.testing.assert_close(rm, expected_mean, atol=1e-3, rtol=1e-3)
     assert not torch.equal(rv, torch.ones_like(rv)), "running_var was not written either"
+
+
+@pytest.mark.smoke
+def test_training_rejects_one_value_per_channel() -> None:
+    """Bessel's correction divides by L - 1; torch refuses the same call.
+
+    Inference applies no correction and takes the shape, as torch does.
+    """
+    C = 4
+    x = torch.randn(1, C, 1, 1, device="cuda", dtype=torch.float32)
+    weight = torch.ones(C, device="cuda", dtype=torch.float32)
+    bias = torch.zeros(C, device="cuda", dtype=torch.float32)
+    rm = torch.zeros(C, device="cuda", dtype=torch.float32)
+    rv = torch.ones(C, device="cuda", dtype=torch.float32)
+
+    with pytest.raises(ValueError, match="more than 1 value per channel"):
+        BatchNormFwdOp(training=True)(x, rm, rv, weight, bias)
+
+    y = BatchNormFwdOp(training=False)(x, rm, rv, weight, bias)
+    expected = torch.nn.functional.batch_norm(
+        x, rm, rv, weight, bias, training=False, eps=BatchNormFwdOp(training=False).eps
+    )
+    torch.testing.assert_close(y, expected, atol=1e-3, rtol=1e-3)


### PR DESCRIPTION
## Problems

- `_fused_add_rms_norm_kernel` chose between forming the row sum in shared memory and in a second fragment by calling `get_sm_count()` inside the builder, with no device index. Two defects follow. It reads whichever device is *current*, where `LayerNormKernel` and `RMSNormKernel` deliberately pass the input's — a kernel built for `cuda:5` was sized by `cuda:0`. And the builder is `lru_cache`d on `(M, N, eps, dtype)`, so the count never entered the key: the first device to build a shape fixed the branch for every later one.
- `_WARP_LANES = 32` in the same file shadows `tileops.utils.WARP_LANES`.
- `select_row_config(n_padded)` never reads its argument. Its sibling `select_row_config_by_width(n_padded)` does, so the two read as a pair that both size themselves from the row.
- The mean/rstd row reduction exists twice: a `@T.macro` factory in `group_norm`, and the same body inline in `ada_layer_norm`.
- `BatchNormFwdOp._resolve_spec` validates rank and dtype but not `L`. Bessel's correction divides the batch variance by `L - 1`, so a training call with one value per channel reaches the kernel and TVM folds the divisor to zero: the build fails with `Check failed: fb->value != 0 : Divide by zero`, where torch answers `Expected more than 1 value per channel when training, got input size ...`.

## Changes

- `sm_count` becomes a parameter of `_fused_add_rms_norm_kernel`, as it already is for the other two row-norm builders, and `forward` passes `get_sm_count(rows.device.index)`. Devices reporting different counts now get different kernels: at `M=100`, `sm_count=132` builds the fragment sum and `sm_count=16` the shared one, where before both returned whichever was cached first.
- `_WARP_LANES` deleted in favour of `tileops.utils.WARP_LANES`.
- `select_row_config` takes no argument; the docstring says why, and points at the sibling that does size itself from the row.
- `_make_row_reduce` moves to `_config` as `make_row_reduce`; `group_norm` imports it and `ada_layer_norm` replaces its inline copy with a call.
- `BatchNormFwdOp` refuses a training call with `L < 2`, raising torch's message with the shape. Only training: inference applies no correction and torch normalizes the same shape, so it keeps working. `L == 1` forces `N == 1` and `S == 1`, which `_select_path` always serves with the whole path, so that build was the only way in.