### PR TITLE
[Perf][Pool] Lower the MeanPooling uniform full-chunk copy to vectorized loads

### DIFF
--- a/src/tileops/kernels/pool/mean_pooling.py
+++ b/src/tileops/kernels/pool/mean_pooling.py
@@ -59,14 +59,24 @@ def _mean_pooling_kernel(
                 start_dim = i_d * bdim
                 end_dim = T.min(start_dim + bdim, dim)
 
-                T.clear(x_shared)
-                # disable_tma=True: the copy extent is a runtime value
-                # (ragged chunks), which the TMA lowering cannot express.
-                T.copy(
-                    x[i_b, start_token:end_token, i_h, start_dim:end_dim],
-                    x_shared[0 : end_token - start_token, : end_dim - start_dim],
-                    disable_tma=True,
-                )
+                # Static fast path: a uniform split with no tail chunk and a `dim`
+                # exactly tiled by `bdim` makes every extent a compile-time constant,
+                # so the copy lowers to vectorized TMA loads instead of the guarded
+                # scalar path below, and the full tile it writes needs no T.clear.
+                if use_offsets == 0 and seq_len % chunk_size == 0 and dim % bdim == 0:
+                    T.copy(
+                        x[i_b, start_token : start_token + chunk_size, i_h, start_dim:end_dim],
+                        x_shared,
+                    )
+                else:
+                    T.clear(x_shared)
+                    # disable_tma=True: the copy extent is a runtime value
+                    # (ragged chunks), which the TMA lowering cannot express.
+                    T.copy(
+                        x[i_b, start_token:end_token, i_h, start_dim:end_dim],
+                        x_shared[0 : end_token - start_token, : end_dim - start_dim],
+                        disable_tma=True,
+                    )
                 T.copy(x_shared, x_local)
                 T.reduce_sum(x_local, output_local, dim=0)
                 for d_idx in T.Parallel(bdim):


### PR DESCRIPTION
## Problems

- On the two uniform-split MeanPoolingFwd workloads the kernel is ~3x behind `torch-view-mean` (conv-pool#meanpoolingfwd, H200): 0.135 ms vs 0.047 ms on uniform-8k, 0.070 ms vs 0.029 ms on uniform-batched, at ~1.0 TB/s where the shape allows 3+ TB/s.
- The chunk bounds are `T.alloc_var`s, so the copy extent `end_token - start_token` is a runtime value even when every chunk is full. `T.copy` then lowers to a guarded scalar loop — one 2B load per element, warp threads 16B apart, ~1/8 sector efficiency — plus a `T.clear` of the tile the copy would fill anyway.

## Changes

- A trace-time fast path in `_mean_pooling_kernel`: when the split is uniform, `seq_len % chunk_size == 0` and `dim % bdim == 0`, the copy uses compile-time extents into the whole `x_shared` tile, with no `T.clear` and no `disable_tma`. It lowers to fully unrolled, coalesced 16B vector loads (8 `uint4` per thread on W4).
- Ragged splits and tail-chunk shapes keep the existing dynamic path. No Op-layer, manifest or API changes.

## Performance

H200, `benchmarks/ops/bench_mean_pooling.py`, CUPTI device-busy time, tune=True:

| workload | before | after | speedup | vs fastest baseline |
| --- | ---: | ---: | ---: | --- |
| uniform-8k | 0.1350 ms | 0.0405 ms | 3.33x | 0.35x -> **1.16x** (torch-view-mean) |
| uniform-batched | 0.0701 ms | 0.0235 ms | 2.98x | 0.41x -> **1.21x** (torch-view-mean) |
| ragged-even | 0.1948 ms | 0.1895 ms | ~1.0x | unchanged (dynamic path) |
| ragged-tail | 0.0794 ms | 0.0782 ms | ~1.0x | unchanged (dynamic path) |
| ragged-batched | 0.1262 ms | 0.1263 ms | ~1.0x | unchanged (dynamic path) |

("before" for the ragged rows is the published nightly; they recompile to the identical dynamic path.)

## Result And Limitations

- Both uniform rows move from below the fastest baseline to above it; effective bandwidth on uniform-8k goes 1.0 -> 3.4 TB/s.
- 12 `tests/ops/test_mean_pooling.py` cases pass; all 5 benchmark workloads pass with reference checks.
- The ragged path keeps the runtime-extent copy: its chunk bounds come from the `offsets` tensor, so the same treatment would need a runtime full-chunk branch, which this PR leaves out.

Fixes #2092