### PR TITLE
[Perf][foundry][Norm] Spread many short BatchNorm channels over narrow blocks

### DIFF
--- a/src/tileops/kernels/norm/batch_norm.py
+++ b/src/tileops/kernels/norm/batch_norm.py
@@ -108,12 +108,26 @@ class _WholePath:
     MAX_L = 32
     BLOCK_THREADS = 256
 
+    # Channel counts and channel lengths from which the narrow block wins. The
+    # two bounds hold for different reasons. A narrow block wastes half of every
+    # transaction -- a warp covers 32 channels, 64 bytes of a 128-byte line --
+    # and that costs the same at every channel count while what it buys grows:
+    # 768 channels fill three blocks of the default width against twelve narrow
+    # ones. The length bound is the register footprint, threads * L elements per
+    # block: only from eight elements per channel does it cap how many blocks of
+    # the default width an SM hosts.
+    SPREAD_MIN_C = 768
+    SPREAD_MIN_L = 8
+    SPREAD_BLOCK_THREADS = 64
+
     @classmethod
-    def launch(cls, L: int, S: int) -> Optional[int]:
+    def launch(cls, L: int, S: int, C: int) -> Optional[int]:
         """The block width this path needs, or None where it does not serve."""
-        if S <= cls.MAX_S and L <= cls.MAX_L:
-            return cls.BLOCK_THREADS
-        return None
+        if S > cls.MAX_S or L > cls.MAX_L:
+            return None
+        if C >= cls.SPREAD_MIN_C and L >= cls.SPREAD_MIN_L:
+            return cls.SPREAD_BLOCK_THREADS
+        return cls.BLOCK_THREADS
 
 
 class _WidePath:
@@ -790,7 +804,7 @@ class BatchNormFwdTrainKernel(Kernel):
 
         Each path class states what owns a channel there and when it is chosen.
         """
-        whole = _WholePath.launch(L, S)
+        whole = _WholePath.launch(L, S, C)
         if whole is not None:
             return "whole", whole
         wide = _WidePath.launch(C, L, S, dtype)


### PR DESCRIPTION
## Summary

- The channel-per-thread path gives the grid one thread per channel and its block was a fixed 256 threads. From 768 channels and eight elements per channel a 64-thread block is faster: 18 of the 80 shapes the path admits change, every one faster or level, 1.009x to 1.159x, geometric mean 1.071x.
- The two bounds hold for different reasons. A narrow block wastes half of every transaction -- a warp covers 32 channels, 64 bytes of a 128-byte line -- and that costs the same at every channel count while what it buys grows: 768 channels fill three blocks of the default width against twelve narrow ones. The length bound is the register footprint, `threads * L` elements per block, which only from eight elements per channel caps how many wide blocks an SM hosts.
- No rule derives the width outside those bounds, and tuning cannot pick it: the kernel runs 1.4 us to 2.8 us of device time while an in-process event loop around the same launch reports 14.5 us to 24.6 us, so every width times the same. Both are shown under Result And Limitations.

## TileFoundry Description

```python
@module(entry="bn_whole", target=CudaTarget("nvidia.h200_sxm"),
        topologies=(Topology("cta", C // W), Topology("thread", W)))
class ChannelPerThread:
    """W channels per CTA, C // W CTAs: one channel per thread throughout."""

    @func
    def bn_whole(x: Tensor[(C // W, W, L), "f16"]):
        with Mesh(("cta",), (C // W,), ("g",)) as cta:
            with Mesh(("thread",), (W,), ("t",)) as m:
                held = tf.reshard(x, ((C // W) @ cta.g, W @ m.t, L), "rmem")
                v = tf.cast(held, "f32")
                mean = tf.reduce(v, (-1,), True, ReduceKind.MEAN)
                var = tf.reduce(tf.square(v - mean), (-1,), True, ReduceKind.MEAN)
                out = (v - mean) * tf.rsqrt(var + EPS)
                return tf.reshard(tf.cast(out, "f16"), (C // W, W, L), "gmem")
```

`analyze` prices the same module at both widths for `C=768, L=32`, `bound-by=memory`, `ideal-ns=21`, `waves=1` either way:

| Block width | CTAs | `predicted-ns` | Measured (us) |
| ---: | ---: | ---: | ---: |
| 256 | 3 | 1033 | 2.336 |
| **64** | **12** | **266** | **2.015** |

The direction is what this PR takes; the magnitude is not reachable. Both figures sit under the launch: an empty-tensor kernel measures 1.216 us on this timer, so 3.9x of predicted device time is 1.159x of what the row costs.

The prediction also does not hold below the bounds, which is why the rule carries them. At 64 channels `analyze` prices 8 CTAs of 8 threads at `predicted-ns=40` against 266 for one CTA of 64, and measured the narrow grid is slower, 1.696 us against 1.345 us: it does not model the half-line transaction a block narrower than a full warp's worth of channels leaves behind.

## Performance

Operator: `BatchNormFwdTrainKernel`, channel-per-thread path (`S == 1`, `L <= 32`)

| Environment | Value |
| --- | --- |
| image | ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-afcebed1-tilefoundry-latest |
| digest | sha256:ca13df9bda340edf248b8b443b88880f36e3190ab9d470f52d66ccc21c15fd59 |
| gpu | NVIDIA H200 |
| driver | 595.71.05 |
| cuda | 13.2 |
| torch | 2.13.0+cu132 |
| tilelang | 0.1.11+cu132.gitafcebed1 |
| tilefoundry | 0.1.dev146+g2bec6420e (the image's editable install at /opt/tilefoundry) |
| timer | native CUPTI device-busy time, L2 cleared per iteration |

Method: both widths of the same kernel timed back to back in one process on one card, five repeats each, median reported and the spread taken as the wider of the two deviations. Ratio: default / candidate. &#x1F7E2; > 1 means the candidate is faster.

Every shape the rule changes:

| C | L | This PR, 64 threads (us) | Default, 256 threads (us) | Ratio |
| ---: | ---: | ---: | ---: | ---: |
| 768 | 8 | 1.760 (+/-1.8%) | 1.824 (+/-1.7%) | &#x1F7E2;&nbsp;1.036x |
| 1024 | 8 | 1.792 (+/-0.0%) | 1.808 (+/-0.9%) | 1.009x |
| 1536 | 8 | 1.824 (+/-0.1%) | 1.887 (+/-0.8%) | &#x1F7E2;&nbsp;1.035x |
| 2048 | 8 | 1.856 (+/-1.7%) | 1.889 (+/-1.7%) | 1.018x |
| 3072 | 8 | 1.920 (+/-1.6%) | 1.953 (+/-1.6%) | 1.017x |
| 4096 | 8 | 1.920 (+/-1.7%) | 1.983 (+/-0.1%) | &#x1F7E2;&nbsp;1.033x |
| 768 | 16 | 1.840 (+/-0.9%) | 1.952 (+/-1.7%) | &#x1F7E2;&nbsp;1.061x |
| 1024 | 16 | 1.888 (+/-1.7%) | 2.048 (+/-1.6%) | &#x1F7E2;&nbsp;1.085x |
| 1536 | 16 | 1.920 (+/-0.0%) | 2.048 (+/-1.6%) | &#x1F7E2;&nbsp;1.067x |
| 2048 | 16 | 1.984 (+/-1.6%) | 2.080 (+/-1.5%) | &#x1F7E2;&nbsp;1.048x |
| 3072 | 16 | 1.984 (+/-0.0%) | 2.112 (+/-0.0%) | &#x1F7E2;&nbsp;1.065x |
| 4096 | 16 | 2.048 (+/-1.6%) | 2.143 (+/-1.4%) | &#x1F7E2;&nbsp;1.047x |
| 768 | 32 | 2.015 (+/-1.6%) | 2.336 (+/-0.0%) | **&#x1F7E2;&nbsp;1.159x** |
| 1024 | 32 | 2.080 (+/-1.5%) | 2.368 (+/-1.4%) | **&#x1F7E2;&nbsp;1.138x** |
| 1536 | 32 | 2.080 (+/-1.5%) | 2.400 (+/-0.0%) | **&#x1F7E2;&nbsp;1.154x** |
| 2048 | 32 | 2.144 (+/-1.5%) | 2.368 (+/-0.0%) | **&#x1F7E2;&nbsp;1.104x** |
| 3072 | 32 | 2.176 (+/-0.0%) | 2.432 (+/-1.3%) | **&#x1F7E2;&nbsp;1.118x** |
| 4096 | 32 | 2.272 (+/-0.0%) | 2.497 (+/-1.2%) | **&#x1F7E2;&nbsp;1.099x** |
| geometric mean | | 1.968 | 2.107 | **&#x1F7E2;&nbsp;1.071x** |

The 62 shapes the rule leaves on 256 threads are unchanged by construction: the width they launch is the width they launch today.

## Result And Limitations

- **No benchmark row exercises this path's new corner.** `resnet50-fc` is the only `BatchNormFwdOp` row that takes the channel-per-thread path, at C=64, so `bench_batch_norm.py` reports the same five numbers before and after. The gain is for a two-dimensional BatchNorm of 768 channels or more, which the benchmark does not carry.
- The bounds are measured crossovers, and the table they come from is wider than the rule: 80 shapes, `L` in {2, 4, 8, 16, 32} crossed with `C` in {32, 64, 96, 128, 192, 256, 320, 384, 512, 640, 768, 1024, 1536, 2048, 3072, 4096}, six widths from 32 to 1024, five repeats each. 37 of those shapes have a width faster than 256 by more than their own spread.
- No rule reaches all of them. Twenty-six candidates were scored against that table -- thresholds on `L`, on `C`, on both, and fixed widths -- and every one loses 0.70x to 0.89x on some shape, because the fastest width is 1024 for a short channel and 32 for a long one and the crossover is not a function of either variable alone. Only rules confined to the `C >= 704..768`, `L >= 4..8` corner regress nothing, and this PR ships the widest of those.
- Tuning does not reach it either, and was implemented and reverted. The kernel is 1.4 us to 2.8 us of device time; an in-process CUDA-event loop around the same launch reports 14.5 us to 24.6 us, so all six widths land within 1-3% of each other and the tuner picked the default on six of eight shapes where the CUPTI ranking says otherwise. Clearing L2 inside the tuner makes it worse, 24 us to 25 us, because the flush lands inside the measured window. A tune-time timer that resolves a 2 us kernel is what this would need.
- What the rule does not change: the path's admission (`S == 1`, `L <= 32`), the prim_func, and the reduction. A block width is all that moves, and the prim_func reads it only for `blocks = ceildiv(C, threads)` and `c = bx * threads + tid`, with `if c < C` guarding the tail -- there is no shared memory, no shuffle and no barrier on this path.

## Test

`tests/ops/test_batch_norm.py`, `tests/ops/test_norm_ops.py`, `tests/ops/test_norm_lazy_cache.py`: 31 passed. Test node delta: 0.

Beyond the suite, the widths were checked against `torch` on 216 combinations -- three dtypes crossed with `L` in {7, 8, 9, 16, 31, 32} and `C` in {767, 768, 769, 800, 831, 1000, 1023, 1024, 1025, 1537, 4095, 4096}, so both sides of each bound and channel counts no candidate width divides -- comparing output, `mean`, `rstd` and both running statistics. No mismatch.


