### PR TITLE
[BugFix][MoE] Keep decode off the fused tight PrePermute, and cut narrative comments

### DIFF
--- a/src/tileops/kernels/moe/fused_topk.py
+++ b/src/tileops/kernels/moe/fused_topk.py
@@ -1,59 +1,27 @@
-"""MoE fused top-k routing kernel (fused scoring + top-k selection).
+"""MoE fused top-k routing kernel: scoring and top-k selection in one pass.
 
-Single TileLang kernel fusing scoring and top-k into one pass (no global memory
-roundtrip for intermediate scores).
+One warp owns one token, and lane l holds experts {l, l+32, l+64, ...} in
+registers, so every reduction is an intra-warp ``shfl_xor`` and the kernel
+issues no ``__syncthreads()``. Intermediate scores never reach global memory.
+Expert slots past E are held at -inf so they lose every argmax.
 
-Algorithm (TOKENS_PER_BLOCK tokens per block, 1 warp per token):
-  Each warp of 32 lanes independently handles one token.
-  Thread lane l holds experts {l, l+32, l+64, ...} in local registers.
+``renormalize=True`` divides the K selected weights by their own sum inside the
+kernel, so the caller needs no second pass over ``topk_weights``. Under softmax
+it also makes the row-sum reduction unnecessary, because
+``(exp_i/rowsum) / sum_j(exp_j/rowsum)`` equals ``exp_i / sum_j exp_j``.
 
-  1. Load: each lane reads ceil(E/32) experts from global memory into registers.
-     Padding elements (idx >= E) are initialized to -inf.
-  2. Scoring:
-       softmax → warp-level 2-pass (max shfl-reduce, exp+sum shfl-reduce); no syncs
-       sigmoid → element-wise sigmoid in-register; no syncs
-  3. K-pass argmax: for each of K iterations:
-       - Lane-local argmax over ceil(E/32) register elements
-       - Warp-level (val, idx) all-reduce via shfl_xor (no barrier)
-       - Lane 0 writes topk_weights[token_id, k] and topk_ids[token_id, k]
-       - All lanes independently mask their selected expert to -inf in registers
-  4. renormalize=True: the K winning scores stay in registers and are divided by
-     their own sum before the weight writeback, so the caller needs no second
-     pass over topk_weights. For softmax this also drops the row-sum warp
-     reduction — renormalizing by the selected sum cancels the row sum,
-     (exp_i/rowsum) / Σ(exp_j/rowsum) == exp_i / Σ exp_j — so it is never needed.
+``with_correction_bias=True`` adds a per-expert bias to the sigmoid scores for
+selection only; ``topk_weights`` still carries the original unbiased sigmoid
+score. Used by Kimi K2 and DeepSeek-V3-variant models.
 
-correction_bias variant (with_correction_bias=True):
-  Adds a per-expert bias to sigmoid scores before top-k selection, while
-  writing the original (unbiased) sigmoid score to topk_weights.
-  Used by Kimi K2 / DeepSeekV3-variant models.
+Ties in the argmax go to the lower expert index.
 
-  Extra register array my_biased[ELEMS_PER_THREAD] = sigmoid(logit) + bias.
-  K-pass argmax compares my_biased; output uses my_scores (unbiased sigmoid).
-  Warp all-reduce tracks both l_best_val (biased, for tie-breaking) and
-  l_best_orig (unbiased, for output) via paired shfl_xor.
-
-Barrier analysis:
-  All reduces are intra-warp (shfl_xor, no __syncthreads).
-  ZERO __syncthreads() calls for all paths.
-  vs old 1-block-per-token: 22 syncs (softmax), 18 syncs (sigmoid)
-  vs vLLM (CUB BlockReduce, 2 kernels): ~29 syncs
-
-Grid/occupancy (T=4096, E=256, TOKENS_PER_BLOCK=16):
-  Grid = ceil(T / TOKENS_PER_BLOCK) = 256 blocks
-  Threads per block = TOKENS_PER_BLOCK * 32 = 512
-  Max blocks/SM = 2048 / 512 = 4  →  4 * 132 = 528 concurrent blocks
-  256 < 528 → all blocks run in 1 wave
-
-TOKENS_PER_BLOCK is the tunable parameter (default 16; try 4 or 8 for small T).
-
-Supported scoring functions:
-  "softmax" — row-wise softmax (Qwen3, Qwen2, Qwen3.5)
-  "sigmoid" — element-wise sigmoid (DeepSeek-V3, GLM-4, Kimi K2)
+Scoring functions: ``softmax`` (Qwen3, Qwen2, Qwen3.5) and ``sigmoid``
+(DeepSeek-V3, GLM-4, Kimi K2).
 
 Outputs:
-  topk_weights  [T, K]  float32 — routing weights (optionally renormalized)
-  topk_ids      [T, K]  int32   — expert indices
+    topk_weights: [T, K] float32 routing weights, renormalized when asked.
+    topk_ids: [T, K] int32 expert indices.
 """
 
 import functools
@@ -102,17 +70,13 @@ def _fused_topk_kernel(
     @tilelang.jit(out_idx=[])
     def _func(TOKENS_PER_BLOCK):
         WARP_SIZE = WARP_LANES
-        # Each lane handles ceil(E / 32) experts stored in local registers.
         ELEMS_PER_THREAD = -(-num_experts // WARP_SIZE)  # ceildiv(E, 32)
         LOG_WARP = int(math.log2(WARP_SIZE))  # = 5 for WARP_SIZE=32
         HALF_WARP = WARP_SIZE // 2  # = 16
         num_blocks = -(-num_tokens // TOKENS_PER_BLOCK)  # ceildiv(T, TPB)
 
         if with_correction_bias:
-            # ── Variant: sigmoid + per-expert correction bias ─────────────────
-            # Kernel signature adds correction_bias [E] float32.
-            # K-pass argmax selects based on (sigmoid + bias); output writes
-            # the original (unbiased) sigmoid score.
+
             @T.prim_func
             def main(
                 gating_output: T.Tensor([num_tokens, num_experts], "float32"),
@@ -126,13 +90,11 @@ def _fused_topk_kernel(
                     lane_id = tx % WARP_SIZE
                     token_id = block_id * TOKENS_PER_BLOCK + warp_id
 
-                    # my_scores[j]:  original sigmoid(logit)  — for output weight
-                    # my_biased[j]:  sigmoid(logit) + bias    — for argmax selection
+                    # my_biased only decides selection; my_scores is what gets written.
                     my_scores = T.alloc_local([ELEMS_PER_THREAD], "float32")
                     my_biased = T.alloc_local([ELEMS_PER_THREAD], "float32")
 
                     if token_id < num_tokens:
-                        # ── Step 1: Load raw logits ───────────────────────────
                         for j in T.serial(ELEMS_PER_THREAD):
                             expert_idx = j * WARP_SIZE + lane_id
                             if expert_idx < num_experts:
@@ -140,7 +102,6 @@ def _fused_topk_kernel(
                             else:
                                 my_scores[j] = -T.infinity("float32")
 
-                        # ── Step 2: Sigmoid + bias (element-wise, no syncs) ───
                         for j in T.serial(ELEMS_PER_THREAD):
                             expert_idx = j * WARP_SIZE + lane_id
                             if expert_idx < num_experts:
@@ -152,27 +113,16 @@ def _fused_topk_kernel(
                                 my_scores[j] = -T.infinity("float32")
                                 my_biased[j] = -T.infinity("float32")
 
-                        # ── Step 3: K-pass argmax (zero syncs) ────────────────
-                        #
-                        # Compare using my_biased (biased) for expert selection.
-                        # Write my_scores (original sigmoid) to topk_weights.
-                        # Track l_best_orig alongside l_best_val through the
-                        # warp shfl_xor all-reduce so lane 0 has the correct
-                        # unbiased weight to write.
                         l_best_val = T.alloc_var(T.float32)  # biased (for selection)
                         l_best_orig = T.alloc_var(T.float32)  # original sigmoid (for output)
                         l_best_idx = T.alloc_var(T.int32)
 
                         if renormalize:
-                            # The winning unbiased scores stay in registers, so the
-                            # normalization divisor is known without reading
-                            # topk_weights back from global memory.
                             sel_vals = T.alloc_local([top_k], "float32")
                             sel_sum = T.alloc_var(T.float32)
                             sel_sum = T.float32(0)
 
                         for k in T.serial(top_k):
-                            # Lane-local argmax on biased scores
                             l_best_val = -T.infinity("float32")
                             l_best_orig = T.float32(0)
                             l_best_idx = T.int32(-1)
@@ -182,16 +132,12 @@ def _fused_topk_kernel(
                                     l_best_orig = my_scores[j]
                                     l_best_idx = j * T.int32(WARP_SIZE) + lane_id
 
-                            # Warp (biased_val, orig_val, idx) all-reduce via shfl_xor.
-                            # Winner decided by biased_val with tie-breaking on lower idx.
-                            # l_best_orig is carried along so all lanes end up with the
-                            # original sigmoid score of the winning expert.
                             for i in T.serial(LOG_WARP):
                                 mask = T.int32(HALF_WARP) >> i
                                 other_val = T.shfl_xor(l_best_val, mask)
                                 other_orig = T.shfl_xor(l_best_orig, mask)
                                 other_idx = T.shfl_xor(l_best_idx, mask)
-                                # Update orig first (uses old l_best_val / l_best_idx)
+                                # Must precede l_best_val/l_best_idx: it reads the old pair.
                                 l_best_orig = T.if_then_else(
                                     other_val > l_best_val,
                                     other_orig,
@@ -216,7 +162,6 @@ def _fused_topk_kernel(
                                 )
                                 l_best_val = T.max(l_best_val, other_val)
 
-                            # Lane 0 writes original (unbiased) sigmoid score
                             if renormalize:
                                 sel_vals[k] = l_best_orig
                                 sel_sum = sel_sum + l_best_orig
@@ -227,13 +172,11 @@ def _fused_topk_kernel(
                                     topk_weights[token_id, k] = l_best_orig
                                     topk_ids[token_id, k] = l_best_idx
 
-                            # Mask both arrays so this expert is not selected again
                             for j in T.serial(ELEMS_PER_THREAD):
                                 if j * T.int32(WARP_SIZE) + lane_id == l_best_idx:
                                     my_scores[j] = -T.infinity("float32")
                                     my_biased[j] = -T.infinity("float32")
 
-                        # ── Step 4: fused renormalization ─────────────────────
                         if renormalize:
                             inv_sel_sum = T.alloc_var(T.float32)
                             inv_sel_sum = T.float32(1) / sel_sum
@@ -242,7 +185,7 @@ def _fused_topk_kernel(
                                     topk_weights[token_id, k] = sel_vals[k] * inv_sel_sum
 
         else:
-            # ── Standard variant (no correction bias) ─────────────────────────
+
             @T.prim_func
             def main(
                 gating_output: T.Tensor([num_tokens, num_experts], "float32"),
@@ -253,15 +196,9 @@ def _fused_topk_kernel(
                     tx = T.get_thread_binding()
                     warp_id = tx // WARP_SIZE
                     lane_id = tx % WARP_SIZE
-                    # Each warp handles one token.
                     token_id = block_id * TOKENS_PER_BLOCK + warp_id
-
-                    # ── Local register array ──────────────────────────────────
                     my_scores = T.alloc_local([ELEMS_PER_THREAD], "float32")
-
-                    # ── Guard: skip warps whose token_id is out of range ──────
                     if token_id < num_tokens:
-                        # ── Step 1: Load experts into registers ───────────────
                         for j in T.serial(ELEMS_PER_THREAD):
                             expert_idx = j * WARP_SIZE + lane_id
                             if expert_idx < num_experts:
@@ -269,7 +206,6 @@ def _fused_topk_kernel(
                             else:
                                 my_scores[j] = -T.infinity("float32")
 
-                        # ── Step 2: Scoring (zero __syncthreads, warp shfl only)
                         if not renormalize:
                             inv_row_sum = T.alloc_var(T.float32)
                             inv_row_sum = T.float32(1)  # default (sigmoid / no renorm)
@@ -277,7 +213,6 @@ def _fused_topk_kernel(
                         if scoring_func == "softmax":
                             l_max = T.alloc_var(T.float32)
 
-                            # Warp max all-reduce (shfl_xor, no barrier)
                             l_max = -T.infinity("float32")
                             for j in T.serial(ELEMS_PER_THREAD):
                                 l_max = T.max(l_max, my_scores[j])
@@ -285,14 +220,12 @@ def _fused_topk_kernel(
                                 l_max = T.max(l_max, T.shfl_xor(l_max, T.int32(HALF_WARP) >> i))
 
                             if renormalize:
-                                # The row sum cancels against the selected-sum
-                                # divisor, so skip its warp reduction entirely.
+                                # The row sum cancels against the selected-sum divisor.
                                 for j in T.serial(ELEMS_PER_THREAD):
                                     my_scores[j] = T.exp(my_scores[j] - l_max)
                             else:
                                 l_sum = T.alloc_var(T.float32)
 
-                                # Exp in-place + warp sum all-reduce (shfl_xor, no barrier)
                                 l_sum = T.float32(0)
                                 for j in T.serial(ELEMS_PER_THREAD):
                                     val = T.exp(my_scores[j] - l_max)
@@ -310,20 +243,15 @@ def _fused_topk_kernel(
                                     my_scores[j] = T.float32(1) / (T.float32(1) + T.exp(-val))
                                 # Padding already -inf; sigmoid(-inf)≈0, keep -inf for argmax.
 
-                        # ── Step 3: K-pass argmax (zero __syncthreads, warp shfl)
                         l_best_val = T.alloc_var(T.float32)
                         l_best_idx = T.alloc_var(T.int32)
 
                         if renormalize:
-                            # The winning scores stay in registers, so the
-                            # normalization divisor is known without reading
-                            # topk_weights back from global memory.
                             sel_vals = T.alloc_local([top_k], "float32")
                             sel_sum = T.alloc_var(T.float32)
                             sel_sum = T.float32(0)
 
                         for k in T.serial(top_k):
-                            # Lane-local argmax
                             l_best_val = -T.infinity("float32")
                             l_best_idx = T.int32(-1)
                             for j in T.serial(ELEMS_PER_THREAD):
@@ -331,7 +259,6 @@ def _fused_topk_kernel(
                                     l_best_val = my_scores[j]
                                     l_best_idx = j * T.int32(WARP_SIZE) + lane_id
 
-                            # Warp (val, idx) all-reduce via shfl_xor (no barrier).
                             for i in T.serial(LOG_WARP):
                                 mask = T.int32(HALF_WARP) >> i
                                 other_val = T.shfl_xor(l_best_val, mask)
@@ -349,7 +276,6 @@ def _fused_topk_kernel(
                                 )
                                 l_best_val = T.max(l_best_val, other_val)
 
-                            # Lane 0 writes output
                             if renormalize:
                                 sel_vals[k] = l_best_val
                                 sel_sum = sel_sum + l_best_val
@@ -360,12 +286,10 @@ def _fused_topk_kernel(
                                     topk_weights[token_id, k] = l_best_val * inv_row_sum
                                     topk_ids[token_id, k] = l_best_idx
 
-                            # All lanes mask their own register entry — NO sync needed.
                             for j in T.serial(ELEMS_PER_THREAD):
                                 if j * T.int32(WARP_SIZE) + lane_id == l_best_idx:
                                     my_scores[j] = -T.infinity("float32")
 
-                        # ── Step 4: fused renormalization ─────────────────────
                         if renormalize:
                             inv_sel_sum = T.alloc_var(T.float32)
                             inv_sel_sum = T.float32(1) / sel_sum
@@ -451,7 +375,6 @@ class FusedTopKKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
-        # TOKENS_PER_BLOCK = 16 gives 512 threads/block (16 warps/block).
         return {"TOKENS_PER_BLOCK": 16}
 
     def forward(

--- a/src/tileops/kernels/moe/moe_grouped_gemm_nopad.py
+++ b/src/tileops/kernels/moe/moe_grouped_gemm_nopad.py
@@ -95,15 +95,12 @@ def _tile_scheduler_kernel(num_experts: int, max_tiles: int, block_m: int):
 
                 tx = T.get_thread_binding()
 
-                # Sub-phase (a): thread 0 computes exclusive prefix sum of
-                # ceildiv(true_sizes[e], block_m) into SMEM.
                 if tx == 0:
                     _tiling.cumsum(true_sizes, s_cum)
                     if bx == 0:
                         total_tiles[0] = s_cum[num_experts]
                 T.sync_threads()
 
-                # Sub-phase (b): each thread assigns one tile via binary search.
                 tile_id = bx * threads + tx
                 if tile_id < max_tiles:
                     if tile_id < s_cum[num_experts]:
@@ -159,15 +156,10 @@ def _moe_grouped_gemm_kernel(
         A_shared_shape = (block_m, block_k)
         B_shared_shape = (block_n, block_k)
 
-        # Compile-time constants (all Python ints, baked in at JIT time).
         _k_aligned = K % block_k == 0
-        # _b_copy_ok: use T.copy (TMA-eligible) for both A and B inside T.Pipelined.
-        # Requires K alignment so there are no partial K-tiles to predicate.
-        # N boundary is handled by TMA zero-fill OOB; epilogue guards the C store.
-        # A is declared with block_m extra rows so the last tile's T.copy is in-bounds.
+        # T.copy needs K alignment so no partial K-tile is predicated; TMA zero-fills
+        # past N and A carries block_m extra rows for the last tile's copy.
         _b_copy_ok = _k_aligned
-        # A_shape includes block_m padding rows (used only in _b_copy_ok path so that
-        # T.copy on the last M-tile does not read past the end of the tensor).
         A_shape = (numel + block_m, K) if _b_copy_ok else (numel, K)
         _num_pid_n = math.ceil(N / block_n)  # N-tile count
         _total_ctas = max_tiles * _num_pid_n  # 1-D grid size
@@ -195,10 +187,7 @@ def _moe_grouped_gemm_kernel(
                     }
                 )
 
-                # M-major tile ordering: each M-tile processes all N-tiles
-                # before moving to the next M-tile, maximising A-tile reuse.
-                # For group_size_m=1 (default) this simplifies to a direct
-                # pid → (bx, by) mapping with compile-time constant divisor.
+                # M-major: an M-tile's N-tiles all run before the next, reusing A.
                 if group_size_m == 1:
                     bx = pid // T.int32(_num_pid_n)
                     by = pid % T.int32(_num_pid_n)
@@ -221,9 +210,8 @@ def _moe_grouped_gemm_kernel(
 
                     for k in T.Pipelined(T.ceildiv(K, block_k), num_stages=num_stages):
                         if _b_copy_ok:
-                            # T.copy lets TileLang's WarpSpecialized pass split threads into
-                            # producer (TMA-eligible) and consumer (WGMMA) warpgroups when
-                            # threads=256 on SM90.  No predicates here; epilogue guards writes.
+                            # T.copy is what lets WarpSpecialized split producer and
+                            # consumer warpgroups; the epilogue guards the writes.
                             T.copy(
                                 A[m_start : m_start + block_m, k * block_k : (k + 1) * block_k],
                                 A_shared,
@@ -365,23 +353,15 @@ class MoeGroupedGemmNopadKernel(Kernel):
         block_k = self.config["block_k"]
         max_tiles = self._max_tiles(block_m)
 
-        # When K is block_k-aligned the fast path uses T.copy (TMA-eligible) with no
-        # row predicate on A.  The last M-tile of the last expert reads up to block_m
-        # rows starting at numel — past the end of A.  Pad with block_m zero rows so
-        # the T.copy lands in valid memory; the epilogue guard prevents writing those
-        # zeros to C.  Overhead: block_m × K elements (e.g. 64×2048×bf16 = 256 KB).
-        #
-        # TODO: replace F.pad with TMA's built-in OOB zero-fill once TileLang
-        # exposes that knob via T.copy.  The extra copy here is O(block_m × K),
-        # small vs the O(numel × K) main tensor but still worth eliminating.
+        # The last M-tile's unpredicated T.copy reads up to block_m rows past numel.
+        # Removable once TileLang exposes TMA's OOB zero-fill through T.copy.
         if self.K % block_k == 0:
             A = torch.nn.functional.pad(A, (0, 0, 0, block_m))
 
-        # Phase 1: build tile schedule — total_tiles stays on GPU (no .item())
+        # total_tiles stays on the device: no .item(), so no host sync.
         sched_fn = _tile_scheduler_kernel(self.num_experts, max_tiles, block_m)(_SCHED_THREADS)
         tile_expert_ids, tile_row_offsets, total_tiles_t = sched_fn(true_sizes)
 
-        # Phase 2: GEMM with dead-CTA early-exit — 1D grid with GROUP_SIZE_M reordering
         gemm_fn = _moe_grouped_gemm_kernel(
             self.numel, max_tiles, self.num_experts, self.N, self.K, self.dtype_str
         )(

--- a/src/tileops/kernels/moe/moe_grouped_gemm_persistent_3wg_fused_act.py
+++ b/src/tileops/kernels/moe/moe_grouped_gemm_persistent_3wg_fused_act.py
@@ -7,6 +7,14 @@ Per ffn output N-tile [n0, n0+bn):
     C[:, n0:n0+bn]   = act(gate) * up        (act in {silu_and_mul, gelu_and_mul})
 N-tiling is over ffn; the two accumulators are fused in the epilogue so the
 [numel, 2*ffn] gate_up tensor never reaches global memory.
+
+Every epilogue guards its C_shared refill with a WG-scoped named barrier
+(``barrier_id`` plus ``arrive_count=128``), never a CTA-wide ``T.sync_threads()``:
+the producer WG never enters an epilogue and the two math WGs can take different
+paths in one wave, so a CTA-wide sync would wait on warpgroups that never arrive
+and deadlock. Each epilogue then fences its generic-proxy SMEM writes against the
+async-proxy TMA read that follows. ``forward()`` enforces ``ffn % block_n == 0``,
+so no epilogue needs a column guard.
 """
 
 import functools
@@ -57,7 +65,6 @@ def _fused_act_expr(name):
     if name == "silu_and_mul":
         return lambda gate, up: gate / (T.float32(1.0) + T.exp(-gate)) * up
     if name == "gelu_and_mul":
-        # exact erf GELU: 0.5*g*(1+erf(g/sqrt(2)))
         return lambda gate, up: (
             T.float32(0.5) * gate * (T.float32(1.0) + T.erf(gate * T.float32(INV_SQRT2))) * up
         )
@@ -69,7 +76,6 @@ class MoeGroupedGemmPersistent3WGFusedActKernel(Kernel):
 
     supported_archs: list[int] = [90]
 
-    # Gated activations this kernel can carry in its epilogue.
     SUPPORTED_ACTIVATIONS = ("gelu_and_mul", "silu_and_mul")
 
     def __init__(
@@ -144,8 +150,7 @@ class MoeGroupedGemmPersistent3WGFusedActKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        # Dual-B doubles the B ring and uses two ffn-wide accumulators, so
-        # block_n is capped at 128 (2x128 fp32 accum ~= one 256 accum).
+        # block_n stays 128: dual-B's two fp32 accumulators cost what one 256 does.
         SMEM_LIMIT = 228 * 1024
         bpe = 2
         configs = []
@@ -208,9 +213,8 @@ class MoeGroupedGemmPersistent3WGFusedActKernel(Kernel):
         sizes[: self.numel % self.num_experts] += 1  # spread remainder; safe when numel < E
         offsets = torch.zeros(self.num_experts, dtype=torch.int32, device="cuda")
         offsets[1:] = torch.cumsum(sizes[:-1], dim=0)
-        # Output shape is config-independent; allocate C once and time the
-        # compiled kernel directly so per-config measurements exclude the C
-        # alloc/zero and per-call lru_cache lookup that self.forward incurs.
+        # Times the compiled kernel, not self.forward: the C alloc and the cache
+        # lookup are not what a config changes.
         C = torch.empty(self.numel, self.N, dtype=self.dtype, device="cuda")
         for cfg in self.autotune_configs:
             try:
@@ -239,19 +243,15 @@ class MoeGroupedGemmPersistent3WGFusedActKernel(Kernel):
             print("Autotune failed for all configs, using default.")
 
     def forward(self, A, B, true_sizes, true_offsets):
-        # Every row belongs to exactly one expert tile and is written by the
-        # masked epilogue, so clearing this intermediate is unnecessary.
+        # Every row is written by the masked epilogue, so C needs no clearing.
         C = torch.empty(self.numel, self.N, dtype=self.dtype, device=A.device)
         bm, bn, bk = self.config["block_m"], self.config["block_n"], self.config["block_k"]
         if self.K % bk != 0:
             raise ValueError(f"K-aligned only: K={self.K}, block_k={bk}")
         if self.N % bn != 0:
             raise ValueError(f"ffn must be divisible by block_n: N={self.N}, block_n={bn}")
-        # A is intentionally NOT padded.  The producer's last M-tile TMA may
-        # address rows past `numel`, but SM90 TMA zero-fills out-of-bounds rows
-        # (the descriptor's globalDim is `numel`) and the partial-tile epilogue
-        # stores only rows i < arows, so those rows are masked out regardless.
-        # This avoids a [numel, K] device copy of A on every forward.
+        # A stays unpadded: SM90 TMA zero-fills the rows past numel that the last
+        # M-tile addresses, and the epilogue stores only i < arows.
         fn = _fused_act_kernel(
             self.numel,
             self.num_experts,
@@ -303,11 +303,9 @@ def _make_pingpong_fused_act_kernel(
         f"fused-act pingpong persistent grouped GEMM requires threads=384 "
         f"(1 producer + 2 consumer WGs); got threads={threads}"
     )
-    # N-tiling is over ffn (the output width), NOT 2*ffn.
     _num_pid_n = math.ceil(ffn / block_n)
     _max_tiles = numel // block_m + num_experts  # over-estimate of M tiles
     _total_ctas_ub = _max_tiles * _num_pid_n
-    # Pingpong: each CTA processes 2 tiles per wave (one per math WG).
     _max_waves = (_total_ctas_ub + 2 * sm_count - 1) // (2 * sm_count) + 1
     _k_iters = K // block_k
     A_shape = (numel, K)  # no M-pad; TMA zero-fills OOB last-tile rows (epilogue masks them)
@@ -323,26 +321,22 @@ def _make_pingpong_fused_act_kernel(
         C: T.Tensor((numel, ffn), dtype),  # type: ignore
     ):
         with T.Kernel(sm_count, threads=threads) as (pid,):
-            # ── Per-WG ring-buffered SMEM (num_stages slots): A + dual B ──
             A_smem_wg0 = T.alloc_shared((num_stages, block_m, block_k), dtype)
             B_gate_smem_wg0 = T.alloc_shared((num_stages, block_n, block_k), dtype)
             B_up_smem_wg0 = T.alloc_shared((num_stages, block_n, block_k), dtype)
             A_smem_wg1 = T.alloc_shared((num_stages, block_m, block_k), dtype)
             B_gate_smem_wg1 = T.alloc_shared((num_stages, block_n, block_k), dtype)
             B_up_smem_wg1 = T.alloc_shared((num_stages, block_n, block_k), dtype)
-            # Dual fp32 accumulators per WG (gate + up).
             C_gate_wg0 = T.alloc_fragment((block_m, block_n), accum_dtype)
             C_up_wg0 = T.alloc_fragment((block_m, block_n), accum_dtype)
             C_gate_wg1 = T.alloc_fragment((block_m, block_n), accum_dtype)
             C_up_wg1 = T.alloc_fragment((block_m, block_n), accum_dtype)
 
-            # ── Epilogue: per-WG cast fragment + TMA-store SMEM (ffn-wide) ──
             C_local_cast_wg0 = T.alloc_fragment((block_m, block_n), dtype)
             C_local_cast_wg1 = T.alloc_fragment((block_m, block_n), dtype)
             C_shared_wg0 = T.alloc_shared((block_m, block_n), dtype)
             C_shared_wg1 = T.alloc_shared((block_m, block_n), dtype)
 
-            # ── Scheduler SMEM (no atomic counter / tile pair) ──
             s_cum = T.alloc_shared((num_experts + 1,), "int32")
             s_total = T.alloc_shared((1,), "int32")
             lo = T.alloc_local((1,), "int32")
@@ -350,9 +344,8 @@ def _make_pingpong_fused_act_kernel(
             _row = T.alloc_local((1,), "int32")
             _ex = T.alloc_local((1,), "int32")
             _ms = T.alloc_local((1,), "int32")
-            # Per-tile metadata hoisted to alloc_local so the interleaved
-            # K-loop body can read m_start/n_start/expert_id across IfFrame
-            # boundaries.
+            # alloc_local, not Python locals: the interleaved K-loop reads these
+            # across IfFrame boundaries.
             ms0 = T.alloc_local((1,), "int32")
             ns0 = T.alloc_local((1,), "int32")
             ex0 = T.alloc_local((1,), "int32")
@@ -375,13 +368,11 @@ def _make_pingpong_fused_act_kernel(
                 }
             )
 
-            # ── Per-WG producer/consumer barriers (arrive_count=128) ──
             ab_full_wg0 = T.alloc_barrier([128] * num_stages)
             ab_empty_wg0 = T.alloc_barrier([128] * num_stages)
             ab_full_wg1 = T.alloc_barrier([128] * num_stages)
             ab_empty_wg1 = T.alloc_barrier([128] * num_stages)
 
-            # ── Phase counters: monotonic, never reset ──
             gi_prod_0 = T.alloc_var("int32", init=0)
             gi_prod_1 = T.alloc_var("int32", init=0)
             gi_cons_0 = T.alloc_var("int32", init=0)
@@ -389,21 +380,18 @@ def _make_pingpong_fused_act_kernel(
 
             tx = T.get_thread_binding()
 
-            # Producer WG: tx < 128
             if tx < 128:
                 T.dec_max_nreg(24)
 
                 if tx == 0:
                     _tiling.cumsum(true_sizes, s_cum)
                     s_total[0] = s_cum[num_experts] * T.int32(_num_pid_n)
-                # CTA-wide sync: publishes s_cum/s_total to consumers.
                 T.sync_threads()
 
                 for w in T.serial(_max_waves):
                     total = s_total[0]
                     base = T.int32(2) * (T.int32(sm_count) * w + pid)
 
-                    # ── Resolve WG0 tile metadata into alloc_local ──
                     flat_id_0 = base
                     if flat_id_0 < total:
                         m_tile_0 = flat_id_0 // T.int32(_num_pid_n)
@@ -416,7 +404,6 @@ def _make_pingpong_fused_act_kernel(
                     else:
                         v0[0] = T.int32(0)
 
-                    # ── Resolve WG1 tile metadata into alloc_local ──
                     flat_id_1 = base + T.int32(1)
                     if flat_id_1 < total:
                         m_tile_1 = flat_id_1 // T.int32(_num_pid_n)
@@ -429,11 +416,9 @@ def _make_pingpong_fused_act_kernel(
                     else:
                         v1[0] = T.int32(0)
 
-                    # ── Interleaved K-loop: WG0 then WG1 each k ──
                     for k in T.Pipelined(_k_iters, num_stages=0):
                         k_start = k * block_k
 
-                        # WG0 stream: load A once, gate AND up B tiles.
                         if v0[0] != 0:
                             slot0 = gi_prod_0 % num_stages
                             T.barrier_wait(ab_empty_wg0[slot0], ((gi_prod_0 // num_stages) & 1) ^ 1)
@@ -459,7 +444,6 @@ def _make_pingpong_fused_act_kernel(
                             T.barrier_arrive(ab_full_wg0[slot0])
                             gi_prod_0 = gi_prod_0 + 1
 
-                        # WG1 stream: load A once, gate AND up B tiles.
                         if v1[0] != 0:
                             slot1 = gi_prod_1 % num_stages
                             T.barrier_wait(ab_empty_wg1[slot1], ((gi_prod_1 // num_stages) & 1) ^ 1)
@@ -485,10 +469,8 @@ def _make_pingpong_fused_act_kernel(
                             T.barrier_arrive(ab_full_wg1[slot1])
                             gi_prod_1 = gi_prod_1 + 1
 
-            # Consumer WG0: 128 ≤ tx < 256 — processes flat_id_0 per wave
             elif tx < 256:
                 T.inc_max_nreg(240)
-                # CTA-wide sync (pairs with producer's post-init sync).
                 T.sync_threads()
 
                 for w in T.serial(_max_waves):
@@ -533,38 +515,23 @@ def _make_pingpong_fused_act_kernel(
                             T.barrier_arrive(ab_empty_wg0[slot])
                             gi_cons_0 = gi_cons_0 + 1
 
-                        # ── Fused epilogue: act(gate) * up → cast → store ──
                         for i, j in T.Parallel(block_m, block_n):
                             C_local_cast_wg0[i, j] = T.cast(
                                 fused_act(C_gate_wg0[i, j], C_up_wg0[i, j]), dtype
                             )
                         if arows_0 == T.int32(block_m):
-                            # WG-scoped named barrier BEFORE refilling C_shared:
-                            # guarantees the prior wave's TMA store finished
-                            # reading C_shared.  MUST be a named barrier
-                            # (barrier_id + arrive_count=128), NOT a CTA-wide
-                            # T.sync_threads(): the producer WG never enters this
-                            # epilogue and the two consumer WGs may take different
-                            # paths this wave, so a CTA-wide sync would wait on
-                            # warpgroups that never arrive and deadlock.
                             T.sync_threads(barrier_id=4, arrive_count=128)
                             T.copy(C_local_cast_wg0, C_shared_wg0)
-                            # Order the generic-proxy SMEM writes above before the
-                            # async-proxy TMA read below, and align all 128 threads of
-                            # this WG so the store never reads a half-written C_shared.
                             T.fence_proxy_async()
                             T.sync_threads(barrier_id=4, arrive_count=128)
                             T.copy(C_shared_wg0, C[m_start_0, n_start_0])
                         else:
-                            # acols == block_n always (ffn % block_n == 0 enforced by forward()); no j-guard needed.
                             for i, j in T.Parallel(block_m, block_n):
                                 if i < arows_0:
                                     C[m_start_0 + i, n_start_0 + j] = C_local_cast_wg0[i, j]
 
-            # Consumer WG1: tx ≥ 256 — processes flat_id_1 per wave
             else:
                 T.inc_max_nreg(240)
-                # CTA-wide sync (pairs with producer's post-init sync).
                 T.sync_threads()
 
                 for w in T.serial(_max_waves):
@@ -609,24 +576,17 @@ def _make_pingpong_fused_act_kernel(
                             T.barrier_arrive(ab_empty_wg1[slot])
                             gi_cons_1 = gi_cons_1 + 1
 
-                        # ── Fused epilogue: act(gate) * up → cast → store ──
                         for i, j in T.Parallel(block_m, block_n):
                             C_local_cast_wg1[i, j] = T.cast(
                                 fused_act(C_gate_wg1[i, j], C_up_wg1[i, j]), dtype
                             )
                         if arows_1 == T.int32(block_m):
-                            # WG-scoped named barrier (barrier_id=5) BEFORE the
-                            # C_shared refill — see WG0 epilogue rationale.
                             T.sync_threads(barrier_id=5, arrive_count=128)
                             T.copy(C_local_cast_wg1, C_shared_wg1)
-                            # Order the generic-proxy SMEM writes above before the
-                            # async-proxy TMA read below, and align all 128 threads of
-                            # this WG so the store never reads a half-written C_shared.
                             T.fence_proxy_async()
                             T.sync_threads(barrier_id=5, arrive_count=128)
                             T.copy(C_shared_wg1, C[m_start_1, n_start_1])
                         else:
-                            # acols == block_n always (ffn % block_n == 0 enforced by forward()); no j-guard needed.
                             for i, j in T.Parallel(block_m, block_n):
                                 if i < arows_1:
                                     C[m_start_1 + i, n_start_1 + j] = C_local_cast_wg1[i, j]
@@ -675,12 +635,10 @@ def _make_cooperative_fused_act_kernel(
         f"cooperative template requires block_m >= 128 (half_m={half_m} < WGMMA minimum M=64)"
     )
 
-    # N-tiling is over ffn (the output width), NOT 2*ffn.
     _num_pid_n = math.ceil(ffn / block_n)
     _max_tiles = numel // block_m + num_experts  # over-estimate of M tiles
     _total_ctas_ub = _max_tiles * _num_pid_n
-    # Cooperative: each CTA processes 1 tile per wave.  Slack of 1 covers
-    # the case where _total_ctas_ub is not a multiple of sm_count.
+    # Slack of 1: _total_ctas_ub need not be a multiple of sm_count.
     _max_waves = (_total_ctas_ub + sm_count - 1) // sm_count + 1
     _k_iters = K // block_k
     A_shape = (numel, K)  # no M-pad; TMA zero-fills OOB last-tile rows (epilogue masks them)
@@ -696,24 +654,20 @@ def _make_cooperative_fused_act_kernel(
         C: T.Tensor((numel, ffn), dtype),  # type: ignore
     ):
         with T.Kernel(sm_count, threads=threads) as (pid,):
-            # ── Split-A SMEM rings (zero-offset WGMMA) + shared dual B rings ──
             A_smem_top = T.alloc_shared((num_stages, half_m, block_k), dtype)
             A_smem_bot = T.alloc_shared((num_stages, half_m, block_k), dtype)
             B_gate_smem = T.alloc_shared((num_stages, block_n, block_k), dtype)
             B_up_smem = T.alloc_shared((num_stages, block_n, block_k), dtype)
-            # Per-WG half-tile dual fp32 accumulators (gate + up).
             C_gate_wg0 = T.alloc_fragment((half_m, block_n), accum_dtype)
             C_up_wg0 = T.alloc_fragment((half_m, block_n), accum_dtype)
             C_gate_wg1 = T.alloc_fragment((half_m, block_n), accum_dtype)
             C_up_wg1 = T.alloc_fragment((half_m, block_n), accum_dtype)
 
-            # ── TMA-store epilogue staging (per-WG half-tile) ──
             C_local_cast_wg0 = T.alloc_fragment((half_m, block_n), dtype)
             C_local_cast_wg1 = T.alloc_fragment((half_m, block_n), dtype)
             C_shared_wg0 = T.alloc_shared((half_m, block_n), dtype)
             C_shared_wg1 = T.alloc_shared((half_m, block_n), dtype)
 
-            # ── Scheduler SMEM (single tile per wave; one binary search) ──
             s_cum = T.alloc_shared((num_experts + 1,), "int32")
             s_total = T.alloc_shared((1,), "int32")
             lo = T.alloc_local((1,), "int32")
@@ -721,7 +675,6 @@ def _make_cooperative_fused_act_kernel(
             _row = T.alloc_local((1,), "int32")
             _ex = T.alloc_local((1,), "int32")
             _ms = T.alloc_local((1,), "int32")
-            # Per-tile metadata in alloc_local (same pattern as pingpong).
             ms = T.alloc_local((1,), "int32")
             ns_ = T.alloc_local((1,), "int32")
             ex = T.alloc_local((1,), "int32")
@@ -739,8 +692,6 @@ def _make_cooperative_fused_act_kernel(
                 }
             )
 
-            # ── Single shared barrier set: producer WG (128 threads)
-            #     fills, both math WGs (256 threads total) drain ──
             ab_full = T.alloc_barrier([128] * num_stages)
             ab_empty = T.alloc_barrier([256] * num_stages)
 
@@ -750,16 +701,12 @@ def _make_cooperative_fused_act_kernel(
 
             tx = T.get_thread_binding()
 
-            # Producer WG: tx < 128
-            # Static-wave scheduler: flat_id = sm_count * w + pid (one
-            # tile per CTA per wave; both math WGs co-process it).
             if tx < 128:
                 T.dec_max_nreg(24)
 
                 if tx == 0:
                     _tiling.cumsum(true_sizes, s_cum)
                     s_total[0] = s_cum[num_experts] * T.int32(_num_pid_n)
-                # CTA-wide sync: publishes s_cum/s_total to consumers
                 T.sync_threads()
 
                 for w in T.serial(_max_waves):
@@ -784,16 +731,13 @@ def _make_cooperative_fused_act_kernel(
                         if v[0] != 0:
                             slot = gi_prod % num_stages
                             T.barrier_wait(ab_empty[slot], ((gi_prod // num_stages) & 1) ^ 1)
-                            # Top half of A (rows ms..ms+half_m).
                             T.tma_copy(
                                 A[ms[0] : ms[0] + half_m, k_start : k_start + block_k],
                                 A_smem_top[slot, :, :],
                                 barrier=ab_full[slot],
                             )
-                            # Sparse decode often has no rows in the bottom
-                            # half. Avoid issuing a TMA that only feeds masked
-                            # output; WG1 still participates in the ring's
-                            # empty-barrier protocol below.
+                            # Sparse decode often leaves the bottom half empty; skip
+                            # its TMA, but keep WG1 in the empty-barrier protocol.
                             if rows[0] > T.int32(half_m):
                                 T.tma_copy(
                                     A[
@@ -803,13 +747,11 @@ def _make_cooperative_fused_act_kernel(
                                     A_smem_bot[slot, :, :],
                                     barrier=ab_full[slot],
                                 )
-                            # Gate B tile (shared between the two math WGs).
                             T.tma_copy(
                                 B[ex[0], ns_[0] : ns_[0] + block_n, k_start : k_start + block_k],
                                 B_gate_smem[slot, :, :],
                                 barrier=ab_full[slot],
                             )
-                            # Up B tile (ffn-row-offset; shared between WGs).
                             T.tma_copy(
                                 B[
                                     ex[0],
@@ -822,10 +764,8 @@ def _make_cooperative_fused_act_kernel(
                             T.barrier_arrive(ab_full[slot])
                             gi_prod = gi_prod + 1
 
-            # Consumer WG0: 128 ≤ tx < 256 — top half (rows 0..half_m)
             elif tx < 256:
                 T.inc_max_nreg(240)
-                # CTA-wide sync (pairs with producer's post-init sync).
                 T.sync_threads()
 
                 for w in T.serial(_max_waves):
@@ -842,7 +782,6 @@ def _make_cooperative_fused_act_kernel(
                         row = _row[0]
                         m_start = _ms[0]
                         n_start = n_tile * T.int32(block_n)
-                        # Top-half row count: clamp(true_arows, 0, half_m).
                         true_arows = true_sizes[expert_id] - row
                         arows0 = T.max(T.int32(0), T.min(T.int32(half_m), true_arows))
 
@@ -871,38 +810,23 @@ def _make_cooperative_fused_act_kernel(
                             T.barrier_arrive(ab_empty[slot])
                             gi_cons_0 = gi_cons_0 + 1
 
-                        # ── Fused epilogue (top half): act(gate) * up → cast → store ──
                         for i, j in T.Parallel(half_m, block_n):
                             C_local_cast_wg0[i, j] = T.cast(
                                 fused_act(C_gate_wg0[i, j], C_up_wg0[i, j]), dtype
                             )
                         if arows0 == T.int32(half_m):
-                            # WG-scoped named barrier BEFORE refilling C_shared:
-                            # guarantees the prior wave's TMA store finished
-                            # reading C_shared.  MUST be a named barrier
-                            # (barrier_id + arrive_count=128), NOT a CTA-wide
-                            # T.sync_threads(): the producer WG never enters this
-                            # epilogue and the two consumer WGs may take different
-                            # paths this wave, so a CTA-wide sync would wait on
-                            # warpgroups that never arrive and deadlock.
                             T.sync_threads(barrier_id=4, arrive_count=128)
                             T.copy(C_local_cast_wg0, C_shared_wg0)
-                            # Order the generic-proxy SMEM writes above before the
-                            # async-proxy TMA read below, and align all 128 threads of
-                            # this WG so the store never reads a half-written C_shared.
                             T.fence_proxy_async()
                             T.sync_threads(barrier_id=4, arrive_count=128)
                             T.copy(C_shared_wg0, C[m_start, n_start])
                         else:
-                            # acols == block_n always (ffn % block_n == 0 enforced by forward()); no j-guard needed.
                             for i, j in T.Parallel(half_m, block_n):
                                 if i < arows0:
                                     C[m_start + i, n_start + j] = C_local_cast_wg0[i, j]
 
-            # Consumer WG1: tx ≥ 256 — bottom half (rows half_m..block_m)
             else:
                 T.inc_max_nreg(240)
-                # CTA-wide sync (pairs with producer's post-init sync).
                 T.sync_threads()
 
                 for w in T.serial(_max_waves):
@@ -919,7 +843,6 @@ def _make_cooperative_fused_act_kernel(
                         row = _row[0]
                         m_start = _ms[0]
                         n_start = n_tile * T.int32(block_n)
-                        # Bottom-half row count: clamp(true_arows-half_m, 0, half_m).
                         true_arows = true_sizes[expert_id] - row
                         arows1 = T.max(
                             T.int32(0), T.min(T.int32(half_m), true_arows - T.int32(half_m))
@@ -951,28 +874,20 @@ def _make_cooperative_fused_act_kernel(
                             T.barrier_arrive(ab_empty[slot])
                             gi_cons_1 = gi_cons_1 + 1
 
-                        # ── Fused epilogue (bottom half): act(gate) * up → cast → store ──
                         for i, j in T.Parallel(half_m, block_n):
                             C_local_cast_wg1[i, j] = T.cast(
                                 fused_act(C_gate_wg1[i, j], C_up_wg1[i, j]), dtype
                             )
                         if arows1 == T.int32(half_m):
-                            # WG-scoped named barrier (barrier_id=5) BEFORE the
-                            # C_shared refill — see WG0 epilogue rationale.
                             T.sync_threads(barrier_id=5, arrive_count=128)
                             T.copy(C_local_cast_wg1, C_shared_wg1)
-                            # Order the generic-proxy SMEM writes above before the
-                            # async-proxy TMA read below, and align all 128 threads of
-                            # this WG so the store never reads a half-written C_shared.
                             T.fence_proxy_async()
                             T.sync_threads(barrier_id=5, arrive_count=128)
                             T.copy(C_shared_wg1, C[m_start + half_m, n_start])
                         elif arows1 > T.int32(0):
-                            # acols == block_n always (ffn % block_n == 0 enforced by forward()); no j-guard needed.
                             for i, j in T.Parallel(half_m, block_n):
                                 if i < arows1:
                                     C[m_start + half_m + i, n_start + j] = C_local_cast_wg1[i, j]
-                        # else: bottom half empty (true_arows ≤ half_m), skip writes
 
     return _gemm_main_fused_coop
 

--- a/src/tileops/kernels/moe/moe_grouped_gemm_separate_act.py
+++ b/src/tileops/kernels/moe/moe_grouped_gemm_separate_act.py
@@ -29,7 +29,6 @@ class MoeGroupedGemmSeparateActKernel(Kernel):
     general = True
     supported_archs: list[int] = [80, 86, 89, 90]
 
-    # Gated activations this kernel can launch after the GEMM.
     SUPPORTED_ACTIVATIONS = tuple(sorted(_ACTIVATIONS))
 
     @classmethod
@@ -60,14 +59,12 @@ class MoeGroupedGemmSeparateActKernel(Kernel):
         self.K = K
         self.dtype = dtype
         self.activation = activation
-        # Composing two launches, each of which carries its own schedule.
         self.init_config(config, tune=False)
         self._gemm = gemm_cls(numel, num_experts, 2 * N, K, dtype=dtype, tune=tune)
         self._act = _ACTIVATIONS[activation](numel, N, dtype, tune=tune)
 
     @property
     def default_config(self) -> dict:
-        # Both launches carry their own schedule.
         return {}
 
     @property

--- a/src/tileops/kernels/moe/permute_align.py
+++ b/src/tileops/kernels/moe/permute_align.py
@@ -36,9 +36,8 @@ __all__ = ["MoePermuteAlignKernel"]
 _THREADS = 1024
 _SCATTER_THREADS = 256
 _SMALL_NUMEL_THRESHOLD = 1024
-# Keep <= 32: the small-batch kernel allocates (worker_threads+1)*num_experts
-# int32s in shared memory.  At num_experts=64 this becomes 4160 entries and
-# causes TileLang JIT to hang during compilation.
+# Keep <= 32: the small-batch kernel's (worker_threads+1)*num_experts int32s of
+# shared memory hang the TileLang JIT at num_experts=64.
 _SMALL_EXPERTS_THRESHOLD = 32
 _FILL_THREADS = 256
 
@@ -67,27 +66,22 @@ def _make_align_kernel(numel: int, num_experts: int, block_size: int):
                 s_vals = T.alloc_shared([threads], "int32")
                 s_warp_sum = T.alloc_shared([num_warps], "int32")
                 s_warp_excl = T.alloc_shared([num_warps], "int32")
-                # s_total is a running accumulator used only by tx==0 to build
-                # s_warp_excl during the inter-warp scan; its final value (grand
-                # total) is derived independently at line 135 and not re-read.
+                # s_total only feeds the inter-warp scan; the total comes from s_vals.
                 s_total = T.alloc_shared([1], "int32")
                 s_cumsum = T.alloc_shared([num_experts + 1], "int32")
 
-                # Step 1: zero s_counts
                 for i in T.serial(T.ceildiv(num_experts, threads)):
                     idx = i * threads + tx
                     if idx < num_experts:
                         s_counts[idx] = T.int32(0)
                 T.sync_threads()
 
-                # Step 1: count tokens per expert
                 for i in T.serial(T.ceildiv(numel, threads)):
                     idx = i * threads + tx
                     if idx < numel:
                         T.atomic_add(s_counts[flat[idx]], 1)
                 T.sync_threads()
 
-                # Step 2: warp-scan prefix-sum on padded counts
                 lane = tx % 32
                 warp_id = tx // 32
 
@@ -98,8 +92,7 @@ def _make_align_kernel(numel: int, num_experts: int, block_size: int):
                 )
                 T.sync_threads()
 
-                # Intra-warp inclusive scan via shuffle_up
-                # 5 rounds = log2(warp_size=32): each round doubles the scan distance
+                # log2(32) rounds, each doubling the scan distance.
                 for d in T.serial(5):
                     stride = 1 << d
                     up_val = T.tvm_warp_shuffle_up(T.uint32(0xFFFFFFFF), s_vals[tx], stride, 32, 32)
@@ -107,12 +100,11 @@ def _make_align_kernel(numel: int, num_experts: int, block_size: int):
                         s_vals[tx] = s_vals[tx] + up_val
                 T.sync_threads()
 
-                # Last lane of each warp records warp sum
                 if lane == 31:
                     s_warp_sum[warp_id] = s_vals[tx]
                 T.sync_threads()
 
-                # Inter-warp exclusive scan (for->if pattern to write shared)
+                # Nesting is deliberate: the loop stays outside the tx == 0 guard.
                 for w in T.serial(num_warps):
                     if tx == 0:
                         if w == 0:
@@ -121,7 +113,6 @@ def _make_align_kernel(numel: int, num_experts: int, block_size: int):
                         s_total[0] = s_total[0] + s_warp_sum[w]
                 T.sync_threads()
 
-                # Convert inclusive scan -> exclusive cumsum entry
                 own_padded = (
                     T.ceildiv(s_counts[tx], block_size) * block_size
                     if tx < num_experts
@@ -139,10 +130,8 @@ def _make_align_kernel(numel: int, num_experts: int, block_size: int):
                     num_tokens_post_pad[0] = total
                 T.sync_threads()
 
-                # Step 3: fill expert_ids linearly — no binary search.
-                # Each thread tx < num_experts owns blocks [e_start, e_end).
-                # Loop bound is max_num_blocks (worst case: all tokens to one
-                # expert), guarded by `blk < e_end` to skip non-owned blocks.
+                # The bound covers all tokens on one expert; the guard picks the
+                # blocks this thread owns.
                 if tx < num_experts:
                     e_start = s_cumsum[tx] // block_size
                     e_end = s_cumsum[tx + 1] // block_size
@@ -151,7 +140,6 @@ def _make_align_kernel(numel: int, num_experts: int, block_size: int):
                         if blk < e_end:
                             expert_ids[blk] = tx
 
-                # Step 4: fill sentinel
                 for i in T.serial(T.ceildiv(max_padded, threads)):
                     idx = i * threads + tx
                     if idx < max_padded:
@@ -191,8 +179,8 @@ def _make_scatter_kernel(numel: int, num_experts: int, block_size: int):
                     idx = gid + i * total_scatter_threads
                     if idx < numel:
                         eid = flat[idx]
-                        # Store the returned slot before indexing with it, so
-                        # TileLang's bounds-check lowering cannot duplicate the atomic.
+                        # Store the slot before indexing with it: bounds-check
+                        # lowering can otherwise duplicate the atomic.
                         slot_buf[0] = T.atomic_add(cumsum[eid], T.int32(1), return_prev=True)
                         slot = slot_buf[0]
                         sorted_token_ids[slot] = idx
@@ -219,9 +207,7 @@ def _make_small_batch_kernel(numel: int, num_experts: int, block_size: int):
     max_num_blocks = math.ceil(max_padded / block_size)
     worker_threads = max(num_experts, 32)
     total_threads = _FILL_THREADS + worker_threads
-    # tokens_cnts layout: (worker_threads+1) rows × num_experts cols (0-indexed).
-    # Row k (k>=1): worker k-1's private counts per expert (0-indexed).
-    # Row 0: reduce accumulator, initialised to 0 by expert threads.
+    # tokens_cnts: row k+1 is worker k's private counts, row 0 the accumulator.
     cnts_size = (worker_threads + 1) * num_experts
 
     @tilelang.jit(out_idx=[], compile_flags=["-O3"])
@@ -239,20 +225,16 @@ def _make_small_batch_kernel(numel: int, num_experts: int, block_size: int):
                 cumsum_s = T.alloc_shared([num_experts + 1], "int32")
                 tokens_cnts = T.alloc_shared([cnts_size], "int32")
 
-                # fill_threads group: fill sentinel (concurrent with worker Phase 0)
                 if tx < _FILL_THREADS:
                     for i in T.serial(T.ceildiv(max_padded, _FILL_THREADS)):
                         idx = i * _FILL_THREADS + tx
                         if idx < max_padded:
                             sorted_token_ids[idx] = numel
 
-                # worker_threads group: Phase 0 — init private count row + count tokens
                 if tx >= _FILL_THREADS:
                     wid = tx - _FILL_THREADS  # 0-indexed worker id
-                    # Init row wid+1 (private row for this worker)
                     for i in T.serial(num_experts):
                         tokens_cnts[(wid + 1) * num_experts + i] = T.int32(0)
-                    # Count tokens owned by this worker (grid-stride over numel)
                     for i in T.serial(T.ceildiv(numel, worker_threads)):
                         idx = wid + i * worker_threads
                         if idx < numel:
@@ -263,8 +245,6 @@ def _make_small_batch_kernel(numel: int, num_experts: int, block_size: int):
 
                 T.sync_threads()  # sync 1
 
-                # worker_threads group: Phase 1 — column-wise inclusive prefix-sum reduce
-                # Thread wid handles column wid (expert wid's counts across all workers)
                 if tx >= _FILL_THREADS:
                     wid = tx - _FILL_THREADS
                     if wid < num_experts:
@@ -274,11 +254,9 @@ def _make_small_batch_kernel(numel: int, num_experts: int, block_size: int):
                                 tokens_cnts[(k + 1) * num_experts + wid]
                                 + tokens_cnts[k * num_experts + wid]
                             )
-                        # After loop: tokens_cnts[worker_threads*E + wid] = total for expert wid
 
                 T.sync_threads()  # sync 2
 
-                # worker_threads group: Phase 2 — wid==0 builds exclusive prefix-sum cumsum
                 if tx >= _FILL_THREADS:
                     wid = tx - _FILL_THREADS
                     if wid == 0:
@@ -290,7 +268,6 @@ def _make_small_batch_kernel(numel: int, num_experts: int, block_size: int):
 
                 T.sync_threads()  # sync 3
 
-                # worker_threads group: Phase 3a — expert_ids fill (0-indexed)
                 if tx >= _FILL_THREADS:
                     wid = tx - _FILL_THREADS
                     if wid < num_experts:
@@ -301,9 +278,6 @@ def _make_small_batch_kernel(numel: int, num_experts: int, block_size: int):
                             if blk < e_end:
                                 expert_ids[blk] = wid  # 0-indexed expert id
 
-                    # Phase 3b: scatter (no atomics — per-worker private rows)
-                    # tokens_cnts[wid*E + eid] holds the running offset for worker wid
-                    # into expert eid's slot range (starts at cumsum_s[eid])
                     for i in T.serial(T.ceildiv(numel, worker_threads)):
                         idx = wid + i * worker_threads
                         if idx < numel:

--- a/src/tileops/kernels/moe/permute_contiguous.py
+++ b/src/tileops/kernels/moe/permute_contiguous.py
@@ -13,11 +13,9 @@ from tileops.kernels.moe.call_spec import PrePermuteCall
 __all__ = ["MoePrePermuteContiguousKernel"]
 
 
-# Above this many routed rows the cooperative fused launch loses to the
-# scan/gather pair: the merged prim_func compiles the gather loop at 32
-# registers where the standalone gather gets 46, so the copy holds far fewer
-# loads in flight. At T=512, H=7168 the fused launch takes 73 us of device time
-# against 28 us for the pair, and at T=4096 779 us against 253 us.
+# Past this many routed rows the fused launch loses: merged, the gather loop
+# compiles at 32 registers against the standalone 46, so it holds far fewer loads
+# in flight -- 73 us against 28 us at T=512, H=7168, and 779 against 253 at T=4096.
 _FUSED_TIGHT_MAX_NUMEL = 64
 
 
@@ -380,8 +378,6 @@ class MoePrePermuteContiguousKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
-        # One CTA owns count, prefix sum, and scatter. Callers may override this
-        # kernel-local default through ``config``.
         return {"threads": 1024}
 
     def forward(

--- a/src/tileops/kernels/moe/permute_contiguous.py
+++ b/src/tileops/kernels/moe/permute_contiguous.py
@@ -13,16 +13,12 @@ from tileops.kernels.moe.call_spec import PrePermuteCall
 __all__ = ["MoePrePermuteContiguousKernel"]
 
 
-def _fused_tight_plan(num_tokens: int, numel: int, hidden_size: int) -> bool:
-    """Whether one cooperative tight launch beats the scan/gather pair.
-
-    Tiny routing problems benefit directly from losing a launch.  At production
-    widths, decode benefits as well, while prefill spends more time holding the
-    cooperative grid across the barrier than the removed launch costs.  The
-    thresholds are the H200 sweep boundary, following the measured planner style
-    used by the fused split-row softmax path.
-    """
-    return numel <= 64 or (num_tokens <= 512 and hidden_size >= 2048)
+# Above this many routed rows the cooperative fused launch loses to the
+# scan/gather pair: the merged prim_func compiles the gather loop at 32
+# registers where the standalone gather gets 46, so the copy holds far fewer
+# loads in flight. At T=512, H=7168 the fused launch takes 73 us of device time
+# against 28 us for the pair, and at T=4096 779 us against 253 us.
+_FUSED_TIGHT_MAX_NUMEL = 64
 
 
 def _make_tight_scan_body(numel: int, num_experts: int, top_k: int, threads: int):
@@ -414,7 +410,7 @@ class MoePrePermuteContiguousKernel(Kernel):
         use_fused_tight = (
             self.layout_key == "tight_physical_psum"
             and self.h200
-            and _fused_tight_plan(self.num_tokens, self.numel, self.hidden_size)
+            and self.numel <= _FUSED_TIGHT_MAX_NUMEL
         )
         if use_fused_tight:
             rows_per_block = max(1, (self.numel + self.sm_count - 1) // self.sm_count)

--- a/src/tileops/kernels/moe/shared_expert_mlp.py
+++ b/src/tileops/kernels/moe/shared_expert_mlp.py
@@ -129,15 +129,12 @@ class SharedExpertMLPKernel(Kernel):
         T_dim = self.num_tokens
         F = self.ffn_size
 
-        # [T, H] @ [2F, H]^T -> [T, 2F]
         gate_up_out = self._gemm_gate_up(hidden, w_gate_up)
 
-        # SiLU + Mul in FP32: kernel reads gate=[:, :F] and up=[:, F:] via index offset,
-        # avoiding intermediate buffer allocations for the split.
+        # The kernel splits gate and up by index offset, allocating nothing.
         silu_mul_fn = _silu_mul_fused_kernel(T_dim, F, self.dtype_str)(
             self.config["block_m"], self.config["block_n"], self.config["threads"]
         )
         gate_up = silu_mul_fn(gate_up_out)
 
-        # [T, F] @ [H, F]^T -> [T, H]
         return self._gemm_down(gate_up, w_down)

--- a/src/tileops/kernels/moe/unpermute.py
+++ b/src/tileops/kernels/moe/unpermute.py
@@ -48,10 +48,8 @@ def _make_unpermute_kernel(
     threads -> 28 elems/thread = 3.5x VEC). Accumulation is in float32, cast to
     dtype on store.
     """
-    # Cap threads at 256: 1024 spills the fp32 acc[H] accumulator to local
-    # memory. Below the cap, scale with hidden_size // VEC and keep power-of-2
-    # alignment so small hidden sizes retain 128-bit (VEC=8) vectorized
-    # load/store instead of scalar 16-bit ops (e.g. H=512 -> 64 threads of 8).
+    # 1024 threads spill the fp32 acc[H] accumulator to local memory, and a count
+    # that is not hidden_size // VEC drops the 128-bit load/store for scalar ops.
     VEC = 8  # 8 x bf16/fp16 = 128 bits
     threads = min(256, hidden_size // VEC)
     if threads > 0:
@@ -70,17 +68,13 @@ def _make_unpermute_kernel(
             output: T.Tensor([num_tokens, hidden_size], dtype),
         ):
             with T.Kernel(num_tokens, threads=threads) as (token_idx,):
-                # float32 accumulator for this token's H slice
                 acc = T.alloc_fragment([hidden_size], "float32")
                 src = T.alloc_fragment([hidden_size], dtype)
 
-                # zero accumulator
                 T.fill(acc, 0.0)
 
-                # accumulate K expert contributions. Software-pipeline the
-                # gathers (num_stages=2) so each scattered row load overlaps the
-                # previous slot's accumulate — the K loads are latency-bound.
-                # Serial fallback when top_k < 2 (pipeline depth > trip count).
+                # num_stages=2 overlaps the latency-bound gathers; top_k < 2 leaves
+                # the pipeline deeper than the trip count, so it runs serial.
                 for k in T.Pipelined(top_k, num_stages=2) if top_k >= 2 else T.serial(top_k):
                     flat_idx = token_idx * T.int32(top_k) + k
                     slot = inverse_indices[flat_idx]
@@ -89,7 +83,6 @@ def _make_unpermute_kernel(
                     for j in T.Parallel(hidden_size):
                         acc[j] = acc[j] + T.Cast("float32", src[j]) * weight
 
-                # cast (and scale) then store
                 out_frag = T.alloc_fragment([hidden_size], dtype)
                 if scaling != 1.0:
                     for j in T.Parallel(hidden_size):
@@ -196,16 +189,13 @@ class MoeUnpermuteKernel(Kernel):
                 )
             if out.dtype != self.dtype:
                 raise ValueError(f"out dtype must be {self.dtype}, got {out.dtype}")
-            # The kernel writes ``out`` on expert_output's device as a row-major compact
-            # tensor; a cross-device or non-contiguous ``out`` would scatter the
-            # store to the wrong memory. Reject rather than corrupt silently.
+            # A cross-device or non-contiguous ``out`` would scatter the store.
             if out.device != dev:
                 raise ValueError(f"out device must be {dev}, got {out.device}")
             if not out.is_contiguous():
                 raise ValueError("out must be contiguous")
-            # The kernel reads ``expert_output`` while writing
-            # ``out`` concurrently, so an ``out`` overlapping ``expert_output`` in
-            # memory races. Disjoint slices of one workspace buffer are allowed.
+            # Overlap races with the concurrent read; disjoint slices of one
+            # workspace buffer are fine.
             if tensors_overlap(out, expert_output):
                 raise ValueError("out must not overlap expert_output in memory")
             output = out

--- a/tests/ops/test_moe_staged_contracts.py
+++ b/tests/ops/test_moe_staged_contracts.py
@@ -8,7 +8,6 @@ import torch
 import tileops.ops.moe.staged as staged_module
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.moe.call_spec import MGroupedGemmCall, PostPermuteCall, PrePermuteCall
-from tileops.kernels.moe.permute_contiguous import _fused_tight_plan
 from tileops.ops import moe as public_moe
 from tileops.ops.moe import (
     ContiguousLayoutSpec,
@@ -28,21 +27,6 @@ from tileops.ops.moe.contracts import (
 )
 
 pytestmark = pytest.mark.smoke
-
-
-@pytest.mark.parametrize(
-    "num_tokens,numel,hidden_size,expected",
-    [
-        (32, 64, 128, True),
-        (512, 1024, 128, False),
-        (512, 4096, 7168, True),
-        (4096, 32768, 7168, False),
-    ],
-)
-def test_fused_tight_plan_keeps_only_measured_wins(
-    num_tokens: int, numel: int, hidden_size: int, expected: bool
-) -> None:
-    assert _fused_tight_plan(num_tokens, numel, hidden_size) is expected
 
 
 def _physical_layout(rows: int = 2, experts: int = 2) -> MaterializedExpertLayout:


### PR DESCRIPTION
## Summary

- `MoePrePermuteContiguousKernel` selects the cooperative fused tight PrePermute for `numel <= _FUSED_TIGHT_MAX_NUMEL` (64) only; the decode clause `num_tokens <= 512 and hidden_size >= 2048` is removed.
- The fused launch costs more device time than the scan/gather pair at every production width: 73 us against 28 us at T=512, H=7168, and 779 us against 253 us at T=4096 (CUPTI device time of the PrePermute kernels alone).
- The grid barrier accounts for 1 us and capping the grid at the SM count for another 1 us. The cost is that the merged prim_func compiles the gather loop at 32 registers where the standalone gather gets 46, so the copy keeps far fewer loads in flight, and that the shared thread count of 1024 leaves 7 elements per thread on a 7168-element row instead of a whole 8-element vector.
- The threshold is a named constant compared at its one call site, replacing a one-expression predicate function.
- `src/tileops/kernels/moe/` loses its narrative comments: step numbering, section banners, and restatements of the line below. Comment lines go from 176 to 44, each survivor a constraint a reader must not break.
- Three contracts every 3WG epilogue repeated — the named barrier before the C_shared refill, the proxy fence around the TMA store, and ffn's divisibility by block_n — had four copies each and are now stated once in the module docstring. `fused_topk`'s module docstring loses its step-by-step algorithm walk and its sync counts against implementations this repo no longer contains.

## Test plan

- [x] `pre-commit run --all-files`
- [x] `pytest` over the six MoE suites that import these kernels — 106 passed, on an H200
- [x] `pytest tests/ops/test_moe_gate_up.py tests/ops/test_moe_fused_moe.py tests/ops/test_moe_shared_fused_moe.py` — 33 passed, on an H200
- [x] AST comparison with docstrings stripped: the seven comment-only kernel files are identical, so only `permute_contiguous.py` and the test file change executable code.

## Test node delta

- `tests/ops/test_moe_staged_contracts.py`: 31 → 27, delta -4.
- The four cases were `test_fused_tight_plan_keeps_only_measured_wins`, which asserted the return of a one-expression predicate against four literals. It guards no code path: the predicate is now a `<=` against a named constant, and the test was written in the same PR as the regression it failed to stop.

## Benchmark

**Environment**: NVIDIA H200, CUDA 13.2, PyTorch 2.13.0+cu132, TileLang 0.1.11+cu132.gitafcebed1

### FusedMoEExpertsNopadPersistent3WGFwdOp

`device_busy_ms`, both sides measured back to back on the same card. `main` is the row this branch replaces.

| Shape (T, H, F, E) | dtype | main (ms) | TileOPs (ms) | vllm-triton (ms) | Speedup | BW (TB/s) |
| ------------------ | ----- | --------- | ------------ | ---------------- | ------- | --------- |
| (512, 7168, 2048, 128) | bfloat16 | 2.8077 | 2.7590 | 2.8351 | 1.028 | 4.0917 |
| (512, 7168, 2048, 128) | float16 | 2.8156 | 2.7607 | 2.8439 | 1.030 | 4.0891 |
| (512, 7168, 2048, 256) | bfloat16 | 5.4402 | 5.3998 | 5.4863 | 1.016 | 4.1785 |
| (512, 7168, 2048, 256) | float16 | 5.4675 | 5.4252 | 5.5117 | 1.016 | 4.1589 |
| (4096, 7168, 2048, 128) | bfloat16 | 6.1040 | 6.1822 | 7.6232 | 1.233 | 1.8427 |
| (4096, 7168, 2048, 128) | float16 | 6.4151 | 6.4174 | 7.8236 | 1.219 | 1.7751 |
| (4096, 7168, 2048, 256) | bfloat16 | 8.6302 | 8.3619 | 9.3046 | 1.113 | 2.7106 |
| (4096, 7168, 2048, 256) | float16 | 8.9035 | 8.8507 | 9.6525 | 1.091 | 2.5609 |

**Takeaways:**

- The four decode rows (T=512) drop 40-55 us, back to where they sat before #2048.
- The four prefill rows (T=4096) run the unchanged two-kernel path; their -268 to +78 us spread is this card's run-to-run variation, which is wider than the decode delta.
- TileOPs stays ahead of vllm-triton on every row.

## Regression

- The nightly `device_busy_ms` rows for the four decode workloads are the check: they rose 51-65 us on 2026-09-04 and held for four nightlies.
- #2048's table quoted `latency_ms`, which the removed launch did improve. `latency_ms` includes host launch gaps and `gap_ms` swings by hundreds of microseconds between runs on one commit, so a device-time regression can hide inside a wall-latency win.
