### PR TITLE
[Fix][Ops] Refuse a call whose declared outputs would all be empty

### DIFF
--- a/docs/design/ops-design-reference.md
+++ b/docs/design/ops-design-reference.md
@@ -118,6 +118,8 @@ Three time points: (1) manifest — constraint structure; (2) `__init__` — use
 - **Op with dynamic dims:** `_infer_output_shapes` called once dynamic dims resolve, and by the fake while tracing.
 - **Kernel construction:** in `_eager_forward`, through `get_or_build_kernel` — never in the traced `forward`, which is one call to the op's operator ([Compile Dispatch Boundary](ops-design.md#compile-dispatch-boundary)). See [Slot S16](op-slot-rules.md#slot-s16).
 - **`_validate_dtypes`:** runs on every call, and is the only place an op rejects a dtype.
+- **Empty outputs:** a call whose every declared output would hold no elements is refused with a `ValueError` naming the op, the input and its shape. TileOPs kernels do not serve one; the launch asserts on `grid_dim` or divides by zero, which says nothing about what is unsupported. The refusal is in `get_or_build_kernel`, so both the eager and the traced path reach it. What decides is the output, not the input: a zero-length axis on an input is legitimate where the op still produces something — a decode reading an empty state, an empty scratch buffer — and those calls are not refused.
+- **Precedence:** a call invalid for more than one reason is refused for whichever check it reaches first. The op's own validation in `_eager_forward` precedes the empty-output refusal, which precedes the kernel build and everything the kernel itself states — so an empty call on a device the kernel does not serve is reported as empty.
 - **Non-runtime consumers** (validator, graph compiler): call `_infer_output_shapes` with concrete shape tuples without constructing tensors. Roofline consumers use interfaces in [`roofline.md`](roofline.md).
 
 ### Inheritance in family-base hierarchies

--- a/docs/design/ops-design-reference.md
+++ b/docs/design/ops-design-reference.md
@@ -118,8 +118,7 @@ Three time points: (1) manifest — constraint structure; (2) `__init__` — use
 - **Op with dynamic dims:** `_infer_output_shapes` called once dynamic dims resolve, and by the fake while tracing.
 - **Kernel construction:** in `_eager_forward`, through `get_or_build_kernel` — never in the traced `forward`, which is one call to the op's operator ([Compile Dispatch Boundary](ops-design.md#compile-dispatch-boundary)). See [Slot S16](op-slot-rules.md#slot-s16).
 - **`_validate_dtypes`:** runs on every call, and is the only place an op rejects a dtype.
-- **Empty outputs:** a call whose every declared output would hold no elements is refused with a `ValueError` naming the op, the input and its shape. TileOPs kernels do not serve one; the launch asserts on `grid_dim` or divides by zero, which says nothing about what is unsupported. The refusal is in `get_or_build_kernel`, so both the eager and the traced path reach it. What decides is the output, not the input: a zero-length axis on an input is legitimate where the op still produces something — a decode reading an empty state, an empty scratch buffer — and those calls are not refused.
-- **Precedence:** a call invalid for more than one reason is refused for whichever check it reaches first. The op's own validation in `_eager_forward` precedes the empty-output refusal, which precedes the kernel build and everything the kernel itself states — so an empty call on a device the kernel does not serve is reported as empty.
+- **Empty outputs:** a call whose every declared output would hold no elements raises `ValueError` from `get_or_build_kernel` — after `_eager_forward`'s own validation, before the kernel build. The output decides, not the input.
 - **Non-runtime consumers** (validator, graph compiler): call `_infer_output_shapes` with concrete shape tuples without constructing tensors. Roofline consumers use interfaces in [`roofline.md`](roofline.md).
 
 ### Inheritance in family-base hierarchies

--- a/src/tileops/ops/op_base.py
+++ b/src/tileops/ops/op_base.py
@@ -1,4 +1,5 @@
 import dataclasses
+import math
 import warnings
 from abc import ABC, abstractmethod
 from types import MappingProxyType
@@ -27,6 +28,7 @@ from tileops.backend import (
 from tileops.backend.dispatch import registered_kernel_builder, select_target
 from tileops.backend.registry import ensure_loaded
 from tileops.kernels.kernel_base import Kernel
+from tileops.manifest import load_manifest
 
 from .compile_boundary import register_instance
 
@@ -350,6 +352,8 @@ class Op(ABC):
             OpNotAvailableError: A target serves this op but the call site handed over no
                 tensor at all; or there is no in-tree implementation and no target.
         """
+        self._refuse_empty_input(inputs)
+
         # Plain attribute reads and dict lookups, no ``self.__dict__``: this
         # runs inside a dynamo-traced forward on every cache hit, and dynamo
         # cannot trace a method call on an instance ``__dict__``.
@@ -604,6 +608,56 @@ class Op(ABC):
         except Exception:
             self._unsettle()
             raise
+
+    def _refuse_empty_input(self, inputs: "Sequence[torch.Tensor | None]") -> None:
+        """Raise for a call whose every declared output would hold no elements.
+
+        Such a call leaves a TileLang launch with a zero-sized grid, which reports itself
+        as an internal assertion on ``grid_dim`` — or, where the op divides by an extent
+        first, as a divide by zero. Neither says what is unsupported.
+
+        Both the eager and the traced path reach kernel selection, so both are refused
+        here. Which problem a call carrying several is refused for follows from the order
+        the checks sit in: the op's own validation in ``_eager_forward`` precedes this, and
+        the kernel build and everything the kernel states come after.
+
+        What decides is the output, not the input. A zero-length axis on an input is
+        legitimate in more places than a shape rule can distinguish:
+        ``EngramDecodeFwdOp`` decodes from an empty ``conv_state`` when no history has
+        accumulated, and ``FusedMoEExpertsNopadPersistent3WGFwdOp`` runs with an empty
+        scratch buffer. Both produce a non-empty output, so neither is refused.
+
+        Raises:
+            ValueError: The op cannot produce the empty output this call asks for.
+        """
+        if not any(t is not None and t.numel() == 0 for t in inputs):
+            return
+
+        entry = load_manifest().get(type(self).__name__)
+        if entry is None:
+            return
+        names = tuple(entry["signature"]["inputs"])
+        if len(names) != len(inputs):
+            return
+        try:
+            shapes = self._infer_output_shapes(
+                *(None if t is None else tuple(t.shape) for t in inputs)
+            )
+        except (TypeError, ValueError, KeyError):
+            return  # an op whose shape inference this order does not describe
+        declared = entry["signature"]["outputs"]
+        if any(name not in shapes for name in declared):
+            return
+        if any(math.prod(shapes[name]) for name in declared):
+            return
+
+        name, tensor = next(
+            (n, t) for n, t in zip(names, inputs, strict=True) if t is not None and t.numel() == 0
+        )
+        raise ValueError(
+            f"{type(self).__name__} does not support an empty tensor: input {name!r} has "
+            f"shape {tuple(tensor.shape)}, which holds no elements."
+        )
 
     def _unsettle(self) -> None:
         """Undo a settling whose call did not finish, dropping what it built."""

--- a/src/tileops/ops/op_base.py
+++ b/src/tileops/ops/op_base.py
@@ -612,20 +612,13 @@ class Op(ABC):
     def _refuse_empty_input(self, inputs: "Sequence[torch.Tensor | None]") -> None:
         """Raise for a call whose every declared output would hold no elements.
 
-        Such a call leaves a TileLang launch with a zero-sized grid, which reports itself
-        as an internal assertion on ``grid_dim`` — or, where the op divides by an extent
-        first, as a divide by zero. Neither says what is unsupported.
+        Such a call leaves the launch a zero-sized grid, which reports itself as an
+        internal assertion saying nothing about what is unsupported.
 
-        Both the eager and the traced path reach kernel selection, so both are refused
-        here. Which problem a call carrying several is refused for follows from the order
-        the checks sit in: the op's own validation in ``_eager_forward`` precedes this, and
-        the kernel build and everything the kernel states come after.
+        Kernel selection hosts this because both the eager and the traced path reach it.
 
-        What decides is the output, not the input. A zero-length axis on an input is
-        legitimate in more places than a shape rule can distinguish:
-        ``EngramDecodeFwdOp`` decodes from an empty ``conv_state`` when no history has
-        accumulated, and ``FusedMoEExpertsNopadPersistent3WGFwdOp`` runs with an empty
-        scratch buffer. Both produce a non-empty output, so neither is refused.
+        The output decides, not the input: a zero-length axis on an input is legitimate
+        wherever the op still produces something.
 
         Raises:
             ValueError: The op cannot produce the empty output this call asks for.

--- a/tests/ops/test_empty_tensor.py
+++ b/tests/ops/test_empty_tensor.py
@@ -12,7 +12,7 @@ import torch
 
 from tileops.ops.elementwise import AddFwdOp, ReluFwdOp
 from tileops.ops.norm import BatchNormFwdOp, RMSNormFwdOp
-from tileops.ops.reduction import SoftmaxFwdOp, SumFwdOp, VarMeanFwdOp
+from tileops.ops.reduction import SumFwdOp, VarMeanFwdOp
 
 pytestmark = [
     pytest.mark.smoke,
@@ -40,7 +40,6 @@ def empty() -> torch.Tensor:
         pytest.param(lambda x: ReluFwdOp()(x), "ReluFwdOp", "input", id="unary"),
         pytest.param(lambda x: AddFwdOp()(x, x), "AddFwdOp", "input", id="binary"),
         pytest.param(lambda x: SumFwdOp(dim=1)(x), "SumFwdOp", "x", id="reduce_to_empty"),
-        pytest.param(lambda x: SoftmaxFwdOp(dim=1)(x), "SoftmaxFwdOp", "x", id="softmax"),
         pytest.param(
             lambda x: RMSNormFwdOp((8,))(x, torch.ones(8, device=x.device, dtype=x.dtype)),
             "RMSNormFwdOp",
@@ -57,10 +56,7 @@ def test_empty_input_is_refused(empty, call, op_class_name, input_name):
 
 
 def test_batch_norm_training_is_refused():
-    """An op reading a private multi-output from its kernel is refused like any other.
-
-    Its training path used to reach a divide by zero rather than a launch.
-    """
+    """An op reading a private multi-output from its kernel is refused like any other."""
     x = torch.empty(0, 4, 2, 2, device="cuda", dtype=DTYPE)
     stat = lambda: torch.zeros(4, device="cuda")  # noqa: E731
     with pytest.raises(ValueError, match=re.escape(_message("BatchNormFwdOp", "x", (0, 4, 2, 2)))):
@@ -76,11 +72,7 @@ def test_compiled_call_is_refused_the_same_way(empty):
 
 
 def test_the_op_s_own_validation_precedes_the_refusal():
-    """A call invalid for two reasons is refused for whichever check it reaches first.
-
-    ``_eager_forward``'s prelude runs before kernel selection, so the device mismatch is
-    what this call hears about.
-    """
+    """``_eager_forward``'s prelude runs before kernel selection, so it reports first."""
     with pytest.raises(ValueError, match="needs every input on one device"):
         AddFwdOp()(torch.empty(0, 2), torch.empty(0, 2, device="cuda"))
 
@@ -91,17 +83,7 @@ def test_the_refusal_precedes_what_the_kernel_states():
         ReluFwdOp()(torch.empty(0, 8))
 
 
-def test_a_non_empty_call_is_untouched(empty):
-    """A call whose output holds elements takes the same path it always did."""
-    assert ReluFwdOp()(torch.randn(4, 8, device="cuda", dtype=DTYPE)).shape == (4, 8)
-
-
 def test_an_empty_input_with_a_non_empty_output_is_not_refused(empty):
-    """A reduction over the empty axis still reaches its kernel.
-
-    Its output is non-empty, and an input's zero-length axis is legitimate where the op
-    produces something — refusing on the input would refuse a decode reading an empty
-    state. This call fails inside the kernel, as it did before the guard.
-    """
+    """An input's zero-length axis is legitimate where the op still produces something."""
     with pytest.raises(ZeroDivisionError):
         SumFwdOp(dim=0)(empty)

--- a/tests/ops/test_empty_tensor.py
+++ b/tests/ops/test_empty_tensor.py
@@ -1,0 +1,107 @@
+"""TileOPs refuses a call whose declared outputs would all be empty.
+
+One case per distinct shape of the answer, not one per op: the refusal is decided in
+``Op.get_or_build_kernel`` for every family, so a second op of the same shape re-tests
+the same branch.
+"""
+
+import re
+
+import pytest
+import torch
+
+from tileops.ops.elementwise import AddFwdOp, ReluFwdOp
+from tileops.ops.norm import BatchNormFwdOp, RMSNormFwdOp
+from tileops.ops.reduction import SoftmaxFwdOp, SumFwdOp, VarMeanFwdOp
+
+pytestmark = [
+    pytest.mark.smoke,
+    pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required"),
+]
+
+DTYPE = torch.float16
+
+
+def _message(op_class_name: str, input_name: str, shape: tuple) -> str:
+    return (
+        f"{op_class_name} does not support an empty tensor: input '{input_name}' "
+        f"has shape {shape}, which holds no elements."
+    )
+
+
+@pytest.fixture
+def empty() -> torch.Tensor:
+    return torch.randn(0, 8, device="cuda", dtype=DTYPE)
+
+
+@pytest.mark.parametrize(
+    "call, op_class_name, input_name",
+    [
+        pytest.param(lambda x: ReluFwdOp()(x), "ReluFwdOp", "input", id="unary"),
+        pytest.param(lambda x: AddFwdOp()(x, x), "AddFwdOp", "input", id="binary"),
+        pytest.param(lambda x: SumFwdOp(dim=1)(x), "SumFwdOp", "x", id="reduce_to_empty"),
+        pytest.param(lambda x: SoftmaxFwdOp(dim=1)(x), "SoftmaxFwdOp", "x", id="softmax"),
+        pytest.param(
+            lambda x: RMSNormFwdOp((8,))(x, torch.ones(8, device=x.device, dtype=x.dtype)),
+            "RMSNormFwdOp",
+            "x",
+            id="norm",
+        ),
+        pytest.param(lambda x: VarMeanFwdOp(dim=1)(x), "VarMeanFwdOp", "x", id="two_outputs"),
+    ],
+)
+def test_empty_input_is_refused(empty, call, op_class_name, input_name):
+    """The message names the op, the input and its shape."""
+    with pytest.raises(ValueError, match=re.escape(_message(op_class_name, input_name, (0, 8)))):
+        call(empty)
+
+
+def test_batch_norm_training_is_refused():
+    """An op reading a private multi-output from its kernel is refused like any other.
+
+    Its training path used to reach a divide by zero rather than a launch.
+    """
+    x = torch.empty(0, 4, 2, 2, device="cuda", dtype=DTYPE)
+    stat = lambda: torch.zeros(4, device="cuda")  # noqa: E731
+    with pytest.raises(ValueError, match=re.escape(_message("BatchNormFwdOp", "x", (0, 4, 2, 2)))):
+        BatchNormFwdOp(training=True)(x, stat(), stat(), stat(), stat())
+
+
+def test_compiled_call_is_refused_the_same_way(empty):
+    """The traced path reaches kernel selection too, so it gets the same message."""
+    compiled = torch.compile(ReluFwdOp(), fullgraph=True)
+    assert compiled(torch.randn(4, 8, device="cuda", dtype=DTYPE)).shape == (4, 8)
+    with pytest.raises(ValueError, match=re.escape(_message("ReluFwdOp", "input", (0, 8)))):
+        compiled(empty)
+
+
+def test_the_op_s_own_validation_precedes_the_refusal():
+    """A call invalid for two reasons is refused for whichever check it reaches first.
+
+    ``_eager_forward``'s prelude runs before kernel selection, so the device mismatch is
+    what this call hears about.
+    """
+    with pytest.raises(ValueError, match="needs every input on one device"):
+        AddFwdOp()(torch.empty(0, 2), torch.empty(0, 2, device="cuda"))
+
+
+def test_the_refusal_precedes_what_the_kernel_states():
+    """The kernel's device statement is made at launch, which this call never reaches."""
+    with pytest.raises(ValueError, match=re.escape(_message("ReluFwdOp", "input", (0, 8)))):
+        ReluFwdOp()(torch.empty(0, 8))
+
+
+def test_a_non_empty_call_is_untouched(empty):
+    """A call whose output holds elements takes the same path it always did."""
+    assert ReluFwdOp()(torch.randn(4, 8, device="cuda", dtype=DTYPE)).shape == (4, 8)
+
+
+def test_an_empty_input_with_a_non_empty_output_is_not_refused(empty):
+    """A reduction over the empty axis still reaches its kernel.
+
+    Its output is non-empty, and an input's zero-length axis is legitimate where the op
+    produces something — refusing on the input would refuse a decode reading an empty
+    state. This call fails inside the kernel, as it did before the guard.
+    """
+    with pytest.raises(ZeroDivisionError):
+        SumFwdOp(dim=0)(empty)


### PR DESCRIPTION
## Problems

- Every op crashes on a zero-element input with a TileLang internal assertion — `grid dimension must be positive`, or a divide by zero where the op divides by an extent first. Neither says what is unsupported.
- No manifest entry constrains a zero-length axis, so the case is undefined rather than declared.

## Changes

- `Op.get_or_build_kernel` raises `ValueError` when every declared output would hold no elements, naming the op, the input and its shape. Kernel selection hosts it because both the eager and the traced path reach it; `Op.__call__` does not work, Dynamo trips on it.
- Precedence, documented in `ops-design-reference.md` and pinned by two tests: `_eager_forward`'s own validation, then this refusal, then the kernel build and whatever the kernel states.
- The **output** decides, not the input. An input's zero-length axis is legitimate where the op still produces something: `EngramDecodeFwdOp` decodes from an empty `conv_state`, `FusedMoEExpertsNopadPersistent3WGFwdOp` runs on an empty scratch buffer. An earlier revision keyed on the input and broke the first; the full smoke set caught it.

## What this does not do

- A reduction over a zero-length axis whose output is non-empty — `SumFwdOp(dim=0)` on `(0, 8)` — still raises `ZeroDivisionError`; torch returns the identity. Its output holds elements, and every rule that catches it also catches the Engram decode above. A test asserts it still reaches the kernel.
- It does not reproduce the error a kernel would have raised. A kernel's refusal is only observable by calling it, so no check before the launch can match it.