### PR TITLE
[Perf][foundry][Pool] Read an adaptive max-pool plane once, and thin the 1d index scan

### DIFF
--- a/src/tileops/kernels/pool/adaptive_avg_pool2d.py
+++ b/src/tileops/kernels/pool/adaptive_avg_pool2d.py
@@ -76,13 +76,10 @@ def _launch_adaptive_avg_pool2d(
     out_h: int,
     out_w: int,
     dtype: str,
-    block_m: int,
-    threads: int,
+    config: dict,
     x: torch.Tensor,
 ) -> torch.Tensor:
-    return _adaptive_avg_pool2d_kernel(n, c_in, h_in, w_in, out_h, out_w, dtype)(block_m, threads)(
-        x
-    )
+    return _adaptive_avg_pool2d_kernel(n, c_in, h_in, w_in, out_h, out_w, dtype)(**config)(x)
 
 
 class AdaptiveAvgPool2dKernel(AdaptivePool2dKernelBase):

--- a/src/tileops/kernels/pool/adaptive_max_pool2d.py
+++ b/src/tileops/kernels/pool/adaptive_max_pool2d.py
@@ -1,5 +1,5 @@
 import functools
-from typing import Optional, Tuple
+from typing import Tuple
 
 import tilelang
 import tilelang.language as T
@@ -14,22 +14,90 @@ from .common import (
 
 __all__ = ["AdaptiveMaxPool2dKernel", "AdaptiveMaxPool2dWithIndicesKernel"]
 
+# Staged bytes a block aims for. Small keeps the grid longer than the device has
+# multiprocessors, which is what these shapes are short of: the whole input is a
+# megabyte or two, so a block that takes more planes only empties the grid.
+_TILE_BYTES = 4096
 
-def _stage_planes(
-    block_m: int, out_h: int, out_w: int, c_in: int, h_in: int, w_in: int, dtype: str
-) -> Optional[int]:
-    """(batch, channel) planes a block stages in shared, or None to read global.
+# Elements one thread carries in the staging copy. The copy is the kernel's whole
+# memory cost, so the block width follows from it rather than from the output count.
+_COPY_RUN = 8
 
-    Neighbouring outputs read bins that start ``w_in // out_w`` apart. A block
-    holding whole planes reads each plane once instead.
+# Widest staged tile the tuned space offers. Past this a block holds more shared memory
+# and the grid holds fewer blocks, which is the wrong direction for a shape whose whole
+# input is a megabyte or two, so those plane counts are not worth a tuning run.
+_TUNE_TILE_BYTES = 4 * _TILE_BYTES
+
+
+def _divisors(value: int) -> Tuple[int, ...]:
+    return tuple(d for d in range(1, value + 1) if value % d == 0)
+
+
+def _spread(values: Tuple[int, ...], limit: int) -> Tuple[int, ...]:
+    """At most ``limit`` of ``values``, both ends kept and the rest evenly spaced."""
+    if len(values) <= limit:
+        return values
+    step = (len(values) - 1) / (limit - 1)
+    return tuple(sorted({values[round(i * step)] for i in range(limit)}))
+
+
+def _plane_counts(rows: int, plane: int, dtype: str) -> Tuple[int, ...]:
+    """Planes a block may take at once: divisors of ``rows`` whose tile fits shared.
+
+    A run of planes is contiguous in the flat ``(rows, h_in, w_in)`` view whatever the
+    batch and channel extents are, so the only constraints are the shared budget and an
+    even split of the grid. Every divisor is offered when one plane alone will not fit,
+    where the reduction reads global memory instead.
     """
-    planes = max(1, block_m // (out_h * out_w))
-    # Dividing c_in keeps every block inside one image, so the copy is one slice.
-    if planes > c_in or c_in % planes:
-        return None
-    if not fits_static_shared(planes * h_in * w_in, dtype):
-        return None
-    return planes
+    if not fits_static_shared(plane, dtype):
+        return _divisors(rows)
+    return tuple(d for d in _divisors(rows) if fits_static_shared(d * plane, dtype))
+
+
+def _check_planes(planes: int, rows: int) -> None:
+    """Refuse a plane count the grid cannot cover.
+
+    The grid is ``rows // planes`` blocks of ``planes`` planes each, so a count that does
+    not divide ``rows`` would leave the last planes unwritten. Both config sources draw
+    from :func:`_plane_counts`, which offers divisors only; this catches a hand-written
+    config before it returns uninitialized output.
+    """
+    if rows % planes:
+        raise ValueError(f"planes={planes} must divide rows={rows}")
+
+
+def _block_threads(planes: int, plane: int) -> int:
+    width = 1 << max(0, (planes * plane // _COPY_RUN - 1).bit_length())
+    return min(512, max(128, width))
+
+
+def _default_config(rows: int, h_in: int, w_in: int, dtype: str) -> dict:
+    plane = h_in * w_in
+    itemsize = 4 if dtype in ("float", "float32") else 2
+    counts = _plane_counts(rows, plane, dtype)
+    fitting = [p for p in counts if p * plane * itemsize <= _TILE_BYTES]
+    planes = max(fitting) if fitting else min(counts)
+    return {"planes": planes, "threads": _block_threads(planes, plane)}
+
+
+def _autotune_configs(rows: int, h_in: int, w_in: int, dtype: str) -> list[dict]:
+    plane = h_in * w_in
+    itemsize = 4 if dtype in ("float", "float32") else 2
+    counts = _plane_counts(rows, plane, dtype)
+    worth = tuple(p for p in counts if p * plane * itemsize <= _TUNE_TILE_BYTES)
+    return [
+        {"planes": planes, "threads": threads}
+        for planes in _spread(worth or counts[:1], 4)
+        for threads in (128, 256, 512)
+    ]
+
+
+def _bin_extent(size_in: int, size_out: int) -> Tuple[int, bool]:
+    """The widest bin on this axis, and whether every bin on it is that wide."""
+    extent = max_adaptive_bin_extent(size_in, size_out)
+    return extent, all(
+        e - s == extent for s, e in (adaptive_bin(o, size_in, size_out) for o in range(size_out))
+    )
 
 
 @functools.lru_cache(maxsize=32)
@@ -43,53 +111,57 @@ def _adaptive_max_pool2d_kernel(
     dtype: str = "float16",
 ):
     accum_dtype = "float"
-    total_output = n * c_in * out_h * out_w
-    max_kh = max_adaptive_bin_extent(h_in, out_h)
-    max_kw = max_adaptive_bin_extent(w_in, out_w)
+    rows = n * c_in
+    plane = h_in * w_in
+    out_plane = out_h * out_w
+    max_kh, uniform_h = _bin_extent(h_in, out_h)
+    max_kw, uniform_w = _bin_extent(w_in, out_w)
 
     @tilelang.jit(out_idx=[1], compile_flags=["-O3", "-DENABLE_BF16"])
-    def _adaptive_max_pool2d_func(block_m: int, threads: int):
+    def _adaptive_max_pool2d_func(planes: int, threads: int):
+        _check_planes(planes, rows)
+        staged = fits_static_shared(planes * plane, dtype)
+
+        @T.macro
+        def _max_bin(src, src_plane, dst, dst_plane, oh, ow):
+            """Store the max over one adaptive bin of ``src[src_plane]``."""
+            ih_start, ih_end = adaptive_bin(oh, h_in, out_h)
+            iw_start, iw_end = adaptive_bin(ow, w_in, out_w)
+            run = T.alloc_var(T.float32)
+            run = -T.infinity(accum_dtype)
+            # Static-bound loops: TileLang rejects a dynamic T.serial bound, so the
+            # widest bin sets the trip count and a short bin skips its missing taps.
+            for kh in T.serial(max_kh):
+                ih = ih_start + kh
+                if uniform_h or ih < ih_end:
+                    for kw in T.serial(max_kw):
+                        iw = iw_start + kw
+                        if uniform_w or iw < iw_end:
+                            v = T.cast(src[src_plane, ih, iw], accum_dtype)
+                            # NaN enters `run` and never leaves, since a later value
+                            # fails `v > NaN`.
+                            run = T.if_then_else(T.isnan(v) or (v > run), v, run)
+            dst[dst_plane, oh, ow] = T.cast(run, dtype)
+
         @T.prim_func
         def _adaptive_max_pool2d_main(
-            x: T.Tensor((n, c_in, h_in, w_in), dtype),  # type: ignore
-            out: T.Tensor((n, c_in, out_h, out_w), dtype),  # type: ignore
+            x: T.Tensor((rows, h_in, w_in), dtype),  # type: ignore
+            out: T.Tensor((rows, out_h, out_w), dtype),  # type: ignore
         ):
-            with T.Kernel(T.ceildiv(total_output, block_m), threads=threads) as bx:
-                for i in T.Parallel(block_m):
-                    out_idx = bx * block_m + i
-                    if out_idx < total_output:
-                        ow = out_idx % out_w
-                        spatial_idx = out_idx // out_w
-                        oh = spatial_idx % out_h
-                        channel_batch_idx = spatial_idx // out_h
-                        c_idx = channel_batch_idx % c_in
-                        batch = channel_batch_idx // c_in
-
-                        ih_start, ih_end = adaptive_bin(oh, h_in, out_h)
-                        iw_start, iw_end = adaptive_bin(ow, w_in, out_w)
-
-                        max_val = T.alloc_var(T.float32)
-                        has_nan = T.alloc_var(T.bool)
-                        max_val = T.cast(float("-inf"), accum_dtype)
-                        has_nan = False
-                        # Static-bound loops (TileLang rejects dynamic T.serial
-                        # bounds); guard skips lanes outside this output's bin.
-                        for kh in T.serial(max_kh):
-                            for kw in T.serial(max_kw):
-                                if ih_start + kh < ih_end and iw_start + kw < iw_end:
-                                    val = T.cast(
-                                        x[batch, c_idx, ih_start + kh, iw_start + kw],
-                                        accum_dtype,
-                                    )
-                                    has_nan = has_nan | T.isnan(val)
-                                    max_val = T.max(max_val, val)
-
-                        result = T.if_then_else(
-                            has_nan,
-                            T.cast(float("nan"), accum_dtype),
-                            max_val,
-                        )
-                        out[batch, c_idx, oh, ow] = T.cast(result, dtype)
+            with T.Kernel(rows // planes, threads=threads) as bx:
+                base = bx * planes
+                if staged:
+                    tile = T.alloc_shared((planes, h_in, w_in), dtype)
+                    T.copy(x[base : base + planes, :, :], tile)
+                for i in T.Parallel(planes * out_plane):
+                    p = i // out_plane
+                    o = i - p * out_plane
+                    oh = o // out_w
+                    ow = o - oh * out_w
+                    if staged:
+                        _max_bin(tile, p, out, base + p, oh, ow)
+                    else:
+                        _max_bin(x, base + p, out, base + p, oh, ow)
 
         return _adaptive_max_pool2d_main
 
@@ -104,20 +176,11 @@ def _launch_adaptive_max_pool2d(
     out_h: int,
     out_w: int,
     dtype: str,
-    block_m: int,
-    threads: int,
+    config: dict,
     x: torch.Tensor,
 ) -> torch.Tensor:
-    return _adaptive_max_pool2d_kernel(n, c_in, h_in, w_in, out_h, out_w, dtype)(block_m, threads)(
-        x
-    )
-
-
-class AdaptiveMaxPool2dKernel(AdaptivePool2dKernelBase):
-    """Adaptive max pooling forward kernel for NCHW inputs."""
-
-    _build = staticmethod(_adaptive_max_pool2d_kernel)
-    _dispatch = staticmethod(_launch_adaptive_max_pool2d)
+    kernel = _adaptive_max_pool2d_kernel(n, c_in, h_in, w_in, out_h, out_w, dtype)(**config)
+    return kernel(x.reshape(n * c_in, h_in, w_in)).view(n, c_in, out_h, out_w)
 
 
 @functools.lru_cache(maxsize=32)
@@ -131,105 +194,67 @@ def _adaptive_max_pool2d_with_indices_kernel(
     dtype: str = "float16",
 ):
     accum_dtype = "float"
-    total_output = n * c_in * out_h * out_w
-    max_kh = max_adaptive_bin_extent(h_in, out_h)
-    max_kw = max_adaptive_bin_extent(w_in, out_w)
+    rows = n * c_in
+    plane = h_in * w_in
+    out_plane = out_h * out_w
+    max_kh, uniform_h = _bin_extent(h_in, out_h)
+    max_kw, uniform_w = _bin_extent(w_in, out_w)
+    # The flat index spans one h_in * w_in plane. Carrying it as int32 keeps the
+    # arithmetic on the update path off the 64-bit path; the stored index is int64 to
+    # match PyTorch.
+    idx_dtype = "int32" if plane < 2**31 else "int64"
 
     @tilelang.jit(out_idx=[1, 2], compile_flags=["-O3", "-DENABLE_BF16"])
-    def _adaptive_max_pool2d_with_indices_func(block_m: int, threads: int):
-        stage_planes = _stage_planes(block_m, out_h, out_w, c_in, h_in, w_in, dtype)
-        # The flat index spans one h_in * w_in plane. Carrying it as int32
-        # keeps the div/mod the compiler sinks into the update path off the
-        # 64-bit path; the stored index stays int64 to match PyTorch.
-        idx_dtype = "int32" if h_in * w_in < 2**31 else "int64"
+    def _adaptive_max_pool2d_with_indices_func(planes: int, threads: int):
+        _check_planes(planes, rows)
+        staged = fits_static_shared(planes * plane, dtype)
 
         @T.macro
-        def _reduce_bin(src, src_c, src_p, oh, ow, out, indices, out_c, out_p):
-            """Store the max and its index over one adaptive bin of ``src[src_c, src_p]``."""
+        def _argmax_bin(src, src_plane, dst, indices, dst_plane, oh, ow):
+            """Store the max and its flat position over one adaptive bin of ``src``."""
             ih_start, ih_end = adaptive_bin(oh, h_in, out_h)
             iw_start, iw_end = adaptive_bin(ow, w_in, out_w)
-
-            max_val = T.alloc_var(T.float32)
-            has_nan = T.alloc_var(T.bool)
-            max_idx = T.alloc_var(idx_dtype)
-            nan_idx = T.alloc_var(idx_dtype)
-            first_valid = T.alloc_var(T.bool)
-            max_val = T.cast(float("-inf"), accum_dtype)
-            has_nan = False
-            max_idx = T.cast(0, idx_dtype)
-            nan_idx = T.cast(0, idx_dtype)
-            first_valid = True
-            # Static-bound loops (TileLang rejects dynamic T.serial
-            # bounds); guard skips lanes outside this output's bin.
+            run = T.alloc_var(T.float32)
+            best = T.alloc_var(idx_dtype)
+            run = -T.infinity(accum_dtype)
+            # Bins are never empty, so the first tap is in range and seeds the
+            # position: a bin holding nothing but -inf reports that tap.
+            best = T.cast(ih_start * w_in + iw_start, idx_dtype)
             for kh in T.serial(max_kh):
-                for kw in T.serial(max_kw):
-                    if ih_start + kh < ih_end and iw_start + kw < iw_end:
-                        ih = ih_start + kh
+                ih = ih_start + kh
+                if uniform_h or ih < ih_end:
+                    for kw in T.serial(max_kw):
                         iw = iw_start + kw
-                        val = T.cast(src[src_c, src_p, ih, iw], accum_dtype)
-                        flat_idx = T.cast(ih * w_in + iw, idx_dtype)
-                        is_nan = T.isnan(val)
-                        has_nan = has_nan | is_nan
-                        # PyTorch records the last NaN visited in a window.
-                        nan_idx = T.if_then_else(is_nan, flat_idx, nan_idx)
-                        # first_valid: an all--inf window still takes its first element.
-                        take = (not is_nan) and (first_valid or val > max_val)
-                        max_val = T.if_then_else(take, val, max_val)
-                        max_idx = T.if_then_else(take, flat_idx, max_idx)
-                        first_valid = first_valid and is_nan
-
-            result = T.if_then_else(
-                has_nan,
-                T.cast(float("nan"), accum_dtype),
-                max_val,
-            )
-            out[out_c, out_p, oh, ow] = T.cast(result, dtype)
-            indices[out_c, out_p, oh, ow] = T.cast(
-                T.if_then_else(has_nan, nan_idx, max_idx), "int64"
-            )
+                        if uniform_w or iw < iw_end:
+                            v = T.cast(src[src_plane, ih, iw], accum_dtype)
+                            # Strict > keeps the first maximum; a NaN takes the position
+                            # and holds it, so the last NaN in the bin wins.
+                            take = T.isnan(v) or (v > run)
+                            run = T.if_then_else(take, v, run)
+                            best = T.if_then_else(take, T.cast(ih * w_in + iw, idx_dtype), best)
+            dst[dst_plane, oh, ow] = T.cast(run, dtype)
+            indices[dst_plane, oh, ow] = T.cast(best, "int64")
 
         @T.prim_func
         def _adaptive_max_pool2d_with_indices_main(
-            x: T.Tensor((n, c_in, h_in, w_in), dtype),  # type: ignore
-            out: T.Tensor((n, c_in, out_h, out_w), dtype),  # type: ignore
-            indices: T.Tensor((n, c_in, out_h, out_w), "int64"),  # type: ignore
+            x: T.Tensor((rows, h_in, w_in), dtype),  # type: ignore
+            out: T.Tensor((rows, out_h, out_w), dtype),  # type: ignore
+            indices: T.Tensor((rows, out_h, out_w), "int64"),  # type: ignore
         ):
-            with T.Kernel(T.ceildiv(total_output, block_m), threads=threads) as bx:
-                for i in T.Parallel(block_m):
-                    out_idx = bx * block_m + i
-                    if out_idx < total_output:
-                        ow = out_idx % out_w
-                        spatial_idx = out_idx // out_w
-                        oh = spatial_idx % out_h
-                        channel_batch_idx = spatial_idx // out_h
-                        c_idx = channel_batch_idx % c_in
-                        batch = channel_batch_idx // c_in
-                        _reduce_bin(x, batch, c_idx, oh, ow, out, indices, batch, c_idx)
-
-        if stage_planes is not None:
-            # Leading axis of 1 so the macro indexes the tile and x alike.
-            @T.prim_func
-            def _adaptive_max_pool2d_with_indices_staged_main(
-                x: T.Tensor((n, c_in, h_in, w_in), dtype),  # type: ignore
-                out: T.Tensor((n, c_in, out_h, out_w), dtype),  # type: ignore
-                indices: T.Tensor((n, c_in, out_h, out_w), "int64"),  # type: ignore
-            ):
-                with T.Kernel(T.ceildiv(n * c_in, stage_planes), threads=threads) as bx:
-                    tile = T.alloc_shared((1, stage_planes, h_in, w_in), dtype)
-                    batch = bx * stage_planes // c_in
-                    c_base = bx * stage_planes % c_in
-                    T.copy(
-                        x[batch, c_base : c_base + stage_planes, 0:h_in, 0:w_in],
-                        tile[0, :, 0:h_in, 0:w_in],
-                    )
-                    for i in T.Parallel(stage_planes * out_h * out_w):
-                        ow = i % out_w
-                        spatial_idx = i // out_w
-                        oh = spatial_idx % out_h
-                        plane = spatial_idx // out_h
-                        _reduce_bin(tile, 0, plane, oh, ow, out, indices, batch, c_base + plane)
-
-            return _adaptive_max_pool2d_with_indices_staged_main
+            with T.Kernel(rows // planes, threads=threads) as bx:
+                base = bx * planes
+                if staged:
+                    tile = T.alloc_shared((planes, h_in, w_in), dtype)
+                    T.copy(x[base : base + planes, :, :], tile)
+                for i in T.Parallel(planes * out_plane):
+                    p = i // out_plane
+                    o = i - p * out_plane
+                    oh = o // out_w
+                    ow = o - oh * out_w
+                    if staged:
+                        _argmax_bin(tile, p, out, indices, base + p, oh, ow)
+                    else:
+                        _argmax_bin(x, base + p, out, indices, base + p, oh, ow)
 
         return _adaptive_max_pool2d_with_indices_main
 
@@ -244,16 +269,36 @@ def _launch_adaptive_max_pool2d_with_indices(
     out_h: int,
     out_w: int,
     dtype: str,
-    block_m: int,
-    threads: int,
+    config: dict,
     x: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    return _adaptive_max_pool2d_with_indices_kernel(n, c_in, h_in, w_in, out_h, out_w, dtype)(
-        block_m, threads
-    )(x)
+    kernel = _adaptive_max_pool2d_with_indices_kernel(n, c_in, h_in, w_in, out_h, out_w, dtype)(
+        **config
+    )
+    values, indices = kernel(x.reshape(n * c_in, h_in, w_in))
+    return values.view(n, c_in, out_h, out_w), indices.view(n, c_in, out_h, out_w)
 
 
-class AdaptiveMaxPool2dWithIndicesKernel(AdaptivePool2dKernelBase):
+class _AdaptiveMaxPool2dKernelBase(AdaptivePool2dKernelBase):
+    """Plane-staged config policy shared by the two adaptive max-pool kernels."""
+
+    @property
+    def default_config(self) -> dict:
+        return _default_config(self.n * self.c_in, self.h_in, self.w_in, self.dtype_str)
+
+    @property
+    def autotune_configs(self) -> list[dict]:
+        return _autotune_configs(self.n * self.c_in, self.h_in, self.w_in, self.dtype_str)
+
+
+class AdaptiveMaxPool2dKernel(_AdaptiveMaxPool2dKernelBase):
+    """Adaptive max pooling forward kernel for NCHW inputs."""
+
+    _build = staticmethod(_adaptive_max_pool2d_kernel)
+    _dispatch = staticmethod(_launch_adaptive_max_pool2d)
+
+
+class AdaptiveMaxPool2dWithIndicesKernel(_AdaptiveMaxPool2dKernelBase):
     """Adaptive max pooling forward kernel returning values and int64 indices."""
 
     _build = staticmethod(_adaptive_max_pool2d_with_indices_kernel)

--- a/src/tileops/kernels/pool/adaptive_max_pool2d.py
+++ b/src/tileops/kernels/pool/adaptive_max_pool2d.py
@@ -14,20 +14,6 @@ from .common import (
 
 __all__ = ["AdaptiveMaxPool2dKernel", "AdaptiveMaxPool2dWithIndicesKernel"]
 
-# Staged bytes a block aims for. Small keeps the grid longer than the device has
-# multiprocessors, which is what these shapes are short of: the whole input is a
-# megabyte or two, so a block that takes more planes only empties the grid.
-_TILE_BYTES = 4096
-
-# Elements one thread carries in the staging copy. The copy is the kernel's whole
-# memory cost, so the block width follows from it rather than from the output count.
-_COPY_RUN = 8
-
-# Widest staged tile the tuned space offers. Past this a block holds more shared memory
-# and the grid holds fewer blocks, which is the wrong direction for a shape whose whole
-# input is a megabyte or two, so those plane counts are not worth a tuning run.
-_TUNE_TILE_BYTES = 4 * _TILE_BYTES
-
 
 def _divisors(value: int) -> Tuple[int, ...]:
     return tuple(d for d in range(1, value + 1) if value % d == 0)
@@ -41,55 +27,86 @@ def _spread(values: Tuple[int, ...], limit: int) -> Tuple[int, ...]:
     return tuple(sorted({values[round(i * step)] for i in range(limit)}))
 
 
-def _plane_counts(rows: int, plane: int, dtype: str) -> Tuple[int, ...]:
-    """Planes a block may take at once: divisors of ``rows`` whose tile fits shared.
+class _PlaneStaging:
+    """How many planes a block of these kernels stages, and how wide that block is.
 
-    A run of planes is contiguous in the flat ``(rows, h_in, w_in)`` view whatever the
-    batch and channel extents are, so the only constraints are the shared budget and an
-    even split of the grid. Every divisor is offered when one plane alone will not fit,
-    where the reduction reads global memory instead.
+    These figures describe this kernel's access pattern, not the device, and are held
+    here so that a later kernel does not read them as general truths.
     """
-    if not fits_static_shared(plane, dtype):
-        return _divisors(rows)
-    return tuple(d for d in _divisors(rows) if fits_static_shared(d * plane, dtype))
 
+    # A block staging more than this leaves the grid shorter than the device has
+    # multiprocessors, and these shapes hold a megabyte or two in total.
+    _TILE_BYTES = 4096
+    # The tuned space reaches four times the default and no further, the trade above
+    # only continuing in the wrong direction.
+    _TUNE_TILE_BYTES = 4 * _TILE_BYTES
+    # Elements one thread carries in the staging copy. That copy is the kernel's whole
+    # memory cost, so the block width follows from it and not from the output count.
+    _COPY_RUN = 8
+    # Block widths offered, narrowest and widest also clamping the derived width.
+    _THREAD_CHOICES = (128, 256, 512)
+    # Plane counts a tuning run tries. With the widths above that is at most twelve
+    # builds, and the ceiling above has already dropped the counts that cannot win.
+    _TUNED_PLANE_COUNTS = 4
 
-def _check_planes(planes: int, rows: int) -> None:
-    """Refuse a plane count the grid cannot cover.
+    def __init__(self, rows: int, h_in: int, w_in: int, dtype: str) -> None:
+        self._rows = rows
+        self._plane = h_in * w_in
+        self._dtype = dtype
 
-    The grid is ``rows // planes`` blocks of ``planes`` planes each, so a count that does
-    not divide ``rows`` would leave the last planes unwritten. Both config sources draw
-    from :func:`_plane_counts`, which offers divisors only; this catches a hand-written
-    config before it returns uninitialized output.
-    """
-    if rows % planes:
-        raise ValueError(f"planes={planes} must divide rows={rows}")
+    def _tile_bytes(self, planes: int) -> int:
+        itemsize = 4 if self._dtype in ("float", "float32") else 2
+        return planes * self._plane * itemsize
 
+    def counts(self) -> Tuple[int, ...]:
+        """Plane counts a block may take: divisors of ``rows`` whose tile fits shared.
 
-def _block_threads(planes: int, plane: int) -> int:
-    width = 1 << max(0, (planes * plane // _COPY_RUN - 1).bit_length())
-    return min(512, max(128, width))
+        A run of planes is contiguous in the flat ``(rows, h_in, w_in)`` view for every
+        batch and channel extent, so the shared budget and an even split of the grid are
+        the only constraints. One plane that will not fit leaves every divisor on offer,
+        the reduction reading global memory instead.
+        """
+        if not fits_static_shared(self._plane, self._dtype):
+            return _divisors(self._rows)
+        return tuple(
+            d for d in _divisors(self._rows) if fits_static_shared(d * self._plane, self._dtype)
+        )
 
+    def stages(self, planes: int) -> bool:
+        """Whether a block of ``planes`` planes reads them from shared memory.
 
-def _default_config(rows: int, h_in: int, w_in: int, dtype: str) -> dict:
-    plane = h_in * w_in
-    itemsize = 4 if dtype in ("float", "float32") else 2
-    counts = _plane_counts(rows, plane, dtype)
-    fitting = [p for p in counts if p * plane * itemsize <= _TILE_BYTES]
-    planes = max(fitting) if fitting else min(counts)
-    return {"planes": planes, "threads": _block_threads(planes, plane)}
+        A tile that will not fit leaves the reduction reading global memory, where a
+        thread walks its own bin and the reads no longer coalesce.
+        """
+        return fits_static_shared(planes * self._plane, self._dtype)
 
+    def check(self, planes: int) -> None:
+        """Refuse a plane count the grid cannot cover.
 
-def _autotune_configs(rows: int, h_in: int, w_in: int, dtype: str) -> list[dict]:
-    plane = h_in * w_in
-    itemsize = 4 if dtype in ("float", "float32") else 2
-    counts = _plane_counts(rows, plane, dtype)
-    worth = tuple(p for p in counts if p * plane * itemsize <= _TUNE_TILE_BYTES)
-    return [
-        {"planes": planes, "threads": threads}
-        for planes in _spread(worth or counts[:1], 4)
-        for threads in (128, 256, 512)
-    ]
+        The grid is ``rows // planes`` blocks, so a count that does not divide ``rows``
+        leaves the last planes unwritten instead of failing.
+        """
+        if self._rows % planes:
+            raise ValueError(f"planes={planes} must divide rows={self._rows}")
+
+    def threads(self, planes: int) -> int:
+        width = 1 << max(0, (planes * self._plane // self._COPY_RUN - 1).bit_length())
+        return min(max(width, self._THREAD_CHOICES[0]), self._THREAD_CHOICES[-1])
+
+    def default(self) -> dict:
+        counts = self.counts()
+        fitting = [p for p in counts if self._tile_bytes(p) <= self._TILE_BYTES]
+        planes = max(fitting) if fitting else min(counts)
+        return {"planes": planes, "threads": self.threads(planes)}
+
+    def tuned(self) -> list[dict]:
+        counts = self.counts()
+        worth = tuple(p for p in counts if self._tile_bytes(p) <= self._TUNE_TILE_BYTES)
+        return [
+            {"planes": planes, "threads": threads}
+            for planes in _spread(worth or counts[:1], self._TUNED_PLANE_COUNTS)
+            for threads in self._THREAD_CHOICES
+        ]
 
 
 def _bin_extent(size_in: int, size_out: int) -> Tuple[int, bool]:
@@ -112,15 +129,15 @@ def _adaptive_max_pool2d_kernel(
 ):
     accum_dtype = "float"
     rows = n * c_in
-    plane = h_in * w_in
     out_plane = out_h * out_w
     max_kh, uniform_h = _bin_extent(h_in, out_h)
     max_kw, uniform_w = _bin_extent(w_in, out_w)
+    staging = _PlaneStaging(rows, h_in, w_in, dtype)
 
     @tilelang.jit(out_idx=[1], compile_flags=["-O3", "-DENABLE_BF16"])
     def _adaptive_max_pool2d_func(planes: int, threads: int):
-        _check_planes(planes, rows)
-        staged = fits_static_shared(planes * plane, dtype)
+        staging.check(planes)
+        staged = staging.stages(planes)
 
         @T.macro
         def _max_bin(src, src_plane, dst, dst_plane, oh, ow):
@@ -199,15 +216,15 @@ def _adaptive_max_pool2d_with_indices_kernel(
     out_plane = out_h * out_w
     max_kh, uniform_h = _bin_extent(h_in, out_h)
     max_kw, uniform_w = _bin_extent(w_in, out_w)
-    # The flat index spans one h_in * w_in plane. Carrying it as int32 keeps the
-    # arithmetic on the update path off the 64-bit path; the stored index is int64 to
-    # match PyTorch.
+    staging = _PlaneStaging(rows, h_in, w_in, dtype)
+    # The flat index spans one h_in * w_in plane, so carrying it as int32 keeps the
+    # update path off 64-bit arithmetic; the stored index is int64 to match PyTorch.
     idx_dtype = "int32" if plane < 2**31 else "int64"
 
     @tilelang.jit(out_idx=[1, 2], compile_flags=["-O3", "-DENABLE_BF16"])
     def _adaptive_max_pool2d_with_indices_func(planes: int, threads: int):
-        _check_planes(planes, rows)
-        staged = fits_static_shared(planes * plane, dtype)
+        staging.check(planes)
+        staged = staging.stages(planes)
 
         @T.macro
         def _argmax_bin(src, src_plane, dst, indices, dst_plane, oh, ow):
@@ -280,15 +297,18 @@ def _launch_adaptive_max_pool2d_with_indices(
 
 
 class _AdaptiveMaxPool2dKernelBase(AdaptivePool2dKernelBase):
-    """Plane-staged config policy shared by the two adaptive max-pool kernels."""
+    """Binds both adaptive max-pool kernels to the plane-staging config policy."""
+
+    def _staging(self) -> _PlaneStaging:
+        return _PlaneStaging(self.n * self.c_in, self.h_in, self.w_in, self.dtype_str)
 
     @property
     def default_config(self) -> dict:
-        return _default_config(self.n * self.c_in, self.h_in, self.w_in, self.dtype_str)
+        return self._staging().default()
 
     @property
     def autotune_configs(self) -> list[dict]:
-        return _autotune_configs(self.n * self.c_in, self.h_in, self.w_in, self.dtype_str)
+        return self._staging().tuned()
 
 
 class AdaptiveMaxPool2dKernel(_AdaptiveMaxPool2dKernelBase):

--- a/src/tileops/kernels/pool/common.py
+++ b/src/tileops/kernels/pool/common.py
@@ -124,7 +124,6 @@ class AdaptivePool2dKernelBase(Kernel):
             self.out_h,
             self.out_w,
             self.dtype_str,
-            self.config["block_m"],
-            self.config["threads"],
+            self.config,
             x,
         )

--- a/src/tileops/kernels/pool/max_pool1d.py
+++ b/src/tileops/kernels/pool/max_pool1d.py
@@ -53,7 +53,8 @@ def _max_pool1d_kernel(
     accum_dtype = "float"
     out_l = pool_output_dim(l_in, kernel_w, stride_w, pad_w, ceil_mode, dilation_w)
     total_output = n * c_in * out_l
-    always_in_bounds = pad_w == 0 and (out_l - 1) * stride_w + (kernel_w - 1) * dilation_w < l_in
+    eff_w = dilation_w * (kernel_w - 1) + 1
+    always_in_bounds = pad_w == 0 and (out_l - 1) * stride_w + eff_w - 1 < l_in
 
     @tilelang.jit(out_idx=[1], compile_flags=["-O3", "-DENABLE_BF16"])
     def _max_pool1d_func(block_m: int, threads: int):
@@ -276,7 +277,8 @@ def _max_pool1d_with_indices_kernel(
     total_output = n * c_in * out_l
     # Static specialization: with zero padding and no ceil overshoot every window
     # lies fully inside the input, so the per-element bounds check can be dropped.
-    always_in_bounds = pad_w == 0 and (out_l - 1) * stride_w + (kernel_w - 1) * dilation_w < l_in
+    eff_w = dilation_w * (kernel_w - 1) + 1
+    always_in_bounds = pad_w == 0 and (out_l - 1) * stride_w + eff_w - 1 < l_in
 
     @tilelang.jit(out_idx=[1, 2], compile_flags=["-O3", "-DENABLE_BF16"])
     def _max_pool1d_with_indices_func(block_m: int, threads: int):
@@ -286,56 +288,48 @@ def _max_pool1d_with_indices_kernel(
         def _reduce_window(src, src_c, src_row, ow, out, indices, out_c, out_row):
             """Store the max and its index over one window of ``src[src_c, src_row]``."""
             max_val = T.alloc_var(T.float32)
-            has_nan = T.alloc_var(T.bool)
             max_idx = T.alloc_var(T.int32)
+            # -1 until a NaN is seen, so it is also the flag saying one was.
             nan_idx = T.alloc_var(T.int32)
             first_valid = T.alloc_var(T.bool)
-            # Loop-invariant window corner, materialized so it is not
-            # re-inlined into every window element.
             iw0 = T.alloc_var(T.int32)
             max_val = T.cast(float("-inf"), accum_dtype)
-            has_nan = False
+            nan_idx = -1
             first_valid = True
             iw0 = ow * stride_w - pad_w
-            if always_in_bounds:
-                # Window element 0 is in bounds here, so its flat index is
-                # the correct seed: an all--inf window reports the first
-                # position, matching PyTorch, and first_valid is unneeded.
-                max_idx = iw0
-                nan_idx = iw0
-            else:
-                max_idx = 0
-                nan_idx = 0
+            # With the window inside the row its first element is in bounds, so its
+            # position is the right seed and `first_valid` is unneeded: an all--inf
+            # window then reports that position, which is what PyTorch does.
+            max_idx = iw0 if always_in_bounds else 0
             for kw in T.serial(kernel_w):
                 iw = iw0 + kw * dilation_w
                 if always_in_bounds:
                     val = T.cast(src[src_c, src_row, iw], accum_dtype)
-                    is_nan = T.isnan(val)
-                    # Branch-free update. Strict > keeps the first
-                    # maximum; NaN never touches max_val/max_idx and
-                    # records the last NaN visited, matching PyTorch.
-                    take = (not is_nan) and (val > max_val)
+                    # `max_val` starts at -inf and only a passing compare replaces
+                    # it, so it is never NaN; NaN fails `>`. The compare alone
+                    # therefore rejects NaN and no separate test is needed.
+                    take = val > max_val
                     max_val = T.if_then_else(take, val, max_val)
                     max_idx = T.if_then_else(take, iw, max_idx)
-                    nan_idx = T.if_then_else(is_nan, iw, nan_idx)
-                    has_nan = has_nan or is_nan
+                    nan_idx = T.if_then_else(T.isnan(val), iw, nan_idx)
                 elif iw >= 0 and iw < l_in:
                     val = T.cast(src[src_c, src_row, iw], accum_dtype)
                     is_nan = T.isnan(val)
+                    # `first_valid` admits the first element whatever it is, so the
+                    # NaN test cannot come out of the compare here.
                     take = (not is_nan) and (first_valid or (val > max_val))
                     max_val = T.if_then_else(take, val, max_val)
                     max_idx = T.if_then_else(take, iw, max_idx)
                     first_valid = first_valid and is_nan
                     nan_idx = T.if_then_else(is_nan, iw, nan_idx)
-                    has_nan = has_nan or is_nan
 
-            result = T.if_then_else(
-                has_nan,
-                T.cast(float("nan"), accum_dtype),
-                max_val,
+            # PyTorch reports the last NaN a window visited.
+            out[out_c, out_row, ow] = T.cast(
+                T.if_then_else(nan_idx >= 0, T.cast(float("nan"), accum_dtype), max_val), dtype
             )
-            out[out_c, out_row, ow] = T.cast(result, dtype)
-            indices[out_c, out_row, ow] = T.cast(T.if_then_else(has_nan, nan_idx, max_idx), "int64")
+            indices[out_c, out_row, ow] = T.cast(
+                T.if_then_else(nan_idx >= 0, nan_idx, max_idx), "int64"
+            )
 
         @T.prim_func
         def _max_pool1d_with_indices_main(

--- a/tests/ops/test_pool.py
+++ b/tests/ops/test_pool.py
@@ -2611,6 +2611,19 @@ class AdaptiveMaxPool2dFixture(FixtureBase):
                     marks=pytest.mark.full,
                     id="full-partial-none-fp16",
                 ),
+                # Shape coverage: an output wider than the input gives bins of 1 and 2,
+                # so the widest bin exceeds ceil(in/out), and the other axis is ragged.
+                pytest.param(
+                    1,
+                    8,
+                    8,
+                    8,
+                    (12, 3),
+                    torch.float16,
+                    False,
+                    marks=pytest.mark.full,
+                    id="full-expanding-bins-fp16",
+                ),
             ],
         ),
     ]


### PR DESCRIPTION
## Summary

- Stage the input through shared memory: a block takes a contiguous run of `planes` planes and copies it in with every thread, where a thread used to own one output and walk its bin in global memory.
- Address the input as flat `(rows, h_in, w_in)`, so any run of planes is contiguous. That drops the staged path's condition that the plane count divide `c_in`, which kept both 56x56 rows off staging entirely and sent the ragged row's default config to the uncoalesced path.
- Derive the config from the shape rather than fixing it at `block_m=256, threads=256`. On all three rows it lands within measurement noise of the best the tuned space offers, so no tuning run is needed to reach it.
- Take the with-indices maximum with PyTorch's own predicate and a position seeded at the bin's first tap, replacing five accumulators that reproduced the same three properties the long way.
- Hold the staging policy in `_PlaneStaging` instead of the module namespace, where the next kernel in this file would read its constants as general truths.
- Drop two redundant terms from the 1d index scan, folded in from #2088: the compare alone rejects NaN where the window is known to lie inside the row, and `nan_idx` starting at -1 replaces the `has_nan` accumulator in both arms.

## TileFoundry Description

```python
@module(
    entry="adaptive_max_pool2d",
    target=CudaTarget("nvidia.h200_sxm"),
    topologies=(Topology("cta", 132),),
)
class Nondiv7x7:
    @func
    def adaptive_max_pool2d(
        x: Tensor[(2, 64, 55, 57), "bf16"],
    ) -> tuple[Tensor[(2, 64, 7, 7), "bf16"], Tensor[(2, 64, 7, 7), "i64"]]:
        rows = [
            tf.concat(
                [
                    x[:, :, s + kh : s + kh + 1, :]
                    if s + kh < e
                    else tf.full_like(x[:, :, 0:1, :], value=NEG_INF)
                    for s, e in BINS_H
                ],
                axis=2,
            )
            for kh in range(MAX_KH)
        ]
        taps = tf.stack([...], axis=-1)  # (2, 64, 7, 7, MAX_KH * MAX_KW)
        return tf.reduce(taps, axes=(-1,), keepdim=False, kind="max"), tf.argmax(taps, axis=-1)
```

PyTorch splits an axis into `[floor(o*in/out), ceil((o+1)*in/out))`, so bins overlap, their widths differ, and an output wider than the input gives bins of 1 and 2. A tap is gathered by concatenating one slice per output position with -inf in a short bin's missing slots; a -inf slot never wins a max over real data, so `argmax` over the flattened tap axis is the ordinal PyTorch's flat position decodes to. The delivered HIR expands every bound to a literal, since the parser reads the body as written.

`tilefoundry check --inputs random --fn equal` against the evaluator running that program:

| module | shape | values | positions |
| --- | --- | --- | --- |
| `Global1x1` | `f16[8,2048,1,1]` | 0 of 16384 mismatched | 0 of 16384 |
| `Spp6x6` | `f16[2,128,6,6]` | 0 of 9216 | 0 of 9216 |
| `Nondiv7x7` | `bf16[2,64,7,7]` | 0 of 6272 | 0 of 6272 |

`tilefoundry analyze --roofline` reports `bound_by: memory`, `compute_ns 1` against `memory_ns` of 2711, 3040 and 1679. That is what the changes follow: the reduction is free at this size, so the only thing worth changing is how the taps reach the lanes.

## Performance

| Environment | Value |
| --- | --- |
| image | ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-afcebed1-tilefoundry-latest |
| digest | sha256:ca13df9bda340edf248b8b443b88880f36e3190ab9d470f52d66ccc21c15fd59 |
| gpu | NVIDIA H200 |
| driver | 595.71.05 |
| cuda | 13.2 |
| torch | 2.13.0+cu132 |
| tilelang | 0.1.11+cu132.gitafcebed1 |
| tilefoundry | 0.1.dev146+g2bec6420e, the image's editable install at /opt/tilefoundry |
| timer | native CUPTI |

Method: every figure below was measured at this PR's head on one idle card, each op's columns in one process. Each kernel was checked against `F.adaptive_max_pool2d` or `F.max_pool1d` before timing — values bitwise and int64 positions element-for-element, with NaN and -inf injected — then timed by `bench_kernel` through CUPTI with an L2 reset before every iteration. `torch._dynamo.reset()` runs before each compiled case. Ratio is best comparator / candidate, and where a torch baseline varied between runs it is quoted at its fastest reading rather than the one measured beside the candidate.

`AdaptiveMaxPool2dIndicesFwd`:

| workload | candidate | default cfg | incumbent | torch-compile | torch-ref | ratio |
| --- | --- | --- | --- | --- | --- | --- |
| global-1x1 f16 | 2.496us | 2.464us | 2.880us | 6.432us | 33.696us | 🟢 2.58 |
| spp-6x6 f16 | 3.103us | 3.072us | 7.456us | 12.064us | 12.096us | 🟢 3.89 |
| nondiv-7x7 bf16 | 2.912us | 2.880us | 5.344us | 9.953us | 9.888us | 🟢 3.40 |

`AdaptiveMaxPool2dFwd`, which shares the code path:

| workload | candidate | default cfg | incumbent | torch-compile | torch-ref | ratio |
| --- | --- | --- | --- | --- | --- | --- |
| global-1x1 f16 | 2.448us | 2.496us | 2.528us | 3.232us | 33.696us | 🟢 1.32 |
| spp-6x6 f16 | 3.008us | 3.008us | 4.704us | 12.096us | 12.096us | 🟢 4.02 |
| nondiv-7x7 bf16 | 2.816us | 2.816us | 5.857us | 9.888us | 9.888us | 🟢 3.51 |

`MaxPool1dIndicesFwd`, the op the folded-in change touches:

| workload | main | this PR | torch-compile | torch-ref | ratio |
| --- | --- | --- | --- | --- | --- |
| sincnet-speaker-local f16 | 15.905us | 15.936us | 15.295us | 38.816us | 🔴 0.96 |
| textcnn-global f16 | 4.416us | 3.840us | 4.832us | 20.832us | 🟢 1.26 |
| ecg-cnn-dilated bf16 | 12.736us | 10.975us | 10.816us | 27.264us | 🔴 0.99 |

`sincnet-speaker-local` is flat against main even though it takes the arm both terms came out of. It moves 55.9 MB at 3.5 TB/s, so the scan is not what its time is spent on; `textcnn-global` moves 4.4 MB and is the row where removing work from the scan shows.

Against a floor measured the same way — a kernel reading the same bytes coalesced and writing both outputs:

| workload | bytes | floor | candidate / floor |
| --- | --- | --- | --- |
| global-1x1 | 1.769 MB | 1.696us | 1.47 |
| spp-6x6 | 1.698 MB | 1.664us | 1.86 |
| nondiv-7x7 | 0.865 MB | 2.528us | 1.15 |

## Limitations

- The nightly rows naming this op measured `b4fc7863`, before #2064 landed the staged path, so they do not describe current main. Only `nondiv-7x7` was genuinely behind, and its cause was the config policy, not the kernel body.
- Two 1d rows stay behind torch-compile, `sincnet-speaker-local` at 0.96 and `ecg-cnn-dilated` at 0.99. The gap predates the folded-in change, which narrows it without closing it. #2088's own report calls `ecg-cnn-dilated` unchanged; it gains 1.16x, because `has_nan` left both arms rather than only the unguarded one.
- Three directions were tried for those two rows. Half their traffic is the int64 positions the op must return and the index stores are already full-width, so only the reads were left to change.
  - Staging each block's band of inputs in shared memory left `sincnet-speaker-local` flat at 16.128 to 16.064us and cost `ecg-cnn-dilated` 51%, 12.608 to 19.041us. The premise was wrong: `ecg-cnn-dilated` reads each element 2.5 times, but those reads come from adjacent windows in one warp and already hit L1, so there was no traffic to save and the shared round trip and its barrier were pure cost.
  - Giving a block one row's segment of outputs, so the row decode costs four integer divisions per block rather than per output, cost `sincnet-speaker-local` 10%, 15.968 to 17.793us, and gave `ecg-cnn-dilated` back what the scan change won, 11.008 to 12.672us. The flat grid's full blocks are worth more than the divisions: a row segment leaves the last block of each row partly idle, 12.5% of all slots at `out_l=1365`.
  - Unrolling the compare for a specific kernel width needs nothing, since `kernel_w` is already a build-time constant and the tap loop is unrolled as it stands.
- `spp-6x6` sits 1.86x off the floor. Its bins overlap by a column, so it reads 3600 taps per plane for 3136 elements.
- Splitting an adaptive bin across lanes that fold their parts in bin order was worth 6% on `global-1x1` and was dropped: its fold needs a barrier, and that barrier hangs the kernel together with the staging copy at 2 and 4 planes, while hand-writing the copy fixes 4 planes but not 2. A failure that moves with the plane count is not characterized.

## Tests

- One `full` case, `(1, 8, 8, 8)` to `(12, 3)`, id `full-expanding-bins-fp16`. Shape coverage: an output wider than the input gives bins of 1 and 2, so the widest bin exceeds `ceil(in/out)`, and the other axis is ragged. No case covered `out > in`, and the build-time `uniform_h` / `uniform_w` claims that decide whether a bin guard is emitted rest on it.
- `scripts/test_node_delta.py tests/ops/test_pool.py`: 263 to 264, +1, that case.
- `pytest tests/ops/test_pool.py`: 264 passed.
- Beyond the suite: every tuned config on nine adaptive shapes, and the 1d scan on seven shapes across both arms of its bounds specialization, three dtypes and three input kinds including all -inf — values and positions equal to torch, 0 mismatches.
- The `_PlaneStaging` move changes no behaviour: identical configs across fifteen shapes and three dtypes, and byte-identical emitted CUDA for sixteen kernels.
