### PR TITLE
[Refactor][Attention] Route dense GQA decode to decode kernels

### DIFF
--- a/benchmarks/ops/attention/bench_gqa.py
+++ b/benchmarks/ops/attention/bench_gqa.py
@@ -13,6 +13,7 @@ from benchmarks.benchmark_base import (
     workload_params,
 )
 from benchmarks.ops.attention.workload_args import (
+    gqa_dense_decode_args,
     gqa_prefill_paged_args,
     gqa_prefill_varlen_args,
     gqa_qkv_args,
@@ -20,6 +21,7 @@ from benchmarks.ops.attention.workload_args import (
 from tileops.manifest import load_workloads
 from tileops.ops import (
     GroupedQueryAttentionBwdOp,
+    GroupedQueryAttentionDenseFwdOp,
     GroupedQueryAttentionPrefillPagedWithKVCacheFwdOp,
     GroupedQueryAttentionPrefillVarlenFwdOp,
 )
@@ -27,6 +29,7 @@ from workloads.attention.gqa import (
     GQAPrefillPagedWithKVCacheFwdWorkload,
     GQAPrefillVarlenFwdWorkload,
     GroupedQueryAttentionBwdWorkload,
+    GroupedQueryAttentionDenseDecodeWorkload,
 )
 
 
@@ -137,6 +140,143 @@ def test_gqa_bwd_bench(
 
     bm.compare(functors, *inputs)
     # No FlashInfer baseline for bwd (FlashInfer has no backward API)
+
+
+def _fa3_gqa_dense_decode(test: GroupedQueryAttentionDenseDecodeWorkload):
+    """Return the contiguous FA3 decode baseline where its defaults match."""
+    if test.sm_scale != test.dim**-0.5 or test.softcap != 0.0:
+        return None
+    try:
+        from flash_attn_interface import flash_attn_with_kvcache
+    except ImportError:
+        return None
+
+    cache_seqlens = torch.full((test.batch,), test.seq_len_kv, dtype=torch.int32, device="cuda")
+
+    def baseline_fn(q, k, v):
+        out = flash_attn_with_kvcache(q, k, v, cache_seqlens=cache_seqlens)
+        return out[0] if isinstance(out, tuple) else out
+
+    return baseline_fn
+
+
+def _flashinfer_gqa_dense_decode(
+    test: GroupedQueryAttentionDenseDecodeWorkload,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+):
+    """Set up FlashInfer's contiguous or synthetic-paged decode baseline."""
+    if test.sm_scale != test.dim**-0.5 or test.softcap != 0.0:
+        return None
+    if test.heads // test.heads_kv > 8:
+        return None
+
+    batch, _, heads, dim = q.shape
+    heads_kv = k.shape[2]
+    if batch == 1:
+        try:
+            from flashinfer.decode import single_decode_with_kv_cache
+        except ImportError:
+            return None
+
+        def run_fn(q, k, v):
+            out = single_decode_with_kv_cache(
+                q[0, 0],
+                k[0],
+                v[0],
+                kv_layout="NHD",
+                use_tensor_cores=True,
+            )
+            return out.view(1, 1, heads, dim)
+
+        return run_fn
+
+    try:
+        from flashinfer.decode import BatchDecodeWithPagedKVCacheWrapper
+    except ImportError:
+        return None
+
+    seq_len_kv = k.shape[1]
+    page_size = 256
+    if seq_len_kv % page_size != 0:
+        return None
+    pages_per_seq = seq_len_kv // page_size
+    total_pages = batch * pages_per_seq
+    indptr = torch.arange(0, batch + 1, dtype=torch.int32, device=q.device) * pages_per_seq
+    indices = torch.arange(total_pages, dtype=torch.int32, device=q.device)
+    last_page_len = torch.full((batch,), page_size, dtype=torch.int32, device=q.device)
+    workspace = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device=q.device)
+    wrapper = BatchDecodeWithPagedKVCacheWrapper(workspace, kv_layout="NHD")
+    wrapper.plan(
+        indptr=indptr,
+        indices=indices,
+        last_page_len=last_page_len,
+        num_qo_heads=heads,
+        num_kv_heads=heads_kv,
+        head_dim=dim,
+        page_size=page_size,
+        q_data_type=q.dtype,
+    )
+
+    def run_fn(q, k, v):
+        k_pages = k.view(total_pages, page_size, heads_kv, dim)
+        v_pages = v.view(total_pages, page_size, heads_kv, dim)
+        return wrapper.run(q.squeeze(1), (k_pages, v_pages)).unsqueeze(1)
+
+    return run_fn
+
+
+_GQA_DENSE_DECODE_BENCH_PARAMS = workload_params(
+    load_workloads(GroupedQueryAttentionDenseFwdOp),
+    then_dtype(gqa_dense_decode_args),
+)
+
+
+@pytest.mark.parametrize(
+    "batch, heads, heads_kv, seq_len_kv, dim, sm_scale, softcap, dtype",
+    _GQA_DENSE_DECODE_BENCH_PARAMS,
+)
+def test_gqa_dense_decode_bench(
+    batch: int,
+    heads: int,
+    heads_kv: int,
+    seq_len_kv: int,
+    dim: int,
+    sm_scale: float | None,
+    softcap: float | None,
+    dtype: torch.dtype,
+) -> None:
+    test = GroupedQueryAttentionDenseDecodeWorkload(
+        batch,
+        heads,
+        heads_kv,
+        seq_len_kv,
+        dim,
+        dtype,
+        sm_scale=sm_scale,
+        softcap=softcap,
+    )
+    inputs = test.gen_inputs()
+    op = GroupedQueryAttentionDenseFwdOp(sm_scale=sm_scale, softcap=softcap)
+    bm = ManifestBenchmark(op, test)
+    functors = {"tileops": op}
+
+    fa3_fn = _fa3_gqa_dense_decode(test)
+    if fa3_fn is not None:
+        assert_matches_reference(fa3_fn, op, *inputs, **reference_tolerance(dtype))
+        functors["fa3"] = fa3_fn
+
+    flashinfer_fn = _flashinfer_gqa_dense_decode(test, *inputs)
+    if flashinfer_fn is not None:
+        assert_matches_reference(flashinfer_fn, op, *inputs, **reference_tolerance(dtype))
+        functors["flashinfer"] = flashinfer_fn
+
+    if fa3_fn is None and flashinfer_fn is None:
+        assert_matches_reference(op, test.ref_program, *inputs, **reference_tolerance(dtype))
+        functors["torch-ref"] = test.ref_program
+
+    bm.compare(functors, *inputs)
 
 
 def _fa3_gqa_prefill_varlen(test: GQAPrefillVarlenFwdWorkload):

--- a/benchmarks/ops/attention/workload_args.py
+++ b/benchmarks/ops/attention/workload_args.py
@@ -16,6 +16,26 @@ def gqa_qkv_args(workload: dict[str, Any]) -> tuple[int, int, int, int, int, boo
     return batch, seq_len, heads, heads_kv, dim, workload.get("is_causal", True)
 
 
+def gqa_dense_decode_args(
+    workload: dict[str, Any],
+) -> tuple[int, int, int, int, int, float | None, float | None]:
+    batch, seq_len_q, heads, dim = workload["q_shape"]
+    batch_kv, seq_len_kv, heads_kv, dim_kv = workload["kv_shape"]
+    if seq_len_q != 1:
+        raise ValueError("a Dense decode workload requires q_shape sequence length 1")
+    if batch_kv != batch or dim_kv != dim:
+        raise ValueError("q_shape and kv_shape must share batch and head dimension")
+    return (
+        batch,
+        heads,
+        heads_kv,
+        seq_len_kv,
+        dim,
+        workload.get("sm_scale"),
+        workload.get("softcap"),
+    )
+
+
 def gqa_prefill_paged_args(
     workload: dict[str, Any],
 ) -> tuple[

--- a/src/tileops/kernels/attention/gqa_decode.py
+++ b/src/tileops/kernels/attention/gqa_decode.py
@@ -21,7 +21,7 @@ __all__ = ["GQADecodeKernel"]
 
 
 @functools.lru_cache(maxsize=32)
-def _gqa_decode_no_split_kernel(batch, heads, groups, seqlen_kv, dim, sm_scale, softcap, dtype):
+def _gqa_decode_no_split_kernel(batch, heads, groups, dim, sm_scale, softcap, dtype):
     score_scale = dim**-0.5 if sm_scale is None else sm_scale
     use_softcap = softcap > 0.0
     scale = LOG2E if use_softcap else score_scale * LOG2E
@@ -35,6 +35,7 @@ def _gqa_decode_no_split_kernel(batch, heads, groups, seqlen_kv, dim, sm_scale, 
         compile_flags=["-O3", "-DENABLE_BF16"],
     )
     def _func(block_H, block_N, num_stages, threads):
+        seqlen_kv = T.dynamic("seqlen_kv")
         shape_q = [batch, heads, dim]
         shape_k = [batch, seqlen_kv, groups, dim]
         shape_v = [batch, seqlen_kv, groups, dim]
@@ -56,7 +57,6 @@ def _gqa_decode_no_split_kernel(batch, heads, groups, seqlen_kv, dim, sm_scale, 
             Q: T.Tensor(shape_q, dtype),
             K: T.Tensor(shape_k, dtype),
             V: T.Tensor(shape_v, dtype),
-            real_seqlen_kv: T.int32,
             Output: T.Tensor(shape_o, dtype),
         ):
             with T.Kernel(batch, heads // valid_block_H, 1, threads=threads) as (bx, by, bz):
@@ -82,7 +82,7 @@ def _gqa_decode_no_split_kernel(batch, heads, groups, seqlen_kv, dim, sm_scale, 
                 T.fill(logsum, 0)
                 T.fill(scores_max, -T.infinity(accum_dtype))
 
-                loop_range = T.ceildiv(real_seqlen_kv, block_N)
+                loop_range = T.ceildiv(seqlen_kv, block_N)
                 for k in T.Pipelined(loop_range, num_stages=num_stages):
                     T.copy(K[bid, k * block_N : (k + 1) * block_N, cur_kv_head, :], K_shared)
                     T.clear(acc_s)
@@ -91,7 +91,7 @@ def _gqa_decode_no_split_kernel(batch, heads, groups, seqlen_kv, dim, sm_scale, 
                     )
                     for i, j in T.Parallel(block_H, block_N):
                         acc_s[i, j] = T.if_then_else(
-                            (k * block_N + j < real_seqlen_kv),
+                            (k * block_N + j < seqlen_kv),
                             acc_s[i, j],
                             -T.infinity(accum_dtype),
                         )
@@ -121,7 +121,7 @@ def _gqa_decode_no_split_kernel(batch, heads, groups, seqlen_kv, dim, sm_scale, 
 
 
 @functools.lru_cache(maxsize=32)
-def _gqa_decode_split_kernel(batch, heads, groups, seqlen_kv, dim, sm_scale, softcap, dtype):
+def _gqa_decode_split_kernel(batch, heads, groups, dim, sm_scale, softcap, dtype):
     score_scale = dim**-0.5 if sm_scale is None else sm_scale
     use_softcap = softcap > 0.0
     scale = LOG2E if use_softcap else score_scale * LOG2E
@@ -135,6 +135,7 @@ def _gqa_decode_split_kernel(batch, heads, groups, seqlen_kv, dim, sm_scale, sof
         compile_flags=["-O3", "-DENABLE_BF16"],
     )
     def _func(block_H, block_N, num_split, num_stages, threads):
+        seqlen_kv = T.dynamic("seqlen_kv")
         shape_q = [batch, heads, dim]
         shape_k = [batch, seqlen_kv, groups, dim]
         shape_v = [batch, seqlen_kv, groups, dim]
@@ -143,7 +144,7 @@ def _gqa_decode_split_kernel(batch, heads, groups, seqlen_kv, dim, sm_scale, sof
 
         part_shape = [batch, heads, num_split, dim]
         valid_block_H = min(block_H, kv_group_num)
-        valid_block_N = min(block_N, seqlen_kv // num_split)
+        valid_block_N = block_N
 
         online_softmax_split = make_online_softmax(scale, accum_dtype, block_H, valid_block_N)
         apply_softcap = (
@@ -158,7 +159,6 @@ def _gqa_decode_split_kernel(batch, heads, groups, seqlen_kv, dim, sm_scale, sof
             Q: T.Tensor(shape_q, dtype),
             K: T.Tensor(shape_k, dtype),
             V: T.Tensor(shape_v, dtype),
-            real_seqlen_kv: T.int32,
             glse: T.Tensor([batch, heads, num_split], dtype),
             Output_partial: T.Tensor(part_shape, dtype),
             split_length: T.Tensor(num_split, "int32"),
@@ -183,8 +183,6 @@ def _gqa_decode_split_kernel(batch, heads, groups, seqlen_kv, dim, sm_scale, sof
 
                 split_length_shared = T.alloc_shared([num_split], "int32")
                 T.copy(split_length, split_length_shared, disable_tma=True)
-
-                seqlen_kv = real_seqlen_kv
 
                 bid = bx
                 hid = by
@@ -292,13 +290,12 @@ def _gqa_decode_split_kernel(batch, heads, groups, seqlen_kv, dim, sm_scale, sof
             Q: T.Tensor(shape_q, dtype),
             K: T.Tensor(shape_k, dtype),
             V: T.Tensor(shape_v, dtype),
-            real_seqlen_kv: T.int32,
             glse: T.Tensor([batch, heads, num_split], dtype),
             Output_partial: T.Tensor(part_shape, dtype),
             split_length: T.Tensor(num_split, "int32"),
             Output: T.Tensor(shape_o, dtype),
         ):
-            _gqa_decode_split(Q, K, V, real_seqlen_kv, glse, Output_partial, split_length)
+            _gqa_decode_split(Q, K, V, glse, Output_partial, split_length)
             combine(glse, Output_partial, Output)
 
         return gqa_decode_split
@@ -314,8 +311,6 @@ def _gqa_decode_no_split_op(
     batch: int,
     heads: int,
     groups: int,
-    seqlen_kv: int,
-    real_seqlen_kv: int,
     dim: int,
     sm_scale: float,
     softcap: float,
@@ -328,9 +323,9 @@ def _gqa_decode_no_split_op(
     K: torch.Tensor,
     V: torch.Tensor,
 ) -> torch.Tensor:
-    return _gqa_decode_no_split_kernel(
-        batch, heads, groups, seqlen_kv, dim, sm_scale, softcap, dtype
-    )(block_H, block_N, num_stages, threads)(Q, K, V, real_seqlen_kv)
+    return _gqa_decode_no_split_kernel(batch, heads, groups, dim, sm_scale, softcap, dtype)(
+        block_H, block_N, num_stages, threads
+    )(Q, K, V)
 
 
 @_gqa_decode_no_split_op.register_fake
@@ -338,8 +333,6 @@ def _(
     batch: int,
     heads: int,
     groups: int,
-    seqlen_kv: int,
-    real_seqlen_kv: int,
     dim: int,
     sm_scale: float,
     softcap: float,
@@ -360,8 +353,6 @@ def _gqa_decode_split_op(
     batch: int,
     heads: int,
     groups: int,
-    seqlen_kv: int,
-    real_seqlen_kv: int,
     dim: int,
     sm_scale: float,
     softcap: float,
@@ -378,9 +369,9 @@ def _gqa_decode_split_op(
     Output_partial: torch.Tensor,
     split_length: torch.Tensor,
 ) -> torch.Tensor:
-    return _gqa_decode_split_kernel(batch, heads, groups, seqlen_kv, dim, sm_scale, softcap, dtype)(
+    return _gqa_decode_split_kernel(batch, heads, groups, dim, sm_scale, softcap, dtype)(
         block_H, block_N, num_split, num_stages, threads
-    )(Q, K, V, real_seqlen_kv, glse, Output_partial, split_length)
+    )(Q, K, V, glse, Output_partial, split_length)
 
 
 @_gqa_decode_split_op.register_fake
@@ -388,8 +379,6 @@ def _(
     batch: int,
     heads: int,
     groups: int,
-    seqlen_kv: int,
-    real_seqlen_kv: int,
     dim: int,
     sm_scale: float,
     softcap: float,
@@ -424,36 +413,36 @@ class GQADecodeKernel(Kernel):
         self,
         batch,
         heads,
-        groups,
-        seqlen_kv,
+        heads_kv,
+        seq_len_kv,
         dim,
         dtype="float16",
         sm_scale: Optional[float] = None,
         softcap: float = 0.0,
         config: Optional[dict] = None,
         tune=False,
+        device_index: Optional[int] = None,
     ):
-        super().__init__()
+        super().__init__(device_index=device_index)
         self.batch = batch
         self.heads = heads
-        self.groups = groups
-        self.seqlen_kv = seqlen_kv
+        self.groups = heads_kv
+        self.seqlen_kv = seq_len_kv
         self.dim = dim
         self.dtype = dtype
         self.sm_scale = dim**-0.5 if sm_scale is None else sm_scale
         self.softcap = softcap
         if self.groups <= 0:
-            raise ValueError("groups must be positive")
+            raise ValueError("heads_kv must be positive")
         if self.heads % self.groups != 0:
-            raise ValueError("heads must be divisible by groups")
+            raise ValueError("heads must be divisible by heads_kv")
         if self.seqlen_kv <= 0:
-            raise ValueError("seqlen_kv must be positive")
+            raise ValueError("seq_len_kv must be positive")
 
         self.no_split_jit = _gqa_decode_no_split_kernel(
             self.batch,
             self.heads,
             self.groups,
-            self.seqlen_kv,
             self.dim,
             self.sm_scale,
             self.softcap,
@@ -463,7 +452,6 @@ class GQADecodeKernel(Kernel):
             self.batch,
             self.heads,
             self.groups,
-            self.seqlen_kv,
             self.dim,
             self.sm_scale,
             self.softcap,
@@ -476,7 +464,7 @@ class GQADecodeKernel(Kernel):
         self.init_config(config, tune)
 
     def _make_supply_prog(self):
-        """Create a supply_prog that handles the scalar real_seqlen_kv parameter."""
+        """Supply a representative value for the dynamic KV sequence extent."""
         from tilelang.utils.tensor import get_tensor_supply as _get_tensor_supply
 
         default_supply = _get_tensor_supply(tilelang.TensorSupplyType.Auto)
@@ -526,7 +514,7 @@ class GQADecodeKernel(Kernel):
             candidate = 32
         else:
             candidate = 16
-        return min(candidate, self.seqlen_kv)
+        return candidate
 
     @property
     def autotune_configs(self) -> list[dict]:
@@ -549,7 +537,23 @@ class GQADecodeKernel(Kernel):
         ]
         return configs
 
-    def forward(self, Q: torch.Tensor, K: torch.Tensor, V: torch.Tensor, real_seqlen_kv: int):
+    def forward(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        q_scale: Optional[torch.Tensor] = None,
+        k_scale: Optional[torch.Tensor] = None,
+        v_scale: Optional[torch.Tensor] = None,
+        rope_cos: Optional[torch.Tensor] = None,
+        rope_sin: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        self._require_cuda(q=q, k=k, v=v)
+        del q_scale, k_scale, v_scale, rope_cos, rope_sin
+        Q = q.squeeze(1)
+        K = k
+        V = v
+        real_seqlen_kv = k.shape[1]
         block_H = self.config["block_H"]
         block_N = self.config["block_N"]
         num_split = self.config["num_split"]
@@ -559,12 +563,10 @@ class GQADecodeKernel(Kernel):
         # Dispatch: use no-split for short sequences where splitting is not beneficial
         threshold = num_split * block_N
         if real_seqlen_kv < threshold:
-            return _gqa_decode_no_split_op(
+            output = _gqa_decode_no_split_op(
                 self.batch,
                 self.heads,
                 self.groups,
-                self.seqlen_kv,
-                real_seqlen_kv,
                 self.dim,
                 self.sm_scale,
                 self.softcap,
@@ -577,6 +579,7 @@ class GQADecodeKernel(Kernel):
                 K,
                 V,
             )
+            return output.unsqueeze(1)
 
         # Split path: compute per-split lengths
         base_len = real_seqlen_kv // (num_split * block_N) * block_N
@@ -588,12 +591,10 @@ class GQADecodeKernel(Kernel):
             (self.batch, self.heads, num_split, self.dim), dtype=self.dtype, device=Q.device
         )
 
-        return _gqa_decode_split_op(
+        output = _gqa_decode_split_op(
             self.batch,
             self.heads,
             self.groups,
-            self.seqlen_kv,
-            real_seqlen_kv,
             self.dim,
             self.sm_scale,
             self.softcap,
@@ -610,3 +611,4 @@ class GQADecodeKernel(Kernel):
             Output_partial,
             split_length,
         )
+        return output.unsqueeze(1)

--- a/src/tileops/kernels/attention/gqa_decode_bs1.py
+++ b/src/tileops/kernels/attention/gqa_decode_bs1.py
@@ -1,6 +1,6 @@
 """Warp-specialized batch=1 GQA decode kernel (Hopper), context-split.
 
-``GQADecodeBs1Kernel`` dispatches on the runtime ``real_seqlen_kv``: lengths >= 1024
+``GQADecodeBs1Kernel`` dispatches on the runtime K/V sequence extent: lengths >= 1024
 run a context-only warp-specialized split (one TMA producer warp feeding a four-warp
 wgmma consumer warpgroup, exp2-domain online softmax, fp32 partial reduce via a combine
 kernel); shorter lengths fall back to the generic non-split decode kernel. Hopper-only,
@@ -31,7 +31,7 @@ __all__ = ["GQADecodeBs1Kernel"]
 
 
 @functools.lru_cache(maxsize=32)
-def _gqa_decode_bs1_ctx_kernel(batch, heads, groups, seqlen_kv, dim, sm_scale, softcap, dtype):
+def _gqa_decode_bs1_ctx_kernel(batch, heads, groups, dim, sm_scale, softcap, dtype):
     score_scale = dim**-0.5 if sm_scale is None else sm_scale
     scale = score_scale * LOG2E
     accum_dtype = "float"
@@ -45,6 +45,7 @@ def _gqa_decode_bs1_ctx_kernel(batch, heads, groups, seqlen_kv, dim, sm_scale, s
         compile_flags=COMPILE_FLAGS,
     )
     def _func(block_M, block_N, ctx_splits, threads):
+        seqlen_kv = T.dynamic("seqlen_kv")
         shape_q = [batch, heads, dim]
         shape_k = [batch, seqlen_kv, groups, dim]
         shape_o = [batch, heads, dim]
@@ -93,12 +94,11 @@ def _gqa_decode_bs1_ctx_kernel(batch, heads, groups, seqlen_kv, dim, sm_scale, s
             Q: T.Tensor(shape_q, dtype),
             K: T.Tensor(shape_k, dtype),
             V: T.Tensor(shape_k, dtype),
-            real_seqlen_kv: T.int32,
             glse: T.Tensor(lse_shape, accum_dtype),
             Output_partial: T.Tensor(part_shape, accum_dtype),
             Output: T.Tensor(shape_o, dtype),
         ):
-            split(Q, K, V, K, real_seqlen_kv, glse, Output_partial)
+            split(Q, K, V, K, seqlen_kv, glse, Output_partial)
             combine(glse, Output_partial, Output)
 
         return gqa_decode_bs1_ctx
@@ -111,8 +111,6 @@ def _gqa_decode_bs1_ctx_op(
     batch: int,
     heads: int,
     groups: int,
-    seqlen_kv: int,
-    real_seqlen_kv: int,
     dim: int,
     sm_scale: float,
     softcap: float,
@@ -127,9 +125,9 @@ def _gqa_decode_bs1_ctx_op(
     glse: torch.Tensor,
     Output_partial: torch.Tensor,
 ) -> torch.Tensor:
-    return _gqa_decode_bs1_ctx_kernel(
-        batch, heads, groups, seqlen_kv, dim, sm_scale, softcap, dtype
-    )(block_M, block_N, ctx_splits, threads)(Q, K, V, real_seqlen_kv, glse, Output_partial)
+    return _gqa_decode_bs1_ctx_kernel(batch, heads, groups, dim, sm_scale, softcap, dtype)(
+        block_M, block_N, ctx_splits, threads
+    )(Q, K, V, glse, Output_partial)
 
 
 @_gqa_decode_bs1_ctx_op.register_fake
@@ -137,8 +135,6 @@ def _(
     batch: int,
     heads: int,
     groups: int,
-    seqlen_kv: int,
-    real_seqlen_kv: int,
     dim: int,
     sm_scale: float,
     softcap: float,
@@ -159,7 +155,7 @@ def _(
 class GQADecodeBs1Kernel(GQADecodeBs1KernelMixin, Kernel):
     """Hopper warp-specialized batch=1 GQA decode kernel with a context-length switch.
 
-    ``forward`` dispatches on the runtime ``real_seqlen_kv``: >= 1024 runs the context-only
+    ``forward`` dispatches on the runtime K/V sequence extent: >= 1024 runs the context-only
     split, shorter lengths run the generic non-split GQA decode kernel.
     """
 
@@ -173,45 +169,60 @@ class GQADecodeBs1Kernel(GQADecodeBs1KernelMixin, Kernel):
         self,
         batch,
         heads,
-        groups,
-        seqlen_kv,
+        heads_kv,
+        seq_len_kv,
         dim,
         dtype="float16",
         sm_scale: Optional[float] = None,
         softcap: float = 0.0,
         config: Optional[dict] = None,
         tune=False,
+        device_index: Optional[int] = None,
     ):
-        super().__init__()
+        super().__init__(device_index=device_index)
         self.batch = batch
         self.heads = heads
-        self.groups = groups
-        self.seqlen_kv = seqlen_kv
+        self.groups = heads_kv
+        self.seqlen_kv = seq_len_kv
         self.dim = dim
         self.dtype = dtype
         self.sm_scale = dim**-0.5 if sm_scale is None else sm_scale
         self.softcap = softcap
         if self.groups <= 0:
-            raise ValueError("groups must be positive")
+            raise ValueError("heads_kv must be positive")
         if self.heads % self.groups != 0:
-            raise ValueError("heads must be divisible by groups")
+            raise ValueError("heads must be divisible by heads_kv")
         if self.seqlen_kv <= 0:
-            raise ValueError("seqlen_kv must be positive")
+            raise ValueError("seq_len_kv must be positive")
         self.init_config(config, tune)
 
     @property
     def default_config(self) -> dict:
         return {"block_M": 64, "block_N": 128, "threads": 160}
 
-    def forward(self, Q: torch.Tensor, K: torch.Tensor, V: torch.Tensor, real_seqlen_kv: int):
+    def forward(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        q_scale: Optional[torch.Tensor] = None,
+        k_scale: Optional[torch.Tensor] = None,
+        v_scale: Optional[torch.Tensor] = None,
+        rope_cos: Optional[torch.Tensor] = None,
+        rope_sin: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        self._require_cuda(q=q, k=k, v=v)
+        del q_scale, k_scale, v_scale, rope_cos, rope_sin
+        Q = q.squeeze(1)
+        K = k
+        V = v
+        real_seqlen_kv = k.shape[1]
         c = self.config
         if real_seqlen_kv < self._MIN_CTX:
-            return _gqa_decode_no_split_op(
+            output = _gqa_decode_no_split_op(
                 self.batch,
                 self.heads,
                 self.groups,
-                self.seqlen_kv,
-                real_seqlen_kv,
                 self.dim,
                 self.sm_scale,
                 self.softcap,
@@ -224,15 +235,14 @@ class GQADecodeBs1Kernel(GQADecodeBs1KernelMixin, Kernel):
                 K,
                 V,
             )
+            return output.unsqueeze(1)
 
         ctx_splits = self._ctx_splits_for(real_seqlen_kv)
         glse, Output_partial = self._allocate_partials(Q, ctx_splits)
-        return _gqa_decode_bs1_ctx_op(
+        output = _gqa_decode_bs1_ctx_op(
             self.batch,
             self.heads,
             self.groups,
-            self.seqlen_kv,
-            real_seqlen_kv,
             self.dim,
             self.sm_scale,
             self.softcap,
@@ -247,3 +257,4 @@ class GQADecodeBs1Kernel(GQADecodeBs1KernelMixin, Kernel):
             glse,
             Output_partial,
         )
+        return output.unsqueeze(1)

--- a/src/tileops/manifest/attention.yaml
+++ b/src/tileops/manifest/attention.yaml
@@ -122,6 +122,8 @@ GroupedQueryAttentionDenseFwdOp:
     kernel: tileops/kernels/attention/gqa_dense.py
     kernel_map:
       gqa_dense: GQADenseCausalWsKernel
+      gqa_dense_decode: GQADecodeKernel
+      gqa_dense_decode_bs1: GQADecodeBs1Kernel
       gqa_dense_sliding_window: GQADenseSlidingWindowKernel
     op: tileops/ops/attention/gqa.py
     test: tests/ops/attention/test_gqa.py

--- a/src/tileops/manifest/attention.yaml
+++ b/src/tileops/manifest/attention.yaml
@@ -113,7 +113,21 @@ GroupedQueryAttentionDenseFwdOp:
       - "o.shape == (B, S_q, H, D)"
       - "H % H_kv == 0"
 
-  workloads: []
+  workloads:
+    # Dense decode: one query token over a contiguous KV cache.
+    - {q_shape: [32, 1, 32, 128], kv_shape: [32, 4096, 8, 128], dtypes: [float16, bfloat16], label: "decode-llama-8b-4k"}
+    - {q_shape: [8, 1, 32, 128], kv_shape: [8, 32768, 8, 128], dtypes: [float16, bfloat16], label: "decode-llama-8b-32k"}
+    - {q_shape: [16, 1, 64, 128], kv_shape: [16, 4096, 8, 128], dtypes: [float16, bfloat16], label: "decode-llama-70b-4k"}
+    - {q_shape: [4, 1, 64, 128], kv_shape: [4, 32768, 8, 128], dtypes: [float16, bfloat16], label: "decode-llama-70b-32k"}
+    - {q_shape: [32, 1, 32, 128], kv_shape: [32, 4096, 8, 128], softcap: 50.0, dtypes: [float16], label: "decode-llama-8b-4k-softcap50"}
+    - {q_shape: [1, 1, 32, 128], kv_shape: [1, 1024, 4, 128], dtypes: [float16], label: "decode-qwen3-30b-a3b-bs1-1k"}
+    - {q_shape: [1, 1, 32, 128], kv_shape: [1, 4096, 4, 128], dtypes: [float16], label: "decode-qwen3-30b-a3b-bs1-4k"}
+    - {q_shape: [1, 1, 32, 128], kv_shape: [1, 8192, 4, 128], dtypes: [float16], label: "decode-qwen3-30b-a3b-bs1-8k"}
+    - {q_shape: [1, 1, 32, 128], kv_shape: [1, 16384, 4, 128], dtypes: [float16], label: "decode-qwen3-30b-a3b-bs1-16k"}
+    - {q_shape: [1, 1, 32, 128], kv_shape: [1, 32768, 4, 128], dtypes: [float16], label: "decode-qwen3-30b-a3b-bs1-32k"}
+    - {q_shape: [1, 1, 32, 128], kv_shape: [1, 65536, 4, 128], dtypes: [float16], label: "decode-qwen3-30b-a3b-bs1-64k"}
+    - {q_shape: [1, 1, 32, 128], kv_shape: [1, 131072, 4, 128], dtypes: [float16], label: "decode-qwen3-30b-a3b-bs1-128k"}
+    - {q_shape: [1, 1, 32, 128], kv_shape: [1, 262144, 4, 128], dtypes: [float16], label: "decode-qwen3-30b-a3b-bs1-256k"}
 
   roofline:
     func: "tileops.perf.formulas.gqa_fwd_roofline"
@@ -128,6 +142,7 @@ GroupedQueryAttentionDenseFwdOp:
     op: tileops/ops/attention/gqa.py
     test: tests/ops/attention/test_gqa.py
     bench: benchmarks/ops/attention/bench_gqa.py
+    bench_manifest_driven: true
 
 GroupedQueryAttentionVarlenFwdOp:
   ref_api: "none"

--- a/src/tileops/ops/attention/gqa.py
+++ b/src/tileops/ops/attention/gqa.py
@@ -7,6 +7,8 @@ from tileops.backend import Target
 from tileops.kernels.attention import (
     FlashAttnBwdPreprocessKernel,
     GQABwdWgmmaPipelinedKernel,
+    GQADecodeBs1Kernel,
+    GQADecodeKernel,
     GQADecodePagedBs1Kernel,
     GQADecodePagedKernel,
     GQADenseCausalWsKernel,
@@ -293,6 +295,8 @@ class GroupedQueryAttentionDenseFwdOp(Op):
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {
             "gqa_dense": GQADenseCausalWsKernel,
+            "gqa_dense_decode": GQADecodeKernel,
+            "gqa_dense_decode_bs1": GQADecodeBs1Kernel,
             "gqa_dense_sliding_window": GQADenseSlidingWindowKernel,
         }
 
@@ -458,8 +462,24 @@ class GroupedQueryAttentionDenseFwdOp(Op):
         batch, seq_len_q, heads, dim = q.shape
         _, seq_len_kv, heads_kv, _ = k.shape
         uses_window = self.window_size_left != -1 or self.window_size_right != -1
-        role = "gqa_dense_sliding_window" if uses_window else "gqa_dense"
         rope_on = self.pos_encoding_mode == "rope"
+        uses_decode = seq_len_q == 1 and not uses_window and not rope_on
+        uses_bs1_decode = (
+            uses_decode
+            and batch == 1
+            and q.dtype == torch.float16
+            and dim == 128
+            and self.softcap == 0.0
+            and 1 <= heads // heads_kv <= 64
+        )
+        if uses_bs1_decode:
+            role = "gqa_dense_decode_bs1"
+        elif uses_decode:
+            role = "gqa_dense_decode"
+        elif uses_window:
+            role = "gqa_dense_sliding_window"
+        else:
+            role = "gqa_dense"
         rope_kwargs = {
             "fuse_rope": rope_on,
             "max_position": rope_cos.shape[0] if rope_cos is not None else 1,
@@ -469,6 +489,18 @@ class GroupedQueryAttentionDenseFwdOp(Op):
 
         def build() -> Kernel:
             self._validate_builtin_call(q, k)
+            if uses_decode:
+                return self.kernel_map[role](
+                    batch=batch,
+                    heads=heads,
+                    heads_kv=heads_kv,
+                    seq_len_kv=seq_len_kv,
+                    dim=dim,
+                    dtype=q.dtype,
+                    sm_scale=self.sm_scale,
+                    softcap=self.softcap,
+                    device_index=q.device.index,
+                )
             if uses_window:
                 return self.kernel_map[role](
                     batch=batch,

--- a/src/tileops/ops/attention/gqa.py
+++ b/src/tileops/ops/attention/gqa.py
@@ -289,6 +289,8 @@ class GroupedQueryAttentionDenseFwdOp(Op):
         self.rope_layout = rope_layout
         self.dtype = dtype
         self.target = target
+        self._roofline_kwargs: Optional[dict] = None
+        self._last_input_dtype: Optional[torch.dtype] = None
         self.dispatch_kernel()
 
     @property
@@ -347,8 +349,17 @@ class GroupedQueryAttentionDenseFwdOp(Op):
                 raise ValueError(f"{name} must have dtype {output_dtype}")
 
     def eval_roofline(self) -> tuple[int, int]:
-        """Keep this spec-only Op concrete until its roofline is implemented."""
-        raise NotImplementedError("Dense GQA has no in-tree implementation yet")
+        if self._roofline_kwargs is None:
+            raise RuntimeError(
+                f"{type(self).__name__}.eval_roofline() requires a prior forward() call"
+            )
+        from tileops.perf.formulas import gqa_fwd_roofline
+
+        return gqa_fwd_roofline(**self._roofline_kwargs)
+
+    def compute_roof(self) -> str:
+        """Dense attention's contractions are priced on tensor cores."""
+        return tensor_core_roof(self._last_input_dtype)
 
     def _validate_forward_inputs(
         self,
@@ -602,7 +613,15 @@ class GroupedQueryAttentionDenseFwdOp(Op):
         self._validate_forward_inputs(q, k, v, q_scale, k_scale, v_scale, rope_cos, rope_sin)
         inputs = self._canonicalize_inputs(q, k, v, q_scale, k_scale, v_scale, rope_cos, rope_sin)
         kernel = self._get_kernel(inputs)
-        return kernel(*inputs)
+        output = kernel(*inputs)
+        self._last_input_dtype = q.dtype
+        self._roofline_kwargs = {
+            "q_shape": tuple(q.shape),
+            "k_shape": tuple(k.shape),
+            "is_causal": self.is_causal,
+            "dtype": q.dtype,
+        }
+        return output
 
 
 class GroupedQueryAttentionVarlenFwdOp(Op):

--- a/src/tileops/perf/formulas.py
+++ b/src/tileops/perf/formulas.py
@@ -120,15 +120,19 @@ def mha_bwd_roofline(op: Any | None = None, **kwargs: Any) -> tuple[int, int]:
 
 
 def gqa_fwd_roofline(op: Any | None = None, **kwargs: Any) -> tuple[int, int]:
-    """Roofline for grouped-query attention forward (prefill)."""
+    """Roofline for dense grouped-query attention forward."""
     data = _shape_or_attrs(op, kwargs)
     if "q_shape" in data:
-        batch, seq_len, heads, dim = data["q_shape"]
-        _, _, heads_kv, _ = data["kv_shape"]
+        batch, seq_len_q, heads, dim = data["q_shape"]
+        kv_shape = data.get("k_shape", data.get("kv_shape"))
+        if kv_shape is None:
+            raise KeyError("dense GQA roofline requires k_shape or kv_shape")
+        _, seq_len_kv, heads_kv, _ = kv_shape
     else:
-        batch, seq_len, heads, heads_kv, dim = (
+        batch, seq_len_q, seq_len_kv, heads, heads_kv, dim = (
             data["batch"],
-            data["seq_len"],
+            data.get("seq_len_q", data.get("seq_len")),
+            data.get("seq_len_kv", data.get("seq_len")),
             data["heads"],
             data["heads_kv"],
             data["dim"],
@@ -136,11 +140,12 @@ def gqa_fwd_roofline(op: Any | None = None, **kwargs: Any) -> tuple[int, int]:
     is_causal = bool(data.get("is_causal", True))
     elem_bytes = _dtype_itemsize(data.get("dtype", data.get("dtypes", "float16")))
 
-    flops = 4 * batch * heads * seq_len * seq_len * dim
+    visible_scores = seq_len_q * seq_len_kv
     if is_causal:
-        flops //= 2
-    q_elems = batch * seq_len * heads * dim
-    kv_elems = batch * seq_len * heads_kv * dim
+        visible_scores = seq_len_q * (seq_len_kv - seq_len_q) + seq_len_q * (seq_len_q + 1) // 2
+    flops = 4 * batch * heads * visible_scores * dim
+    q_elems = batch * seq_len_q * heads * dim
+    kv_elems = batch * seq_len_kv * heads_kv * dim
     return int(flops), int(2 * (q_elems + kv_elems) * elem_bytes)
 
 

--- a/tests/ops/attention/test_gqa.py
+++ b/tests/ops/attention/test_gqa.py
@@ -7,9 +7,12 @@ from torch.nn.attention import SDPBackend, sdpa_kernel
 
 from tests.test_base import FixtureBase, TestBase
 from tileops.kernels.attention import (
+    GQADecodeBs1Kernel,
+    GQADecodeKernel,
     GQADenseCausalWsKernel,
     GQADenseSlidingWindowKernel,
 )
+from tileops.kernels.kernel_base import Kernel
 from tileops.ops import (
     GroupedQueryAttentionBwdOp,
     GroupedQueryAttentionDenseFwdOp,
@@ -178,11 +181,11 @@ def test_gqa_dense_reuses_one_kernel_across_sequence_lengths(batch: int) -> None
     op = GroupedQueryAttentionDenseFwdOp()
 
     for seq_len_q, seq_len_kv in (
-        (1, 270),
-        (1, 271),
+        (2, 270),
+        (2, 271),
         (160, 270),
         (896, 896),
-        (1, 270),
+        (2, 270),
     ):
         q = torch.randn(batch, seq_len_q, heads, dim, device="cuda", dtype=torch.float16)
         k = torch.randn(batch, seq_len_kv, heads_kv, dim, device="cuda", dtype=torch.float16)
@@ -196,6 +199,54 @@ def test_gqa_dense_reuses_one_kernel_across_sequence_lengths(batch: int) -> None
         )
 
     assert len(list(op.iter_kernels())) == 1
+
+
+@pytest.mark.parametrize(
+    "batch, dtype, seq_lens_kv, kernel_type",
+    [
+        pytest.param(
+            1,
+            torch.float16,
+            (257, 1057),
+            GQADecodeBs1Kernel,
+            id="bs1-fp16",
+        ),
+        pytest.param(
+            2,
+            torch.bfloat16,
+            (257, 2051),
+            GQADecodeKernel,
+            id="batched-bf16",
+        ),
+    ],
+)
+@pytest.mark.smoke
+def test_gqa_dense_decode_dispatch_and_dynamic_sequence_lengths(
+    batch: int,
+    dtype: torch.dtype,
+    seq_lens_kv: tuple[int, ...],
+    kernel_type: type[Kernel],
+) -> None:
+    if not torch.cuda.is_available() or get_sm_version() != 90:
+        pytest.skip("Dense decode requires SM90")
+    heads, heads_kv, dim = 8, 2, 128
+    op = GroupedQueryAttentionDenseFwdOp()
+
+    for seq_len_kv in seq_lens_kv:
+        q = torch.randn(batch, 1, heads, dim, device="cuda", dtype=dtype)
+        k = torch.randn(batch, seq_len_kv, heads_kv, dim, device="cuda", dtype=dtype)
+        v = torch.randn_like(k)
+        output = op(q, k, v)
+        torch.testing.assert_close(
+            output,
+            _gqa_prefill_ref(q, k, v, heads=heads, heads_kv=heads_kv, is_causal=True),
+            atol=1.6e-2 if dtype == torch.bfloat16 else 5e-3,
+            rtol=1.6e-2 if dtype == torch.bfloat16 else 1e-5,
+        )
+
+    kernels = list(op.iter_kernels())
+    assert len(kernels) == 1
+    assert isinstance(kernels[0], kernel_type)
 
 
 @pytest.mark.parametrize("use_rope", [False, True])

--- a/workloads/attention/gqa.py
+++ b/workloads/attention/gqa.py
@@ -164,6 +164,54 @@ class GroupedQueryAttentionBwdWorkload(WorkloadBase):
         return q, k, v, o, grad_output, lse
 
 
+class GroupedQueryAttentionDenseDecodeWorkload(WorkloadBase):
+    """Single-token decode over a contiguous BSHD KV cache."""
+
+    def __init__(
+        self,
+        batch: int,
+        heads: int,
+        heads_kv: int,
+        seq_len_kv: int,
+        dim: int,
+        dtype: torch.dtype,
+        sm_scale: float | None = None,
+        softcap: float | None = None,
+    ) -> None:
+        self.batch = batch
+        self.heads = heads
+        self.heads_kv = heads_kv
+        self.seq_len_kv = seq_len_kv
+        self.dim = dim
+        self.dtype = dtype
+        self.sm_scale = dim**-0.5 if sm_scale is None else sm_scale
+        self.softcap = 0.0 if softcap is None else softcap
+
+    def gen_inputs(self) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        q = torch.randn(self.batch, 1, self.heads, self.dim, device="cuda", dtype=self.dtype)
+        k = torch.randn(
+            self.batch,
+            self.seq_len_kv,
+            self.heads_kv,
+            self.dim,
+            device="cuda",
+            dtype=self.dtype,
+        )
+        v = torch.randn_like(k)
+        return q, k, v
+
+    def ref_program(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
+        groups = self.heads // self.heads_kv
+        q_bhsd = q.transpose(1, 2).float()
+        k_bhsd = k.repeat_interleave(groups, dim=2).transpose(1, 2).float()
+        v_bhsd = v.repeat_interleave(groups, dim=2).transpose(1, 2).float()
+        scores = torch.matmul(q_bhsd, k_bhsd.transpose(-2, -1)) * self.sm_scale
+        if self.softcap > 0:
+            scores = self.softcap * torch.tanh(scores / self.softcap)
+        probs = torch.softmax(scores, dim=-1)
+        return torch.matmul(probs, v_bhsd).transpose(1, 2).to(q.dtype).contiguous()
+
+
 class GroupedQueryAttentionDecodePagedWorkload(WorkloadBase):
     def __init__(
         self,


### PR DESCRIPTION
## Summary

- Route `GroupedQueryAttentionDenseFwdOp` calls with `S_q = 1` to the existing contiguous decode kernels.
- Use the Hopper batch-1 specialization where applicable; otherwise use the general split/no-split decode kernel.
- Keep the public BSHD ABI and derive the runtime KV length from `k.shape[1]`.
- Make `S_kv` dynamic so one compiled kernel/cache entry serves changing context lengths.
- Restore the previous Dense Decode workload matrix under the unified Dense Op, with explicit `decode-*` workload names.

## Decode benchmark coverage

The manifest contains the same 13 workload rows / 17 dtype cases as the previous contiguous Decode Op:

- Llama 8B and 70B, 4K and 32K KV lengths, FP16 and BF16.
- Llama 8B 4K with `softcap=50`.
- Qwen3-30B-A3B batch-1 decode from 1K through 256K KV length.

FA3 remains the exact contiguous-KV baseline. FlashInfer uses its contiguous single-decode path for batch 1 and its planned paged wrapper for batched comparisons. The adapters consume each invocation's tensors, so they remain compatible with the benchmark shifting-input pool.

## Performance

Native-CUPTI `device_busy_ms` on a clock-locked H200 (SM 1500 MHz):

| Workload | TileOps | FA3 | FlashInfer |
| --- | ---: | ---: | ---: |
| Qwen3-30B-A3B, B=1, KV=1K, FP16 | 0.0069 ms | 0.0162 ms | 0.0095 ms |
| Llama-8B, B=32, KV=4K, FP16 | 0.2118 ms | 0.1510 ms | 0.2239 ms |
