### PR TITLE
[Perf][foundry][Pool] Prove a max-pool tap index in range, and widen the block space

### DIFF
--- a/src/tileops/kernels/pool/max_pool1d.py
+++ b/src/tileops/kernels/pool/max_pool1d.py
@@ -12,19 +12,37 @@ from tileops.kernels.pool.common import fits_static_shared, pool_output_dim
 __all__ = ["MaxPool1dKernel", "MaxPool1dWithIndicesKernel"]
 
 
+def _window_geometry(
+    l_in: int,
+    kernel_w: int,
+    stride_w: int,
+    pad_w: int,
+    dilation_w: int,
+    ceil_mode: bool,
+) -> Tuple[int, bool]:
+    """Outputs along the pooled axis, and whether every window stays in its row.
+
+    The second decides whether a tap carries a bounds test, and both 1d max-pool
+    kernels read it, so the test for it has one home.
+    """
+    out_l = pool_output_dim(l_in, kernel_w, stride_w, pad_w, ceil_mode, dilation_w)
+    last_tap = (out_l - 1) * stride_w + dilation_w * (kernel_w - 1)
+    return out_l, pad_w == 0 and last_tap < l_in
+
+
 def _stage_rows(
     block_m: int, out_l: int, c_in: int, l_in: int, dtype: str
 ) -> Optional[Tuple[int, int]]:
-    """Rows of one image a block stages, and the pad between them, or None.
+    """Rows of one image a block stages, and the width of one staged row, or None.
 
     None means the block reads global instead, which every shape does unless its
-    outputs form whole rows of one image and those rows fit in shared memory.
+    outputs form whole rows of one image and those rows fit in shared memory. The
+    width exceeds `l_in` by the pad that keeps two staged rows off one bank.
     """
     # A warp's width. At or below it a warp spans more than one (batch, channel)
     # row, so neighbouring threads read global memory `l_in` elements apart.
     max_out_l = 32
-    # Pad the shared row off a whole number of banks, or the staged rows collide.
-    # The width is measured, on an H200; re-measure it on other hardware.
+    # Off a whole number of banks. Measured on an H200; re-measure elsewhere.
     row_pad = 8
 
     if out_l > max_out_l or block_m % out_l:
@@ -33,9 +51,10 @@ def _stage_rows(
     # Dividing c_in leaves no ragged last block, so the staged body needs no test.
     if rows > c_in or c_in % rows:
         return None
-    if not fits_static_shared(rows * (l_in + row_pad), dtype):
+    row_width = l_in + row_pad
+    if not fits_static_shared(rows * row_width, dtype):
         return None
-    return rows, row_pad
+    return rows, row_width
 
 
 @functools.lru_cache(maxsize=32)
@@ -51,10 +70,10 @@ def _max_pool1d_kernel(
     dtype: str = "float16",
 ):
     accum_dtype = "float"
-    out_l = pool_output_dim(l_in, kernel_w, stride_w, pad_w, ceil_mode, dilation_w)
+    out_l, always_in_bounds = _window_geometry(
+        l_in, kernel_w, stride_w, pad_w, dilation_w, ceil_mode
+    )
     total_output = n * c_in * out_l
-    eff_w = dilation_w * (kernel_w - 1) + 1
-    always_in_bounds = pad_w == 0 and (out_l - 1) * stride_w + eff_w - 1 < l_in
 
     @tilelang.jit(out_idx=[1], compile_flags=["-O3", "-DENABLE_BF16"])
     def _max_pool1d_func(block_m: int, threads: int):
@@ -124,8 +143,8 @@ def _max_pool1d_kernel(
                             batch = channel_batch_idx // c_in
                             _reduce_window_global(x, batch, c_idx, ow, out, batch, c_idx)
                 else:
-                    stage_rows, row_pad = staged
-                    tile = T.alloc_shared((1, stage_rows, l_in + row_pad), dtype)
+                    stage_rows, row_width = staged
+                    tile = T.alloc_shared((1, stage_rows, row_width), dtype)
                     batch = bx * stage_rows // c_in
                     c_base = bx * stage_rows % c_in
                     T.copy(x[batch, c_base : c_base + stage_rows, 0:l_in], tile[0, :, 0:l_in])
@@ -230,10 +249,8 @@ class _MaxPool1dKernelBase(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        # `block_m` counts outputs, so 1024 of them is four per thread at 256
-        # threads, and the 512 this space stopped at is two. A row of a real
-        # workload runs into the thousands of outputs, and four per thread
-        # measured faster than two on an H200; re-measure on other hardware.
+        # `block_m` counts outputs, and a row of a real workload runs into the
+        # thousands of them, so the widest block here is four per thread at 256.
         return [
             {"block_m": block_m, "threads": threads}
             for block_m, threads in itertools.product([128, 256, 512, 1024], [128, 256, 512])
@@ -277,12 +294,10 @@ def _max_pool1d_with_indices_kernel(
     dtype: str = "float16",
 ):
     accum_dtype = "float"
-    out_l = pool_output_dim(l_in, kernel_w, stride_w, pad_w, ceil_mode, dilation_w)
+    out_l, always_in_bounds = _window_geometry(
+        l_in, kernel_w, stride_w, pad_w, dilation_w, ceil_mode
+    )
     total_output = n * c_in * out_l
-    # Static specialization: with zero padding and no ceil overshoot every window
-    # lies fully inside the input, so the per-element bounds check can be dropped.
-    eff_w = dilation_w * (kernel_w - 1) + 1
-    always_in_bounds = pad_w == 0 and (out_l - 1) * stride_w + eff_w - 1 < l_in
 
     @tilelang.jit(out_idx=[1, 2], compile_flags=["-O3", "-DENABLE_BF16"])
     def _max_pool1d_with_indices_func(block_m: int, threads: int):
@@ -298,29 +313,28 @@ def _max_pool1d_with_indices_kernel(
             max_val = T.cast(float("-inf"), accum_dtype)
             nan_idx = -1
             if always_in_bounds:
-                # An expression, because a mutable variable is opaque to the
-                # range analysis: every tap would then load under a bounds check
-                # this window's own extent rules out, addressed in 64 bits.
+                # An expression, not a variable: a variable is opaque to the range
+                # analysis, and each tap would load under a bounds check this
+                # window's extent rules out.
                 iw0 = ow * stride_w - pad_w
                 max_idx = iw0
             else:
-                # Each tap carries a bounds test anyway, so nothing is left to
-                # prove and a variable keeps the position arithmetic out of all
-                # of them.
+                # A variable, because each tap is bounds-tested anyway and this
+                # then stays out of all of them.
                 iw0 = T.alloc_var(T.int32)
                 iw0 = ow * stride_w - pad_w
-                # The window's first tap the row holds, on the dilation grid.
-                # Only padding starts a window before position 0, and an
-                # all--inf window reports that tap, which is what PyTorch does.
+                # The first tap the row holds, on the dilation grid. Only padding
+                # starts a window before position 0, and that tap is the position
+                # PyTorch reports when every tap the row holds is -inf.
                 max_idx = iw0 + dilation_w * T.ceildiv(T.max(-iw0, 0), dilation_w)
             for kw in T.serial(kernel_w):
                 iw = iw0 + kw * dilation_w
                 if always_in_bounds or (iw >= 0 and iw < l_in):
                     val = T.cast(src[src_c, src_row, iw], accum_dtype)
                     # `max_val` is never NaN and NaN fails `>`, so the compare
-                    # rejects NaN without a separate test, and a tap equal to the
-                    # seed is rejected too -- which is why the seed is the
-                    # position that tap would have reported.
+                    # rejects NaN without a separate test. Strict `>` also keeps
+                    # the seed against a tap equal to it, and the first maximum
+                    # against a later equal one, which is what PyTorch reports.
                     take = val > max_val
                     max_val = T.if_then_else(take, val, max_val)
                     max_idx = T.if_then_else(take, iw, max_idx)
@@ -351,8 +365,8 @@ def _max_pool1d_with_indices_kernel(
                             batch = channel_batch_idx // c_in
                             _reduce_window(x, batch, c_idx, ow, out, indices, batch, c_idx)
                 else:
-                    stage_rows, row_pad = staged
-                    tile = T.alloc_shared((1, stage_rows, l_in + row_pad), dtype)
+                    stage_rows, row_width = staged
+                    tile = T.alloc_shared((1, stage_rows, row_width), dtype)
                     batch = bx * stage_rows // c_in
                     c_base = bx * stage_rows % c_in
                     T.copy(x[batch, c_base : c_base + stage_rows, 0:l_in], tile[0, :, 0:l_in])

--- a/src/tileops/kernels/pool/max_pool1d.py
+++ b/src/tileops/kernels/pool/max_pool1d.py
@@ -295,45 +295,36 @@ def _max_pool1d_with_indices_kernel(
             max_idx = T.alloc_var(T.int32)
             # -1 until a NaN is seen, so it is also the flag saying one was.
             nan_idx = T.alloc_var(T.int32)
-            first_valid = T.alloc_var(T.bool)
             max_val = T.cast(float("-inf"), accum_dtype)
             nan_idx = -1
-            first_valid = True
             if always_in_bounds:
                 # An expression, because a mutable variable is opaque to the
                 # range analysis: every tap would then load under a bounds check
                 # this window's own extent rules out, addressed in 64 bits.
                 iw0 = ow * stride_w - pad_w
+                max_idx = iw0
             else:
                 # Each tap carries a bounds test anyway, so nothing is left to
                 # prove and a variable keeps the position arithmetic out of all
                 # of them.
                 iw0 = T.alloc_var(T.int32)
                 iw0 = ow * stride_w - pad_w
-            # With the window inside the row its first element is in bounds, so its
-            # position is the right seed and `first_valid` is unneeded: an all--inf
-            # window then reports that position, which is what PyTorch does.
-            max_idx = iw0 if always_in_bounds else 0
+                # The window's first tap the row holds, on the dilation grid.
+                # Only padding starts a window before position 0, and an
+                # all--inf window reports that tap, which is what PyTorch does.
+                max_idx = iw0 + dilation_w * T.ceildiv(T.max(-iw0, 0), dilation_w)
             for kw in T.serial(kernel_w):
                 iw = iw0 + kw * dilation_w
-                if always_in_bounds:
+                if always_in_bounds or (iw >= 0 and iw < l_in):
                     val = T.cast(src[src_c, src_row, iw], accum_dtype)
                     # `max_val` is never NaN and NaN fails `>`, so the compare
-                    # rejects NaN without a separate test.
+                    # rejects NaN without a separate test, and a tap equal to the
+                    # seed is rejected too -- which is why the seed is the
+                    # position that tap would have reported.
                     take = val > max_val
                     max_val = T.if_then_else(take, val, max_val)
                     max_idx = T.if_then_else(take, iw, max_idx)
                     nan_idx = T.if_then_else(T.isnan(val), iw, nan_idx)
-                elif iw >= 0 and iw < l_in:
-                    val = T.cast(src[src_c, src_row, iw], accum_dtype)
-                    is_nan = T.isnan(val)
-                    # `first_valid` admits the first element whatever it is, so the
-                    # NaN test cannot come out of the compare here.
-                    take = (not is_nan) and (first_valid or (val > max_val))
-                    max_val = T.if_then_else(take, val, max_val)
-                    max_idx = T.if_then_else(take, iw, max_idx)
-                    first_valid = first_valid and is_nan
-                    nan_idx = T.if_then_else(is_nan, iw, nan_idx)
 
             # PyTorch reports the last NaN a window visited.
             out[out_c, out_row, ow] = T.cast(

--- a/src/tileops/kernels/pool/max_pool1d.py
+++ b/src/tileops/kernels/pool/max_pool1d.py
@@ -230,9 +230,13 @@ class _MaxPool1dKernelBase(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
+        # `block_m` counts outputs, so 1024 of them is four per thread at 256
+        # threads, and the 512 this space stopped at is two. A row of a real
+        # workload runs into the thousands of outputs, and four per thread
+        # measured faster than two on an H200; re-measure on other hardware.
         return [
             {"block_m": block_m, "threads": threads}
-            for block_m, threads in itertools.product([128, 256, 512], [128, 256, 512])
+            for block_m, threads in itertools.product([128, 256, 512, 1024], [128, 256, 512])
         ]
 
     def forward(self, x: torch.Tensor) -> Any:
@@ -292,11 +296,20 @@ def _max_pool1d_with_indices_kernel(
             # -1 until a NaN is seen, so it is also the flag saying one was.
             nan_idx = T.alloc_var(T.int32)
             first_valid = T.alloc_var(T.bool)
-            iw0 = T.alloc_var(T.int32)
             max_val = T.cast(float("-inf"), accum_dtype)
             nan_idx = -1
             first_valid = True
-            iw0 = ow * stride_w - pad_w
+            if always_in_bounds:
+                # An expression, because a mutable variable is opaque to the
+                # range analysis: every tap would then load under a bounds check
+                # this window's own extent rules out, addressed in 64 bits.
+                iw0 = ow * stride_w - pad_w
+            else:
+                # Each tap carries a bounds test anyway, so nothing is left to
+                # prove and a variable keeps the position arithmetic out of all
+                # of them.
+                iw0 = T.alloc_var(T.int32)
+                iw0 = ow * stride_w - pad_w
             # With the window inside the row its first element is in bounds, so its
             # position is the right seed and `first_valid` is unneeded: an all--inf
             # window then reports that position, which is what PyTorch does.


### PR DESCRIPTION
## Summary

- `iw0`, a window's first tap position, is an expression instead of a `T.alloc_var` where every tap is in bounds: a variable is opaque to TVM's range analysis, so each tap was loading under a bounds check the window's own extent rules out. Worth 2.6%.
- The padded branch keeps the variable, because its taps are bounds-tested anyway; inlining it there measured 20% slower.
- A padded window is seeded with the first tap its row holds, so `first_valid` goes and both branches collapse into one scan of five operations a tap instead of nine.
- `autotune_configs` gains `block_m=1024`, four outputs per thread at 256 threads; `MaxPool1dFwdOp` shares that space and takes the widening too.
- A third commit changes no behaviour: the staging pad stays inside `_stage_rows`, `_window_geometry` derives the in-bounds test once instead of twice, and comments recording a value's history are gone.

## TileFoundry Description

`Reference` is what `check` runs: no placement, padding as an explicit `-inf` prefix, the value and its position off one reduction axis. The position it reports for an all--inf window is the first tap the row holds, which is the seed this PR gives the kernel.

`Windowed` and `Staged` are placed, and are what `analyze` prices. The op's shapes divide into those two residencies and the kernel has a body for each.

```python
import math

from tilefoundry import func, module
from tilefoundry.dsl import Mesh, ReduceKind, Tensor, Topology, tf
from tilefoundry.target import CudaTarget

_H200 = CudaTarget("nvidia.h200_sxm")
_CTA = Topology("cta", 1)

NEG_INF = -math.inf

# sincnet-speaker-local: [32, 80, 4096] k3 s3 p0 d1, fp16.
N, C, L_IN, K, S, P, D = 32, 80, 4096, 3, 3, 0, 1
OUT_L = 1365
ROWS = N * C
SPAN = (OUT_L - 1) * S + 1
TPB = 128
CTAS = ROWS * OUT_L // TPB

# textcnn-global: [64, 256, 128] k128 s1 p0 d1, fp16 -- one output per row.
G_N, G_C, G_L = 64, 256, 128
G_ROWS = G_N * G_C
G_TPB = 128
G_CTAS = G_ROWS // G_TPB


# ecg-cnn-dilated: [16, 128, 2048] k5 s2 p2 d2 ceil, bf16 -- the padded regime.
E_N, E_C, E_L, E_K, E_S, E_P, E_D = 16, 128, 2048, 5, 2, 2, 2
E_OUT_L = 1023
E_SPAN = (E_OUT_L - 1) * E_S + 1


@module(entry="max_pool1d_indices", target=_H200, topologies=(_CTA,))
class Reference:
    """The padded dilated workload, with no placement: what `check` runs."""

    @func
    def max_pool1d_indices(x: Tensor[(16, 128, 2048), "bf16"]):
        vals = tf.cast(x, "f32")
        # The prefix is the padding; the suffix is the ceil-mode overshoot, where
        # the last windows reach past the row. PyTorch drops both from the max,
        # which -inf does, and neither can win a position.
        padded = tf.concat(
            [
                tf.full_like(vals[:, :, 0:E_P], NEG_INF),
                vals,
                tf.full_like(vals[:, :, 0:3], NEG_INF),
            ],
            axis=-1,
        )
        taps = tf.stack(
            [padded[:, :, kw * E_D : kw * E_D + E_SPAN : E_S] for kw in range(E_K)],
            axis=-1,
        )
        best = tf.reduce(taps, axes=(-1,), keepdim=False, kind=ReduceKind.MAX)
        winner = tf.argmax(taps, -1)
        starts = tf.reshape(
            tf.arange(Tensor[(E_OUT_L,), "i64", "gmem"], start=0, step=E_S),
            new_shape=(1, 1, E_OUT_L),
        )
        return tf.cast(best, "bf16"), winner * E_D + starts - E_P

@module(
    entry="max_pool1d_indices",
    target=_H200,
    topologies=(Topology("cta", CTAS), Topology("thread", TPB)),
)
class Windowed:
    """A row wider than a block: one thread owns a window, its taps in registers."""

    @func
    def max_pool1d_indices(x: Tensor[(32, 80, 4096), "f16"]):
        # The windows are K strided views of the row: tap `kw` of output `ow` sits
        # at `ow * S + kw * D`. The views name the reduction axis; nothing is
        # moved until a reshard reads one. `P` is zero here, which is what lets a
        # tap be a slice at all -- a padded window reaches before the row, and the
        # reference program writes that as an explicit `-inf` prefix.
        rows = tf.reshape(x, new_shape=(ROWS, L_IN))
        with Mesh(("cta",), layout=(CTAS,), names=("blk",)) as cta:
            with Mesh(("thread",), layout=(TPB,), names=("t",)) as m:
                # Registers and not shared memory: with `S >= D * (K - 1) + 1` the
                # K views partition the row, so no element is read twice and a
                # staging copy would be pure addition. Where they do overlap, the
                # second read is an L1 hit -- staging that was measured and is not
                # faster.
                window = tf.cast(
                    tf.stack(
                        [
                            tf.reshard(
                                tf.reshape(
                                    rows[:, kw * D : kw * D + SPAN : S],
                                    new_shape=(CTAS, TPB),
                                ),
                                (CTAS @ cta.blk, TPB @ m.t),
                                "rmem",
                            )
                            for kw in range(K)
                        ],
                        axis=-1,
                    ),
                    "f32",
                )
                # The value and the position come off the same axis, so the window
                # is walked once and the tap that won is the reduction's own.
                best = tf.reduce(window, axes=(-1,), keepdim=False, kind=ReduceKind.MAX)
                winner = tf.argmax(window, -1)
                # The output index is the participant's own coordinate, and it
                # carries its row: the window starts at `(o % OUT_L) * S - P`.
                # Nothing is read to know this.
                o = cta.blk * TPB + m.t
                start = (o % OUT_L) * S - P
                return (
                    tf.reshard(tf.cast(best, "f16"), (CTAS, TPB), "gmem"),
                    tf.reshard(winner * D + start, (CTAS, TPB), "gmem"),
                )


@module(
    entry="max_pool1d_indices",
    target=_H200,
    topologies=(Topology("cta", G_CTAS), Topology("thread", G_TPB)),
)
class Staged:
    """A row narrower than a block: the block's rows reach shared memory once."""

    @func
    def max_pool1d_indices(x: Tensor[(64, 256, 128), "f16"]):
        rows = tf.reshape(x, new_shape=(G_CTAS, G_TPB, G_L))
        with Mesh(("cta",), layout=(G_CTAS,), names=("blk",)) as cta:
            # The window is the whole row, so every element is read once whatever
            # the residency. Shared memory is what makes the read coalesced: one
            # thread's taps are a contiguous run, and a warp's are not.
            staged = tf.reshard(rows, (G_CTAS @ cta.blk, G_TPB, G_L), "smem")
            with Mesh(("thread",), layout=(G_TPB,), names=("t",)) as m:
                held = tf.reshard(staged, (G_CTAS @ cta.blk, G_TPB @ m.t, G_L), "rmem")
                window = tf.cast(held, "f32")
                best = tf.reduce(window, axes=(-1,), keepdim=False, kind=ReduceKind.MAX)
                winner = tf.argmax(window, -1)
                values = tf.reshard(tf.cast(best, "f16"), (G_CTAS, G_TPB), "gmem")
                where = tf.reshard(winner, (G_CTAS, G_TPB), "gmem")
                return (
                    tf.reshape(values, new_shape=(G_N, G_C, 1)),
                    tf.reshape(where, new_shape=(G_N, G_C, 1)),
                )
```

| Program | Workload | gmem read | gmem write | ideal-ns |
| --- | --- | ---: | ---: | ---: |
| `Windowed` | sincnet-speaker-local | 20,966,400 | 34,944,000 | 11,648 |
| `Staged` | textcnn-global | 4,194,304 | 163,840 | 908 |

Both are the manifest `roofline` byte count exactly, so neither program moves anything the operator does not owe. `Windowed` names mesh coordinates, which the evaluator does not model, so it prices a placement and cannot be run; `Reference` and `Staged` are exact against `torch.nn.functional.max_pool1d(return_indices=True)`, and the shipped kernel is exact against `Reference`.

## Performance

**Environment**: NVIDIA H200, CUDA 13.2, PyTorch 2.13.0+cu132, TileLang 0.1.11+cu132.gitafcebed1, image `ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-afcebed1-tilefoundry-latest` (`sha256:ca13df9bda340edf248b8b443b88880f36e3190ab9d470f52d66ccc21c15fd59`), native CUPTI device-busy time.

Method: the manifest benchmark's own comparison, run twice back to back in one container on one card, once with this branch and once with `main`, so every column sits in one window. Both sides autotuned. Ratio is implementation / candidate: &#x1F7E2; > 1 means the candidate is faster.

### MaxPool1dIndicesFwdOp

| Workload | Shape | Dtype | This PR (ms) | main (ms) | torch-compile (ms) | torch-ref (ms) |
| --- | --- | --- | ---: | ---: | ---: | ---: |
| sincnet-speaker-local | (32, 80, 4096) k3 s3 | float16 | 0.0159 | 0.0161 &#x1F7E2;&nbsp;1.013x | 0.0156 &#x1F534;&nbsp;0.981x | 0.0389 &#x1F7E2;&nbsp;2.45x |
| textcnn-global | (64, 256, 128) k128 s1 | float16 | 0.0039 | 0.0039 &nbsp;1.000x | 0.0049 &#x1F7E2;&nbsp;1.256x | 0.0208 &#x1F7E2;&nbsp;5.33x |
| ecg-cnn-dilated | (16, 128, 2048) k5 s2 p2 d2 ceil | bfloat16 | 0.0106 | 0.0109 &#x1F7E2;&nbsp;1.028x | 0.0108 &#x1F7E2;&nbsp;1.019x | 0.0272 &#x1F7E2;&nbsp;2.57x |

### MaxPool1dFwdOp

| Workload | Shape | Dtype | This PR (ms) | main (ms) | torch-compile (ms) |
| --- | --- | --- | ---: | ---: | ---: |
| sincnet-speaker-local | (32, 80, 4096) k3 s3 | float16 | 0.0108 | 0.0113 &#x1F7E2;&nbsp;1.046x | 0.0107 &#x1F534;&nbsp;0.991x |
| textcnn-global | (64, 256, 128) k128 s1 | float16 | 0.0037 | 0.0036 &#x1F534;&nbsp;0.973x | 0.0035 &#x1F534;&nbsp;0.946x |
| ecg-cnn-dilated | (16, 128, 2048) k5 s2 p2 d2 ceil | bfloat16 | 0.0067 | 0.0067 &nbsp;1.000x | 0.0069 &#x1F7E2;&nbsp;1.030x |

### Padded shapes off the manifest

Where the seed replaces `first_valid`, with indices, against the commit before it.

| Shape | Dtype | This PR (ms) | Before (ms) |
| --- | --- | ---: | ---: |
| (16, 128, 2048) k5 s2 p2 d2 ceil | bfloat16 | 0.01037 | 0.01046 &#x1F7E2;&nbsp;1.009x |
| (32, 64, 1024) k5 s2 p2 ceil | float16 | 0.00659 | 0.00710 &#x1F7E2;&nbsp;1.077x |
| (8, 256, 4096) k7 s2 p3 | float16 | 0.02592 | 0.02957 &#x1F7E2;&nbsp;1.141x |

The two unpadded manifest workloads take the interior scan, which the seed does not touch: both 1.000x against the same commit.

## Result And Limitations

**two rows cross their comparator, one does not, and the reason it does not is measured**

- `ecg-cnn-dilated` crosses `torch-compile` on both operators, 0.99x to 1.02x and 1.02x to 1.03x; `textcnn-global` was already ahead with indices and stays there.
- `sincnet-speaker-local` with indices goes 0.95x to 0.98x and does not cross: the row moves 55.9 MB, and one streaming elementwise pass over the same bytes costs 0.0156 ms on this card, which is what `torch-compile` costs.
- `analyze` bounds that row at 11.6 us against that 15.6 us pass, so the analytic roofline is out of reach at this size and the streaming measurement is what the row is read against.
- Its `int64` indices output is 28.0 MB of the 55.9 MB, and the signature fixes it.
- `ecg-cnn-dilated` is 13% above its own reachable floor of 0.0091 ms, and the gap is the position rather than the NaN: recording the last NaN is free, while recording the position takes the value reduction off `max.f32` and onto a compare and two selects.
- `textcnn-global` sits at a floor unrelated to its byte count: `torch.neg` over 8.4 MB costs the same 0.0038 ms as this row over 4.4 MB, against an `analyze` bound of 0.9 us.
- `MaxPool1dFwdOp`'s `textcnn-global` row is behind `torch-compile` before and after; nothing here touches its reduction.
- `_launch_max_pool1d` and its with-indices twin are mechanically redundant, each re-entering the lru_cached builder for the object `self.kernel` already holds. They stay: `_build` / `_dispatch` is the convention `AdaptivePool2dKernelBase` shares, and retiring it owes `docs/design/ops-design.md` an update.
- `pytest tests/ops/test_pool.py` is 264 nodes and all pass on every commit. Every one of the twelve configs the autotuner may select was also compared against torch on four shapes, with NaN and `-inf` poisoned through the inputs and across each row's padded edge, matching exactly on both outputs.