### PR TITLE
[Feat][Attention] Add RoPE to Dense GQA decode kernels

### DIFF
--- a/src/tileops/kernels/attention/gqa_decode.py
+++ b/src/tileops/kernels/attention/gqa_decode.py
@@ -21,7 +21,19 @@ __all__ = ["GQADecodeKernel"]
 
 
 @functools.lru_cache(maxsize=32)
-def _gqa_decode_no_split_kernel(batch, heads, groups, dim, sm_scale, softcap, dtype):
+def _gqa_decode_no_split_kernel(
+    batch,
+    heads,
+    groups,
+    dim,
+    sm_scale,
+    softcap,
+    dtype,
+    fuse_rope=False,
+    max_position=1,
+    rotary_dim=0,
+    rope_layout="neox",
+):
     score_scale = dim**-0.5 if sm_scale is None else sm_scale
     use_softcap = softcap > 0.0
     scale = LOG2E if use_softcap else score_scale * LOG2E
@@ -40,6 +52,7 @@ def _gqa_decode_no_split_kernel(batch, heads, groups, dim, sm_scale, softcap, dt
         shape_k = [batch, seqlen_kv, groups, dim]
         shape_v = [batch, seqlen_kv, groups, dim]
         shape_o = [batch, heads, dim]
+        rope_shape = [max_position, rotary_dim // 2]
         kv_group_num = heads // groups
 
         valid_block_H = min(block_H, kv_group_num)
@@ -52,13 +65,8 @@ def _gqa_decode_no_split_kernel(batch, heads, groups, dim, sm_scale, softcap, dt
         )
         rescale = make_rescale(block_H, dim)
 
-        @T.prim_func
-        def gqa_decode_no_split(
-            Q: T.Tensor(shape_q, dtype),
-            K: T.Tensor(shape_k, dtype),
-            V: T.Tensor(shape_v, dtype),
-            Output: T.Tensor(shape_o, dtype),
-        ):
+        @T.macro
+        def compute(Q, K, V, rope_cos, rope_sin, Output):
             with T.Kernel(batch, heads // valid_block_H, 1, threads=threads) as (bx, by, bz):
                 Q_shared = T.alloc_shared([block_H, dim], dtype)
                 K_shared = T.alloc_shared([block_N, dim], dtype)
@@ -77,14 +85,83 @@ def _gqa_decode_no_split_kernel(batch, heads, groups, dim, sm_scale, softcap, dt
                 hid = by
                 cur_kv_head = hid // (kv_group_num // valid_block_H)
 
-                T.copy(Q[bid, hid * valid_block_H : hid * valid_block_H + block_H, :], Q_shared)
+                if fuse_rope:
+                    for i, j in T.Parallel(block_H, dim):
+                        if i < valid_block_H:
+                            if j < rotary_dim:
+                                if rope_layout == "neox":
+                                    freq = T.if_then_else(
+                                        j < rotary_dim // 2, j, j - rotary_dim // 2
+                                    )
+                                    partner = T.if_then_else(
+                                        j < rotary_dim // 2,
+                                        j + rotary_dim // 2,
+                                        j - rotary_dim // 2,
+                                    )
+                                    sign = T.if_then_else(j < rotary_dim // 2, -1.0, 1.0)
+                                else:
+                                    freq = j // 2
+                                    partner = T.if_then_else(j % 2 == 0, j + 1, j - 1)
+                                    sign = T.if_then_else(j % 2 == 0, -1.0, 1.0)
+                                x = T.cast(Q[bid, hid * valid_block_H + i, j], "float")
+                                x_partner = T.cast(
+                                    Q[bid, hid * valid_block_H + i, partner], "float"
+                                )
+                                cos = T.cast(rope_cos[seqlen_kv - 1, freq], "float")
+                                sin = T.cast(rope_sin[seqlen_kv - 1, freq], "float")
+                                Q_shared[i, j] = T.cast(x * cos + sign * x_partner * sin, dtype)
+                            else:
+                                Q_shared[i, j] = Q[bid, hid * valid_block_H + i, j]
+                        else:
+                            Q_shared[i, j] = 0
+                    T.sync_threads(3, threads)
+                else:
+                    T.copy(
+                        Q[bid, hid * valid_block_H : hid * valid_block_H + block_H, :],
+                        Q_shared,
+                    )
                 T.fill(acc_o, 0)
                 T.fill(logsum, 0)
                 T.fill(scores_max, -T.infinity(accum_dtype))
 
                 loop_range = T.ceildiv(seqlen_kv, block_N)
                 for k in T.Pipelined(loop_range, num_stages=num_stages):
-                    T.copy(K[bid, k * block_N : (k + 1) * block_N, cur_kv_head, :], K_shared)
+                    if fuse_rope:
+                        for i, j in T.Parallel(block_N, dim):
+                            position = k * block_N + i
+                            if position < seqlen_kv:
+                                if j < rotary_dim:
+                                    if rope_layout == "neox":
+                                        freq = T.if_then_else(
+                                            j < rotary_dim // 2, j, j - rotary_dim // 2
+                                        )
+                                        partner = T.if_then_else(
+                                            j < rotary_dim // 2,
+                                            j + rotary_dim // 2,
+                                            j - rotary_dim // 2,
+                                        )
+                                        sign = T.if_then_else(j < rotary_dim // 2, -1.0, 1.0)
+                                    else:
+                                        freq = j // 2
+                                        partner = T.if_then_else(j % 2 == 0, j + 1, j - 1)
+                                        sign = T.if_then_else(j % 2 == 0, -1.0, 1.0)
+                                    x = T.cast(K[bid, position, cur_kv_head, j], "float")
+                                    x_partner = T.cast(
+                                        K[bid, position, cur_kv_head, partner], "float"
+                                    )
+                                    cos = T.cast(rope_cos[position, freq], "float")
+                                    sin = T.cast(rope_sin[position, freq], "float")
+                                    K_shared[i, j] = T.cast(x * cos + sign * x_partner * sin, dtype)
+                                else:
+                                    K_shared[i, j] = K[bid, position, cur_kv_head, j]
+                            else:
+                                K_shared[i, j] = 0
+                        T.sync_threads(3, threads)
+                    else:
+                        T.copy(
+                            K[bid, k * block_N : (k + 1) * block_N, cur_kv_head, :],
+                            K_shared,
+                        )
                     T.clear(acc_s)
                     T.gemm(
                         Q_shared, K_shared, acc_s, transpose_B=True, policy=T.GemmWarpPolicy.FullRow
@@ -111,6 +188,30 @@ def _gqa_decode_no_split_kernel(batch, heads, groups, dim, sm_scale, softcap, dt
 
                 T.copy(acc_o[:valid_block_H, :], O_shared)
                 T.copy(O_shared, Output[bid, hid * valid_block_H : (hid + 1) * valid_block_H, :])
+
+        if fuse_rope:
+
+            @T.prim_func
+            def gqa_decode_no_split_rope(
+                Q: T.Tensor(shape_q, dtype),
+                K: T.Tensor(shape_k, dtype),
+                V: T.Tensor(shape_v, dtype),
+                rope_cos: T.Tensor(rope_shape, dtype),
+                rope_sin: T.Tensor(rope_shape, dtype),
+                Output: T.Tensor(shape_o, dtype),
+            ):
+                compute(Q, K, V, rope_cos, rope_sin, Output)
+
+            return gqa_decode_no_split_rope
+
+        @T.prim_func
+        def gqa_decode_no_split(
+            Q: T.Tensor(shape_q, dtype),
+            K: T.Tensor(shape_k, dtype),
+            V: T.Tensor(shape_v, dtype),
+            Output: T.Tensor(shape_o, dtype),
+        ):
+            compute(Q, K, V, Q, Q, Output)
 
         return gqa_decode_no_split
 
@@ -348,6 +449,68 @@ def _(
     return torch.empty_like(Q)
 
 
+@torch.library.custom_op("tileops::gqa_decode_no_split_rope_op", mutates_args=())
+def _gqa_decode_no_split_rope_op(
+    batch: int,
+    heads: int,
+    groups: int,
+    dim: int,
+    sm_scale: float,
+    softcap: float,
+    dtype: str,
+    max_position: int,
+    rotary_dim: int,
+    rope_layout: str,
+    block_H: int,
+    block_N: int,
+    num_stages: int,
+    threads: int,
+    Q: torch.Tensor,
+    K: torch.Tensor,
+    V: torch.Tensor,
+    rope_cos: torch.Tensor,
+    rope_sin: torch.Tensor,
+) -> torch.Tensor:
+    return _gqa_decode_no_split_kernel(
+        batch,
+        heads,
+        groups,
+        dim,
+        sm_scale,
+        softcap,
+        dtype,
+        True,
+        max_position,
+        rotary_dim,
+        rope_layout,
+    )(block_H, block_N, num_stages, threads)(Q, K, V, rope_cos, rope_sin)
+
+
+@_gqa_decode_no_split_rope_op.register_fake
+def _(
+    batch: int,
+    heads: int,
+    groups: int,
+    dim: int,
+    sm_scale: float,
+    softcap: float,
+    dtype: str,
+    max_position: int,
+    rotary_dim: int,
+    rope_layout: str,
+    block_H: int,
+    block_N: int,
+    num_stages: int,
+    threads: int,
+    Q: torch.Tensor,
+    K: torch.Tensor,
+    V: torch.Tensor,
+    rope_cos: torch.Tensor,
+    rope_sin: torch.Tensor,
+) -> torch.Tensor:
+    return torch.empty_like(Q)
+
+
 @torch.library.custom_op("tileops::gqa_decode_split_op", mutates_args=())
 def _gqa_decode_split_op(
     batch: int,
@@ -421,6 +584,11 @@ class GQADecodeKernel(Kernel):
         softcap: float = 0.0,
         config: Optional[dict] = None,
         tune=False,
+        *,
+        fuse_rope: bool = False,
+        max_position: int = 1,
+        rotary_dim: int = 0,
+        rope_layout: str = "neox",
         device_index: Optional[int] = None,
     ):
         super().__init__(device_index=device_index)
@@ -432,6 +600,16 @@ class GQADecodeKernel(Kernel):
         self.dtype = dtype
         self.sm_scale = dim**-0.5 if sm_scale is None else sm_scale
         self.softcap = softcap
+        self.fuse_rope = fuse_rope
+        self.max_position = max_position
+        self.rotary_dim = rotary_dim
+        self.rope_layout = rope_layout
+        from tileops.utils import get_sm_version
+
+        arch = get_sm_version(device_index)
+        if fuse_rope and arch != 90:
+            raise ValueError("fused RoPE decode currently requires SM90")
+        self.use_ws_rope = fuse_rope
         if self.groups <= 0:
             raise ValueError("heads_kv must be positive")
         if self.heads % self.groups != 0:
@@ -457,7 +635,6 @@ class GQADecodeKernel(Kernel):
             self.softcap,
             self.dtype_str,
         )
-
         # autotune targets the split kernel
         self.kernel = self.split_jit
         self._supply_prog = self._make_supply_prog()
@@ -549,7 +726,9 @@ class GQADecodeKernel(Kernel):
         rope_sin: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         self._require_cuda(q=q, k=k, v=v)
-        del q_scale, k_scale, v_scale, rope_cos, rope_sin
+        del q_scale, k_scale, v_scale
+        if self.fuse_rope and (rope_cos is None or rope_sin is None):
+            raise ValueError("fused RoPE requires rope_cos and rope_sin")
         Q = q.squeeze(1)
         K = k
         V = v
@@ -563,6 +742,29 @@ class GQADecodeKernel(Kernel):
         # Dispatch: use no-split for short sequences where splitting is not beneficial
         threshold = num_split * block_N
         if real_seqlen_kv < threshold:
+            if self.fuse_rope:
+                output = _gqa_decode_no_split_rope_op(
+                    self.batch,
+                    self.heads,
+                    self.groups,
+                    self.dim,
+                    self.sm_scale,
+                    self.softcap,
+                    self.dtype_str,
+                    self.max_position,
+                    self.rotary_dim,
+                    self.rope_layout,
+                    block_H,
+                    block_N,
+                    num_stages,
+                    threads,
+                    Q,
+                    K,
+                    V,
+                    rope_cos,
+                    rope_sin,
+                )
+                return output.unsqueeze(1)
             output = _gqa_decode_no_split_op(
                 self.batch,
                 self.heads,
@@ -578,6 +780,46 @@ class GQADecodeKernel(Kernel):
                 Q,
                 K,
                 V,
+            )
+            return output.unsqueeze(1)
+
+        if self.use_ws_rope:
+            # The Hopper producer/consumer kernel supports arbitrary batch
+            # sizes; use it here so RoPE stays fused without replacing TMA and
+            # WGMMA with scalar global-memory loads.
+            from .gqa_decode_bs1 import _gqa_decode_bs1_ctx_op
+
+            glse = torch.empty(
+                (self.batch, self.heads, num_split), dtype=torch.float32, device=Q.device
+            )
+            Output_partial = torch.empty(
+                (self.batch, self.heads, num_split, self.dim),
+                dtype=torch.float32,
+                device=Q.device,
+            )
+            output = _gqa_decode_bs1_ctx_op(
+                self.batch,
+                self.heads,
+                self.groups,
+                self.dim,
+                self.sm_scale,
+                self.softcap,
+                self.dtype_str,
+                True,
+                self.max_position,
+                self.rotary_dim,
+                self.rope_layout,
+                64,
+                block_N,
+                num_split,
+                160,
+                Q,
+                K,
+                V,
+                rope_cos,
+                rope_sin,
+                glse,
+                Output_partial,
             )
             return output.unsqueeze(1)
 

--- a/src/tileops/kernels/attention/gqa_decode_bs1.py
+++ b/src/tileops/kernels/attention/gqa_decode_bs1.py
@@ -1,10 +1,12 @@
 """Warp-specialized batch=1 GQA decode kernel (Hopper), context-split.
 
-``GQADecodeBs1Kernel`` dispatches on the runtime K/V sequence extent: lengths >= 1024
-run a context-only warp-specialized split (one TMA producer warp feeding a four-warp
-wgmma consumer warpgroup, exp2-domain online softmax, fp32 partial reduce via a combine
-kernel); shorter lengths fall back to the generic non-split decode kernel. Hopper-only,
-low-level ``tma_copy`` / ``mbarrier`` / ``wgmma_gemm``.
+``GQADecodeBs1Kernel`` dispatches on the runtime K/V sequence extent.  Full-dimensional
+RoPE always uses the context-only warp-specialized split; plain and partial-RoPE calls
+retain the generic single-kernel path below their measured or established crossovers.
+The split path has a TMA producer feeding a four-warp WGMMA consumer, exp2-domain online
+softmax, and FP32 partial reduction through a combine kernel.  Full-dimensional RoPE
+expands the producer into a warpgroup so lookup-table loads and K rotation overlap the
+consumer.  Hopper-only, low-level ``tma_copy`` / ``mbarrier`` / ``wgmma_gemm``.
 """
 
 import functools
@@ -14,24 +16,346 @@ import tilelang
 import tilelang.language as T
 import torch
 
-from tileops.kernels.attention.gqa_decode import _gqa_decode_no_split_op
+from tileops.kernels.attention.gqa_decode import (
+    _gqa_decode_no_split_op,
+    _gqa_decode_no_split_rope_op,
+)
 from tileops.kernels.kernel_base import Kernel
 
 from .call_spec import decode_bs1_region
 from .gqa_decode_bs1_common import (
     COMPILE_FLAGS,
     RING_DEPTH,
-    GQADecodeBs1KernelMixin,
     make_gqa_decode_bs1_combine,
-    make_gqa_decode_bs1_split,
 )
 from .online_softmax import LOG2E
 
 __all__ = ["GQADecodeBs1Kernel"]
 
+CONSUMER_THREADS = 128
+TMA_THREADS = 32
+ROPE_PIPELINE_THREADS = 256
+
+
+def _make_dense_decode_split(
+    batch: int,
+    groups: int,
+    block_m: int,
+    block_n: int,
+    dim: int,
+    dtype: str,
+    scale: float,
+    kv_group_num: int,
+    ctx_splits: int,
+    threads: int,
+    accum_dtype: str,
+    real_seqlen_is_buffer: bool,
+    load_kv,
+    fuse_rope: bool = False,
+    rotary_dim: int = 0,
+    rope_layout: str = "neox",
+):
+    """Create the Dense context-split schedule."""
+    ring_depth = RING_DEPTH
+
+    @T.macro
+    def consumer(
+        Q,
+        bid,
+        hid,
+        sid,
+        this_len,
+        base,
+        seqlen_kv,
+        loop_range,
+        rope_cos,
+        rope_sin,
+        Qs,
+        Ks,
+        Vs,
+        Ps,
+        ready,
+        free,
+        acc_s,
+        acc_o,
+        sm,
+        smp,
+        alpha,
+        ss,
+        logsum,
+        glse,
+        Output_partial,
+    ):
+        T.fill(acc_o, 0)
+        T.fill(logsum, 0)
+        T.fill(sm, -T.infinity(accum_dtype))
+        if fuse_rope:
+            for i, j in T.Parallel(block_m, dim):
+                if i < kv_group_num:
+                    if j < rotary_dim:
+                        if rope_layout == "neox":
+                            freq = T.if_then_else(j < rotary_dim // 2, j, j - rotary_dim // 2)
+                            partner = T.if_then_else(
+                                j < rotary_dim // 2,
+                                j + rotary_dim // 2,
+                                j - rotary_dim // 2,
+                            )
+                            sign = T.if_then_else(j < rotary_dim // 2, -1.0, 1.0)
+                        else:
+                            freq = j // 2
+                            partner = T.if_then_else(j % 2 == 0, j + 1, j - 1)
+                            sign = T.if_then_else(j % 2 == 0, -1.0, 1.0)
+                        x = Q[bid, hid * kv_group_num + i, j]
+                        x_partner = Q[bid, hid * kv_group_num + i, partner]
+                        cos = rope_cos[seqlen_kv - 1, freq]
+                        sin = rope_sin[seqlen_kv - 1, freq]
+                        Qs[i, j] = x * cos + sign * x_partner * sin
+                    else:
+                        Qs[i, j] = Q[bid, hid * kv_group_num + i, j]
+                else:
+                    Qs[i, j] = 0
+            T.sync_threads(3, CONSUMER_THREADS)
+        else:
+            T.copy(
+                Q[bid, hid * kv_group_num : hid * kv_group_num + kv_group_num, :],
+                Qs[0:kv_group_num, :],
+            )
+        for k in T.serial(loop_range):
+            T.mbarrier_wait_parity(ready[k % ring_depth], (k // ring_depth) % ring_depth)
+            if fuse_rope and rotary_dim != dim:
+                for i, freq in T.Parallel(block_n, rotary_dim // 2):
+                    if i < this_len - k * block_n:
+                        d0 = freq if rope_layout == "neox" else 2 * freq
+                        d1 = freq + rotary_dim // 2 if rope_layout == "neox" else 2 * freq + 1
+                        position = base + k * block_n + i
+                        x0 = Ks[k % ring_depth, i, d0]
+                        x1 = Ks[k % ring_depth, i, d1]
+                        cos = rope_cos[position, freq]
+                        sin = rope_sin[position, freq]
+                        Ks[k % ring_depth, i, d0] = x0 * cos - x1 * sin
+                        Ks[k % ring_depth, i, d1] = x1 * cos + x0 * sin
+                T.sync_threads(3, CONSUMER_THREADS)
+            T.wgmma_gemm(
+                Qs,
+                Ks[k % ring_depth, :, :],
+                acc_s,
+                transpose_B=True,
+                policy=T.GemmWarpPolicy.FullRow,
+                clear_accum=True,
+            )
+            T.wait_wgmma(0)
+            for i, j in T.Parallel(block_m, block_n):
+                acc_s[i, j] = T.if_then_else(
+                    k * block_n + j < this_len,
+                    acc_s[i, j],
+                    -T.infinity(accum_dtype),
+                )
+            T.copy(sm, smp)
+            T.reduce_max(acc_s, sm, dim=1, clear=False)
+            for i in T.Parallel(block_m):
+                alpha[i] = T.exp2(smp[i] * scale - sm[i] * scale)
+            for i, j in T.Parallel(block_m, block_n):
+                acc_s[i, j] = T.exp2(acc_s[i, j] * scale - sm[i] * scale)
+            T.reduce_sum(acc_s, ss, dim=1)
+            for i in T.Parallel(block_m):
+                logsum[i] = logsum[i] * alpha[i] + ss[i]
+            for i, j in T.Parallel(block_m, dim):
+                acc_o[i, j] *= alpha[i]
+            T.copy(acc_s, Ps)
+            T.wgmma_gemm(
+                Ps,
+                Vs[k % ring_depth, :, :],
+                acc_o,
+                policy=T.GemmWarpPolicy.FullRow,
+                clear_accum=False,
+            )
+            T.wait_wgmma(0)
+            T.mbarrier_arrive(free[k % ring_depth])
+        for i, j in T.Parallel(block_m, dim):
+            acc_o[i, j] /= T.if_then_else(this_len > 0, logsum[i], 1.0)
+        for i in T.Parallel(block_m):
+            if i < kv_group_num:
+                glse[bid, hid * kv_group_num + i, sid] = T.if_then_else(
+                    this_len > 0,
+                    T.log2(logsum[i]) + sm[i] * scale,
+                    -T.infinity(accum_dtype),
+                )
+        for i, j in T.Parallel(block_m, dim):
+            if i < kv_group_num:
+                Output_partial[bid, hid * kv_group_num + i, sid, j] = T.if_then_else(
+                    this_len > 0,
+                    acc_o[i, j],
+                    0.0,
+                )
+
+    @T.macro
+    def split(
+        Q,
+        K,
+        V,
+        kv_layout,
+        real_seqlen_kv,
+        rope_cos,
+        rope_sin,
+        glse,
+        output_partial,
+    ):
+        with T.Kernel(batch, groups, ctx_splits, threads=threads) as (bid, hid, sid):
+            qs = T.alloc_shared([block_m, dim], dtype)
+            ks = T.alloc_shared([RING_DEPTH, block_n, dim], dtype)
+            vs = T.alloc_shared([RING_DEPTH, block_n, dim], dtype)
+            ps = T.alloc_shared([block_m, block_n], dtype)
+            # Full-dimensional RoPE has enough work to justify a producer
+            # warpgroup.  TMA stages the lookup tables with K/V, then all 128
+            # producer threads rotate K while the consumer computes the other
+            # ring slot.  Partial RoPE keeps the smaller 32-thread TMA producer.
+            tma_rope_pipeline = fuse_rope and rotary_dim == dim
+            if tma_rope_pipeline:
+                rope_cos_s = T.alloc_shared([block_n, rotary_dim // 2], dtype)
+                rope_sin_s = T.alloc_shared([block_n, rotary_dim // 2], dtype)
+            T.annotate_layout(
+                {
+                    qs: tilelang.layout.make_swizzled_layout(qs),
+                    ks: tilelang.layout.make_swizzled_layout(ks),
+                    vs: tilelang.layout.make_swizzled_layout(vs),
+                    ps: tilelang.layout.make_swizzled_layout(ps),
+                }
+            )
+            producer_threads = threads - CONSUMER_THREADS
+            ready = T.alloc_barrier([producer_threads] * RING_DEPTH)
+            free = T.alloc_barrier([CONSUMER_THREADS] * RING_DEPTH)
+            if tma_rope_pipeline:
+                loaded = T.alloc_barrier([TMA_THREADS] * RING_DEPTH)
+            load_ready = loaded if tma_rope_pipeline else ready
+            acc_s = T.alloc_fragment([block_m, block_n], accum_dtype)
+            acc_o = T.alloc_fragment([block_m, dim], accum_dtype)
+            sm = T.alloc_fragment([block_m], accum_dtype)
+            smp = T.alloc_fragment([block_m], accum_dtype)
+            alpha = T.alloc_fragment([block_m], accum_dtype)
+            ss = T.alloc_fragment([block_m], accum_dtype)
+            logsum = T.alloc_fragment([block_m], accum_dtype)
+
+            seqlen_kv_b = real_seqlen_kv[bid] if real_seqlen_is_buffer else real_seqlen_kv
+            # Partition whole KV tiles as evenly as possible.  The old policy
+            # rounded every non-final split down, then assigned the entire
+            # remainder to the final CTA; non-divisible lengths could therefore
+            # leave one split with several times more work than its peers.
+            num_tiles = T.ceildiv(seqlen_kv_b, block_n)
+            base_tiles = num_tiles // ctx_splits
+            extra_tiles = num_tiles % ctx_splits
+            tiles_this_split = base_tiles + T.if_then_else(sid < extra_tiles, 1, 0)
+            tile_begin = sid * base_tiles + T.min(sid, extra_tiles)
+            base = tile_begin * block_n
+            this_len = T.max(
+                T.min(seqlen_kv_b - base, tiles_this_split * block_n),
+                0,
+            )
+            loop_range = T.ceildiv(this_len, block_n)
+            tx = T.get_thread_binding()
+
+            if tx >= CONSUMER_THREADS:
+                for k in T.serial(loop_range):
+                    T.mbarrier_wait_parity(
+                        free[k % RING_DEPTH],
+                        ((k // RING_DEPTH) % RING_DEPTH) ^ 1,
+                    )
+                    if tx < CONSUMER_THREADS + TMA_THREADS:
+                        load_kv(
+                            K,
+                            V,
+                            kv_layout,
+                            bid,
+                            hid,
+                            base,
+                            k,
+                            ks,
+                            vs,
+                            load_ready,
+                        )
+                        if tma_rope_pipeline:
+                            T.tma_copy(
+                                rope_cos[
+                                    base + k * block_n : base + (k + 1) * block_n,
+                                    :,
+                                ],
+                                rope_cos_s,
+                                barrier=loaded[k % RING_DEPTH],
+                            )
+                            T.tma_copy(
+                                rope_sin[
+                                    base + k * block_n : base + (k + 1) * block_n,
+                                    :,
+                                ],
+                                rope_sin_s,
+                                barrier=loaded[k % RING_DEPTH],
+                            )
+                        T.mbarrier_arrive(load_ready[k % RING_DEPTH])
+                    if tma_rope_pipeline:
+                        T.mbarrier_wait_parity(
+                            loaded[k % RING_DEPTH],
+                            (k // RING_DEPTH) % RING_DEPTH,
+                        )
+                        for i, freq in T.Parallel(block_n, rotary_dim // 2):
+                            if i < this_len - k * block_n:
+                                d0 = freq if rope_layout == "neox" else 2 * freq
+                                d1 = (
+                                    freq + rotary_dim // 2
+                                    if rope_layout == "neox"
+                                    else 2 * freq + 1
+                                )
+                                x0 = ks[k % RING_DEPTH, i, d0]
+                                x1 = ks[k % RING_DEPTH, i, d1]
+                                cos = rope_cos_s[i, freq]
+                                sin = rope_sin_s[i, freq]
+                                ks[k % RING_DEPTH, i, d0] = x0 * cos - x1 * sin
+                                ks[k % RING_DEPTH, i, d1] = x1 * cos + x0 * sin
+                        T.mbarrier_arrive(ready[k % RING_DEPTH])
+            else:
+                consumer(
+                    Q,
+                    bid,
+                    hid,
+                    sid,
+                    this_len,
+                    base,
+                    seqlen_kv_b,
+                    loop_range,
+                    rope_cos,
+                    rope_sin,
+                    qs,
+                    ks,
+                    vs,
+                    ps,
+                    ready,
+                    free,
+                    acc_s,
+                    acc_o,
+                    sm,
+                    smp,
+                    alpha,
+                    ss,
+                    logsum,
+                    glse,
+                    output_partial,
+                )
+
+    return split
+
 
 @functools.lru_cache(maxsize=32)
-def _gqa_decode_bs1_ctx_kernel(batch, heads, groups, dim, sm_scale, softcap, dtype):
+def _gqa_decode_bs1_ctx_kernel(
+    batch,
+    heads,
+    groups,
+    dim,
+    sm_scale,
+    softcap,
+    dtype,
+    fuse_rope=False,
+    max_position=1,
+    rotary_dim=0,
+    rope_layout="neox",
+):
     score_scale = dim**-0.5 if sm_scale is None else sm_scale
     scale = score_scale * LOG2E
     accum_dtype = "float"
@@ -49,6 +373,7 @@ def _gqa_decode_bs1_ctx_kernel(batch, heads, groups, dim, sm_scale, softcap, dty
         shape_q = [batch, heads, dim]
         shape_k = [batch, seqlen_kv, groups, dim]
         shape_o = [batch, heads, dim]
+        rope_shape = [max_position, rotary_dim // 2]
         part_shape = [batch, heads, ctx_splits, dim]
         lse_shape = [batch, heads, ctx_splits]
 
@@ -65,7 +390,7 @@ def _gqa_decode_bs1_ctx_kernel(batch, heads, groups, dim, sm_scale, softcap, dty
                 barrier=ready[k % RING_DEPTH],
             )
 
-        split = make_gqa_decode_bs1_split(
+        split = _make_dense_decode_split(
             batch,
             groups,
             block_M,
@@ -79,6 +404,9 @@ def _gqa_decode_bs1_ctx_kernel(batch, heads, groups, dim, sm_scale, softcap, dty
             accum_dtype,
             False,
             load_kv,
+            fuse_rope,
+            rotary_dim,
+            rope_layout,
         )
         combine = make_gqa_decode_bs1_combine(
             batch,
@@ -89,6 +417,34 @@ def _gqa_decode_bs1_ctx_kernel(batch, heads, groups, dim, sm_scale, softcap, dty
             accum_dtype,
         )
 
+        if fuse_rope:
+
+            @T.prim_func
+            def gqa_decode_bs1_ctx_rope(
+                Q: T.Tensor(shape_q, dtype),
+                K: T.Tensor(shape_k, dtype),
+                V: T.Tensor(shape_k, dtype),
+                rope_cos: T.Tensor(rope_shape, dtype),
+                rope_sin: T.Tensor(rope_shape, dtype),
+                glse: T.Tensor(lse_shape, accum_dtype),
+                Output_partial: T.Tensor(part_shape, accum_dtype),
+                Output: T.Tensor(shape_o, dtype),
+            ):
+                split(
+                    Q,
+                    K,
+                    V,
+                    K,
+                    seqlen_kv,
+                    rope_cos,
+                    rope_sin,
+                    glse,
+                    Output_partial,
+                )
+                combine(glse, Output_partial, Output)
+
+            return gqa_decode_bs1_ctx_rope
+
         @T.prim_func
         def gqa_decode_bs1_ctx(
             Q: T.Tensor(shape_q, dtype),
@@ -98,7 +454,7 @@ def _gqa_decode_bs1_ctx_kernel(batch, heads, groups, dim, sm_scale, softcap, dty
             Output_partial: T.Tensor(part_shape, accum_dtype),
             Output: T.Tensor(shape_o, dtype),
         ):
-            split(Q, K, V, K, seqlen_kv, glse, Output_partial)
+            split(Q, K, V, K, seqlen_kv, Q, Q, glse, Output_partial)
             combine(glse, Output_partial, Output)
 
         return gqa_decode_bs1_ctx
@@ -115,6 +471,10 @@ def _gqa_decode_bs1_ctx_op(
     sm_scale: float,
     softcap: float,
     dtype: str,
+    fuse_rope: bool,
+    max_position: int,
+    rotary_dim: int,
+    rope_layout: str,
     block_M: int,
     block_N: int,
     ctx_splits: int,
@@ -122,12 +482,27 @@ def _gqa_decode_bs1_ctx_op(
     Q: torch.Tensor,
     K: torch.Tensor,
     V: torch.Tensor,
+    rope_cos: torch.Tensor,
+    rope_sin: torch.Tensor,
     glse: torch.Tensor,
     Output_partial: torch.Tensor,
 ) -> torch.Tensor:
-    return _gqa_decode_bs1_ctx_kernel(batch, heads, groups, dim, sm_scale, softcap, dtype)(
-        block_M, block_N, ctx_splits, threads
-    )(Q, K, V, glse, Output_partial)
+    kernel = _gqa_decode_bs1_ctx_kernel(
+        batch,
+        heads,
+        groups,
+        dim,
+        sm_scale,
+        softcap,
+        dtype,
+        fuse_rope,
+        max_position,
+        rotary_dim,
+        rope_layout,
+    )(block_M, block_N, ctx_splits, threads)
+    if fuse_rope:
+        return kernel(Q, K, V, rope_cos, rope_sin, glse, Output_partial)
+    return kernel(Q, K, V, glse, Output_partial)
 
 
 @_gqa_decode_bs1_ctx_op.register_fake
@@ -139,6 +514,10 @@ def _(
     sm_scale: float,
     softcap: float,
     dtype: str,
+    fuse_rope: bool,
+    max_position: int,
+    rotary_dim: int,
+    rope_layout: str,
     block_M: int,
     block_N: int,
     ctx_splits: int,
@@ -146,20 +525,66 @@ def _(
     Q: torch.Tensor,
     K: torch.Tensor,
     V: torch.Tensor,
+    rope_cos: torch.Tensor,
+    rope_sin: torch.Tensor,
     glse: torch.Tensor,
     Output_partial: torch.Tensor,
 ) -> torch.Tensor:
     return torch.empty_like(Q)
 
 
-class GQADecodeBs1Kernel(GQADecodeBs1KernelMixin, Kernel):
+class GQADecodeBs1Kernel(Kernel):
     """Hopper warp-specialized batch=1 GQA decode kernel with a context-length switch.
 
-    ``forward`` dispatches on the runtime K/V sequence extent: >= 1024 runs the context-only
-    split, shorter lengths run the generic non-split GQA decode kernel.
+    ``forward`` always uses the context pipeline for full-dimensional RoPE.  Plain calls
+    below 640 and partial-RoPE calls below 1024 retain the generic single-kernel path.
     """
 
     supported_archs: list[int] = [90]
+    _MIN_CTX = 1024
+    _PLAIN_CTX_MIN = 640
+    _TARGET_PARTIAL_CTAS = 128
+    _CTX_SPLIT_CANDIDATES = (1, 2, 4, 8, 16, 32, 64)
+
+    def _dense_ctx_splits_for(
+        self,
+        real_seqlen_kv: int,
+        *,
+        allow_empty: bool = True,
+    ) -> int:
+        block_n = self.config["block_N"]
+        num_tiles = (real_seqlen_kv + block_n - 1) // block_n
+        split_capacity = max(
+            1,
+            min(self._CTX_SPLIT_CANDIDATES[-1], self._TARGET_PARTIAL_CTAS // self.groups),
+        )
+        selected = 1
+        for ctx_splits in self._CTX_SPLIT_CANDIDATES:
+            if ctx_splits > split_capacity:
+                break
+            if not allow_empty and ctx_splits > num_tiles:
+                break
+            selected = ctx_splits
+            if allow_empty and ctx_splits >= num_tiles:
+                break
+        return selected
+
+    def _allocate_partials(
+        self,
+        q: torch.Tensor,
+        ctx_splits: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        glse = torch.empty(
+            (self.batch, self.heads, ctx_splits),
+            dtype=torch.float32,
+            device=q.device,
+        )
+        output_partial = torch.empty(
+            (self.batch, self.heads, ctx_splits, self.dim),
+            dtype=torch.float32,
+            device=q.device,
+        )
+        return glse, output_partial
 
     @classmethod
     def applies(cls, call) -> bool:
@@ -177,6 +602,11 @@ class GQADecodeBs1Kernel(GQADecodeBs1KernelMixin, Kernel):
         softcap: float = 0.0,
         config: Optional[dict] = None,
         tune=False,
+        *,
+        fuse_rope: bool = False,
+        max_position: int = 1,
+        rotary_dim: int = 0,
+        rope_layout: str = "neox",
         device_index: Optional[int] = None,
     ):
         super().__init__(device_index=device_index)
@@ -188,6 +618,10 @@ class GQADecodeBs1Kernel(GQADecodeBs1KernelMixin, Kernel):
         self.dtype = dtype
         self.sm_scale = dim**-0.5 if sm_scale is None else sm_scale
         self.softcap = softcap
+        self.fuse_rope = fuse_rope
+        self.max_position = max_position
+        self.rotary_dim = rotary_dim
+        self.rope_layout = rope_layout
         if self.groups <= 0:
             raise ValueError("heads_kv must be positive")
         if self.heads % self.groups != 0:
@@ -212,13 +646,42 @@ class GQADecodeBs1Kernel(GQADecodeBs1KernelMixin, Kernel):
         rope_sin: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         self._require_cuda(q=q, k=k, v=v)
-        del q_scale, k_scale, v_scale, rope_cos, rope_sin
+        del q_scale, k_scale, v_scale
+        if self.fuse_rope and (rope_cos is None or rope_sin is None):
+            raise ValueError("fused RoPE requires rope_cos and rope_sin")
         Q = q.squeeze(1)
         K = k
         V = v
         real_seqlen_kv = k.shape[1]
         c = self.config
-        if real_seqlen_kv < self._MIN_CTX:
+        full_rope_pipeline = self.fuse_rope and self.rotary_dim == self.dim
+        use_ctx_pipeline = full_rope_pipeline or real_seqlen_kv >= (
+            self._MIN_CTX if self.fuse_rope else self._PLAIN_CTX_MIN
+        )
+        if not use_ctx_pipeline:
+            if self.fuse_rope:
+                output = _gqa_decode_no_split_rope_op(
+                    self.batch,
+                    self.heads,
+                    self.groups,
+                    self.dim,
+                    self.sm_scale,
+                    self.softcap,
+                    self.dtype_str,
+                    self.max_position,
+                    self.rotary_dim,
+                    self.rope_layout,
+                    64,
+                    128,
+                    2,
+                    128,
+                    Q,
+                    K,
+                    V,
+                    rope_cos,
+                    rope_sin,
+                )
+                return output.unsqueeze(1)
             output = _gqa_decode_no_split_op(
                 self.batch,
                 self.heads,
@@ -237,7 +700,38 @@ class GQADecodeBs1Kernel(GQADecodeBs1KernelMixin, Kernel):
             )
             return output.unsqueeze(1)
 
-        ctx_splits = self._ctx_splits_for(real_seqlen_kv)
+        ctx_splits = self._dense_ctx_splits_for(
+            real_seqlen_kv,
+            allow_empty=not self.fuse_rope or full_rope_pipeline,
+        )
+        if self.fuse_rope:
+            glse, Output_partial = self._allocate_partials(Q, ctx_splits)
+            output = _gqa_decode_bs1_ctx_op(
+                self.batch,
+                self.heads,
+                self.groups,
+                self.dim,
+                self.sm_scale,
+                self.softcap,
+                self.dtype_str,
+                True,
+                self.max_position,
+                self.rotary_dim,
+                self.rope_layout,
+                c["block_M"],
+                c["block_N"],
+                ctx_splits,
+                ROPE_PIPELINE_THREADS if self.rotary_dim == self.dim else c["threads"],
+                Q,
+                K,
+                V,
+                rope_cos,
+                rope_sin,
+                glse,
+                Output_partial,
+            )
+            return output.unsqueeze(1)
+
         glse, Output_partial = self._allocate_partials(Q, ctx_splits)
         output = _gqa_decode_bs1_ctx_op(
             self.batch,
@@ -247,6 +741,10 @@ class GQADecodeBs1Kernel(GQADecodeBs1KernelMixin, Kernel):
             self.sm_scale,
             self.softcap,
             self.dtype_str,
+            False,
+            1,
+            0,
+            "neox",
             c["block_M"],
             c["block_N"],
             ctx_splits,
@@ -254,6 +752,8 @@ class GQADecodeBs1Kernel(GQADecodeBs1KernelMixin, Kernel):
             Q,
             K,
             V,
+            Q,
+            Q,
             glse,
             Output_partial,
         )

--- a/src/tileops/ops/attention/gqa.py
+++ b/src/tileops/ops/attention/gqa.py
@@ -474,7 +474,7 @@ class GroupedQueryAttentionDenseFwdOp(Op):
         _, seq_len_kv, heads_kv, _ = k.shape
         uses_window = self.window_size_left != -1 or self.window_size_right != -1
         rope_on = self.pos_encoding_mode == "rope"
-        uses_decode = seq_len_q == 1 and not uses_window and not rope_on
+        uses_decode = seq_len_q == 1 and not uses_window
         uses_bs1_decode = (
             uses_decode
             and batch == 1
@@ -510,6 +510,7 @@ class GroupedQueryAttentionDenseFwdOp(Op):
                     dtype=q.dtype,
                     sm_scale=self.sm_scale,
                     softcap=self.softcap,
+                    **rope_kwargs,
                     device_index=q.device.index,
                 )
             if uses_window:

--- a/tests/ops/attention/test_gqa.py
+++ b/tests/ops/attention/test_gqa.py
@@ -202,12 +202,14 @@ def test_gqa_dense_reuses_one_kernel_across_sequence_lengths(batch: int) -> None
 
 
 @pytest.mark.parametrize(
-    "batch, dtype, seq_lens_kv, kernel_type",
+    "batch, dtype, seq_lens_kv, rope_layout, rotary_dim, kernel_type",
     [
         pytest.param(
             1,
             torch.float16,
             (257, 1057),
+            None,
+            None,
             GQADecodeBs1Kernel,
             id="bs1-fp16",
         ),
@@ -215,8 +217,37 @@ def test_gqa_dense_reuses_one_kernel_across_sequence_lengths(batch: int) -> None
             2,
             torch.bfloat16,
             (257, 2051),
+            None,
+            None,
             GQADecodeKernel,
             id="batched-bf16",
+        ),
+        pytest.param(
+            1,
+            torch.float16,
+            (271,),
+            "neox",
+            64,
+            GQADecodeBs1Kernel,
+            id="bs1-fp16-neox-partial",
+        ),
+        pytest.param(
+            1,
+            torch.float16,
+            (1057,),
+            "neox",
+            128,
+            GQADecodeBs1Kernel,
+            id="bs1-fp16-neox-full-ctx-tail",
+        ),
+        pytest.param(
+            2,
+            torch.bfloat16,
+            (257,),
+            "interleaved",
+            128,
+            GQADecodeKernel,
+            id="batched-bf16-interleaved-full",
         ),
     ],
 )
@@ -225,21 +256,50 @@ def test_gqa_dense_decode_dispatch_and_dynamic_sequence_lengths(
     batch: int,
     dtype: torch.dtype,
     seq_lens_kv: tuple[int, ...],
+    rope_layout: Optional[str],
+    rotary_dim: Optional[int],
     kernel_type: type[Kernel],
 ) -> None:
     if not torch.cuda.is_available() or get_sm_version() != 90:
         pytest.skip("Dense decode requires SM90")
     heads, heads_kv, dim = 8, 2, 128
-    op = GroupedQueryAttentionDenseFwdOp()
+    op = GroupedQueryAttentionDenseFwdOp(
+        pos_encoding_mode="rope" if rope_layout is not None else "none",
+        rotary_dim=rotary_dim,
+        rope_layout="neox" if rope_layout is None else rope_layout,
+    )
 
     for seq_len_kv in seq_lens_kv:
         q = torch.randn(batch, 1, heads, dim, device="cuda", dtype=dtype)
         k = torch.randn(batch, seq_len_kv, heads_kv, dim, device="cuda", dtype=dtype)
         v = torch.randn_like(k)
-        output = op(q, k, v)
+        if rope_layout is None:
+            rope_cos = rope_sin = None
+            q_ref, k_ref = q, k
+        else:
+            assert rotary_dim is not None
+            angles = torch.randn(seq_len_kv, rotary_dim // 2, device="cuda") * 0.1
+            rope_cos, rope_sin = angles.cos().to(dtype), angles.sin().to(dtype)
+            q_ref = _apply_dense_rope(
+                q,
+                torch.tensor([seq_len_kv - 1], device="cuda"),
+                rope_cos,
+                rope_sin,
+                rotary_dim=rotary_dim,
+                layout=rope_layout,
+            )
+            k_ref = _apply_dense_rope(
+                k,
+                torch.arange(seq_len_kv, device="cuda"),
+                rope_cos,
+                rope_sin,
+                rotary_dim=rotary_dim,
+                layout=rope_layout,
+            )
+        output = op(q, k, v, rope_cos=rope_cos, rope_sin=rope_sin)
         torch.testing.assert_close(
             output,
-            _gqa_prefill_ref(q, k, v, heads=heads, heads_kv=heads_kv, is_causal=True),
+            _gqa_prefill_ref(q_ref, k_ref, v, heads=heads, heads_kv=heads_kv, is_causal=True),
             atol=1.6e-2 if dtype == torch.bfloat16 else 5e-3,
             rtol=1.6e-2 if dtype == torch.bfloat16 else 1e-5,
         )


### PR DESCRIPTION
## Summary

- Fuse NeoX/interleaved RoPE directly into Dense decode Q/K loading.
- Pipeline full-dimensional RoPE table loads and K rotation with the WGMMA consumer.
- Select Dense context splits from KV-tile count and KV-head parallelism.
- Balance non-divisible KV tiles across split CTAs and safely handle empty split buckets.
- Keep Paged decode outside this PR's implementation scope.

## Validation

- H200 Dense decode/sliding suite: **7 passed, 12 deselected**
- H200 Paged-decode regression suite: **22 passed**
- Partial-RoPE and non-divisible full-RoPE tails match the PyTorch reference.
- FlashInfer same-semantics check: maximum absolute error **0.000244**
- `ruff` and `git diff --check` pass.

## Performance

Native CUPTI, three alternating rounds on a clock-locked H200. Values are median full activity envelopes.

| Shape | TileOps | FlashInfer | Relative |
| --- | ---: | ---: | ---: |
| B1, H/Hkv=32/4, Skv=1024, D=128 | 12.24 us | 15.66 us | 128.0% |
| B1, H/Hkv=32/4, Skv=16384, D=128 | 26.02 us | 26.77 us | 102.9% |
| B8, H/Hkv=32/8, Skv=4096, D=128 | 164.86 us | 146.51 us | 88.9% |
| B32, H/Hkv=32/8, Skv=4096, D=128 | 512.08 us | 554.56 us | 108.3% |

TileOps and FlashInfer both emit two GPU activities, so fused RoPE adds no extra launch. The B8/B32 workloads use the general batched decode kernel and are unchanged by the batch-1 optimization.

For non-divisible full-RoPE lengths at B1 and H/Hkv=32/4:

| Skv | Before | After |
| ---: | ---: | ---: |
| 1057 | 11.23 us | 10.34 us |
| 2176 | 13.39 us | 11.23 us |
| 3072 | 14.61 us | 11.60 us |
