### PR TITLE
[Perf][foundry][Pool] Read a mean-pooling chunk across the whole trailing width, and check a ragged chunk map once

### DIFF
--- a/src/tileops/kernels/pool/mean_pooling.py
+++ b/src/tileops/kernels/pool/mean_pooling.py
@@ -10,49 +10,79 @@ from tileops.utils import WARP_LANES, get_sm_count
 
 __all__ = ["MeanPoolingFwdKernel"]
 
-# The block widths a `heads * dim` may be cut into.
-_BLOCK_WIDTHS = (8192, 4096, 2048, 1024, 512, 256, 128, 64, 32)
 
-# Elements one lane accumulates; eight fp16 of them is a 16-byte load.
-_LANE_ELEMS = 8
-# The shares a lane is tried at when tuning, either side of `_LANE_ELEMS`.
-_TUNED_LANE_ELEMS = (4, 8, 16)
+class _BlockTiling:
+    """How one chunk's ``heads * dim`` is cut into blocks, and each block into lanes.
 
-
-def _block_widths(width: int) -> list[int]:
-    """The block widths to try for a `heads * dim` of ``width``, widest first.
-
-    A width the block divides is covered exactly, so those widths come first; a width none
-    of them divides — one that is not a multiple of the warp size — is covered with a
-    bounds test on the last block instead.
+    The widths and lane shares below describe this kernel's access pattern, not the
+    device, and are held here so that a later kernel does not read them as general truths.
     """
-    listed = [w for w in _BLOCK_WIDTHS if w <= width] or [_BLOCK_WIDTHS[-1]]
-    return [w for w in listed if width % w == 0] or listed
 
+    # Widths a block may take. One that divides `heads * dim` covers it exactly; where none
+    # does -- a width that is not a whole number of warps -- the last block is bounds-tested.
+    _WIDTHS = (8192, 4096, 2048, 1024, 512, 256, 128, 64, 32)
+    # Elements a lane accumulates; eight fp16 of them is a 16-byte load.
+    _LANE_ELEMS = 8
+    # Lane shares a tuning run tries, either side of `_LANE_ELEMS`.
+    _TUNED_LANE_ELEMS = (4, 8, 16)
+    # Widths a tuning run tries around the default, wider and narrower.
+    _TUNED_WIDER = 1
+    _TUNED_NARROWER = 2
+    # Threads a CUDA block can hold.
+    _MAX_THREADS = 1024
 
-def _threads_for(bwidth: int, lane_elems: int) -> int:
-    """The largest whole-warp thread count dividing ``bwidth`` into ``lane_elems`` or more."""
-    threads = min(1024, max(WARP_LANES, bwidth // lane_elems // WARP_LANES * WARP_LANES))
-    while threads > WARP_LANES and bwidth % threads:
-        threads -= WARP_LANES
-    return threads
+    def __init__(self, width: int, blocks: int, sm_count: int) -> None:
+        """Fix the tiling for one call's shape.
 
+        Args:
+            width: ``heads * dim``, the axis a block takes its share of.
+            blocks: One block per chunk, before the width is cut.
+            sm_count: Multiprocessors the grid has to cover.
+        """
+        self._width = width
+        self._blocks = blocks
+        self._sm_count = sm_count
 
-def _launch(width: int, blocks: int, sm_count: int) -> tuple[int, int]:
-    """The widest block whose grid still covers the SMs, and the threads to run it with.
+    def _widths(self) -> list[int]:
+        """The widths this ``heads * dim`` admits, widest first."""
+        listed = [w for w in self._WIDTHS if w <= self._width] or [self._WIDTHS[-1]]
+        return [w for w in listed if self._width % w == 0] or listed
 
-    A block reads one chunk's share of the width, so a narrower block buys more blocks at
-    the cost of a shorter contiguous run in each. The width is cut only until the grid
-    reaches one block per SM: below that the machine sits idle, above it the reads shorten
-    for nothing.
-    """
-    widths = _block_widths(width)
-    bwidth = widths[-1]
-    for candidate in widths:
-        if blocks * -(-width // candidate) >= sm_count:
-            bwidth = candidate
-            break
-    return bwidth, _threads_for(bwidth, _LANE_ELEMS)
+    def _threads(self, bwidth: int, lane_elems: int) -> int:
+        """The largest whole-warp count dividing ``bwidth`` into ``lane_elems`` or more."""
+        threads = min(
+            self._MAX_THREADS,
+            max(WARP_LANES, bwidth // lane_elems // WARP_LANES * WARP_LANES),
+        )
+        while threads > WARP_LANES and bwidth % threads:
+            threads -= WARP_LANES
+        return threads
+
+    def default(self) -> dict:
+        """The widest block whose grid still covers the SMs, and its thread count.
+
+        A block reads one chunk's share of the width, so a narrower block buys more blocks
+        at the cost of a shorter contiguous run in each. The width is cut only until the
+        grid reaches one block per SM.
+        """
+        widths = self._widths()
+        bwidth = widths[-1]
+        for candidate in widths:
+            if self._blocks * -(-self._width // candidate) >= self._sm_count:
+                bwidth = candidate
+                break
+        return {"bwidth": bwidth, "threads": self._threads(bwidth, self._LANE_ELEMS)}
+
+    def space(self) -> list[dict]:
+        """`default`'s width and its neighbours, at each lane share."""
+        widths = self._widths()
+        chosen = widths.index(self.default()["bwidth"])
+        band = widths[max(0, chosen - self._TUNED_WIDER) : chosen + self._TUNED_NARROWER + 1]
+        return [
+            {"bwidth": w, "threads": t}
+            for w in band
+            for t in sorted({self._threads(w, e) for e in self._TUNED_LANE_ELEMS})
+        ]
 
 
 @functools.lru_cache(maxsize=32)
@@ -83,8 +113,8 @@ def _mean_pooling_kernel(
         def in_width(col):
             """The lane's bound, or `True` where no block reaches past the axis.
 
-            A value rather than `whole_blocks or col < width`, whose `or` would drop the
-            comparison in Python before TileLang traced it.
+            Why: written as `whole_blocks or col < width`, Python's `or` would drop the
+            comparison before TileLang traced it.
             """
             return True if whole_blocks else col < width
 
@@ -124,9 +154,8 @@ def _mean_pooling_kernel(
                         start_token = offsets[seq_id] + local_chunk_id * chunk_size
                         end_token = T.min(start_token + chunk_size, offsets[seq_id + 1])
 
-                    # The chunk's own token count bounds the loop. Walking `chunk_size`
-                    # rows and dropping the ones past the end instead predicates the load,
-                    # which is slower on every ragged workload.
+                    # The chunk's own token count bounds the loop; predicating each row
+                    # of a `chunk_size` walk instead is slower.
                     for s in T.serial(end_token - start_token):
                         for j in T.Parallel(bwidth):
                             if in_width(start_col + j):
@@ -233,9 +262,11 @@ class MeanPoolingFwdKernel(Kernel):
         self.dtype = dtype
         self.accum_dtype = accum_dtype
         self.accum_dtype_str = self.dtype_to_str(self.accum_dtype)
-        self.width = heads * dim
-        # One block per chunk before the width is cut; what the launch rule divides.
-        self.blocks = batch_size * chunks_per_batch
+        self._tiling = _BlockTiling(
+            width=heads * dim,
+            blocks=batch_size * chunks_per_batch,
+            sm_count=get_sm_count(),
+        )
 
         self.kernel = _mean_pooling_kernel(
             self.batch_size,
@@ -269,8 +300,8 @@ class MeanPoolingFwdKernel(Kernel):
 
         def supply_prog(params):
             device = get_current_device()
-            # Sequences split the tokens evenly; a slot past the last sequence
-            # clamps onto it and repeats a chunk of the same size.
+            # Sequences split the tokens evenly; a slot past the last sequence clamps
+            # onto it, repeating a chunk of the same size.
             bounds = torch.linspace(0, seq_len, seq_num + 1, device=device).to(torch.int32)
             per_seq = max(1, seq_len // seq_num)
             chunks_per_seq = max(1, (per_seq + chunk_size - 1) // chunk_size)
@@ -305,23 +336,11 @@ class MeanPoolingFwdKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
-        bwidth, threads = _launch(self.width, self.blocks, get_sm_count())
-        return {"bwidth": bwidth, "threads": threads}
+        return self._tiling.default()
 
     @property
     def autotune_configs(self) -> list[dict]:
-        """The launch rule's width and its neighbours, at 8, 16 and 32 bytes per lane.
-
-        A band narrow enough that every member is close to the best, with the untuned
-        default a member of it.
-        """
-        widths = _block_widths(self.width)
-        chosen = widths.index(self.default_config["bwidth"])
-        return [
-            {"bwidth": w, "threads": t}
-            for w in widths[max(0, chosen - 1) : chosen + 3]
-            for t in sorted({_threads_for(w, e) for e in _TUNED_LANE_ELEMS})
-        ]
+        return self._tiling.space()
 
     def forward(
         self, x: torch.Tensor, offsets: torch.Tensor, indices: torch.Tensor

--- a/src/tileops/kernels/pool/mean_pooling.py
+++ b/src/tileops/kernels/pool/mean_pooling.py
@@ -6,8 +6,53 @@ import tilelang.language as T
 import torch
 
 from tileops.kernels.kernel_base import Kernel
+from tileops.utils import WARP_LANES, get_sm_count
 
 __all__ = ["MeanPoolingFwdKernel"]
+
+# The block widths a `heads * dim` may be cut into.
+_BLOCK_WIDTHS = (8192, 4096, 2048, 1024, 512, 256, 128, 64, 32)
+
+# Elements one lane accumulates; eight fp16 of them is a 16-byte load.
+_LANE_ELEMS = 8
+# The shares a lane is tried at when tuning, either side of `_LANE_ELEMS`.
+_TUNED_LANE_ELEMS = (4, 8, 16)
+
+
+def _block_widths(width: int) -> list[int]:
+    """The block widths to try for a `heads * dim` of ``width``, widest first.
+
+    A width the block divides is covered exactly, so those widths come first; a width none
+    of them divides — one that is not a multiple of the warp size — is covered with a
+    bounds test on the last block instead.
+    """
+    listed = [w for w in _BLOCK_WIDTHS if w <= width] or [_BLOCK_WIDTHS[-1]]
+    return [w for w in listed if width % w == 0] or listed
+
+
+def _threads_for(bwidth: int, lane_elems: int) -> int:
+    """The largest whole-warp thread count dividing ``bwidth`` into ``lane_elems`` or more."""
+    threads = min(1024, max(WARP_LANES, bwidth // lane_elems // WARP_LANES * WARP_LANES))
+    while threads > WARP_LANES and bwidth % threads:
+        threads -= WARP_LANES
+    return threads
+
+
+def _launch(width: int, blocks: int, sm_count: int) -> tuple[int, int]:
+    """The widest block whose grid still covers the SMs, and the threads to run it with.
+
+    A block reads one chunk's share of the width, so a narrower block buys more blocks at
+    the cost of a shorter contiguous run in each. The width is cut only until the grid
+    reaches one block per SM: below that the machine sits idle, above it the reads shorten
+    for nothing.
+    """
+    widths = _block_widths(width)
+    bwidth = widths[-1]
+    for candidate in widths:
+        if blocks * -(-width // candidate) >= sm_count:
+            bwidth = candidate
+            break
+    return bwidth, _threads_for(bwidth, _LANE_ELEMS)
 
 
 @functools.lru_cache(maxsize=32)
@@ -23,64 +68,76 @@ def _mean_pooling_kernel(
     dtype: str,
     accum_dtype: str,
 ) -> Callable:
+    # Neither `heads` nor `dim` is reduced and they are the two innermost axes of a
+    # contiguous tensor, so a block reads them as one contiguous width.
+    width = heads * dim
+    # Every chunk is then `chunk_size` tokens at `i_t * chunk_size`, an index that bound
+    # analysis places inside the sequence axis without a per-row guard.
+    full_chunks = use_offsets == 0 and seq_len % chunk_size == 0
+
     @tilelang.jit(out_idx=[1])
-    def _mean_pooling_func(bdim: int, threads: int) -> None:
+    def _mean_pooling_func(bwidth: int, threads: int) -> None:
+        # Only a width no block width divides leaves a last block reaching past the axis.
+        whole_blocks = width % bwidth == 0
+
+        def in_width(col):
+            """The lane's bound, or `True` where no block reaches past the axis.
+
+            A value rather than `whole_blocks or col < width`, whose `or` would drop the
+            comparison in Python before TileLang traced it.
+            """
+            return True if whole_blocks else col < width
+
         @T.prim_func
         def _mean_pooling_main(
-            x: T.Tensor((batch_size, seq_len, heads, dim), dtype),
-            o: T.Tensor((batch_size, chunks_per_batch, heads, dim), dtype),
+            x: T.Tensor((batch_size, seq_len, width), dtype),
+            o: T.Tensor((batch_size, chunks_per_batch, width), dtype),
             offsets: T.Tensor((seq_num + 1,), T.int32),
             indices: T.Tensor(
                 (chunks_per_batch, 2), T.int32
             ),  # columns are (seq_id, chunk_id within that sequence)
         ) -> None:
             with T.Kernel(
-                T.ceildiv(dim, bdim), chunks_per_batch, batch_size * heads, threads=threads
-            ) as (i_d, i_t, i_bh):
-                i_b = i_bh // heads
-                i_h = i_bh % heads
-                x_shared = T.alloc_shared((chunk_size, bdim), dtype)
-                x_local = T.alloc_fragment((chunk_size, bdim), dtype)
-                output_local = T.alloc_fragment((bdim,), accum_dtype)
+                T.ceildiv(width, bwidth), chunks_per_batch, batch_size, threads=threads
+            ) as (i_w, i_t, i_b):
+                total = T.alloc_fragment((bwidth,), accum_dtype)
+                start_col = i_w * bwidth
+                T.clear(total)
 
-                start_token = T.alloc_var(T.int32)
-                end_token = T.alloc_var(T.int32)
-
-                if use_offsets == 0:
-                    start_token = i_t * chunk_size
-                    end_token = T.min(start_token + chunk_size, seq_len)
+                if full_chunks:
+                    for s in T.serial(chunk_size):
+                        for j in T.Parallel(bwidth):
+                            if in_width(start_col + j):
+                                total[j] += T.cast(
+                                    x[i_b, i_t * chunk_size + s, start_col + j], accum_dtype
+                                )
+                    scale = T.cast(1.0 / chunk_size, accum_dtype)
                 else:
-                    seq_id = indices[i_t, 0]
-                    local_chunk_id = indices[i_t, 1]
-                    start_token = offsets[seq_id] + local_chunk_id * chunk_size
-                    end_token = T.min(start_token + chunk_size, offsets[seq_id + 1])
+                    start_token = T.alloc_var(T.int32)
+                    end_token = T.alloc_var(T.int32)
+                    if use_offsets == 0:
+                        start_token = i_t * chunk_size
+                        end_token = T.min(start_token + chunk_size, seq_len)
+                    else:
+                        seq_id = indices[i_t, 0]
+                        local_chunk_id = indices[i_t, 1]
+                        start_token = offsets[seq_id] + local_chunk_id * chunk_size
+                        end_token = T.min(start_token + chunk_size, offsets[seq_id + 1])
 
-                start_dim = i_d * bdim
-                end_dim = T.min(start_dim + bdim, dim)
+                    # The chunk's own token count bounds the loop. Walking `chunk_size`
+                    # rows and dropping the ones past the end instead predicates the load,
+                    # which is slower on every ragged workload.
+                    for s in T.serial(end_token - start_token):
+                        for j in T.Parallel(bwidth):
+                            if in_width(start_col + j):
+                                total[j] += T.cast(
+                                    x[i_b, start_token + s, start_col + j], accum_dtype
+                                )
+                    scale = T.cast(1.0, accum_dtype) / T.cast(end_token - start_token, accum_dtype)
 
-                # Every extent is a compile-time constant here, so the copy
-                # lowers to vectorized TMA loads and the full tile it writes
-                # needs no T.clear.
-                if use_offsets == 0 and seq_len % chunk_size == 0 and dim % bdim == 0:
-                    T.copy(
-                        x[i_b, start_token : start_token + chunk_size, i_h, start_dim:end_dim],
-                        x_shared,
-                    )
-                else:
-                    T.clear(x_shared)
-                    # disable_tma=True: the copy extent is a runtime value
-                    # (ragged chunks), which the TMA lowering cannot express.
-                    T.copy(
-                        x[i_b, start_token:end_token, i_h, start_dim:end_dim],
-                        x_shared[0 : end_token - start_token, : end_dim - start_dim],
-                        disable_tma=True,
-                    )
-                T.copy(x_shared, x_local)
-                T.reduce_sum(x_local, output_local, dim=0)
-                for d_idx in T.Parallel(bdim):
-                    o[i_b, i_t, i_h, start_dim + d_idx] = T.cast(
-                        output_local[d_idx] / T.cast(end_token - start_token, accum_dtype), dtype
-                    )
+                for j in T.Parallel(bwidth):
+                    if in_width(start_col + j):
+                        o[i_b, i_t, start_col + j] = T.cast(total[j] * scale, dtype)
 
         return _mean_pooling_main
 
@@ -99,13 +156,14 @@ def _mean_pooling_wrapped_kernel(
     use_offsets: int,
     dtype: str,
     accum_dtype: str,
-    bdim: int,
+    bwidth: int,
     threads: int,
     x: torch.Tensor,
     offsets: torch.Tensor,
     indices: torch.Tensor,
 ) -> torch.Tensor:
-    return _mean_pooling_kernel(
+    width = heads * dim
+    pooled = _mean_pooling_kernel(
         batch_size=batch_size,
         seq_len=seq_len,
         heads=heads,
@@ -116,7 +174,8 @@ def _mean_pooling_wrapped_kernel(
         use_offsets=use_offsets,
         dtype=dtype,
         accum_dtype=accum_dtype,
-    )(bdim, threads)(x, offsets, indices)
+    )(bwidth, threads)(x.view(batch_size, seq_len, width), offsets, indices)
+    return pooled.view(batch_size, chunks_per_batch, heads, dim)
 
 
 @_mean_pooling_wrapped_kernel.register_fake
@@ -131,11 +190,11 @@ def _(
     use_offsets: int,
     dtype: str,
     accum_dtype: str,
-    bdim: int,
+    bwidth: int,
     threads: int,
     *inputs: tuple[Any],
 ) -> torch.Tensor:
-    _ = (seq_len, chunk_size, seq_num, bdim, use_offsets, dtype, accum_dtype, threads)
+    _ = (seq_len, chunk_size, seq_num, bwidth, use_offsets, dtype, accum_dtype, threads)
     x = inputs[0]
     return torch.empty(
         (batch_size, chunks_per_batch, heads, dim),
@@ -174,6 +233,9 @@ class MeanPoolingFwdKernel(Kernel):
         self.dtype = dtype
         self.accum_dtype = accum_dtype
         self.accum_dtype_str = self.dtype_to_str(self.accum_dtype)
+        self.width = heads * dim
+        # One block per chunk before the width is cut; what the launch rule divides.
+        self.blocks = batch_size * chunks_per_batch
 
         self.kernel = _mean_pooling_kernel(
             self.batch_size,
@@ -194,9 +256,9 @@ class MeanPoolingFwdKernel(Kernel):
     def autotune_supply_prog(self):
         """Supply autotuning the chunk map a real call carries.
 
-        The kernel takes each chunk's token range from ``offsets[seq_id]`` and
-        ``offsets[seq_id + 1]`` and divides by that range's length, so random
-        values leave it empty or inverted.
+        The kernel takes a ragged chunk's token range from ``offsets[seq_id]`` and
+        ``offsets[seq_id + 1]`` and divides by that range's length, so random values leave
+        it empty or inverted.
         """
         from tilelang.utils.device import get_current_device
         from tilelang.utils.tensor import get_tensor_supply
@@ -243,16 +305,23 @@ class MeanPoolingFwdKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
-        return {
-            "bdim": 128,
-            "threads": 128,
-        }
+        bwidth, threads = _launch(self.width, self.blocks, get_sm_count())
+        return {"bwidth": bwidth, "threads": threads}
 
     @property
     def autotune_configs(self) -> list[dict]:
-        threads = [32, 64, 128, 256]
-        bdim = [16, 32, 64, 128]
-        return [{"bdim": b, "threads": t} for b in bdim for t in threads]
+        """The launch rule's width and its neighbours, at 8, 16 and 32 bytes per lane.
+
+        A band narrow enough that every member is close to the best, with the untuned
+        default a member of it.
+        """
+        widths = _block_widths(self.width)
+        chosen = widths.index(self.default_config["bwidth"])
+        return [
+            {"bwidth": w, "threads": t}
+            for w in widths[max(0, chosen - 1) : chosen + 3]
+            for t in sorted({_threads_for(w, e) for e in _TUNED_LANE_ELEMS})
+        ]
 
     def forward(
         self, x: torch.Tensor, offsets: torch.Tensor, indices: torch.Tensor
@@ -269,7 +338,7 @@ class MeanPoolingFwdKernel(Kernel):
             self.use_offsets,
             self.dtype_str,
             self.accum_dtype_str,
-            self.config["bdim"],
+            self.config["bwidth"],
             self.config["threads"],
             x,
             offsets,

--- a/src/tileops/manifest/pool.yaml
+++ b/src/tileops/manifest/pool.yaml
@@ -811,10 +811,10 @@ MeanPoolingFwdOp:
     - "indices is None or (indices.ndim == 2 and indices.shape[1] == 2)"
     - "indices is None or output.shape == (batch, indices.shape[0], heads, dim)"
     - "indices is not None or output.shape == (batch, -(-seq_len // chunk_size), heads, dim)"
-    # A warp reduction spans the chunk, so the chunk must fill whole warps.
+    # Declared limits, not kernel limits. A block reduces a chunk without a warp
+    # reduction, so it reads any `chunk_size`; it takes a power-of-two share of
+    # `heads * dim` and bounds-tests a share that does not divide it, so it reads any `dim`.
     - "chunk_size > 0 and chunk_size % 32 == 0"
-    # The kernel tiles `dim` by a width of at most 128, and a tile that is neither the whole
-    # `dim` nor an exact divisor of it has no valid layout.
     - "dim <= 128 or dim % 128 == 0"
 
   workloads:

--- a/src/tileops/ops/pool.py
+++ b/src/tileops/ops/pool.py
@@ -1,3 +1,4 @@
+import weakref
 from collections.abc import Sequence
 from typing import Any, ClassVar, Dict, Optional, Tuple
 
@@ -144,6 +145,9 @@ class MeanPoolingFwdOp(Op):
         ```
     """
 
+    # How many distinct chunk maps stay remembered at once. See `_validate_ragged`.
+    _CHECKED_MAP_ENTRIES: ClassVar[int] = 8
+
     def __init__(
         self,
         chunk_size: int,
@@ -172,6 +176,8 @@ class MeanPoolingFwdOp(Op):
         # Keyed by (device, shape): the uniform path hands the kernel tensors it never
         # reads, and a placeholder on the wrong device would route the launch there.
         self._placeholders: Dict[tuple, torch.Tensor] = {}
+        # One entry per chunk map this op has already checked. See `_validate_ragged`.
+        self._checked_maps: Dict[tuple, tuple] = {}
         self.dispatch_kernel(kernel_map)
 
     @property
@@ -240,9 +246,9 @@ class MeanPoolingFwdOp(Op):
 
         Args:
             x: Input tensor, ``[batch, seq, heads, dim]``, dtype ``float16``, ``bfloat16``
-                or ``float32``. ``dim`` is at most 128 or a multiple of it: the kernel
-                tiles it by a width of at most 128, and a tile that is neither the whole
-                ``dim`` nor an exact divisor of it has no valid layout.
+                or ``float32``, contiguous — ``heads`` and ``dim`` are read as one width.
+                ``dim`` is at most 128 or a multiple of it, which is what the manifest
+                declares rather than what the kernel needs.
             offsets: Sequence boundaries, ``[seq_num + 1]``, dtype ``int32``. Passing it
                 selects the ragged split, and it comes with ``indices``.
             indices: One ``(sequence, chunk-within-sequence)`` pair per output chunk,
@@ -254,13 +260,15 @@ class MeanPoolingFwdOp(Op):
             ragged one.
 
         Raises:
-            ValueError: ``x`` is not 4D; exactly one of ``offsets`` and ``indices`` was
-                passed; ``chunk_size`` does not divide into whole warps; ``indices`` does
-                not hold one row per chunk ``offsets`` implies; or an input's dtype is
-                outside what the manifest declares.
+            ValueError: ``x`` is not 4D or not contiguous; exactly one of ``offsets`` and
+                ``indices`` was passed; ``chunk_size`` does not divide into whole warps;
+                ``indices`` does not hold one row per chunk ``offsets`` implies; or an
+                input's dtype is outside what the manifest declares.
         """
         if x.ndim != 4:
             raise ValueError(f"x must be [batch, seq, heads, dim]; got {tuple(x.shape)}")
+        if not x.is_contiguous():
+            raise ValueError("x must be contiguous; heads and dim are read as one width")
         if (offsets is None) != (indices is None):
             raise ValueError(
                 "offsets and indices describe one ragged split, so either both are passed "
@@ -271,8 +279,9 @@ class MeanPoolingFwdOp(Op):
             raise ValueError(f"chunk_size must be a positive multiple of 32; got {self.chunk_size}")
 
         batch_size, seq_len, heads, dim = x.shape
-        # The kernel tiles `dim` by a width of at most 128; a width that is neither the
-        # whole `dim` nor an exact divisor of it has no valid layout.
+        # The manifest's declared trailing width. A block takes a power-of-two share of
+        # `heads * dim` and bounds-tests its last block, so this is the contract's bound
+        # rather than the kernel's.
         if dim > 128 and dim % 128:
             raise ValueError(f"dim must be at most 128 or a multiple of 128; got {dim}")
         ragged = offsets is not None
@@ -306,6 +315,43 @@ class MeanPoolingFwdOp(Op):
         return out
 
     def _validate_ragged(
+        self, offsets: torch.Tensor, indices: torch.Tensor, seq_len: int, chunks: int
+    ) -> None:
+        """Check a chunk map once, then skip it while the same tensors come back unchanged.
+
+        `_check_ragged` reads `offsets` and `indices` element by element, costing a dozen
+        device launches and as many syncs, which a ragged call would otherwise pay before
+        every pooling. A chunk map is built once and passed to many calls, so its result is
+        remembered against the two tensors it was read from.
+
+        An entry applies only while both weak references still resolve to the objects that
+        were checked and neither `_version` has moved, so a tensor written in place, freed,
+        or replaced is checked again.
+        """
+        key = (id(offsets), id(indices), seq_len, chunks)
+        remembered = self._checked_maps.get(key)
+        if remembered is not None:
+            offsets_ref, indices_ref, versions = remembered
+            if (
+                offsets_ref() is offsets
+                and indices_ref() is indices
+                and versions == (offsets._version, indices._version)
+            ):
+                return
+
+        self._check_ragged(offsets, indices, seq_len, chunks)
+
+        # A dead tensor leaves its key behind, so the table is dropped rather than grown
+        # once a caller has cycled through this many maps.
+        if len(self._checked_maps) >= self._CHECKED_MAP_ENTRIES:
+            self._checked_maps.clear()
+        self._checked_maps[key] = (
+            weakref.ref(offsets),
+            weakref.ref(indices),
+            (offsets._version, indices._version),
+        )
+
+    def _check_ragged(
         self, offsets: torch.Tensor, indices: torch.Tensor, seq_len: int, chunks: int
     ) -> None:
         """Check `indices` against `offsets` rather than believing its row count.

--- a/src/tileops/ops/pool.py
+++ b/src/tileops/ops/pool.py
@@ -120,6 +120,53 @@ def validate_pool_params(
         raise ValueError("divisor_override must not be zero")
 
 
+class _CheckedChunkMaps:
+    """The chunk maps whose values have already been through `MeanPoolingFwdOp`'s checks.
+
+    An entry stands only while both weak references still resolve to the tensors that were
+    checked and neither `_version` has moved, so a map written in place, freed, or replaced
+    is checked again.
+    """
+
+    # Distinct maps remembered at once. A dead tensor leaves its key behind, so the table is
+    # dropped rather than grown once a caller has cycled through this many.
+    _ENTRIES = 8
+
+    def __init__(self) -> None:
+        """Start empty. An entry maps a key to (weak offsets, weak indices, both versions)."""
+        self._seen: Dict[tuple, tuple] = {}
+
+    @staticmethod
+    def _key(offsets: torch.Tensor, indices: torch.Tensor, seq_len: int, chunks: int) -> tuple:
+        return (id(offsets), id(indices), seq_len, chunks)
+
+    def checked(
+        self, offsets: torch.Tensor, indices: torch.Tensor, seq_len: int, chunks: int
+    ) -> bool:
+        """Whether this map, unchanged since it was checked, may skip the checks."""
+        entry = self._seen.get(self._key(offsets, indices, seq_len, chunks))
+        if entry is None:
+            return False
+        offsets_ref, indices_ref, versions = entry
+        return (
+            offsets_ref() is offsets
+            and indices_ref() is indices
+            and versions == (offsets._version, indices._version)
+        )
+
+    def remember(
+        self, offsets: torch.Tensor, indices: torch.Tensor, seq_len: int, chunks: int
+    ) -> None:
+        """Record that this map passed the checks."""
+        if len(self._seen) >= self._ENTRIES:
+            self._seen.clear()
+        self._seen[self._key(offsets, indices, seq_len, chunks)] = (
+            weakref.ref(offsets),
+            weakref.ref(indices),
+            (offsets._version, indices._version),
+        )
+
+
 class MeanPoolingFwdOp(Op):
     """Chunked mean over the sequence axis of a ``[batch, seq, heads, dim]`` tensor.
 
@@ -144,9 +191,6 @@ class MeanPoolingFwdOp(Op):
         chunk_means = op(x, offsets, indices)      # ragged, one row of indices per chunk
         ```
     """
-
-    # How many distinct chunk maps stay remembered at once. See `_validate_ragged`.
-    _CHECKED_MAP_ENTRIES: ClassVar[int] = 8
 
     def __init__(
         self,
@@ -176,8 +220,7 @@ class MeanPoolingFwdOp(Op):
         # Keyed by (device, shape): the uniform path hands the kernel tensors it never
         # reads, and a placeholder on the wrong device would route the launch there.
         self._placeholders: Dict[tuple, torch.Tensor] = {}
-        # One entry per chunk map this op has already checked. See `_validate_ragged`.
-        self._checked_maps: Dict[tuple, tuple] = {}
+        self._checked_maps = _CheckedChunkMaps()
         self.dispatch_kernel(kernel_map)
 
     @property
@@ -320,36 +363,13 @@ class MeanPoolingFwdOp(Op):
         """Check a chunk map once, then skip it while the same tensors come back unchanged.
 
         `_check_ragged` reads `offsets` and `indices` element by element, costing a dozen
-        device launches and as many syncs, which a ragged call would otherwise pay before
-        every pooling. A chunk map is built once and passed to many calls, so its result is
-        remembered against the two tensors it was read from.
-
-        An entry applies only while both weak references still resolve to the objects that
-        were checked and neither `_version` has moved, so a tensor written in place, freed,
-        or replaced is checked again.
+        device launches and as many syncs that a ragged call would otherwise pay before
+        every pooling. A chunk map is built once and passed to many calls.
         """
-        key = (id(offsets), id(indices), seq_len, chunks)
-        remembered = self._checked_maps.get(key)
-        if remembered is not None:
-            offsets_ref, indices_ref, versions = remembered
-            if (
-                offsets_ref() is offsets
-                and indices_ref() is indices
-                and versions == (offsets._version, indices._version)
-            ):
-                return
-
+        if self._checked_maps.checked(offsets, indices, seq_len, chunks):
+            return
         self._check_ragged(offsets, indices, seq_len, chunks)
-
-        # A dead tensor leaves its key behind, so the table is dropped rather than grown
-        # once a caller has cycled through this many maps.
-        if len(self._checked_maps) >= self._CHECKED_MAP_ENTRIES:
-            self._checked_maps.clear()
-        self._checked_maps[key] = (
-            weakref.ref(offsets),
-            weakref.ref(indices),
-            (offsets._version, indices._version),
-        )
+        self._checked_maps.remember(offsets, indices, seq_len, chunks)
 
     def _check_ragged(
         self, offsets: torch.Tensor, indices: torch.Tensor, seq_len: int, chunks: int

--- a/tests/ops/test_mean_pooling.py
+++ b/tests/ops/test_mean_pooling.py
@@ -158,6 +158,18 @@ def test_mean_pooling_rejects_indices_that_disagree_with_offsets() -> None:
 
 
 @pytest.mark.smoke
+def test_mean_pooling_rechecks_a_chunk_map_written_in_place() -> None:
+    """A map's checks are skipped while the same tensors come back unchanged, so one edited
+    in place has to be checked again instead of riding the earlier call's result."""
+    op = _op()
+    offsets, indices = mean_pooling_chunk_index([32, 32], 32)
+    op(_x(), offsets, indices)
+    indices[1, 1] = 5  # a chunk its sequence does not have
+    with pytest.raises(ValueError, match="does not have"):
+        op(_x(), offsets, indices)
+
+
+@pytest.mark.smoke
 def test_mean_pooling_rejects_offsets_that_leave_tokens_out() -> None:
     """`offsets` partitions the sequence axis. Bounds that stop short would drop rows from
     the mean without saying so."""

--- a/tests/ops/test_mean_pooling.py
+++ b/tests/ops/test_mean_pooling.py
@@ -95,9 +95,10 @@ def test_mean_pooling_op(
 def test_mean_pooling_dim_not_one_full_tile(dim: int) -> None:
     """`dim` values the manifest allows but no workload row carries.
 
-    The kernel tiles `dim` by a width of at most 128: 100 is one tile with a short tail, 256
-    is two whole tiles. Between them TileLang finds no layout, which is why the manifest
-    rules out that range rather than the op checking for it.
+    A block takes a power-of-two share of `heads * dim`: `dim` 100 gives a width of 200
+    that no share divides, so the last block is bounds-tested; 256 gives 512 that they
+    divide. The range the manifest rules out between them is a contract bound, not a shape
+    the kernel cannot read.
     """
     test = MeanPoolingTest(
         batch=1,


### PR DESCRIPTION
## Summary

- `heads` and `dim` are the two innermost axes of a contiguous input and neither is reduced, so a block reads them as one contiguous width instead of tiling `dim` alone. A block used to take 64 rows of 256 bytes spaced 16 KB apart and stage them through shared memory; it now reads rows of up to 16 KB straight into an accumulator. Per-CTA global reads go from 16 KB to 128 KB and the shared-memory round trip of the whole input -- 134 MB in and 134 MB out, which the roofline never charged for -- is gone with it.
- The uniform full-chunk path indexes its token as `i_t * chunk_size + s`, which bound analysis places inside the sequence axis, so no load is predicated. The released kernel wrapped every load in a `condval` select with a zero-filled else branch.
- The ragged path bounds its row loop by the chunk's own token count. Predicating each row of a `chunk_size` walk instead measured 18% to 30% slower on every ragged workload.
- `_validate_ragged` ran a dozen device reductions and as many syncs on every call, so a ragged call launched 25 kernels where the pooling needs one. Its result is remembered against weak references to `offsets` and `indices` plus their `_version`, so a map written in place, freed, or replaced is checked again. Kernels per call go from 25 to 1 on all three ragged workloads.
- The block width comes from the shape: the widest power-of-two share of `heads * dim` whose grid still covers the SMs. A share that does not divide the axis bounds-tests its last block, which is what lets any `dim` be read.
- The autotune space is that width and its neighbours at 8, 16 and 32 bytes per lane -- 12 configs where it was 16, with the untuned default a member of it.
- The block widths, lane shares and the two functions reading them are held in `_BlockTiling` rather than the module namespace, where the next kernel added to this file would read them as general truths. `width` and `blocks` were kernel attributes with no reader outside the class and move into it; the 1024 thread clamp and the tuning band's width offsets get names.
- The checked-map table, its eviction bound and the two operations on it are held in `_CheckedChunkMaps` instead of a `Dict[tuple, tuple]`, a class attribute and twenty lines of positional unpacking spread across `MeanPoolingFwdOp`.
- The manifest's `chunk_size` and `dim` rules are unchanged, but neither a warp reduction nor a 128-wide `dim` tile exists any more, so their comments now say they are declared limits rather than kernel limits. Relaxing them is a separate change.

## TileFoundry Description

Both placements of the same step, at the manifest's `uniform-8k` workload. `Staged` is what
ships today; `WidthTiled` is this PR.

```python
BATCH, SEQ, HEADS, DIM = 1, 8192, 64, 128
CHUNK = 64
CHUNKS = SEQ // CHUNK
WIDTH = HEADS * DIM  # the trailing axes are contiguous and neither is reduced

_H200 = CudaTarget("nvidia.h200_sxm")

# The released placement: one CTA per (chunk, head), a `dim`-wide tile through smem.
_CTA_PER_HEAD = Topology("cta", CHUNKS * HEADS)
_THREAD_PER_DIM = Topology("thread", DIM)

# This PR: one CTA per (chunk, width tile) over the flattened trailing axis.
WIDTH_TILE = 1024
WIDTH_TILES = WIDTH // WIDTH_TILE
THREADS = 128
LANE = WIDTH_TILE // THREADS
_CTA_PER_TILE = Topology("cta", CHUNKS * WIDTH_TILES)
_THREAD_PER_LANE = Topology("thread", THREADS)


@module(entry="mean_pooling", target=_H200, topologies=(_CTA_PER_HEAD, _THREAD_PER_DIM))
class Staged:
    """What ships today: a (chunk, head) CTA stages its tile through shared memory."""

    @func
    def mean_pooling(x: Tensor[(BATCH, SEQ, HEADS, DIM), "f16"]):
        # The chunk axis is a reshape of the sequence axis, not a gather: chunk `t` is
        # tokens [t * CHUNK, (t + 1) * CHUNK).
        chunked = tf.reshape(x, new_shape=(BATCH, CHUNKS, CHUNK, HEADS, DIM))
        with Mesh(("cta",), layout=(CHUNKS, HEADS), names=("t", "h")) as cta:
            # A CTA owns one head of one chunk, so its rows are DIM wide -- 256 B -- and
            # sit HEADS * DIM apart. It stages them in shared memory before reducing.
            staged = tf.reshard(
                chunked, (BATCH, CHUNKS @ cta.t, CHUNK, HEADS @ cta.h, DIM), "smem"
            )
            with Mesh(("thread",), layout=(DIM,), names=("d",)) as m:
                held = tf.reshard(
                    staged,
                    (BATCH, CHUNKS @ cta.t, CHUNK, HEADS @ cta.h, DIM @ m.d),
                    "rmem",
                )
                pooled = tf.reduce(tf.cast(held, "f32"), (2,), False, ReduceKind.MEAN)
                return tf.reshard(
                    tf.cast(pooled, "f16"), (BATCH, CHUNKS, HEADS, DIM), "gmem"
                )


@module(entry="mean_pooling", target=_H200, topologies=(_CTA_PER_TILE, _THREAD_PER_LANE))
class WidthTiled:
    """This PR: a (chunk, width tile) CTA accumulates in registers, with no smem hop."""

    @func
    def mean_pooling(x: Tensor[(BATCH, SEQ, HEADS, DIM), "f16"]):
        # `heads` and `dim` are the two innermost axes and neither is reduced, so they
        # flatten into one width the reduction never has to address separately. Splitting
        # that width into (tile, lane, element) is what names the CTA's and the lane's
        # share of it below; none of these reshapes moves a byte.
        flat = tf.reshape(
            x, new_shape=(BATCH, CHUNKS, CHUNK, WIDTH_TILES, THREADS, LANE)
        )
        with Mesh(("cta",), layout=(CHUNKS, WIDTH_TILES), names=("t", "w")) as cta:
            with Mesh(("thread",), layout=(THREADS,), names=("j",)) as m:
                # One reshard, straight to registers: the CTA's rows are WIDTH_TILE wide
                # and contiguous, and a lane takes LANE of them, so the load is one
                # 16-byte access per row per lane. Nothing lands in shared memory.
                held = tf.reshard(
                    flat,
                    (
                        BATCH,
                        CHUNKS @ cta.t,
                        CHUNK,
                        WIDTH_TILES @ cta.w,
                        THREADS @ m.j,
                        LANE,
                    ),
                    "rmem",
                )
                # Axis 2 is the chunk's token axis, the only reduced one. It is local to
                # the CTA, so the mean leaves nothing pending across the mesh.
                pooled = tf.reduce(tf.cast(held, "f32"), (2,), False, ReduceKind.MEAN)
                out = tf.reshard(
                    tf.cast(pooled, "f16"),
                    (BATCH, CHUNKS, WIDTH_TILES, THREADS, LANE),
                    "gmem",
                )
                return tf.reshape(out, new_shape=(BATCH, CHUNKS, HEADS, DIM))
```

`tilefoundry analyze <module> --compute-cost --memory --roofline`:

```text
Staged      traffic=gmem:r134217728/w2097152@r16384/w256,
                    rmem:r408944640/w408944640@r49920/w49920,
                    smem:r134217728/w134217728@r16384/w16384
            peak-footprint=gmem:268435456,rmem:49152,smem:16384
            roofline ideal-ns=28399 bound-by=memory

WidthTiled  traffic=gmem:r134217728/w2097152@r131072/w2048,
                    rmem:r408944640/w408944640@r399360/w399360
            peak-footprint=gmem:268435456,rmem:393216
            roofline ideal-ns=28399 bound-by=memory
```

What the analysis decided, before any kernel was written:

- Global traffic is identical and already minimal in both -- one read of the input, one write of the output -- and both are `bound-by=memory` at the same `ideal-ns`. So the win was never going to come from moving fewer bytes, and cutting flops would buy nothing.
- The whole difference is in the `@` projection and the `smem` line. Per-CTA global reads go from `r16384` to `r131072`: the same bytes in runs 8x longer. `Staged` also carries `smem:r134217728/w134217728`, a full round trip of the input that the roofline prices at zero because gmem is the bound, and that the measurement does not.
- `peak-footprint` bounds the authored tile: `WIDTH_TILE` 2048 asks for 524288 B of rmem against the 262144 B the target states, so 1024 is the widest tile this form can be authored at. The shipped kernel goes wider because it streams the chunk's rows through one accumulator, where `Reduce` here takes the whole `(CHUNK, WIDTH_TILE)` operand materialized. That is a limit of writing the reduction as one op, not of the placement.

The ragged split is not authored here. HIR's only way to name a data-dependent token start is `tf.index_select`, and it prices as a materialized gather wherever it is placed -- inside the mesh or outside it, `ideal-ns` goes 28399 to 84330 and gmem reads go 134 MB to 268 MB, because the gathered tensor is written and read back. The kernel does that gather with address arithmetic inside the CTA and materializes nothing, so an authored ragged module would state a round trip the kernel does not make. Everything after the token start, the ragged path reads exactly as `WidthTiled` does.

## Performance

Operator: `MeanPoolingFwdOp`

| Environment | Value |
| --- | --- |
| image | ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-afcebed1-tilefoundry-latest |
| digest | sha256:ca13df9bda340edf248b8b443b88880f36e3190ab9d470f52d66ccc21c15fd59 |
| gpu | NVIDIA H200 |
| driver | 595.71.05 |
| cuda | 13.2 |
| torch | 2.13.0+cu132 |
| tilelang | 0.1.11+cu132.gitafcebed1 |
| tilefoundry | 0.1.dev146+g2bec6420e |
| timer | native CUPTI device-busy time |

Method: One process, one GPU, one set of inputs, the manifest benchmark's own comparison harness -- same warmup and repeat budget, same L2 flush before every iteration (`cudaCtxResetPersistingL2Cache` plus a zeroed 2x-L2 buffer, so every reading is cold), same CUPTI attribution, autotuning on. Device-busy time is the union of a call's kernel execution intervals, so it excludes the gaps between them. Reported latency is the median of three whole-comparison repeats; the percentage beside it is the min-to-max spread across those repeats. Base is `main` at 1d48e1f5, measured in the same window, alternating with the candidate.

Ratio in comparator columns: implementation / candidate. &#x1F7E2; > 1 means the candidate is faster;
&#x1F534; <= 1 means it is not.

| Workload | B | S | H | D | chunk | split | Dtype | This PR (ms) | Base (ms)<br>/ candidate | torch-view-mean (ms)<br>/ candidate | torch-compile (ms)<br>/ candidate | torch-ref (ms)<br>/ candidate |
| --- | ---: | ---: | ---: | ---: | ---: | --- | --- | ---: | ---: | ---: | ---: | ---: |
| uniform-8k | 1 | 8192 | 64 | 128 | 64 | uniform | float16 | 0.0389125 (+/-0.16%) | **0.04048 (+/-0.40%)<br>&#x1F7E2;&nbsp;1.0403x** | 0.043136 (+/-0.22%)<br>&#x1F7E2;&nbsp;1.1085x | 0.353312 (+/-0.30%)<br>&#x1F7E2;&nbsp;9.0797x | 0.537031 (+/-0.37%)<br>&#x1F7E2;&nbsp;13.8010x |
| uniform-batched | 2 | 2048 | 64 | 128 | 64 | uniform | float16 | 0.022336 (+/-0.86%) | **0.022976 (+/-0.00%)<br>&#x1F7E2;&nbsp;1.0287x** | 0.0262235 (+/-0.61%)<br>&#x1F7E2;&nbsp;1.1740x | 0.122353 (+/-0.15%)<br>&#x1F7E2;&nbsp;5.4778x | 0.220157 (+/-0.45%)<br>&#x1F7E2;&nbsp;9.8566x |
| ragged-even | 1 | 8192 | 64 | 128 | 64 | ragged | float16 | 0.0408 (+/-0.55%) | **0.149471 (+/-0.71%)<br>&#x1F7E2;&nbsp;3.6635x** | n/a | 0.538183 (+/-0.06%)<br>&#x1F7E2;&nbsp;13.1908x | 0.53805 (+/-0.06%)<br>&#x1F7E2;&nbsp;13.1875x |
| ragged-tail | 1 | 1000 | 64 | 128 | 32 | ragged | float16 | 0.0088165 (+/-0.36%) | **0.063874 (+/-1.26%)<br>&#x1F7E2;&nbsp;7.2448x** | n/a | 0.186832 (+/-0.85%)<br>&#x1F7E2;&nbsp;21.1912x | 0.186914 (+/-0.58%)<br>&#x1F7E2;&nbsp;21.2005x |
| ragged-batched | 2 | 2048 | 64 | 128 | 64 | ragged | float16 | 0.023872 (+/-0.47%) | **0.099808 (+/-1.04%)<br>&#x1F7E2;&nbsp;4.1810x** | n/a | 0.275134 (+/-0.11%)<br>&#x1F7E2;&nbsp;11.5254x | 0.275097 (+/-0.27%)<br>&#x1F7E2;&nbsp;11.5238x |
| geometric mean |  |  |  |  |  |  |  | 0.0236912 | **0.0615903<br>&#x1F7E2;&nbsp;2.5997x** | 0.033633 (2 rows)<br>&#x1F7E2;&nbsp;1.1408x | 0.260339<br>&#x1F7E2;&nbsp;10.9888x | 0.318373<br>&#x1F7E2;&nbsp;13.4384x |

`torch-view-mean` is `x.view(b, chunks, chunk, h, d).mean(2)`. It exists only where every
chunk is full, so it has no result on the three ragged rows and its geometric mean is over
the two uniform rows against the same two candidate rows.

## Result And Limitations

**measured SOTA**

- Every-row SOTA: all five manifest workloads are faster than every runnable baseline, against a run-to-run spread of at most 1.3%. The narrowest margin is 1.11x on `uniform-8k` against `torch-view-mean`, the strongest thing PyTorch can express for this op.
- The last nightly had `torch-view-mean` at 0.35x and 0.41x on the two uniform rows. That snapshot is `001ef398`, which predates #2093, so those two rows were already positive on `main` before this PR; what this PR moves is the three ragged rows, which nightly reported as passing.
- Kernels per call go from 25 to 1 on every ragged workload. Twenty-four of the twenty-five were the chunk-map validation, not the pooling, which is most of what those rows measured.
- The uniform rows are at this card's read rate, and the 4.77 TB/s roof is the wrong target. Counted in read bytes per second, cold, in one window on `(1, 8192, 64, 128)`: this kernel 43.2 us / 3.11 TB/s, a plain streaming read of the same 134.2 MB 48.2 us / 2.79 TB/s, `clone`'s read stream 68.2 us / 1.97 TB/s. `clone`'s headline 3.95 TB/s counts writes that partly sit dirty in L2 past the timing window, so it is not a ceiling. Nothing constructed here reads these bytes faster than the kernel does.
- Convergence: three further rounds found no direction. (1) A cold-L2 sweep of 85 variants -- block width 1024 to 8192, 8/16/32 elements per lane, serial against unrolled 2/4/8 against 2/4/8 independent accumulators -- spans 43.3 to 44.0 us, a 1.6% band, so memory-level parallelism is not what limits this. (2) The read-ceiling measurement above. (3) Splitting the full-chunk case out of the ragged loop, which a cold probe put 6.5% ahead, is +0.2% in the harness; it was reverted rather than ship a duplicated loop body for noise. Global traffic is already provably minimal -- the analysis above shows one read of the input and one write of the output -- so bytes moved is not a lever either.
- `ragged-tail` stays at 1.91 TB/s. It is 17 MB over 34 chunks, and both knobs are flat there: 12 block widths within 1% of each other, and 16 loop forms (static, dynamic, unrolled 2/4/8, pipelined 2/4/8) within 1% of each other. Nothing in the kernel's shape moves it, so it is left alone.
- The autotuner picks `bwidth=8192, threads=1024` -- one block per chunk, reading the chunk's 1 MB whole -- the best of the 12 configs in the band. The untuned launch rule picks `(4096, 512)`, 3.5% behind, so a `tune=False` caller stays inside the 4% the band claims. The rule cuts the width because `blocks=128` falls just under `sm_count=132`; every threshold that would fix that one shape is either arbitrary or degenerates to the narrowest width on many-wave shapes, so it is left as it is.
- Correctness is checked beyond the manifest shapes: `dim` 100 and 256 with `heads` 2, which exercise a width no block width divides and one they do; a ragged map whose last chunk of every sequence is short; and the five rejection paths the op declares. 23 nodes pass on an H200.
- The op now rejects a non-contiguous `x` explicitly. The released kernel already required it -- it indexed a 4-D `T.Tensor` with default strides -- but said so nowhere.
- `_validate_ragged` still raises on a zero-chunk ragged call, where `indices` is empty and `seq_ids.min()` reduces an empty tensor. That path is unchanged by this PR and such a call cannot launch anyway; it wants its own fix.