### PR TITLE
[Perf][foundry][Norm] Walk a register-held norm row once, and read its affine before it

### DIFF
--- a/src/tileops/kernels/norm/_config.py
+++ b/src/tileops/kernels/norm/_config.py
@@ -1,25 +1,21 @@
 """What the row-wise norm kernels share: tile-config selection and the row reduction.
 
-These kernels hold a ``(block_m, N_padded)`` row block in register fragments and
-reduce along the row. When ``N_padded`` is not a power of two, TileLang's layout
-inference places a partitioned layout for some ``block_m`` but falls back to a
-replicated one for others -- each thread owns a whole row, spills to local
-memory, and the cross-thread ``AllReduce`` degenerates into a serial loop. That
-is 5-16x slower yet numerically correct, so no correctness test catches it.
+These kernels hold a ``(block_m, n_padded)`` row block in register fragments and
+reduce along the row. When ``n_padded`` is not a power of two, TileLang's layout
+inference places a partitioned layout for some ``block_m`` and a replicated one
+for others -- each thread owns a whole row, spills to local memory, and the
+cross-thread ``AllReduce`` degenerates into a serial loop. That is 5-16x slower
+yet numerically correct, so no correctness test catches it. Every config chosen
+here pins ``block_m=1``, where the per-row uniformity the reduction needs holds
+for any width, thread count and dtype.
 
-``select_row_config`` pins ``block_m=1``: with one row per CTA the per-row
-uniformity the reduction needs always holds, so the collapse is impossible for
-any N/threads/dtype -- structural, not a tuned value. ``threads=128`` is what it
-pins, because a row padded to the 256-element alignment often divides by nothing
-wider. ``select_row_configs`` keeps ``block_m`` as a swept autotune knob so the
-kernel interface is not narrowed; configs that collapse lose on their measured
-runtime.
-
-A row of a few thousand elements is latency-bound, not instruction-bound: what
-decides it is how many loads one thread has in flight. ``select_row_config_by_width``
-sizes the block from :data:`_TARGET_ELEMENTS_PER_THREAD` for that reason, over widths
-that reach down to one warp for a row short enough to keep a thread's share small.
+Of the two row reductions here, :func:`make_row_reduce` walks the row twice and
+holds one fp32 copy of it, and :func:`make_shifted_row_reduce` walks it once and
+holds two: a kernel reading the row straight into fragments can afford the
+second, one staging it through shared memory cannot.
 """
+
+from typing import Optional
 
 import tilelang.language as T
 import torch
@@ -29,40 +25,35 @@ from tileops.kernels.tiling import ALIGNMENT
 
 __all__ = [
     "CANDIDATE_THREADS_BY_WIDTH",
+    "NARROW_ROW",
     "make_row_reduce",
+    "make_shifted_row_reduce",
     "row_padding",
     "select_row_config",
     "select_row_config_by_width",
     "select_row_configs",
+    "widths_for_row",
 ]
 
 # Powers of two only (tl::AllReduce is an XOR butterfly) that also divide
-# N_padded, or layout inference reports "no available layout". CUDA caps at 1024.
+# n_padded, or layout inference reports "no available layout". CUDA caps a block
+# at 1024 threads.
 _CANDIDATE_THREADS = (128, 256, 512, 1024)
 
-# Row width at or below which a block narrower than 128 is offered. Above it a
-# narrow block hands one thread hundreds of elements, and layout inference
-# answers that with the replicated layout this module's docstring describes.
-NARROW_ROW = 2048
-
-# The widths a row sized by :data:`_TARGET_ELEMENTS_PER_THREAD` can land on.
-# Separate from :data:`_CANDIDATE_THREADS` so a block narrower than one warp
-# reaches only the kernels that ask for this tuple, and only for a row short
-# enough to keep a thread's share of it small.
+# The widths a short row may also use. Separate from :data:`_CANDIDATE_THREADS`
+# so a block narrower than one warp reaches only the kernels that ask for it.
 CANDIDATE_THREADS_BY_WIDTH = (32, 64) + _CANDIDATE_THREADS
 
+# Row width at or below which a block narrower than 128 is offered. Above it a
+# narrow block hands one thread hundreds of columns, which layout inference
+# answers with the replicated layout this module's docstring describes.
+NARROW_ROW = 2048
 
-def widths_for_row(n_padded: int) -> tuple:
-    """Block widths a row of *n_padded* elements may be split across."""
-    return CANDIDATE_THREADS_BY_WIDTH if n_padded <= NARROW_ROW else _CANDIDATE_THREADS
-
-
-# block_m values offered to autotune; block_m=1 is always the safe default.
-_CANDIDATE_BLOCK_M = (1, 2, 4, 8)
-
-_DEFAULT_THREADS = 128  # divides every aligned row; see the module docstring
-
+_CANDIDATE_BLOCK_M = (1, 2, 4, 8)  # rows per block offered to autotune
+_DEFAULT_THREADS = 128  # divides every row padded to a multiple of ALIGNMENT
 _ROW_SMEM_BUDGET_BYTES = 48 * 1024
+
+_TARGET_ELEMENTS_PER_THREAD = 32  # what select_row_config_by_width aims for
 
 
 def row_padding(n: int, elem_bytes: int) -> int:
@@ -79,21 +70,9 @@ def row_padding(n: int, elem_bytes: int) -> int:
     return -(-n // ALIGNMENT) * ALIGNMENT
 
 
-# Row elements a thread carries. Enough of them keep loads in flight to cover
-# the latency the row is bound by.
-_TARGET_ELEMENTS_PER_THREAD = 32
-
-
-def select_row_config_by_width(n_padded: int) -> dict:
-    """``{block_m, threads}`` for a row reduction, sized by the row itself.
-
-    For a row padded to a power of two, which admits every candidate width.
-    """
-    threads = n_padded // _TARGET_ELEMENTS_PER_THREAD
-    for candidate in sorted(widths_for_row(n_padded), reverse=True):
-        if candidate <= threads and n_padded % candidate == 0:
-            return {"block_m": 1, "threads": candidate}
-    return {"block_m": 1, "threads": _DEFAULT_THREADS}
+def widths_for_row(n_padded: int) -> tuple:
+    """Block widths a row of *n_padded* columns may be split across."""
+    return CANDIDATE_THREADS_BY_WIDTH if n_padded <= NARROW_ROW else _CANDIDATE_THREADS
 
 
 def _feasible_threads(
@@ -101,8 +80,8 @@ def _feasible_threads(
 ) -> list[int]:
     """Thread counts that divide the row and keep loads 128-bit vectorizable.
 
-    128-bit needs ``16 // element_size`` elements per thread (8 for fp16/bf16,
-    4 for fp32). If no candidate meets that floor (small rows), fall back to any
+    128-bit needs ``16 // element_size`` columns per thread (8 for fp16/bf16, 4
+    for fp32). If no candidate meets that floor (small rows), fall back to any
     thread count that divides the row so the autotune space is never empty.
 
     Args:
@@ -125,40 +104,63 @@ def select_row_config() -> dict:
     return {"block_m": 1, "threads": _DEFAULT_THREADS}
 
 
+def select_row_config_by_width(n_padded: int, widths: Optional[tuple] = None) -> dict:
+    """``{block_m, threads}`` for a row reduction, sized by the row itself.
+
+    Args:
+        n_padded: Padded row width.
+        widths: Block widths to choose from. A caller that narrows its autotune
+            space passes the same tuple here, so the untuned default stays a
+            member of it. When every width in it overshoots the target, the
+            narrowest is the closest the tuple gets.
+    """
+    narrowed = widths is not None
+    if widths is None:
+        widths = widths_for_row(n_padded)
+    usable = sorted(t for t in widths if n_padded % t == 0)
+    target = n_padded // _TARGET_ELEMENTS_PER_THREAD
+    for candidate in reversed(usable):
+        if candidate <= target:
+            return {"block_m": 1, "threads": candidate}
+    if narrowed and usable:
+        return {"block_m": 1, "threads": usable[0]}
+    return select_row_config()
+
+
 def select_row_configs(
     n_padded: int,
     dtype: torch.dtype = torch.float16,
     num_buffers: int = 1,
     widths: tuple = _CANDIDATE_THREADS,
+    block_ms: tuple = _CANDIDATE_BLOCK_M,
 ) -> list[dict]:
-    """Autotune space: block_m x usable thread counts, default always included.
+    """Autotune space: *block_ms* x the thread counts *widths* admits.
 
-    block_m is swept (not pinned) so the interface is preserved; configs that
-    collapse are rejected by the autotuner's own measured runtime. block_m is
-    capped by the 48 KB shared-memory budget for ``num_buffers`` row-sized
-    buffers, which bounds the kernels that stage a row block in shared memory;
-    for one that holds the block in registers the cap is simply not the binding
-    limit. The default is always a member so the list is never empty.
+    block_m defaults to the full sweep so the kernel interface is not narrowed;
+    a caller whose kernel is too short for the autotuner to rank pins it
+    instead. block_m is capped by the shared-memory budget for ``num_buffers``
+    row-sized buffers, which binds only the kernels that stage a row block in
+    shared memory.
 
     Args:
         n_padded: Padded row width.
         dtype: Element type the row is stored in.
         num_buffers: Row-sized shared buffers the kernel holds live at once.
         widths: Block widths to draw from.
+        block_ms: Rows-per-block values to offer.
     """
     threads = _feasible_threads(n_padded, dtype, widths)
     smem_per_row = n_padded * torch.tensor([], dtype=dtype).element_size()
-    max_block_m = (48 * 1024) // (num_buffers * smem_per_row)
+    max_block_m = _ROW_SMEM_BUDGET_BYTES // (num_buffers * smem_per_row)
     configs = [
         {"block_m": block_m, "threads": t}
-        for block_m in _CANDIDATE_BLOCK_M
+        for block_m in block_ms
         if block_m <= max_block_m
         for t in threads
     ]
-    default = select_row_config()
-    if default not in configs:
-        configs.insert(0, default)
-    return configs
+    # A row so wide that no offered block_m fits the budget still needs one
+    # config to tune over.
+    return configs or [select_row_config()]
 
 
 def make_row_reduce(block_m, n, n_padded, eps):
@@ -197,3 +199,41 @@ def make_row_reduce(block_m, n, n_padded, eps):
             )
 
     return row_reduce
+
+
+def make_shifted_row_reduce(block_m, n, eps):
+    """Create the macro turning an already-shifted row block into mean and rstd.
+
+    Reads the two fragments the load fills and rewrites neither: ``d`` holds
+    ``x - shift`` and ``sq`` holds its square. ``mean_val`` comes back shifted by
+    the same amount, so the output pass reads ``d[i, j] - mean_val[i]`` and gets
+    ``x - E[x]``.
+
+    Two things the caller supplies:
+
+    - ``shift`` is a value from the row itself. Without it the difference of the
+      two sums loses the variance to cancellation as soon as a row's mean
+      outgrows its spread.
+    - A pad column holds zero in both fragments, which is why no correction term
+      for the padding appears here.
+
+    Args:
+        block_m: Rows per block.
+        n: Row length.
+        eps: Epsilon for numerical stability.
+
+    Returns:
+        A ``@T.macro`` taking ``(d, sq, acc_shifted, acc_squares, mean_val, rstd)``.
+    """
+
+    @T.macro
+    def shifted_row_reduce(d, sq, acc_shifted, acc_squares, mean_val, rstd):
+        # One accumulator each: sharing one puts a block-wide barrier between
+        # the two sums and makes the second wait on the first.
+        T.reduce_sum(d, acc_shifted, dim=1)
+        T.reduce_sum(sq, acc_squares, dim=1)
+        for i in T.Parallel(block_m):
+            mean_val[i] = acc_shifted[i] / float(n)
+            rstd[i] = T.rsqrt(acc_squares[i] / float(n) - mean_val[i] * mean_val[i] + eps)
+
+    return shifted_row_reduce

--- a/src/tileops/kernels/norm/group_norm.py
+++ b/src/tileops/kernels/norm/group_norm.py
@@ -19,9 +19,13 @@ whole row, and the derivation collapses to ``c = m % C``.
 
 256-element alignment (512 bytes for fp16/bf16) is required by T.copy() shared
 memory instructions. Both kernels here handle a non-aligned D and a tail row
-block inside the prim_func, so neither needs a host-side padding copy. Padding
-zeros contribute 0 to the mean; the centered two-pass variance computation
-subtracts their exact contribution.
+block inside the prim_func, so neither needs a host-side padding copy.
+
+A row held in registers is walked once: the load writes both ``x - shift`` and
+its square, and the reduction reads the two. A row wide enough to stage through
+shared memory has room for one fp32 row instead and takes the centered
+two-pass, where the padding zeros contribute a mean-squared term that reduction
+subtracts back out.
 """
 
 import functools
@@ -36,6 +40,7 @@ from tileops.kernels.kernel_base import Kernel
 from ._config import (
     NARROW_ROW,
     make_row_reduce,
+    make_shifted_row_reduce,
     row_padding,
     select_row_config_by_width,
     select_row_configs,
@@ -43,6 +48,93 @@ from ._config import (
 )
 
 __all__ = ["GroupNormKernel", "GroupNormNoAffineKernel"]
+
+
+def _holds_row_in_registers(D: int, D_padded: int) -> bool:
+    """Whether a row of this width is read from global memory into fragments.
+
+    A row whose width the block divides is. A padded one loses the vectorized
+    copy to a per-element guard, so it only stays in registers while it is narrow
+    enough that staging through shared memory would cost more.
+
+    Args:
+        D: Row length.
+        D_padded: *D* rounded up to a width the block divides.
+    """
+    return D_padded == D or D_padded <= NARROW_ROW
+
+
+class _RowNormKernel(Kernel):
+    """What both kernels here share: the row's tiling and the config space for it.
+
+    Whether the row is read from global memory straight into register fragments
+    decides which reduction the program uses and which block widths are worth
+    offering, so both follow from one predicate rather than from either caller.
+
+    Args:
+        D: Row length = (C / G) * spatial_size.
+        eps: Epsilon for numerical stability.
+        dtype: Data type (float32, float16, or bfloat16).
+        config: Optional tile config dict.
+        tune: If True, autotune tile config.
+    """
+
+    supported_archs: list[int] = [80, 86, 89, 90]
+
+    # Columns one thread carries, for a row held in register fragments. Below the
+    # floor it has too few accesses in flight to cover the row's latency; above
+    # the ceiling the two fp32 fragments outgrow what it can hold.
+    _ELEMENTS_PER_THREAD_BAND = (16, 64)
+
+    # A padded row takes one width rather than a band: every column a thread
+    # carries there also pays the per-element bounds guard.
+    _GUARDED_ELEMENTS_PER_THREAD = 16
+
+    def __init__(
+        self,
+        D: int,
+        eps: float,
+        dtype: torch.dtype,
+        config: Optional[dict] = None,
+        tune: bool = False,
+    ):
+        super().__init__()
+        self.D = D
+        self.eps = eps
+        self.dtype = dtype
+        self.D_padded = row_padding(D, dtype.itemsize)
+        self._tune_pending = tune  # tuning needs a program, so it waits for the first call
+        self.init_config(config, tune=False)
+
+    @property
+    def _row_widths(self) -> tuple:
+        """Block widths this row admits, narrowed while it is held in registers."""
+        widths = widths_for_row(self.D_padded)
+        if not _holds_row_in_registers(self.D, self.D_padded):
+            return widths
+        if self.D_padded != self.D:
+            low = high = self._GUARDED_ELEMENTS_PER_THREAD
+        else:
+            low, high = self._ELEMENTS_PER_THREAD_BAND
+        banded = tuple(
+            t for t in widths if self.D_padded % t == 0 and low <= self.D_padded // t <= high
+        )
+        return banded or widths
+
+    @property
+    def default_config(self) -> dict:
+        return select_row_config_by_width(self.D_padded, self._row_widths)
+
+    @property
+    def autotune_configs(self) -> list[dict]:
+        if _holds_row_in_registers(self.D, self.D_padded):
+            # One row per block, pinned rather than swept: a row this narrow runs
+            # in under three microseconds, which the autotuner cannot rank, and
+            # more rows per block only measure slower.
+            return select_row_configs(
+                self.D_padded, self.dtype, widths=self._row_widths, block_ms=(1,)
+            )
+        return select_row_configs(self.D_padded, self.dtype, widths=self._row_widths)
 
 
 def _channel_of(row, col, num_groups: int, channels_per_group: int, spatial_size: int):
@@ -93,14 +185,13 @@ def _group_norm_kernel(M, D, eps, dtype, num_groups, channels_per_group):
         masked = D_padded != D
         # One channel owns the whole row exactly when a group holds one channel.
         row_constant_affine = channels_per_group == 1
-        # A row whose width the block divides is read from global memory straight
-        # into the register fragment. A padded row loses the vectorized copy to a
-        # per-element guard, so above NARROW_ROW it stages through shared memory,
-        # the only path that allocates it.
-        register_direct = not masked or D_padded <= NARROW_ROW
+        register_direct = _holds_row_in_registers(D, D_padded)
         # A tail row block runs past the end unless every index is guarded.
         guarded = masked or M % block_m != 0
-        row_reduce = make_row_reduce(block_m, D, D_padded, eps)
+        if register_direct:
+            row_reduce = make_shifted_row_reduce(block_m, D, eps)
+        else:
+            row_reduce = make_row_reduce(block_m, D, D_padded, eps)
 
         @T.prim_func
         def main(
@@ -110,10 +201,14 @@ def _group_norm_kernel(M, D, eps, dtype, num_groups, channels_per_group):
             y: T.Tensor[(M, D), dtype],
         ):
             with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
-                if not register_direct:
+                if register_direct:
+                    centered_row = T.alloc_fragment((block_m, D_padded), "float32")
+                    squares = T.alloc_fragment((block_m, D_padded), "float32")
+                    shift = T.alloc_fragment((block_m,), "float32")
+                    acc_squares = T.alloc_fragment((block_m,), "float32")
+                else:
                     shared_buf = T.alloc_shared((block_m, D_padded), dtype)
-                x_local = T.alloc_fragment((block_m, D_padded), dtype)
-                x_f32 = T.alloc_fragment((block_m, D_padded), "float32")
+                    x_f32 = T.alloc_fragment((block_m, D_padded), "float32")
                 acc = T.alloc_fragment((block_m,), "float32")
                 mean_val = T.alloc_fragment((block_m,), "float32")
                 rstd = T.alloc_fragment((block_m,), "float32")
@@ -121,20 +216,34 @@ def _group_norm_kernel(M, D, eps, dtype, num_groups, channels_per_group):
                     scale = T.alloc_fragment((block_m,), "float32")
                     bias_row = T.alloc_fragment((block_m,), "float32")
 
-                if register_direct and guarded:
-                    for i, j in T.Parallel(block_m, D_padded):
-                        v = T.if_then_else(
-                            T.And(pid_m * block_m + i < M, j < D),
-                            x[pid_m * block_m + i, j],
-                            T.cast(0.0, dtype),
-                        )
-                        x_local[i, j] = v
-                        x_f32[i, j] = T.cast(v, "float32")
-                elif register_direct:
-                    for i, j in T.Parallel(block_m, D_padded):
-                        v = x[pid_m * block_m + i, j]
-                        x_local[i, j] = v
-                        x_f32[i, j] = T.cast(v, "float32")
+                # Ahead of the row load, so the two reads are in flight while
+                # it runs. ``scale`` holds the weight until rstd exists.
+                if row_constant_affine:
+                    for i in T.Parallel(block_m):
+                        c = (pid_m * block_m + i) % num_groups
+                        scale[i] = T.cast(weight[c], "float32")
+                        bias_row[i] = T.cast(bias[c], "float32")
+
+                if register_direct:
+                    # The shift the one-pass reduction needs. A tail block's
+                    # row index is clamped to stay inside the tensor.
+                    for i in T.Parallel(block_m):
+                        shift[i] = T.cast(x[T.min(pid_m * block_m + i, M - 1), 0], "float32")
+                    if guarded:
+                        for i, j in T.Parallel(block_m, D_padded):
+                            v = T.if_then_else(
+                                T.And(pid_m * block_m + i < M, j < D),
+                                T.cast(x[pid_m * block_m + i, j], "float32") - shift[i],
+                                T.cast(0.0, "float32"),
+                            )
+                            centered_row[i, j] = v
+                            squares[i, j] = v * v
+                    else:
+                        for i, j in T.Parallel(block_m, D_padded):
+                            v = T.cast(x[pid_m * block_m + i, j], "float32") - shift[i]
+                            centered_row[i, j] = v
+                            squares[i, j] = v * v
+                    row_reduce(centered_row, squares, acc, acc_squares, mean_val, rstd)
                 else:
                     # A padded wide row keeps its input in shared memory for the
                     # output pass: the reduction overwrites the fp32 copy with
@@ -146,25 +255,20 @@ def _group_norm_kernel(M, D, eps, dtype, num_groups, channels_per_group):
                             T.cast(0.0, dtype),
                         )
                         x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
-
-                row_reduce(x_f32, acc, mean_val, rstd)
+                    row_reduce(x_f32, acc, mean_val, rstd)
 
                 # --- Output: y = (x - mean) * rstd * weight[c] + bias[c] ---
                 if row_constant_affine:
                     # A group of one channel gives the whole row one weight and
-                    # one bias, so the channel derivation and the two gathers
-                    # leave the element loop. Centering stays in it: folding it
-                    # into a shift term subtracts two large products.
+                    # one bias, so the two gathers leave the element loop.
                     for i in T.Parallel(block_m):
-                        c = (pid_m * block_m + i) % num_groups
-                        scale[i] = rstd[i] * T.cast(weight[c], "float32")
-                        bias_row[i] = T.cast(bias[c], "float32")
+                        scale[i] = scale[i] * rstd[i]
                     for i, j in T.Parallel(block_m, D_padded):
                         if (not guarded) or T.And(pid_m * block_m + i < M, j < D):
                             y[pid_m * block_m + i, j] = T.cast(
                                 (
                                     T.cast(
-                                        x_local[i, j] if register_direct else shared_buf[i, j],
+                                        centered_row[i, j] if register_direct else shared_buf[i, j],
                                         "float32",
                                     )
                                     - mean_val[i]
@@ -185,12 +289,13 @@ def _group_norm_kernel(M, D, eps, dtype, num_groups, channels_per_group):
                             )
                             y[pid_m * block_m + i, j] = (
                                 T.cast(
-                                    x_local[i, j] if register_direct else shared_buf[i, j],
+                                    centered_row[i, j] if register_direct else shared_buf[i, j],
                                     "float32",
                                 )
                                 - mean_val[i]
                             ) * rstd[i] * T.cast(weight[c], "float32") + T.cast(bias[c], "float32")
                 else:
+                    # Not guarded means D_padded == D, which is a register-held row.
                     for i, j in T.Parallel(block_m, D_padded):
                         c = _channel_of(
                             pid_m * block_m + i,
@@ -199,16 +304,16 @@ def _group_norm_kernel(M, D, eps, dtype, num_groups, channels_per_group):
                             channels_per_group,
                             spatial_size,
                         )
-                        y[pid_m * block_m + i, j] = (
-                            T.cast(x_local[i, j], "float32") - mean_val[i]
-                        ) * rstd[i] * T.cast(weight[c], "float32") + T.cast(bias[c], "float32")
+                        y[pid_m * block_m + i, j] = (centered_row[i, j] - mean_val[i]) * rstd[
+                            i
+                        ] * T.cast(weight[c], "float32") + T.cast(bias[c], "float32")
 
         return main
 
     return _func
 
 
-class GroupNormKernel(Kernel):
+class GroupNormKernel(_RowNormKernel):
     """GroupNorm forward kernel with a per-channel affine.
 
     Normalizes each group's (C/G, *spatial) slice independently and applies
@@ -232,8 +337,6 @@ class GroupNormKernel(Kernel):
         tune: If True, autotune tile config.
     """
 
-    supported_archs: list[int] = [80, 86, 89, 90]
-
     def __init__(
         self,
         D: int,
@@ -249,23 +352,9 @@ class GroupNormKernel(Kernel):
         The program for a given row count is resolved in ``forward``, memoized by
         ``_group_norm_kernel``.
         """
-        super().__init__()
-        self.D = D
-        self.eps = eps
-        self.dtype = dtype
         self.num_groups = num_groups
         self.channels_per_group = channels_per_group
-        self.D_padded = row_padding(D, self.dtype.itemsize)
-        self._tune_pending = tune  # tuning needs a program, so it waits for the first call
-        self.init_config(config, tune=False)
-
-    @property
-    def default_config(self) -> dict:
-        return select_row_config_by_width(self.D_padded)
-
-    @property
-    def autotune_configs(self) -> list[dict]:
-        return select_row_configs(self.D_padded, self.dtype, widths=widths_for_row(self.D_padded))
+        super().__init__(D, eps, dtype, config=config, tune=tune)
 
     def forward(
         self,
@@ -336,12 +425,13 @@ def _group_norm_no_affine_kernel(M, D, eps, dtype):
     def _func(block_m, threads):
         # A non-aligned D would read and write columns >= D unless masked.
         masked = D_padded != D
-        # A row whose width the block divides is read straight into the register
-        # fragment; a padded one only while it is narrow.
-        register_direct = not masked or D_padded <= NARROW_ROW
+        register_direct = _holds_row_in_registers(D, D_padded)
         # A tail row block runs past the end unless every index is guarded.
         guarded = masked or M % block_m != 0
-        row_reduce = make_row_reduce(block_m, D, D_padded, eps)
+        if register_direct:
+            row_reduce = make_shifted_row_reduce(block_m, D, eps)
+        else:
+            row_reduce = make_row_reduce(block_m, D, D_padded, eps)
 
         @T.prim_func
         def main(
@@ -349,28 +439,38 @@ def _group_norm_no_affine_kernel(M, D, eps, dtype):
             y: T.Tensor[(M, D), dtype],
         ):
             with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
-                if not register_direct:
+                if register_direct:
+                    centered_row = T.alloc_fragment((block_m, D_padded), "float32")
+                    squares = T.alloc_fragment((block_m, D_padded), "float32")
+                    shift = T.alloc_fragment((block_m,), "float32")
+                    acc_squares = T.alloc_fragment((block_m,), "float32")
+                else:
                     shared_buf = T.alloc_shared((block_m, D_padded), dtype)
-                x_local = T.alloc_fragment((block_m, D_padded), dtype)
-                x_f32 = T.alloc_fragment((block_m, D_padded), "float32")
+                    x_f32 = T.alloc_fragment((block_m, D_padded), "float32")
                 acc = T.alloc_fragment((block_m,), "float32")
                 mean_val = T.alloc_fragment((block_m,), "float32")
                 rstd = T.alloc_fragment((block_m,), "float32")
 
-                if register_direct and guarded:
-                    for i, j in T.Parallel(block_m, D_padded):
-                        v = T.if_then_else(
-                            T.And(pid_m * block_m + i < M, j < D),
-                            x[pid_m * block_m + i, j],
-                            T.cast(0.0, dtype),
-                        )
-                        x_local[i, j] = v
-                        x_f32[i, j] = T.cast(v, "float32")
-                elif register_direct:
-                    for i, j in T.Parallel(block_m, D_padded):
-                        v = x[pid_m * block_m + i, j]
-                        x_local[i, j] = v
-                        x_f32[i, j] = T.cast(v, "float32")
+                if register_direct:
+                    # The shift the one-pass reduction needs. A tail block's
+                    # row index is clamped to stay inside the tensor.
+                    for i in T.Parallel(block_m):
+                        shift[i] = T.cast(x[T.min(pid_m * block_m + i, M - 1), 0], "float32")
+                    if guarded:
+                        for i, j in T.Parallel(block_m, D_padded):
+                            v = T.if_then_else(
+                                T.And(pid_m * block_m + i < M, j < D),
+                                T.cast(x[pid_m * block_m + i, j], "float32") - shift[i],
+                                T.cast(0.0, "float32"),
+                            )
+                            centered_row[i, j] = v
+                            squares[i, j] = v * v
+                    else:
+                        for i, j in T.Parallel(block_m, D_padded):
+                            v = T.cast(x[pid_m * block_m + i, j], "float32") - shift[i]
+                            centered_row[i, j] = v
+                            squares[i, j] = v * v
+                    row_reduce(centered_row, squares, acc, acc_squares, mean_val, rstd)
                 else:
                     # A padded wide row keeps its input in shared memory for the
                     # output pass: the reduction overwrites the fp32 copy with
@@ -382,8 +482,7 @@ def _group_norm_no_affine_kernel(M, D, eps, dtype):
                             T.cast(0.0, dtype),
                         )
                         x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
-
-                row_reduce(x_f32, acc, mean_val, rstd)
+                    row_reduce(x_f32, acc, mean_val, rstd)
 
                 # No-affine output: y = (x - mean) * rstd.
                 if guarded:
@@ -392,7 +491,7 @@ def _group_norm_no_affine_kernel(M, D, eps, dtype):
                             y[pid_m * block_m + i, j] = T.cast(
                                 (
                                     T.cast(
-                                        x_local[i, j] if register_direct else shared_buf[i, j],
+                                        centered_row[i, j] if register_direct else shared_buf[i, j],
                                         "float32",
                                     )
                                     - mean_val[i]
@@ -401,10 +500,10 @@ def _group_norm_no_affine_kernel(M, D, eps, dtype):
                                 dtype,
                             )
                 else:
+                    # Not guarded means D_padded == D, which is a register-held row.
                     for i, j in T.Parallel(block_m, D_padded):
                         y[pid_m * block_m + i, j] = T.cast(
-                            (T.cast(x_local[i, j], "float32") - mean_val[i]) * rstd[i],
-                            dtype,
+                            (centered_row[i, j] - mean_val[i]) * rstd[i], dtype
                         )
 
         return main
@@ -412,7 +511,7 @@ def _group_norm_no_affine_kernel(M, D, eps, dtype):
     return _func
 
 
-class GroupNormNoAffineKernel(Kernel):
+class GroupNormNoAffineKernel(_RowNormKernel):
     """GroupNorm forward kernel without affine scale/shift.
 
     Computes ``y = (x - mean) * rstd`` row-wise for shape $[M \\times D]$ reshaped
@@ -428,37 +527,6 @@ class GroupNormNoAffineKernel(Kernel):
         config: Optional tile config dict.
         tune: If True, autotune tile config.
     """
-
-    supported_archs: list[int] = [80, 86, 89, 90]
-
-    def __init__(
-        self,
-        D: int,
-        eps: float,
-        dtype: torch.dtype,
-        config: Optional[dict] = None,
-        tune: bool = False,
-    ):
-        """Build for a row length and dtype.
-
-        The program for a given row count is resolved in ``forward``, memoized by
-        ``_group_norm_no_affine_kernel``.
-        """
-        super().__init__()
-        self.D = D
-        self.eps = eps
-        self.dtype = dtype
-        self.D_padded = row_padding(D, self.dtype.itemsize)
-        self._tune_pending = tune  # tuning needs a program, so it waits for the first call
-        self.init_config(config, tune=False)
-
-    @property
-    def default_config(self) -> dict:
-        return select_row_config_by_width(self.D_padded)
-
-    @property
-    def autotune_configs(self) -> list[dict]:
-        return select_row_configs(self.D_padded, self.dtype, widths=widths_for_row(self.D_padded))
 
     def forward(
         self,

--- a/src/tileops/kernels/pool/adaptive_max_pool2d.py
+++ b/src/tileops/kernels/pool/adaptive_max_pool2d.py
@@ -37,16 +37,13 @@ class _PlaneStaging:
     # A block staging more than this leaves the grid shorter than the device has
     # multiprocessors, and these shapes hold a megabyte or two in total.
     _TILE_BYTES = 4096
-    # The tuned space reaches four times the default and no further, the trade above
-    # only continuing in the wrong direction.
     _TUNE_TILE_BYTES = 4 * _TILE_BYTES
     # Elements one thread carries in the staging copy. That copy is the kernel's whole
     # memory cost, so the block width follows from it and not from the output count.
     _COPY_RUN = 8
     # Block widths offered, narrowest and widest also clamping the derived width.
     _THREAD_CHOICES = (128, 256, 512)
-    # Plane counts a tuning run tries. With the widths above that is at most twelve
-    # builds, and the ceiling above has already dropped the counts that cannot win.
+    # Plane counts a tuning run tries.
     _TUNED_PLANE_COUNTS = 4
 
     def __init__(self, rows: int, h_in: int, w_in: int, dtype: str) -> None:

--- a/src/tileops/kernels/pool/max_pool1d.py
+++ b/src/tileops/kernels/pool/max_pool1d.py
@@ -305,9 +305,8 @@ def _max_pool1d_with_indices_kernel(
                 iw = iw0 + kw * dilation_w
                 if always_in_bounds:
                     val = T.cast(src[src_c, src_row, iw], accum_dtype)
-                    # `max_val` starts at -inf and only a passing compare replaces
-                    # it, so it is never NaN; NaN fails `>`. The compare alone
-                    # therefore rejects NaN and no separate test is needed.
+                    # `max_val` is never NaN and NaN fails `>`, so the compare
+                    # rejects NaN without a separate test.
                     take = val > max_val
                     max_val = T.if_then_else(take, val, max_val)
                     max_idx = T.if_then_else(take, iw, max_idx)

--- a/src/tileops/kernels/pool/mean_pooling.py
+++ b/src/tileops/kernels/pool/mean_pooling.py
@@ -32,14 +32,13 @@ def _mean_pooling_kernel(
             offsets: T.Tensor((seq_num + 1,), T.int32),
             indices: T.Tensor(
                 (chunks_per_batch, 2), T.int32
-            ),  # [chunks_per_batch, 2] (seq_id, chunk_id in sequence)
+            ),  # columns are (seq_id, chunk_id within that sequence)
         ) -> None:
             with T.Kernel(
                 T.ceildiv(dim, bdim), chunks_per_batch, batch_size * heads, threads=threads
             ) as (i_d, i_t, i_bh):
                 i_b = i_bh // heads
                 i_h = i_bh % heads
-                # load data [chunk_size, D]
                 x_shared = T.alloc_shared((chunk_size, bdim), dtype)
                 x_local = T.alloc_fragment((chunk_size, bdim), dtype)
                 output_local = T.alloc_fragment((bdim,), accum_dtype)
@@ -59,10 +58,9 @@ def _mean_pooling_kernel(
                 start_dim = i_d * bdim
                 end_dim = T.min(start_dim + bdim, dim)
 
-                # Static fast path: a uniform split with no tail chunk and a `dim`
-                # exactly tiled by `bdim` makes every extent a compile-time constant,
-                # so the copy lowers to vectorized TMA loads instead of the guarded
-                # scalar path below, and the full tile it writes needs no T.clear.
+                # Every extent is a compile-time constant here, so the copy
+                # lowers to vectorized TMA loads and the full tile it writes
+                # needs no T.clear.
                 if use_offsets == 0 and seq_len % chunk_size == 0 and dim % bdim == 0:
                     T.copy(
                         x[i_b, start_token : start_token + chunk_size, i_h, start_dim:end_dim],
@@ -137,7 +135,6 @@ def _(
     threads: int,
     *inputs: tuple[Any],
 ) -> torch.Tensor:
-    # Output shape is [batch_size, chunks_per_batch, heads, dim]
     _ = (seq_len, chunk_size, seq_num, bdim, use_offsets, dtype, accum_dtype, threads)
     x = inputs[0]
     return torch.empty(


### PR DESCRIPTION
## Summary

- A row the kernel holds in register fragments is walked once instead of twice: the load writes both `x - shift` and its square while the value is in a register, and the reduction reads both and rewrites neither. A row wide enough to stage through shared memory has room for one fp32 row only and keeps the centered two-pass.
- `shift` is the row's own first element. Reading the variance off `E[x^2] - E[x]^2` loses it to cancellation once a row's mean outgrows its spread; subtracting a sample of the row first removes that at no measurable cost.
- `weight` and `bias` are read before the row load instead of after the reduction, where they sat between it and the store with nothing to overlap their latency.
- The two sums take one accumulator each. Sharing one put a block-wide barrier between them and made the second wait on the first.
- The autotune space for a register-held row is now the widths whose share of the row falls inside a measured band, with one row per block instead of a swept knob, and the untuned default is a member of that space. The old space let the autotuner select a config measured 4.8% to 13% slower.
- `GroupNormKernel` and `GroupNormNoAffineKernel` take that tiling from a shared `_RowNormKernel` base rather than repeating `supported_archs`, the `__init__` body, `default_config` and `autotune_configs` verbatim.
- A second commit cuts pool comments that restate the code they sit above. No code changed there; each file's AST is identical to before.

## Benchmark

**Environment**: NVIDIA H200, CUDA 13.2, PyTorch 2.13.0+cu132, TileLang 0.1.11+cu132.gitafcebed1

| | |
| --- | --- |
| image | `ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-afcebed1-tilefoundry-latest` |
| digest | `sha256:ca13df9bda340edf248b8b443b88880f36e3190ab9d470f52d66ccc21c15fd59` |
| tilefoundry | 0.1.dev146+g2bec6420e |
| driver | 595.71.05 |
| timer | native CUPTI, `device_busy`, L2 cleared per iteration |

Method: the merge base and this branch ran the same script alternately in one window on one card, four rounds each side, best of the four. The script times every comparator in the same process, so `torch-compile` is measured on both sides and pins the card's drift: it came out 0.985x to 1.000x between them. Speedup is `comparator / TileOPs`.

### InstanceNormFwdOp

Microseconds, not the 0.1 us the bench report rounds to, which is a whole quantum at these sizes.

| Row | Shape | dtype | TileOPs | incumbent | torch-compile | flag_gems | Speedup vs torch-compile | BW (TB/s) |
| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| image-affine | (8, 128, 32, 32) | float16 | 2.688 | 2.751 | 2.784 | 3.263 | 1.036x | 1.56 |
| image-affine | (8, 128, 32, 32) | bfloat16 | 2.688 | 2.752 | 2.816 | 3.328 | 1.048x | 1.56 |
| wider-channel-affine | (4, 256, 28, 28) | float16 | 2.688 | 2.816 | 2.656 | 3.328 | 0.988x | 1.20 |
| tail-spatial-affine | (4, 64, 30, 30) | float16 | 2.080 | 2.208 | 2.080 | 2.432 | 1.000x | 0.44 |
| image | (8, 128, 32, 32) | float16 | 2.560 | 2.655 | 2.624 | 3.168 | 1.025x | 1.64 |
| image | (8, 128, 32, 32) | bfloat16 | 2.688 | 2.656 | 2.656 | 3.072 | 0.988x | 1.56 |
| wider-channel | (4, 256, 28, 28) | float16 | 2.528 | 2.624 | 2.496 | 2.976 | 0.987x | 1.27 |
| tail-spatial | (4, 64, 30, 30) | float16 | 1.952 | 2.016 | 1.984 | 2.272 | 1.016x | 0.47 |

Seven of the eight rows are faster than the incumbent, by 2.3% to 7.8%. Every row is 1.14x to 1.24x ahead of `flag_gems`, which is the tag this op's manifest names, and 3.5x to 6.3x ahead of torch eager.

Measured per width rather than per autotuned pick, on the unpadded row, the kernel is faster than the incumbent in all eight (dtype, affine, width) cells.

### GroupNormFwdOp

Shares the kernel. `image-g32` is read straight into registers and takes the new reduction; `wider-channel-g32` and `tail-spatial-g16` pad to 8192 and stage through shared memory, so they keep the centered two-pass. Run through `benchmarks/ops/bench_group_norm.py` on both sides in the same interleaved protocol, its eight rows measure 1.000x to 1.036x of the incumbent -- no regression on any of them -- and keep a 1.06x to 1.45x lead over torch-compile and 1.03x to 1.24x over `flag_gems`.

`LayerNorm`, `RMSNorm`, `AdaLayerNorm` and `FusedAddRMSNorm` share `_config.py` but not the narrowed space. Their `default_config` and `autotune_configs` were compared across the two sides over 121 (row width, dtype, kernel) combinations and are identical.

**Takeaways:** four of the eight InstanceNorm rows are ahead of torch-compile by 1.6% to 4.8%, one ties it, and three are 1.2% behind. GroupNorm does not regress.

## Limitations

**`wider-channel` and `wider-channel-affine` stay 1.2% behind torch-compile.** The gap is this kernel's memory path, not its reduction, and the two ways to lower that path both measure worse. Microseconds on the 784-wide row, fp16, no affine:

| | us |
| --- | ---: |
| this kernel | 2.528 |
| the same load into one fp32 fragment and store back, no reduction at all | 2.528 |
| torch-compile | 2.496 |
| variant holding the row in its stored dtype instead of fp32 | 2.624 |
| variant staging the row through shared memory | 2.656 |

**`image` in bfloat16 reads 0.988x of the incumbent, and that is the autotuner, not the kernel.** The unpadded row's band admits two widths, and without affine in bfloat16 they differ by 1.2%; the autotuner cannot rank them apart and lands on either. Neither width dominates across the four (dtype, affine) combinations, so pinning one would be pinning noise, and the kernel is faster than the incumbent at both.

**The cross-thread sum is not what the reduction costs.** Six ways to make it cheaper all measure equal or worse than two `T.reduce_sum` calls with one accumulator each:

| variant | measured |
| --- | --- |
| hand-written zero-barrier reduction: one row per warp, per-thread partials in `T.alloc_local`, `T.warp_reduce_sum` | no gain on either padded row, 6% to 44% worse elsewhere |
| row pinned to a warp by `T.annotate_layout`, still `T.reduce_sum` | no gain; image 6% worse, 4096-wide row 44% worse |
| `T.alloc_reducer(..., replication="all")` with `T.finalize_reducer` | 12% to 45% worse |
| one batched AllReduce covering both sums | not expressible: a reducer or fragment carries one index expression per `T.Parallel` loop |
| two-stage reduction over a `(K, n_padded / K)` view | 1.3% faster at `n_padded=1024`, 14% slower at 4096; `K = n_padded / (2 * threads)` as a rule that scales with the row is still 7% slower there |
| 128-bit global accesses through an explicit vec-major `Fragment` | floor unchanged; the fp32 fragments fix the granularity at four elements |

**An L2 eviction hint changes nothing.** `T.copy(..., eviction_policy="evict_first")`, which the inductor kernel these rows are compared against uses, measures the same as no hint. At 3.2 MB against a 60 MB L2 there is no pressure to relieve.

**These shapes are launch-bound as much as bandwidth-bound.** A streaming copy of the same bytes costs 1.60 us at 0.92 MB and 2.50 us at 4.19 MB, which is 3.63 TB/s marginal over a fixed 1.4 us. `tilefoundry analyze` prices the 4.19 MB row at `ideal-ns=874`, `bound-by=memory`, which is 4.80 TB/s: the asymptotic rate, not reachable at this size.

## TileFoundry Description

```python
@module(entry="instance_norm", target=CudaTarget("nvidia.h200_sxm"),
        topologies=(Topology("cta", M), Topology("thread", THREADS)))
class RowNorm:
    @func
    def instance_norm(x: Tensor[(M, D), "f16"]):
        with Mesh(("cta",), (M,), ("row",)) as cta:
            with Mesh(("thread",), (THREADS,), ("t",)) as m:
                held = tf.reshard(x, (M @ cta.row, D @ m.t), "rmem")
                v = tf.cast(held, "f32")
                mean = tf.reduce(v, (-1,), True, ReduceKind.MEAN)
                centered = v - mean
                var = tf.reduce(tf.square(centered), (-1,), True, ReduceKind.MEAN)
                out = tf.cast(centered * tf.rsqrt(var + EPS), "f16")
                return tf.reshard(out, (M, D), "gmem")
```

`analyze --roofline` reports `ideal-ns=874 bound-by=memory` at `M=1024, D=1024`: the row waits on memory, so cutting traffic is the only change worth making, and this operator already reads x once and writes y once.

`analyze --performance` reports `waves=8` at one row per CTA against `waves=1` at eight, predicting 6992 ns against 874 ns. That placement does not hold here: a block of 2, 4 or 8 rows measures 8%, 13% and 22% slower, because TileLang's layout inference spreads each row across the whole block rather than giving it a warp. One row per CTA stays.