### PR TITLE
[Perf][foundry][Norm] Read a fused-add RMSNorm row before writing either output, and put a decode row on several CTAs

### DIFF
--- a/src/tileops/kernels/norm/fused_add_norm.py
+++ b/src/tileops/kernels/norm/fused_add_norm.py
@@ -371,7 +371,10 @@ def _fused_add_rms_norm_kernel(M, N, eps, dtype, splits):
                     for i in T.vectorized(_VEC):
                         b[i] = residual[row, mine + base + i]
                     for i in T.serial(_VEC):
-                        b[i] = T.cast(T.cast(a[i], "float32") + T.cast(b[i], "float32"), dtype)
+                        # A native add, not an f32 round trip: f32 holds the exact sum of
+                        # two 16-bit floats, so rounding that sum back is bit-identical to
+                        # adding in the storage dtype, and overflows to inf either way.
+                        b[i] = a[i] + b[i]
                         v = T.cast(b[i], "float32")
                         acc[0] += v * v
                     for i in T.vectorized(_VEC):
@@ -386,10 +389,7 @@ def _fused_add_rms_norm_kernel(M, N, eps, dtype, splits):
                     for i in T.vectorized(_VEC):
                         b[i] = residual[row, base + i]
                     for i in T.serial(_VEC):
-                        v = T.cast(
-                            T.cast(T.cast(a[i], "float32") + T.cast(b[i], "float32"), dtype),
-                            "float32",
-                        )
+                        v = T.cast(a[i] + b[i], "float32")
                         acc[0] += v * v
 
                 block_rsqrt(tx, acc, warp_sums, rrms)

--- a/src/tileops/kernels/norm/fused_add_norm.py
+++ b/src/tileops/kernels/norm/fused_add_norm.py
@@ -8,12 +8,14 @@ memory round-trip compared to separate add + norm.  Both kernels return dual
 outputs ``(y, x + residual)`` so downstream residual connections can reuse the
 pre-norm sum without recomputation.
 
-The row is held in a register fragment from the load through the store. Shared memory
-is left to the FusedAddRMSNorm path that keeps the pre-norm sum there to stay under the
-register limit on a grid that already fills the device.
+FusedAddLayerNorm holds the row in a register fragment from the load through the store.
 
-256-element alignment (512 bytes for fp16/bf16) required by the T.copy() that fills that
-shared buffer.
+FusedAddRMSNorm reads the row through 16-byte accesses and writes nothing until the
+reduction has settled, so the two reads and the two writes reach memory as two runs
+rather than interleaved. The chunk a CTA writes waits in shared memory in between.
+
+Rows are padded to 256 elements (512 bytes for fp16/bf16), so a 16-byte access always
+divides the row evenly across one warp.
 """
 
 import functools
@@ -24,9 +26,10 @@ import tilelang.language as T
 import torch
 import torch.nn.functional as F
 
+from tileops.kernels.constants import VECTOR_ACCESS_BYTES
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.tiling import ALIGNMENT, align_up
-from tileops.utils import WARP_LANES, get_sm_count
+from tileops.utils import WARP_LANES
 
 from ._config import select_row_config, select_row_configs
 
@@ -228,19 +231,97 @@ class FusedAddLayerNormKernel(Kernel):
 
 # Fused Add + RMSNorm kernel
 
+# Elements one thread moves per access: 16 bytes is the widest access these dtypes have.
+_VEC = VECTOR_ACCESS_BYTES // 2
+
+# Accesses a CTA makes over the row it reduces; the block width follows from it.
+_ROW_ACCESSES = 4
+
+# CTAs put on one row when the call has too few rows to fill the device.
+_ROW_SPLITS = 4
+
+
+def _row_threads(n_padded: int) -> int:
+    """Block width for a row of *n_padded* columns.
+
+    The widest power of two that cuts the row into 16-byte accesses and leaves each CTA
+    :data:`_ROW_ACCESSES` of them. Capped at the 1024 CUDA allows a block, and floored at
+    one warp, which a row padded to :data:`ALIGNMENT` always admits.
+    """
+    target = min(max(n_padded // (_VEC * _ROW_ACCESSES), WARP_LANES), 1024)
+    for threads in (1024, 512, 256, 128, 64, WARP_LANES):
+        if threads <= target and (n_padded // _VEC) % threads == 0:
+            return threads
+    return WARP_LANES
+
+
+def _row_splits(n_padded: int, threads: int, rows: int) -> int:
+    """CTAs to put on one row -- more than one only when the call is a single row.
+
+    A call with rows to spare fills the grid with them. A single row instead leaves one
+    CTA holding it and the rest of the device idle, so the row is cut into as many pieces
+    as divide it evenly at *threads*, up to :data:`_ROW_SPLITS`.
+    """
+    if rows != 1:
+        return 1
+    accesses = n_padded // (_VEC * threads)
+    return max(s for s in (_ROW_SPLITS, 2, 1) if accesses % s == 0)
+
+
+def _make_block_rsqrt(warps, inv_n, eps):
+    """Create the macro folding one fp32 partial per thread into ``rrms[0]``.
+
+    Thread 0 adds the per-warp totals rather than a second butterfly folding them: at
+    these widths there are at most 32 of them.
+
+    Args:
+        warps: Warps in the block.
+        inv_n: Reciprocal of the unpadded row length.
+        eps: Epsilon for numerical stability.
+
+    Returns:
+        A ``@T.macro`` taking ``(tx, acc, warp_sums, rrms)``.
+    """
+
+    @T.macro
+    def block_rsqrt(tx, acc, warp_sums, rrms):
+        for step in T.serial(WARP_LANES.bit_length() - 1):
+            acc[0] += T.shfl_xor(acc[0], T.shift_left(1, step))
+        if tx % WARP_LANES == 0:
+            warp_sums[tx // WARP_LANES] = acc[0]
+        T.sync_threads()
+        if tx == 0:
+            acc[0] = T.cast(0, "float32")
+            for w in T.serial(warps):
+                acc[0] += warp_sums[w]
+            rrms[0] = T.rsqrt(acc[0] * inv_n + eps)
+        T.sync_threads()
+
+    return block_rsqrt
+
 
 @functools.lru_cache(maxsize=32)
-def _fused_add_rms_norm_kernel(M, N, eps, dtype, sm_count):
+def _fused_add_rms_norm_kernel(M, N, eps, dtype, splits):
+    """Return the factory for one CTA per ``(row, chunk)`` pair.
+
+    A CTA reduces a whole row and writes one chunk of it. Nothing is written until the
+    reduction has settled, so the two reads and the two writes reach memory as two runs
+    rather than interleaved -- worth 3% over writing the sum in the first pass.
+
+    With ``splits > 1`` the CTAs sharing a row each reduce the whole row, which costs
+    them reads that L2 serves and buys a single row more than one SM without a second
+    launch. A grid barrier is the other way to spend one launch on it, and measured
+    slower than the redundant reads at every width here.
+    """
     N_padded = align_up(N, ALIGNMENT)
+    chunk = N_padded // splits
 
     @tilelang.jit(out_idx=[3, 4])
-    def _func(block_m, threads):
-        # Forming the sum in shared rather than a second row-wide fragment keeps
-        # bfloat16 off the register limit, but only pays when the registers it
-        # frees buy resident blocks: a single-row call measured 0.94x.
-        sum_in_shared = -(-M // block_m) >= sm_count
-        # A tail row block runs past the end unless every index is guarded.
-        row_guard = M % block_m != 0
+    def _func(threads):
+        own = chunk // (threads * _VEC)  # accesses this CTA reduces and writes
+        rest = (N_padded - chunk) // (threads * _VEC)  # accesses it only reduces
+        # N, not N_padded: a padded column holds zero and contributes nothing.
+        block_rsqrt = _make_block_rsqrt(threads // WARP_LANES, 1.0 / N, eps)
 
         @T.prim_func
         def main(
@@ -250,219 +331,80 @@ def _fused_add_rms_norm_kernel(M, N, eps, dtype, sm_count):
             y: T.Tensor[(M, N_padded), dtype],
             residual_out: T.Tensor[(M, N_padded), dtype],
         ):
-            with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
-                if sum_in_shared:
-                    shared_x = T.alloc_shared((block_m, N_padded), dtype)
-                    shared_r = T.alloc_shared((block_m, N_padded), dtype)
-                x_local = T.alloc_fragment((block_m, N_padded), dtype)
-                xsq_f32 = T.alloc_fragment((block_m, N_padded), "float32")
-                sumsq = T.alloc_fragment((block_m,), "float32")
-                rrms = T.alloc_fragment((block_m,), "float32")
+            with T.Kernel(M * splits, threads=threads) as pid:
+                row = pid // splits
+                mine = (pid % splits) * chunk
+                tx = T.get_thread_binding()
+                a = T.alloc_local([_VEC], dtype)
+                b = T.alloc_local([_VEC], dtype)
+                summed = T.alloc_shared([chunk], dtype)
+                acc = T.alloc_local([1], "float32")
+                warp_sums = T.alloc_shared([threads // WARP_LANES], "float32")
+                rrms = T.alloc_shared([1], "float32")
 
-                if sum_in_shared:
-                    T.copy(x[pid_m * block_m, 0], shared_x)
-                    T.copy(residual[pid_m * block_m, 0], shared_r)
-                    for i, j in T.Parallel(block_m, N_padded):
-                        shared_x[i, j] = T.cast(
-                            T.cast(shared_x[i, j], "float32") + T.cast(shared_r[i, j], "float32"),
-                            dtype,
+                acc[0] = T.cast(0, "float32")
+                for step in T.serial(own):
+                    base = (step * threads + tx) * _VEC
+                    for i in T.vectorized(_VEC):
+                        a[i] = x[row, mine + base + i]
+                    for i in T.vectorized(_VEC):
+                        b[i] = residual[row, mine + base + i]
+                    for i in T.serial(_VEC):
+                        b[i] = T.cast(T.cast(a[i], "float32") + T.cast(b[i], "float32"), dtype)
+                        v = T.cast(b[i], "float32")
+                        acc[0] += v * v
+                    for i in T.vectorized(_VEC):
+                        summed[base + i] = b[i]
+
+                # The rest of the row, reduced but not written. Starting past this CTA's
+                # own chunk keeps the CTAs sharing a row off the same lines at once.
+                for step in T.serial(rest):
+                    base = (mine + chunk + (step * threads + tx) * _VEC) % N_padded
+                    for i in T.vectorized(_VEC):
+                        a[i] = x[row, base + i]
+                    for i in T.vectorized(_VEC):
+                        b[i] = residual[row, base + i]
+                    for i in T.serial(_VEC):
+                        v = T.cast(
+                            T.cast(T.cast(a[i], "float32") + T.cast(b[i], "float32"), dtype),
+                            "float32",
                         )
-                    T.sync_threads()
-                    T.copy(shared_x, residual_out[pid_m * block_m, 0])
-                    T.copy(shared_x, x_local)
+                        acc[0] += v * v
 
-                    for i, j in T.Parallel(block_m, N_padded):
-                        xsq_f32[i, j] = T.cast(x_local[i, j], "float32") * T.cast(
-                            x_local[i, j], "float32"
+                block_rsqrt(tx, acc, warp_sums, rrms)
+
+                scale = rrms[0]
+                for step in T.serial(own):
+                    base = (step * threads + tx) * _VEC
+                    for i in T.vectorized(_VEC):
+                        a[i] = summed[base + i]
+                    for i in T.vectorized(_VEC):
+                        b[i] = weight[mine + base + i]
+                    for i in T.serial(_VEC):
+                        b[i] = T.cast(
+                            T.cast(a[i], "float32") * scale * T.cast(b[i], "float32"), dtype
                         )
-
-                    T.reduce_sum(xsq_f32, sumsq, dim=1)
-
-                    for i in T.Parallel(block_m):
-                        rrms[i] = T.rsqrt(sumsq[i] / float(N) + eps)
-
-                    for i, j in T.Parallel(block_m, N_padded):
-                        if (not row_guard) or pid_m * block_m + i < M:
-                            y[pid_m * block_m + i, j] = T.cast(
-                                T.cast(x_local[i, j], "float32")
-                                * rrms[i]
-                                * T.cast(weight[j], "float32"),
-                                dtype,
-                            )
-                else:
-                    r_local = T.alloc_fragment((block_m, N_padded), dtype)
-
-                    if row_guard:
-                        for i, j in T.Parallel(block_m, N_padded):
-                            x_local[i, j] = T.if_then_else(
-                                pid_m * block_m + i < M,
-                                x[pid_m * block_m + i, j],
-                                T.cast(0.0, dtype),
-                            )
-                        for i, j in T.Parallel(block_m, N_padded):
-                            r_local[i, j] = T.if_then_else(
-                                pid_m * block_m + i < M,
-                                residual[pid_m * block_m + i, j],
-                                T.cast(0.0, dtype),
-                            )
-                    else:
-                        for i, j in T.Parallel(block_m, N_padded):
-                            x_local[i, j] = x[pid_m * block_m + i, j]
-                        for i, j in T.Parallel(block_m, N_padded):
-                            r_local[i, j] = residual[pid_m * block_m + i, j]
-
-                    for i, j in T.Parallel(block_m, N_padded):
-                        x_local[i, j] = T.cast(x_local[i, j], "float32") + T.cast(
-                            r_local[i, j], "float32"
-                        )
-
-                    for i, j in T.Parallel(block_m, N_padded):
-                        xsq_f32[i, j] = T.cast(x_local[i, j], "float32") * T.cast(
-                            x_local[i, j], "float32"
-                        )
-
-                    T.reduce_sum(xsq_f32, sumsq, dim=1)
-
-                    for i in T.Parallel(block_m):
-                        rrms[i] = T.rsqrt(sumsq[i] / float(N) + eps)
-
-                    for i, j in T.Parallel(block_m, N_padded):
-                        if (not row_guard) or pid_m * block_m + i < M:
-                            y[pid_m * block_m + i, j] = T.cast(
-                                T.cast(x_local[i, j], "float32")
-                                * rrms[i]
-                                * T.cast(weight[j], "float32"),
-                                dtype,
-                            )
-
-                    for i, j in T.Parallel(block_m, N_padded):
-                        if (not row_guard) or pid_m * block_m + i < M:
-                            residual_out[pid_m * block_m + i, j] = x_local[i, j]
+                    for i in T.vectorized(_VEC):
+                        residual_out[row, mine + base + i] = a[i]
+                    for i in T.vectorized(_VEC):
+                        y[row, mine + base + i] = b[i]
 
         return main
 
     return _func
 
 
-# Traffic a row must carry before splitting it across blocks pays the two
-# launches that costs. Measured end to end; at half of it the split is 0.94x.
-_SPLIT_MIN_ROW_TRAFFIC = 65536
-
-# Blocks a split row is cut into, and the width each is launched with.
-_SPLIT_BLOCKS = 16
-
-_SPLIT_THREADS = 128
-_SPLIT_PER_THREAD = 8
-
-
-@functools.lru_cache(maxsize=32)
-def _fused_add_rms_norm_split_kernel(N, eps, dtype):
-    """Return the two factories that normalize one row across many blocks.
-
-    A decode call is one row, so the row-per-block program launches a single
-    block and the device idles behind it. These cut the row into
-    :data:`_SPLIT_BLOCKS` pieces: the first sums the squares of its piece and
-    writes the sum out, which is an output anyway; the second merges the
-    partial sums, few enough that every block redoing it beats a launch that
-    does it once, and scales its piece.
-
-    The merge is a different order of fp32 additions from the single-block
-    reduction, so results agree to tolerance rather than bit for bit.
-    """
-    accum = "float32"
-
-    @tilelang.jit
-    def _stats(splits, threads, per):
-        chunk = N // splits
-        n_warps = max(threads // WARP_LANES, 1)
-
-        @T.prim_func
-        def main(
-            x: T.Tensor([N], dtype),
-            residual: T.Tensor([N], dtype),
-            residual_out: T.Tensor([N], dtype),
-            partial: T.Tensor([splits], accum),
-        ):
-            with T.Kernel(splits, threads=threads) as bx:
-                tx = T.get_thread_binding()
-                acc = T.alloc_local([1], accum)
-                a = T.alloc_local([per], dtype)
-                b = T.alloc_local([per], dtype)
-                total = T.alloc_local([per], dtype)
-                acc[0] = T.cast(0, accum)
-                for step in T.serial(chunk // (threads * per)):
-                    base = bx * chunk + (step * threads + tx) * per
-                    for i in T.vectorized(per):
-                        a[i] = x[base + i]
-                    for i in T.vectorized(per):
-                        b[i] = residual[base + i]
-                    for i in T.serial(per):
-                        total[i] = T.cast(T.cast(a[i], accum) + T.cast(b[i], accum), dtype)
-                        v = T.cast(total[i], accum)
-                        acc[0] += v * v
-                    for i in T.vectorized(per):
-                        residual_out[base + i] = total[i]
-                for step in T.serial(5):
-                    acc[0] += T.shfl_xor(acc[0], T.shift_left(1, step))
-                warp_totals = T.alloc_shared([n_warps], accum)
-                if tx % WARP_LANES == 0:
-                    warp_totals[tx // WARP_LANES] = acc[0]
-                T.sync_threads()
-                if tx == 0:
-                    acc[0] = T.cast(0, accum)
-                    for w in T.serial(n_warps):
-                        acc[0] += warp_totals[w]
-                    partial[bx] = acc[0]
-
-        return main
-
-    @tilelang.jit(out_idx=[3])
-    def _apply(splits, threads, per):
-        chunk = N // splits
-
-        @T.prim_func
-        def main(
-            summed: T.Tensor([N], dtype),
-            partial: T.Tensor([splits], accum),
-            weight: T.Tensor([N], dtype),
-            y: T.Tensor([N], dtype),
-        ):
-            with T.Kernel(splits, threads=threads) as bx:
-                tx = T.get_thread_binding()
-                total = T.alloc_local([1], accum)
-                total[0] = T.cast(0, accum)
-                for s in T.serial(splits):
-                    total[0] += partial[s]
-                rrms = T.rsqrt(total[0] / T.cast(N, accum) + T.cast(eps, accum))
-                v = T.alloc_local([per], dtype)
-                o = T.alloc_local([per], dtype)
-                for step in T.serial(chunk // (threads * per)):
-                    base = bx * chunk + (step * threads + tx) * per
-                    for i in T.vectorized(per):
-                        v[i] = summed[base + i]
-                    for i in T.serial(per):
-                        o[i] = T.cast(
-                            T.cast(v[i], accum) * rrms * T.cast(weight[base + i], accum),
-                            dtype,
-                        )
-                    for i in T.vectorized(per):
-                        y[base + i] = o[i]
-
-        return main
-
-    return _stats, _apply
-
-
 class FusedAddRMSNormKernel(Kernel):
     """Fused Add + RMSNorm forward kernel.
 
-    Computes ``y = RMSNorm(x + residual)`` and returns both ``y`` and
-    ``x + residual``.  The residual add is fused into the first load pass
-    to save one global memory round-trip.
+    Computes ``y = RMSNorm(x + residual)`` and returns both ``y`` and ``x + residual``.
+    The residual add is fused into the first load pass to save one global memory round
+    trip, which leaves the four passes over the row that the two inputs and two outputs
+    require and no more.
 
-    Supports SM80+ architectures.  Uses 256-element alignment for the shared
-    buffer the register-relief path fills; every other path holds the row in a
-    register fragment from the load through the store.
+    Supports SM80+ architectures. One CTA reduces a row and writes one chunk of it,
+    through 16-byte accesses; the chunk it writes waits in shared memory while the
+    reduction settles.
     """
 
     supported_archs: list[int] = [80, 86, 89, 90]
@@ -479,40 +421,50 @@ class FusedAddRMSNormKernel(Kernel):
 
         The program for a given row count is resolved in ``forward``, memoized by
         ``_fused_add_rms_norm_kernel``.
+
+        Args:
+            N: Hidden size the rows are normalized over.
+            eps: Epsilon for numerical stability.
+            dtype: Element type the rows are stored in.
+            config: Optional ``{"threads": ...}`` override.
+            tune: Ignored -- the block width follows from the row width, and
+                ``autotune_configs`` says why a search cannot improve on it.
+
+        Raises:
+            ValueError: *config* names a width that does not cut the row into whole
+                16-byte accesses.
         """
         super().__init__()
         self.N = N
         self.eps = eps
         self.dtype = dtype
         self.N_padded = align_up(N, ALIGNMENT)
-        self._tune_pending = tune  # tuning needs a program, so it waits for the first call
         self.init_config(config, tune=False)
-
-    # Passes a row makes over memory: x and residual in, sum and result out.
-    _ROW_PASSES = 4
-
-    def _splits_for(self, rows: int) -> int:
-        """Blocks to cut a row into, or 0 to keep one block to a row.
-
-        The programs below are written for a single row, so this serves the
-        decode shape and nothing else. A call with more rows than that has a
-        grid to fill already.
-        """
-        if rows != 1:
-            return 0
-        if self.N * self._ROW_PASSES < _SPLIT_MIN_ROW_TRAFFIC:
-            return 0
-        if self.N % (_SPLIT_BLOCKS * _SPLIT_THREADS * _SPLIT_PER_THREAD):
-            return 0
-        return _SPLIT_BLOCKS
+        threads = self.config["threads"]
+        # A width that leaves a partial access truncates the per-CTA loop bounds to
+        # zero, which writes no row at all rather than failing.
+        if (self.N_padded // _VEC) % threads:
+            raise ValueError(
+                f"{type(self).__name__} needs a block width that cuts a row of "
+                f"{self.N_padded} columns into whole {VECTOR_ACCESS_BYTES}-byte "
+                f"accesses; {threads} leaves a partial one. "
+                f"{_row_threads(self.N_padded)} is the width this row takes."
+            )
 
     @property
     def default_config(self) -> dict:
-        return select_row_config()
+        return {"threads": _row_threads(self.N_padded)}
 
     @property
     def autotune_configs(self) -> list[dict]:
-        return select_row_configs(self.N_padded, self.dtype, num_buffers=2)
+        """The one width :func:`_row_threads` gives, so a tuned build equals an untuned one.
+
+        There is nothing here a search can rank. This kernel is a pure DRAM stream, and
+        the autotuner times repeats of one candidate back to back, which reads the row
+        out of L2 -- it would be ranking a kernel this one never runs as. Offered widths
+        measured up to 0.8us apart under a cleared cache and inseparable to that timer.
+        """
+        return [self.default_config]
 
     def forward(
         self,
@@ -542,40 +494,23 @@ class FusedAddRMSNormKernel(Kernel):
         rows = x.reshape(-1, self.N)
         residual = residual.reshape(-1, self.N)
         weight = weight.reshape(self.N)
-
-        splits = self._splits_for(rows.shape[0])
-        if splits:
-            stats, apply_ = _fused_add_rms_norm_split_kernel(self.N, self.eps, self.dtype_str)
-            flat_x = rows.reshape(-1)
-            residual_out = torch.empty_like(flat_x)
-            partial = torch.empty(splits, device=flat_x.device, dtype=torch.float32)
-            stats(splits, _SPLIT_THREADS, _SPLIT_PER_THREAD)(
-                flat_x, residual.reshape(-1), residual_out, partial
-            )
-            y = apply_(splits, _SPLIT_THREADS, _SPLIT_PER_THREAD)(residual_out, partial, weight)
-            return [y.reshape(original_shape), residual_out.reshape(original_shape)]
+        m = rows.shape[0]
 
         # Exposed as ``self.kernel`` because that is what autotune and profiling read.
         self.kernel = _fused_add_rms_norm_kernel(
-            rows.shape[0],
+            m,
             self.N,
             self.eps,
             self.dtype_str,
-            # The device the input is on, not whichever is current.
-            get_sm_count(rows.device.index),
+            _row_splits(self.N_padded, self.config["threads"], m),
         )
-        if self._tune_pending:
-            self._tune_pending = False
-            self.autotune()
 
         pad = self.N_padded - self.N
         if pad:
             rows = F.pad(rows, (0, pad))
             residual = F.pad(residual, (0, pad))
             weight = F.pad(weight, (0, pad))
-        outputs = self.kernel(self.config["block_m"], self.config["threads"])(
-            rows, residual, weight
-        )
+        outputs = self.kernel(self.config["threads"])(rows, residual, weight)
         if pad:
             outputs = [out[:, : self.N] for out in outputs]
         return [out.reshape(original_shape) for out in outputs]

--- a/src/tileops/kernels/norm/fused_add_norm.py
+++ b/src/tileops/kernels/norm/fused_add_norm.py
@@ -234,25 +234,46 @@ class FusedAddLayerNormKernel(Kernel):
 # Elements one thread moves per access: 16 bytes is the widest access these dtypes have.
 _VEC = VECTOR_ACCESS_BYTES // 2
 
-# Accesses a CTA makes over the row it reduces; the block width follows from it.
+# Accesses a CTA makes over the row it reduces, where the block width follows from
+# the row rather than the other way round.
 _ROW_ACCESSES = 4
 
 # CTAs put on one row when the call has too few rows to fill the device.
 _ROW_SPLITS = 4
 
+# Columns at or below which a narrow block serves a many-row call better. Under it the
+# shared park is small enough that 16 CTAs stay resident on an SM, which measured 3.9%
+# faster than the widest block; over it the park caps residency whatever the width is,
+# and the widest block wins -- 1.7% at 8192 in fp16, a wash in bf16.
+_NARROW_ROW_COLUMNS = 4096
+_NARROW_THREADS = 128
+_WIDE_THREADS = 512
 
-def _row_threads(n_padded: int) -> int:
-    """Block width for a row of *n_padded* columns.
 
-    The widest power of two that cuts the row into 16-byte accesses and leaves each CTA
-    :data:`_ROW_ACCESSES` of them. Capped at the 1024 CUDA allows a block, and floored at
-    one warp, which a row padded to :data:`ALIGNMENT` always admits.
+def _widest_dividing(target: int, n_padded: int) -> int:
+    """The widest block at or below *target* that cuts the row into whole accesses.
+
+    Floored at one warp, which a row padded to :data:`ALIGNMENT` always admits.
     """
-    target = min(max(n_padded // (_VEC * _ROW_ACCESSES), WARP_LANES), 1024)
     for threads in (1024, 512, 256, 128, 64, WARP_LANES):
         if threads <= target and (n_padded // _VEC) % threads == 0:
             return threads
     return WARP_LANES
+
+
+def _row_threads(n_padded: int) -> int:
+    """Block width for a call with a row per CTA, sized by :data:`_NARROW_ROW_COLUMNS`."""
+    target = _NARROW_THREADS if n_padded <= _NARROW_ROW_COLUMNS else _WIDE_THREADS
+    return _widest_dividing(target, n_padded)
+
+
+def _split_row_threads(n_padded: int) -> int:
+    """Block width for the single-row call, where the CTAs share one row.
+
+    Sized to leave each CTA :data:`_ROW_ACCESSES` accesses over the row it reduces. The
+    many-row width is the wrong answer here: at 8192 it runs 2.43us against 2.08.
+    """
+    return _widest_dividing(min(n_padded // (_VEC * _ROW_ACCESSES), 1024), n_padded)
 
 
 def _row_splits(n_padded: int, threads: int, rows: int) -> int:
@@ -426,7 +447,7 @@ class FusedAddRMSNormKernel(Kernel):
             N: Hidden size the rows are normalized over.
             eps: Epsilon for numerical stability.
             dtype: Element type the rows are stored in.
-            config: Optional ``{"threads": ...}`` override.
+            config: Optional ``{"threads": ...}`` override, for the row-per-CTA case.
             tune: Ignored -- the block width follows from the row width, and
                 ``autotune_configs`` says why a search cannot improve on it.
 
@@ -496,21 +517,20 @@ class FusedAddRMSNormKernel(Kernel):
         weight = weight.reshape(self.N)
         m = rows.shape[0]
 
+        # A single row puts several CTAs on it, which wants a different width from the
+        # row-per-CTA case and so does not read the configured one.
+        threads = _split_row_threads(self.N_padded) if m == 1 else self.config["threads"]
+        splits = _row_splits(self.N_padded, threads, m)
+
         # Exposed as ``self.kernel`` because that is what autotune and profiling read.
-        self.kernel = _fused_add_rms_norm_kernel(
-            m,
-            self.N,
-            self.eps,
-            self.dtype_str,
-            _row_splits(self.N_padded, self.config["threads"], m),
-        )
+        self.kernel = _fused_add_rms_norm_kernel(m, self.N, self.eps, self.dtype_str, splits)
 
         pad = self.N_padded - self.N
         if pad:
             rows = F.pad(rows, (0, pad))
             residual = F.pad(residual, (0, pad))
             weight = F.pad(weight, (0, pad))
-        outputs = self.kernel(self.config["threads"])(rows, residual, weight)
+        outputs = self.kernel(threads)(rows, residual, weight)
         if pad:
             outputs = [out[:, : self.N] for out in outputs]
         return [out.reshape(original_shape) for out in outputs]

--- a/src/tileops/kernels/norm/fused_add_norm.py
+++ b/src/tileops/kernels/norm/fused_add_norm.py
@@ -9,13 +9,11 @@ outputs ``(y, x + residual)`` so downstream residual connections can reuse the
 pre-norm sum without recomputation.
 
 FusedAddLayerNorm holds the row in a register fragment from the load through the store.
+FusedAddRMSNorm reads it through 16-byte accesses and writes nothing until the reduction
+has settled, so the two reads and the two writes reach memory as two runs rather than
+interleaved; the chunk a CTA writes waits in shared memory in between.
 
-FusedAddRMSNorm reads the row through 16-byte accesses and writes nothing until the
-reduction has settled, so the two reads and the two writes reach memory as two runs
-rather than interleaved. The chunk a CTA writes waits in shared memory in between.
-
-Rows are padded to 256 elements (512 bytes for fp16/bf16), so a 16-byte access always
-divides the row evenly across one warp.
+Rows are padded to 256 elements, so a 16-byte access always divides the row across a warp.
 """
 
 import functools
@@ -231,94 +229,8 @@ class FusedAddLayerNormKernel(Kernel):
 
 # Fused Add + RMSNorm kernel
 
-# Elements one thread moves per access: 16 bytes is the widest access these dtypes have.
+# This kernel serves 16-bit dtypes only, so one 16-byte access moves eight elements.
 _VEC = VECTOR_ACCESS_BYTES // 2
-
-# Accesses a CTA makes over the row it reduces, where the block width follows from
-# the row rather than the other way round.
-_ROW_ACCESSES = 4
-
-# CTAs put on one row when the call has too few rows to fill the device.
-_ROW_SPLITS = 4
-
-# Columns at or below which a narrow block serves a many-row call better. Under it the
-# shared park is small enough that 16 CTAs stay resident on an SM, which measured 3.9%
-# faster than the widest block; over it the park caps residency whatever the width is,
-# and the widest block wins -- 1.7% at 8192 in fp16, a wash in bf16.
-_NARROW_ROW_COLUMNS = 4096
-_NARROW_THREADS = 128
-_WIDE_THREADS = 512
-
-
-def _widest_dividing(target: int, n_padded: int) -> int:
-    """The widest block at or below *target* that cuts the row into whole accesses.
-
-    Floored at one warp, which a row padded to :data:`ALIGNMENT` always admits.
-    """
-    for threads in (1024, 512, 256, 128, 64, WARP_LANES):
-        if threads <= target and (n_padded // _VEC) % threads == 0:
-            return threads
-    return WARP_LANES
-
-
-def _row_threads(n_padded: int) -> int:
-    """Block width for a call with a row per CTA, sized by :data:`_NARROW_ROW_COLUMNS`."""
-    target = _NARROW_THREADS if n_padded <= _NARROW_ROW_COLUMNS else _WIDE_THREADS
-    return _widest_dividing(target, n_padded)
-
-
-def _split_row_threads(n_padded: int) -> int:
-    """Block width for the single-row call, where the CTAs share one row.
-
-    Sized to leave each CTA :data:`_ROW_ACCESSES` accesses over the row it reduces. The
-    many-row width is the wrong answer here: at 8192 it runs 2.43us against 2.08.
-    """
-    return _widest_dividing(min(n_padded // (_VEC * _ROW_ACCESSES), 1024), n_padded)
-
-
-def _row_splits(n_padded: int, threads: int, rows: int) -> int:
-    """CTAs to put on one row -- more than one only when the call is a single row.
-
-    A call with rows to spare fills the grid with them. A single row instead leaves one
-    CTA holding it and the rest of the device idle, so the row is cut into as many pieces
-    as divide it evenly at *threads*, up to :data:`_ROW_SPLITS`.
-    """
-    if rows != 1:
-        return 1
-    accesses = n_padded // (_VEC * threads)
-    return max(s for s in (_ROW_SPLITS, 2, 1) if accesses % s == 0)
-
-
-def _make_block_rsqrt(warps, inv_n, eps):
-    """Create the macro folding one fp32 partial per thread into ``rrms[0]``.
-
-    Thread 0 adds the per-warp totals rather than a second butterfly folding them: at
-    these widths there are at most 32 of them.
-
-    Args:
-        warps: Warps in the block.
-        inv_n: Reciprocal of the unpadded row length.
-        eps: Epsilon for numerical stability.
-
-    Returns:
-        A ``@T.macro`` taking ``(tx, acc, warp_sums, rrms)``.
-    """
-
-    @T.macro
-    def block_rsqrt(tx, acc, warp_sums, rrms):
-        for step in T.serial(WARP_LANES.bit_length() - 1):
-            acc[0] += T.shfl_xor(acc[0], T.shift_left(1, step))
-        if tx % WARP_LANES == 0:
-            warp_sums[tx // WARP_LANES] = acc[0]
-        T.sync_threads()
-        if tx == 0:
-            acc[0] = T.cast(0, "float32")
-            for w in T.serial(warps):
-                acc[0] += warp_sums[w]
-            rrms[0] = T.rsqrt(acc[0] * inv_n + eps)
-        T.sync_threads()
-
-    return block_rsqrt
 
 
 @functools.lru_cache(maxsize=32)
@@ -327,12 +239,10 @@ def _fused_add_rms_norm_kernel(M, N, eps, dtype, splits):
 
     A CTA reduces a whole row and writes one chunk of it. Nothing is written until the
     reduction has settled, so the two reads and the two writes reach memory as two runs
-    rather than interleaved -- worth 3% over writing the sum in the first pass.
+    rather than interleaved.
 
-    With ``splits > 1`` the CTAs sharing a row each reduce the whole row, which costs
-    them reads that L2 serves and buys a single row more than one SM without a second
-    launch. A grid barrier is the other way to spend one launch on it, and measured
-    slower than the redundant reads at every width here.
+    With ``splits > 1`` the CTAs sharing a row each reduce the whole row, paying reads
+    that L2 serves to put a single row on more than one SM in one launch.
     """
     N_padded = align_up(N, ALIGNMENT)
     chunk = N_padded // splits
@@ -341,8 +251,24 @@ def _fused_add_rms_norm_kernel(M, N, eps, dtype, splits):
     def _func(threads):
         own = chunk // (threads * _VEC)  # accesses this CTA reduces and writes
         rest = (N_padded - chunk) // (threads * _VEC)  # accesses it only reduces
-        # N, not N_padded: a padded column holds zero and contributes nothing.
-        block_rsqrt = _make_block_rsqrt(threads // WARP_LANES, 1.0 / N, eps)
+        warps = threads // WARP_LANES
+        inv_n = 1.0 / N  # N, not N_padded: a padded column holds zero
+
+        @T.macro
+        def block_rsqrt(tx, acc, warp_sums, rrms):
+            """Fold one fp32 partial per thread into ``rrms[0]``."""
+            for step in T.serial(WARP_LANES.bit_length() - 1):
+                acc[0] += T.shfl_xor(acc[0], T.shift_left(1, step))
+            if tx % WARP_LANES == 0:
+                warp_sums[tx // WARP_LANES] = acc[0]
+            T.sync_threads()
+            # One thread adds the per-warp totals: a block holds at most 32 warps.
+            if tx == 0:
+                acc[0] = T.cast(0, "float32")
+                for w in T.serial(warps):
+                    acc[0] += warp_sums[w]
+                rrms[0] = T.rsqrt(acc[0] * inv_n + eps)
+            T.sync_threads()
 
         @T.prim_func
         def main(
@@ -360,7 +286,7 @@ def _fused_add_rms_norm_kernel(M, N, eps, dtype, splits):
                 b = T.alloc_local([_VEC], dtype)
                 summed = T.alloc_shared([chunk], dtype)
                 acc = T.alloc_local([1], "float32")
-                warp_sums = T.alloc_shared([threads // WARP_LANES], "float32")
+                warp_sums = T.alloc_shared([warps], "float32")
                 rrms = T.alloc_shared([1], "float32")
 
                 acc[0] = T.cast(0, "float32")
@@ -371,9 +297,8 @@ def _fused_add_rms_norm_kernel(M, N, eps, dtype, splits):
                     for i in T.vectorized(_VEC):
                         b[i] = residual[row, mine + base + i]
                     for i in T.serial(_VEC):
-                        # A native add, not an f32 round trip: f32 holds the exact sum of
-                        # two 16-bit floats, so rounding that sum back is bit-identical to
-                        # adding in the storage dtype, and overflows to inf either way.
+                        # Adding in the storage dtype is bit-identical to rounding the
+                        # f32 sum: f32 holds the exact sum of two 16-bit floats.
                         b[i] = a[i] + b[i]
                         v = T.cast(b[i], "float32")
                         acc[0] += v * v
@@ -418,17 +343,69 @@ def _fused_add_rms_norm_kernel(M, N, eps, dtype, splits):
 class FusedAddRMSNormKernel(Kernel):
     """Fused Add + RMSNorm forward kernel.
 
-    Computes ``y = RMSNorm(x + residual)`` and returns both ``y`` and ``x + residual``.
-    The residual add is fused into the first load pass to save one global memory round
-    trip, which leaves the four passes over the row that the two inputs and two outputs
-    require and no more.
+    Computes ``y = RMSNorm(x + residual)`` and returns both ``y`` and ``x + residual``,
+    in the four passes over the row that two inputs and two outputs require.
 
     Supports SM80+ architectures. One CTA reduces a row and writes one chunk of it,
-    through 16-byte accesses; the chunk it writes waits in shared memory while the
-    reduction settles.
+    through 16-byte accesses, parking that chunk in shared memory while the reduction
+    settles.
     """
 
     supported_archs: list[int] = [80, 86, 89, 90]
+
+    # Rows at or below which a row-per-CTA call takes the narrow block: while the shared
+    # park is small a narrow block keeps more CTAs resident on an SM, and past this width
+    # the park caps residency whatever the block is.
+    _NARROW_ROW_COLUMNS = 4096
+    _NARROW_THREADS = 128
+    _WIDE_THREADS = 512
+
+    # Accesses each CTA makes over the row it reduces, when several CTAs share one row.
+    _ROW_ACCESSES = 4
+
+    # Most CTAs a single row is cut across. A power of two, so halving reaches every
+    # candidate the row may admit.
+    _ROW_SPLITS = 4
+
+    # Threads CUDA allows in one block.
+    _MAX_THREADS = 1024
+
+    def _widest_dividing(self, target: int) -> int:
+        """The widest block at or below *target* cutting the row into whole accesses.
+
+        Floored at one warp, which a row padded to :data:`ALIGNMENT` always admits.
+        """
+        threads = self._MAX_THREADS
+        while threads > WARP_LANES and (threads > target or (self.N_padded // _VEC) % threads):
+            threads //= 2
+        return threads
+
+    def _row_threads(self) -> int:
+        """Block width for a call holding one row per CTA."""
+        narrow = self.N_padded <= self._NARROW_ROW_COLUMNS
+        return self._widest_dividing(self._NARROW_THREADS if narrow else self._WIDE_THREADS)
+
+    def _split_row_threads(self) -> int:
+        """Block width for a single-row call, where the CTAs share one row.
+
+        Sized by the whole row every CTA reduces rather than the chunk it writes,
+        which is why it differs from :meth:`_row_threads`.
+        """
+        return self._widest_dividing(self.N_padded // (_VEC * self._ROW_ACCESSES))
+
+    def _row_splits(self, threads: int, rows: int) -> int:
+        """CTAs to put on one row -- more than one only when the call is a single row.
+
+        A call with rows to spare fills the grid with them. A single row instead leaves
+        one CTA holding it and the rest of the device idle.
+        """
+        if rows != 1:
+            return 1
+        accesses = self.N_padded // (_VEC * threads)
+        splits = self._ROW_SPLITS
+        while splits > 1 and accesses % splits:
+            splits //= 2
+        return splits
 
     def __init__(
         self,
@@ -440,16 +417,15 @@ class FusedAddRMSNormKernel(Kernel):
     ):
         """Build for a hidden size and dtype.
 
-        The program for a given row count is resolved in ``forward``, memoized by
-        ``_fused_add_rms_norm_kernel``.
+        The program for a given row count is resolved in ``forward``.
 
         Args:
             N: Hidden size the rows are normalized over.
             eps: Epsilon for numerical stability.
             dtype: Element type the rows are stored in.
             config: Optional ``{"threads": ...}`` override, for the row-per-CTA case.
-            tune: Ignored -- the block width follows from the row width, and
-                ``autotune_configs`` says why a search cannot improve on it.
+            tune: Ignored -- the block width follows from the row width; see
+                ``autotune_configs``.
 
         Raises:
             ValueError: *config* names a width that does not cut the row into whole
@@ -462,28 +438,26 @@ class FusedAddRMSNormKernel(Kernel):
         self.N_padded = align_up(N, ALIGNMENT)
         self.init_config(config, tune=False)
         threads = self.config["threads"]
-        # A width that leaves a partial access truncates the per-CTA loop bounds to
-        # zero, which writes no row at all rather than failing.
+        # A partial access truncates the per-CTA loop bounds to zero, which returns an
+        # untouched row rather than failing.
         if (self.N_padded // _VEC) % threads:
             raise ValueError(
                 f"{type(self).__name__} needs a block width that cuts a row of "
                 f"{self.N_padded} columns into whole {VECTOR_ACCESS_BYTES}-byte "
                 f"accesses; {threads} leaves a partial one. "
-                f"{_row_threads(self.N_padded)} is the width this row takes."
+                f"{self._row_threads()} is the width this row takes."
             )
 
     @property
     def default_config(self) -> dict:
-        return {"threads": _row_threads(self.N_padded)}
+        return {"threads": self._row_threads()}
 
     @property
     def autotune_configs(self) -> list[dict]:
-        """The one width :func:`_row_threads` gives, so a tuned build equals an untuned one.
+        """The one width :meth:`_row_threads` gives, so a tuned build equals an untuned one.
 
-        There is nothing here a search can rank. This kernel is a pure DRAM stream, and
-        the autotuner times repeats of one candidate back to back, which reads the row
-        out of L2 -- it would be ranking a kernel this one never runs as. Offered widths
-        measured up to 0.8us apart under a cleared cache and inseparable to that timer.
+        The autotuner times repeats of one candidate back to back, which reads the row
+        out of L2 and so ranks a kernel this one never runs as.
         """
         return [self.default_config]
 
@@ -519,8 +493,8 @@ class FusedAddRMSNormKernel(Kernel):
 
         # A single row puts several CTAs on it, which wants a different width from the
         # row-per-CTA case and so does not read the configured one.
-        threads = _split_row_threads(self.N_padded) if m == 1 else self.config["threads"]
-        splits = _row_splits(self.N_padded, threads, m)
+        threads = self._split_row_threads() if m == 1 else self.config["threads"]
+        splits = self._row_splits(threads, m)
 
         # Exposed as ``self.kernel`` because that is what autotune and profiling read.
         self.kernel = _fused_add_rms_norm_kernel(m, self.N, self.eps, self.dtype_str, splits)

--- a/tests/ops/test_fused_add_rms_norm.py
+++ b/tests/ops/test_fused_add_rms_norm.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 
 from tests.test_base import FixtureBase, TestBase
+from tileops.kernels.norm import FusedAddRMSNormKernel
 from tileops.ops.norm.fused_add_rms_norm import FusedAddRMSNormFwdOp
 from workloads.normalization import FusedAddRMSNormWorkload
 
@@ -125,3 +126,14 @@ def test_fused_add_rms_norm_3d(batch: int, seq: int, hidden: int, dtype: torch.d
     assert torch.allclose(residual_out, add_ref, atol=atol, rtol=rtol), (
         f"3D residual_out test failed, max err: {(residual_out - add_ref).abs().max()}"
     )
+
+
+@pytest.mark.smoke
+def test_fused_add_rms_norm_rejects_partial_access_width() -> None:
+    """A width leaving a partial 16-byte access is refused at construction.
+
+    It truncates the kernel's per-CTA loop bounds to zero, so the row comes back
+    untouched rather than wrong in a way a tolerance would catch.
+    """
+    with pytest.raises(ValueError, match="whole 16-byte accesses"):
+        FusedAddRMSNormKernel(4096, 1e-6, torch.bfloat16, config={"threads": 768})


### PR DESCRIPTION
## Summary

- Six of nine nightly rows sat below the baseline (2026-09-06 snapshot, run 34050330510): `baseline_ratio` 0.9934 / 0.9934 / 0.9938 at the three prefill widths, 0.9474 at `llama-70b-decode`. All nine now beat every external comparator, at a geometric mean of 1.0985x over FlashInfer and 1.2035x over vLLM.
- Nothing is written until the reduction has settled, so the two reads and the two writes reach memory as two runs rather than interleaved. A CTA parks its chunk in shared memory in between.
- One launch serves a single row: the CTAs sharing it each reduce the whole row and write one chunk, paying duplicated reads that L2 serves. This replaces a second pair of prim_funcs and a second launch that only applied where the width divided `16 * 128 * 8`, which `llama-70b-decode` at 8192 missed.
- The residual add drops its float32 round trip, bit-identically: f32 holds the exact sum of two 16-bit floats, and a sum past the dtype's range becomes inf either way. rmem reads fall from 352378888 to 251715592 bytes with gmem traffic unchanged.
- The block width follows from the row rather than a search, and the two paths size separately. A width leaving a partial access now raises, where it used to truncate the loop bounds to zero and return an untouched row.
- Deletes the two split prim_funcs, the `sum_in_shared` branch and the tail-row guard, since a CTA owns one row and needs no predicate. Net -59 lines. Test-node delta +1 (17 to 18).

## TileFoundry Description

The checked ownership model: one CTA per (row, chunk) pair, reducing the whole row and writing one chunk of it. `SPLITS = 1` with `LANES = 128` is the many-row case; the single-row case is the same program at `SPLITS = 4`, `LANES = 256`. It is held to `equal` on `residual_out`, so the storage-dtype add is tested rather than asserted.

```python
from tilefoundry import func, module
from tilefoundry.dsl import ConstTensor, Mesh, ReduceKind, Tensor, Topology, tf
from tilefoundry.target import CudaTarget

ROWS = 2048
H = 4096
SPLITS = 1  # CTAs on one row: 1 whenever the call has rows enough to fill the grid
LANES = 128  # _row_threads(4096)
PER = 8  # 16 bytes per thread, the widest access these dtypes have
EPS = 1e-6  # manifest params.eps default
DT = "bf16"
INV_H = 1.0 / H

_H200 = CudaTarget("nvidia.h200_sxm")


@module(
    entry="fused_add_rms_norm",
    target=_H200,
    topologies=(Topology("cta", ROWS * SPLITS), Topology("thread", LANES)),
)
class FusedAddRmsNormPlaced:
    @func
    def fused_add_rms_norm(
        x: Tensor[(ROWS, H), DT],
        residual: Tensor[(ROWS, H), DT],
        weight: ConstTensor[(1, H), DT],
    ):
        with Mesh(("cta", "thread"), (ROWS, SPLITS, LANES), ("row", "chunk", "t")) as m:
            # The whole row, for the reduction. The SPLITS factor carries no mesh axis
            # here, so every CTA sharing a row reads all of it.
            whole_x = tf.reshard(x, (ROWS @ m.row, SPLITS, LANES @ m.t, PER), "rmem")
            whole_r = tf.reshard(residual, (ROWS @ m.row, SPLITS, LANES @ m.t, PER), "rmem")
            summed = whole_x + whole_r
            held = tf.cast(summed, "f32")
            total = tf.reduce(tf.square(held), (-1,), True, ReduceKind.SUM)
            rrms = tf.rsqrt(total * INV_H + EPS)
            scale = tf.reshard(weight, (1, SPLITS, LANES @ m.t, PER), "rmem")
            y = tf.cast(held * rrms * tf.cast(scale, "f32"), DT)
            # Each CTA writes one chunk: the SPLITS factor carries m.chunk here.
            return (
                tf.reshard(y, (ROWS @ m.row, SPLITS @ m.chunk, LANES @ m.t, PER), "gmem"),
                tf.reshard(
                    summed, (ROWS @ m.row, SPLITS @ m.chunk, LANES @ m.t, PER), "gmem"
                ),
            )
```

| Selection | traffic | ideal-ns | bound-by |
| --- | --- | --- | --- |
| ROWS=2048 H=4096 SPLITS=1 | `gmem:r33562624/w33554432@r6144/w4096` | 13983 | memory |
| ROWS=1 H=8192 SPLITS=4 | `gmem:r49152/w32768@r49152/w8192` | 18 | memory |

Row one: device traffic equals the manifest's `(4 * M * N + N) * elem_bytes` and `bound-by=memory`, so the four passes are the whole cost -- which ruled out every arithmetic change and pointed at the order they reach memory. `@r6144/w4096` is one CTA's share, the row-per-CTA ownership stated exactly. Row two states the decode placement: `r49152` is the whole row each CTA reads, `w8192` the chunk it writes, and `ideal-ns=18` against 1920 ns measured says that shape is latency-bound, so duplicated reads are worth spending there.

## Performance

Operator: `FusedAddRMSNormFwdOp`

| Environment | Value |
| --- | --- |
| image | `tileops-runner:cu132-torch2.13-tl-afcebed1-tilefoundry-latest` @ `sha256:ca13df9bda340edf248b8b443b88880f36e3190ab9d470f52d66ccc21c15fd59` |
| gpu / driver / cuda | NVIDIA H200 (idle, exclusive) / 595.71.05 / 13.2 |
| torch / tilelang | 2.13.0+cu132 / 0.1.11+cu132.gitafcebed1 |
| flashinfer / vllm | 0.6.16.post3 / 0.27.1 |
| timer | native CUPTI device-busy time, the union of a call's kernel intervals |

Method: the manifest benchmark's own comparison harness -- one process, one set of inputs, L2 flushed before every iteration, CUPTI attribution. Base and candidate ran alternately on the same idle card; reported latency is the median of three whole-comparison repeats, with the min-to-max spread beside it. The candidate is reached by constructing the public Op with manifest arguments, with no candidate-only switch.

Ratio in comparator columns: implementation / candidate. &#x1F7E2; > 1 means the candidate is faster; &#x1F534; <= 1 means it is not.

| Workload | M | N | Dtype | This PR (us) | Base (us)<br>/ candidate | FlashInfer (us)<br>/ candidate | vLLM (us)<br>/ candidate | torch.compile (us)<br>/ candidate |
| --- | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: |
| llama-8b-prefill-float16 | 2048 | 4096 | float16 | 17.920 (+/-0.01%) | **18.336 (+/-1.83%)<br>&#x1F7E2;&nbsp;1.0232x** | 18.336 (+/-0.35%)<br>&#x1F7E2;&nbsp;1.0232x | 17.952 (+/-0.18%)<br>&#x1F7E2;&nbsp;1.0018x | 18.720 (+/-3.85%)<br>&#x1F7E2;&nbsp;1.0446x |
| llama-8b-prefill-bfloat16 | 2048 | 4096 | bfloat16 | 17.888 (+/-0.81%) | **18.624 (+/-0.26%)<br>&#x1F7E2;&nbsp;1.0411x** | 18.304 (+/-0.00%)<br>&#x1F7E2;&nbsp;1.0233x | 18.112 (+/-0.36%)<br>&#x1F7E2;&nbsp;1.0125x | 18.784 (+/-0.26%)<br>&#x1F7E2;&nbsp;1.0501x |
| llama-8b-decode-bfloat16 | 1 | 4096 | bfloat16 | 1.791 (+/-0.92%) | **1.952 (+/-1.64%)<br>&#x1F7E2;&nbsp;1.0896x** | 2.016 (+/-1.59%)<br>&#x1F7E2;&nbsp;1.1253x | 2.624 (+/-0.00%)<br>&#x1F7E2;&nbsp;1.4647x | 2.944 (+/-27.14%)<br>&#x1F7E2;&nbsp;1.6433x |
| llama-70b-prefill-float16 | 2048 | 8192 | float16 | 34.688 (+/-0.19%) | **35.776 (+/-0.36%)<br>&#x1F7E2;&nbsp;1.0314x** | 35.041 (+/-0.18%)<br>&#x1F7E2;&nbsp;1.0102x | 34.816 (+/-0.28%)<br>&#x1F7E2;&nbsp;1.0037x | 36.240 (+/-0.44%)<br>&#x1F7E2;&nbsp;1.0448x |
| llama-70b-prefill-bfloat16 | 2048 | 8192 | bfloat16 | 34.880 (+/-0.37%) | **35.792 (+/-0.40%)<br>&#x1F7E2;&nbsp;1.0262x** | 35.104 (+/-0.27%)<br>&#x1F7E2;&nbsp;1.0064x | 35.008 (+/-0.14%)<br>&#x1F7E2;&nbsp;1.0037x | 36.352 (+/-0.44%)<br>&#x1F7E2;&nbsp;1.0422x |
| llama-70b-decode-bfloat16 | 1 | 8192 | bfloat16 | 1.920 (+/-1.67%) | **2.464 (+/-0.04%)<br>&#x1F7E2;&nbsp;1.2833x** | 2.433 (+/-0.04%)<br>&#x1F7E2;&nbsp;1.2672x | 2.976 (+/-0.03%)<br>&#x1F7E2;&nbsp;1.5500x | 2.560 (+/-82.50%)<br>&#x1F7E2;&nbsp;1.3333x |
| llama-405b-prefill-float16 | 2048 | 16384 | float16 | 67.104 (+/-0.12%) | **69.296 (+/-0.72%)<br>&#x1F7E2;&nbsp;1.0327x** | 69.568 (+/-0.16%)<br>&#x1F7E2;&nbsp;1.0367x | 76.832 (+/-0.04%)<br>&#x1F7E2;&nbsp;1.1450x | 68.592 (+/-0.09%)<br>&#x1F7E2;&nbsp;1.0222x |
| llama-405b-prefill-bfloat16 | 2048 | 16384 | bfloat16 | 67.072 (+/-0.14%) | **69.152 (+/-0.07%)<br>&#x1F7E2;&nbsp;1.0310x** | 69.840 (+/-0.21%)<br>&#x1F7E2;&nbsp;1.0413x | 76.992 (+/-0.15%)<br>&#x1F7E2;&nbsp;1.1479x | 69.296 (+/-0.28%)<br>&#x1F7E2;&nbsp;1.0332x |
| llama-405b-decode-bfloat16 | 1 | 16384 | bfloat16 | 2.432 (+/-1.32%) | **2.784 (+/-1.15%)<br>&#x1F7E2;&nbsp;1.1447x** | 3.456 (+/-0.93%)<br>&#x1F7E2;&nbsp;1.4211x | 4.224 (+/-0.76%)<br>&#x1F7E2;&nbsp;1.7368x | 5.312 (+/-6.63%)<br>&#x1F7E2;&nbsp;2.1842x |
| geometric mean |  |  |  | 13.4704 | **14.4842<br>&#x1F7E2;&nbsp;1.0753x** | 14.7968<br>&#x1F7E2;&nbsp;1.0985x | 16.2112<br>&#x1F7E2;&nbsp;1.2035x | 16.4489<br>&#x1F7E2;&nbsp;1.2211x |

## Result And Limitations

- All nine rows are faster than every external comparator, against a spread of at most 0.8% on the prefill rows and 1.7% on the decode rows. Three margins are thin enough to name: `llama-8b-prefill-float16` is 0.18% ahead of vLLM and the two `llama-70b-prefill` rows 0.37%, the same order as the spread, so those three read as level with vLLM rather than as wins.
- **How far this can go.** `analyze` prices the four passes at 13983 ns for 2048x4096, which is 67.1 MB at the published 4.80 TB/s, and a 50/50 read/write stream does not reach that on this card: a probe streaming two operands in and two results out, with no reduction, measures 3.95 TB/s at the 405b volume, and one write short of it 4.05. This kernel reaches 3.75 / 3.85 / 4.00 TB/s at the three prefill widths. Deleting the reduction while keeping its own access pattern -- the honest floor, since a `T.copy`-only probe lowers it by using a different access shape -- measures 18.24 / 34.40 / 66.82 us against 17.89 / 34.88 / 67.07 for the finished kernel. It is at its floor at all three widths, and the remaining 17-21% to the published roofline is read/write turnaround.
- Correctness beyond the manifest shapes: non-power-of-two widths (3000, 5120), a row count not divisible by the block (1025), 3-D and non-contiguous input, and the single-row shapes at the split boundary. `residual_out` is checked bit-for-bit against `(x.float() + residual.float()).to(dtype)` in both dtypes at 40x the unit normal. A property check over every padded width from 1 to 4099 plus the model widths confirms the width and split rules cover each row exactly once with no truncated loop bound.

Measured and rejected, all against a kernel already at that floor:

| Direction | Result |
| --- | --- |
| Summed row held in registers rather than shared | 19.0 vs 18.0 us at 2048x4096 |
| `T.copy` bulk loads in, or bulk stores out of the park | 18.5-18.8 us in; stores tie and do not earn the second buffer |
| Re-reading the sum from L2 for the second pass, as vLLM's kernel does | 18.8 us |
| More than one row per CTA, each row reduced by its own lane group | Worse at every rows x threads; best 18.69 vs 17.92 us |
| Capping residency with unused shared, to cut concurrent DRAM streams | Monotonically worse: 16 CTAs/SM 17.79, 4 19.81, 2 21.50 us |
| A grid barrier for the decode split | 3.14 vs 2.82 us at 16384 |
| Both outputs from one allocation, so the write streams are adjacent | 0.35% faster at 16384 and not taken -- it makes two tensors from one custom op share a storage while `register_fake` hands torch.compile two independent allocations |
