### PR TITLE
[Refactor][Norm] Share the row reduction and the partial predicate

### DIFF
--- a/src/tileops/kernels/norm/_config.py
+++ b/src/tileops/kernels/norm/_config.py
@@ -27,6 +27,7 @@ __all__ = [
     "select_row_config",
     "select_row_config_by_width",
     "select_row_configs",
+    "use_per_thread_partial",
 ]
 
 # Powers of two only (tl::AllReduce is an XOR butterfly) that also divide
@@ -118,6 +119,23 @@ def select_row_configs(
     if default not in configs:
         configs.insert(0, default)
     return configs
+
+
+def use_per_thread_partial(
+    m: int, block_m: int, n_padded: int, threads: int, sm_count: int, min_elements: int
+) -> bool:
+    """Whether a row reduction should accumulate a per-thread partial first.
+
+    The partial trades the fp32 fragment's ``n_padded / threads`` registers, which cap the
+    resident warps, for a serial walk of shared memory. Only a grid that oversubscribes the
+    device is paid back for the walk, and a thread count that does not divide the row would
+    truncate it.
+    """
+    return (
+        -(-m // block_m) > sm_count
+        and n_padded % threads == 0
+        and n_padded // threads >= min_elements
+    )
 
 
 def make_row_reduce(block_m, n, n_padded, eps):

--- a/src/tileops/kernels/norm/layer_norm.py
+++ b/src/tileops/kernels/norm/layer_norm.py
@@ -21,7 +21,12 @@ from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.tiling import ALIGNMENT, align_up
 from tileops.utils import get_sm_count
 
-from ._config import select_row_config, select_row_configs
+from ._config import (
+    make_row_reduce,
+    select_row_config,
+    select_row_configs,
+    use_per_thread_partial,
+)
 
 __all__ = ["LayerNormKernel"]
 
@@ -34,15 +39,10 @@ def _layer_norm_kernel(M, N, eps, dtype, partial_min_elements, sm_count):
 
     @tilelang.jit(out_idx=[3])
     def _func(block_m, threads):
-        # A partial per thread trades the fp32 fragment's N/threads registers,
-        # which cap the resident warps, for a serial walk of shared memory. Only
-        # a grid that oversubscribes the device is paid back for the walk.
-        per_thread_partial = (
-            -(-M // block_m) > sm_count
-            # A thread count that does not divide the row truncates the walk.
-            and N_padded % threads == 0
-            and N_padded // threads >= partial_min_elements
+        per_thread_partial = use_per_thread_partial(
+            M, block_m, N_padded, threads, sm_count, partial_min_elements
         )
+        row_reduce = make_row_reduce(block_m, N, N_padded, eps)
 
         @T.prim_func
         def main(
@@ -113,19 +113,7 @@ def _layer_norm_kernel(M, N, eps, dtype, partial_min_elements, sm_count):
                         for i, j in T.Parallel(block_m, N_padded):
                             x_f32[i, j] = T.cast(x_local[i, j], "float32")
 
-                    T.reduce_sum(x_f32, acc, dim=1)
-                    for i in T.Parallel(block_m):
-                        mean_val[i] = acc[i] / float(N)
-
-                    # Padded positions (x=0) contribute mean^2; corrected below.
-                    for i, j in T.Parallel(block_m, N_padded):
-                        x_f32[i, j] = (x_f32[i, j] - mean_val[i]) * (x_f32[i, j] - mean_val[i])
-
-                    T.reduce_sum(x_f32, acc, dim=1)
-                    for i in T.Parallel(block_m):
-                        rstd[i] = T.rsqrt(
-                            (acc[i] - float(pad_count) * mean_val[i] * mean_val[i]) / float(N) + eps
-                        )
+                    row_reduce(x_f32, acc, mean_val, rstd)
 
                 # --- Output: y = (x - mean) * rstd * weight + bias ---
                 if needs_pad:

--- a/src/tileops/kernels/norm/rms_norm.py
+++ b/src/tileops/kernels/norm/rms_norm.py
@@ -19,7 +19,7 @@ from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.tiling import ALIGNMENT, align_up
 from tileops.utils import get_sm_count
 
-from ._config import select_row_config, select_row_configs
+from ._config import select_row_config, select_row_configs, use_per_thread_partial
 
 __all__ = ["RMSNormKernel"]
 
@@ -30,14 +30,8 @@ def _rms_norm_kernel(M, N, eps, dtype, partial_min_elements, sm_count):
 
     @tilelang.jit(out_idx=[2])
     def _func(block_m, threads):
-        # A partial per thread trades the fp32 fragment's N/threads registers,
-        # which cap the resident warps, for a serial walk of shared memory. Only
-        # a grid that oversubscribes the device is paid back for the walk.
-        per_thread_partial = (
-            -(-M // block_m) > sm_count
-            # A thread count that does not divide the row truncates the walk.
-            and N_padded % threads == 0
-            and N_padded // threads >= partial_min_elements
+        per_thread_partial = use_per_thread_partial(
+            M, block_m, N_padded, threads, sm_count, partial_min_elements
         )
 
         @T.prim_func


### PR DESCRIPTION
## Problems

- `layer_norm` reduces a loaded fp32 row block to mean and rstd inline, term for term the same as `_config.make_row_reduce`, which `group_norm` and `ada_layer_norm` already call.
- The predicate choosing the per-thread-partial path is five lines, comment included, byte for byte in `layer_norm` and `rms_norm`. It differs only in a threshold both already pass as a parameter.

## Changes

- `layer_norm`'s non-partial branch calls `make_row_reduce`.
- The predicate moves to `_config` as `use_per_thread_partial`; both files call it.

## Not shared

`layer_norm`'s per-thread-partial branch stays written out. It accumulates across a fragment `threads` wide, walking shared memory with a serial stride, where the shared macro rewrites the full row in place — two different reductions that happen to share a tail. `rms_norm`'s partial branch reduces a sum of squares, so it has nothing to share either.

## No behaviour change

Config and generated CUDA dumped for 102 specializations — seven kernel classes, three dtypes, eight shapes, the row counts chosen to build both sides of the predicate and the widths to cover an aligned and a padded row. **Zero differ.** 249 norm tests pass, 5 skipped.
