### PR TITLE
[Refactor][MoE] Delete the duplicated grouped-GEMM kernel body

### DIFF
--- a/src/tileops/kernels/moe/moe_grouped_gemm_nopad.py
+++ b/src/tileops/kernels/moe/moe_grouped_gemm_nopad.py
@@ -173,58 +173,57 @@ def _moe_grouped_gemm_kernel(
         _total_ctas = max_tiles * _num_pid_n  # 1-D grid size
         _num_pid_in_group = group_size_m * _num_pid_n  # CTAs per GROUP_SIZE_M group
 
-        if _b_copy_ok:
+        @T.prim_func
+        def _gemm_main(
+            A: T.Tensor(A_shape, dtype),  # type: ignore
+            B: T.Tensor(B_shape, dtype),  # type: ignore
+            C: T.Tensor(C_shape, dtype),  # type: ignore
+            tile_expert_ids: T.Tensor([max_tiles], "int32"),
+            tile_row_offsets: T.Tensor([max_tiles], "int32"),
+            true_offsets: T.Tensor([num_experts], "int32"),
+            true_sizes: T.Tensor([num_experts], "int32"),
+            total_tiles: T.Tensor([1], "int32"),
+        ):
+            with T.Kernel(_total_ctas, threads=threads) as (pid,):
+                A_shared = T.alloc_shared(A_shared_shape, dtype)
+                B_shared = T.alloc_shared(B_shared_shape, dtype)
+                C_local = T.alloc_fragment([block_m, block_n], accum_dtype)
+                T.annotate_layout(
+                    {
+                        A_shared: tilelang.layout.make_swizzled_layout(A_shared),
+                        B_shared: tilelang.layout.make_swizzled_layout(B_shared),
+                    }
+                )
 
-            @T.prim_func
-            def _gemm_main(
-                A: T.Tensor(A_shape, dtype),  # type: ignore
-                B: T.Tensor(B_shape, dtype),  # type: ignore
-                C: T.Tensor(C_shape, dtype),  # type: ignore
-                tile_expert_ids: T.Tensor([max_tiles], "int32"),
-                tile_row_offsets: T.Tensor([max_tiles], "int32"),
-                true_offsets: T.Tensor([num_experts], "int32"),
-                true_sizes: T.Tensor([num_experts], "int32"),
-                total_tiles: T.Tensor([1], "int32"),
-            ):
-                with T.Kernel(_total_ctas, threads=threads) as (pid,):
-                    A_shared = T.alloc_shared(A_shared_shape, dtype)
-                    B_shared = T.alloc_shared(B_shared_shape, dtype)
-                    C_local = T.alloc_fragment([block_m, block_n], accum_dtype)
-                    T.annotate_layout(
-                        {
-                            A_shared: tilelang.layout.make_swizzled_layout(A_shared),
-                            B_shared: tilelang.layout.make_swizzled_layout(B_shared),
-                        }
-                    )
+                # M-major tile ordering: each M-tile processes all N-tiles
+                # before moving to the next M-tile, maximising A-tile reuse.
+                # For group_size_m=1 (default) this simplifies to a direct
+                # pid → (bx, by) mapping with compile-time constant divisor.
+                if group_size_m == 1:
+                    bx = pid // T.int32(_num_pid_n)
+                    by = pid % T.int32(_num_pid_n)
+                else:
+                    pid_in_group = pid % T.int32(_num_pid_in_group)
+                    group_id = pid // T.int32(_num_pid_in_group)
+                    first_pid_m = group_id * T.int32(group_size_m)
+                    actual_gsm = T.min(T.int32(max_tiles) - first_pid_m, T.int32(group_size_m))
+                    bx = first_pid_m + pid_in_group % actual_gsm
+                    by = pid_in_group // actual_gsm
 
-                    # M-major tile ordering: each M-tile processes all N-tiles
-                    # before moving to the next M-tile, maximising A-tile reuse.
-                    # For group_size_m=1 (default) this simplifies to a direct
-                    # pid → (bx, by) mapping with compile-time constant divisor.
-                    if group_size_m == 1:
-                        bx = pid // T.int32(_num_pid_n)
-                        by = pid % T.int32(_num_pid_n)
-                    else:
-                        pid_in_group = pid % T.int32(_num_pid_in_group)
-                        group_id = pid // T.int32(_num_pid_in_group)
-                        first_pid_m = group_id * T.int32(group_size_m)
-                        actual_gsm = T.min(T.int32(max_tiles) - first_pid_m, T.int32(group_size_m))
-                        bx = first_pid_m + pid_in_group % actual_gsm
-                        by = pid_in_group // actual_gsm
+                if bx < total_tiles[0]:
+                    expert_id = tile_expert_ids[bx]
+                    row_in_expert = tile_row_offsets[bx]
+                    m_start = true_offsets[expert_id] + row_in_expert
+                    n_start = by * T.int32(block_n)
+                    actual_rows = T.min(T.int32(block_m), true_sizes[expert_id] - row_in_expert)
+                    actual_cols = T.min(T.int32(block_n), T.int32(N) - n_start)
+                    T.clear(C_local)
 
-                    if bx < total_tiles[0]:
-                        expert_id = tile_expert_ids[bx]
-                        row_in_expert = tile_row_offsets[bx]
-                        m_start = true_offsets[expert_id] + row_in_expert
-                        n_start = by * T.int32(block_n)
-                        actual_rows = T.min(T.int32(block_m), true_sizes[expert_id] - row_in_expert)
-                        actual_cols = T.min(T.int32(block_n), T.int32(N) - n_start)
-                        T.clear(C_local)
-
-                        # T.copy lets TileLang's WarpSpecialized pass split threads into
-                        # producer (TMA-eligible) and consumer (WGMMA) warpgroups when
-                        # threads=256 on SM90.  No predicates here; epilogue guards writes.
-                        for k in T.Pipelined(T.ceildiv(K, block_k), num_stages=num_stages):
+                    for k in T.Pipelined(T.ceildiv(K, block_k), num_stages=num_stages):
+                        if _b_copy_ok:
+                            # T.copy lets TileLang's WarpSpecialized pass split threads into
+                            # producer (TMA-eligible) and consumer (WGMMA) warpgroups when
+                            # threads=256 on SM90.  No predicates here; epilogue guards writes.
                             T.copy(
                                 A[m_start : m_start + block_m, k * block_k : (k + 1) * block_k],
                                 A_shared,
@@ -237,56 +236,7 @@ def _moe_grouped_gemm_kernel(
                                 ],
                                 B_shared,
                             )
-                            T.gemm(A_shared, B_shared, C_local, transpose_B=True)
-
-                        for i, j in T.Parallel(block_m, block_n):
-                            if i < actual_rows and j < actual_cols:
-                                C[m_start + i, n_start + j] = C_local[i, j]
-        else:
-
-            @T.prim_func
-            def _gemm_main(
-                A: T.Tensor(A_shape, dtype),  # type: ignore
-                B: T.Tensor(B_shape, dtype),  # type: ignore
-                C: T.Tensor(C_shape, dtype),  # type: ignore
-                tile_expert_ids: T.Tensor([max_tiles], "int32"),
-                tile_row_offsets: T.Tensor([max_tiles], "int32"),
-                true_offsets: T.Tensor([num_experts], "int32"),
-                true_sizes: T.Tensor([num_experts], "int32"),
-                total_tiles: T.Tensor([1], "int32"),
-            ):
-                with T.Kernel(_total_ctas, threads=threads) as (pid,):
-                    A_shared = T.alloc_shared(A_shared_shape, dtype)
-                    B_shared = T.alloc_shared(B_shared_shape, dtype)
-                    C_local = T.alloc_fragment([block_m, block_n], accum_dtype)
-                    T.annotate_layout(
-                        {
-                            A_shared: tilelang.layout.make_swizzled_layout(A_shared),
-                            B_shared: tilelang.layout.make_swizzled_layout(B_shared),
-                        }
-                    )
-
-                    if group_size_m == 1:
-                        bx = pid // T.int32(_num_pid_n)
-                        by = pid % T.int32(_num_pid_n)
-                    else:
-                        pid_in_group = pid % T.int32(_num_pid_in_group)
-                        group_id = pid // T.int32(_num_pid_in_group)
-                        first_pid_m = group_id * T.int32(group_size_m)
-                        actual_gsm = T.min(T.int32(max_tiles) - first_pid_m, T.int32(group_size_m))
-                        bx = first_pid_m + pid_in_group % actual_gsm
-                        by = pid_in_group // actual_gsm
-
-                    if bx < total_tiles[0]:
-                        expert_id = tile_expert_ids[bx]
-                        row_in_expert = tile_row_offsets[bx]
-                        m_start = true_offsets[expert_id] + row_in_expert
-                        n_start = by * T.int32(block_n)
-                        actual_rows = T.min(T.int32(block_m), true_sizes[expert_id] - row_in_expert)
-                        actual_cols = T.min(T.int32(block_n), T.int32(N) - n_start)
-                        T.clear(C_local)
-
-                        for k in T.Pipelined(T.ceildiv(K, block_k), num_stages=num_stages):
+                        else:
                             for i, j in T.Parallel(block_m, block_k):
                                 A_shared[i, j] = T.if_then_else(
                                     i < actual_rows and j < K - k * block_k,
@@ -299,11 +249,11 @@ def _moe_grouped_gemm_kernel(
                                     B[expert_id, n_start + i, k * block_k + j],
                                     0,
                                 )
-                            T.gemm(A_shared, B_shared, C_local, transpose_B=True)
+                        T.gemm(A_shared, B_shared, C_local, transpose_B=True)
 
-                        for i, j in T.Parallel(block_m, block_n):
-                            if i < actual_rows and j < actual_cols:
-                                C[m_start + i, n_start + j] = C_local[i, j]
+                    for i, j in T.Parallel(block_m, block_n):
+                        if i < actual_rows and j < actual_cols:
+                            C[m_start + i, n_start + j] = C_local[i, j]
 
         return _gemm_main
 


### PR DESCRIPTION
## Problems

`_moe_grouped_gemm_nopad`'s builder held two `@T.prim_func`s whose bodies were
identical for about sixty lines. They differed only in how the shared tiles are
filled: `T.copy` when `K` divides the tile, a predicated element-wise loop when it
does not. The tile decode, the M-major pid mapping, the `T.gemm` and the epilogue
were each written twice, with nothing to catch a drift between the copies.

## Changes

One `prim_func` carries the body; the `if _b_copy_ok` branch sits where the
difference is, inside the `T.Pipelined` loop. The condition is a Python bool, so
only the selected arm is traced.