### PR TITLE
[Refactor][MoE] Fix the staged grouped GEMM's layout at construction and take its metadata as a tensor

### DIFF
--- a/src/tileops/kernels/moe/call_spec.py
+++ b/src/tileops/kernels/moe/call_spec.py
@@ -38,8 +38,8 @@ class MGroupedGemmCall(CallSpec):
     sub-axes — so a candidate can claim a region such as "every contiguous
     layout with psum metadata" without enumerating keys. ``m`` is the
     materialized row count (``num_groups * max_m`` for masked layouts); it is a
-    fact of the call, not of the specialization, and ``specialization_key``
-    leaves it out.
+    fact of the call and not of the built kernel, so the op keys its kernel
+    cache on this record with ``m`` reset.
     """
 
     kind: str = ""  # "contiguous" | "masked"
@@ -56,11 +56,10 @@ class MGroupedGemmCall(CallSpec):
 
     def __post_init__(self) -> None:
         super().__post_init__()
-        # The layout fields are one layout spec flattened; hold them to the
-        # combinations a spec can express so a candidate never has to. The
-        # all-defaults record (``CallSpec.__str__`` builds one to diff against)
-        # names no layout and is left alone.
-        if self.kind == "":
+        # A record naming no layout is the all-defaults one ``CallSpec.__str__``
+        # diffs against; every other one is held to what a layout spec can express.
+        layout_fields = (self.kind, self.packing, self.metadata_kind, self.alignment, self.max_m)
+        if layout_fields == ("", None, None, 1, None):
             return
         if self.kind == "contiguous":
             if self.packing not in ("tight", "aligned"):
@@ -84,22 +83,6 @@ class MGroupedGemmCall(CallSpec):
                 raise ValueError("masked layouts need a non-negative max_m")
         else:
             raise ValueError(f"kind is 'contiguous' or 'masked', got {self.kind!r}")
-
-    @property
-    def specialization_key(self) -> tuple:
-        """What a built kernel is specialized on: everything but the row count."""
-        return (
-            self.kind,
-            self.packing,
-            self.metadata_kind,
-            self.alignment,
-            self.max_m,
-            self.ab_dtype,
-            self.cd_dtype,
-            self.num_groups,
-            self.n,
-            self.k,
-        )
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/tileops/kernels/moe/call_spec.py
+++ b/src/tileops/kernels/moe/call_spec.py
@@ -32,18 +32,74 @@ class PrePermuteCall(CallSpec):
 
 @dataclasses.dataclass(frozen=True)
 class MGroupedGemmCall(CallSpec):
-    """Complete selection facts for one typed M-grouped GEMM invocation."""
+    """Complete selection facts for one M-grouped GEMM invocation.
 
-    layout_key: str = ""
-    max_m: int | None = None
-    device_type: str = ""
-    input_dtype: torch.dtype | None = None
-    weight_dtype: torch.dtype | None = None
-    output_dtype: torch.dtype | None = None
-    materialized_rows: int = 0
-    num_experts: int = 0
+    The layout arrives structured — ``kind`` first, then the contiguous
+    sub-axes — so a candidate can claim a region such as "every contiguous
+    layout with psum metadata" without enumerating keys. ``m`` is the
+    materialized row count (``num_groups * max_m`` for masked layouts); it is a
+    fact of the call, not of the specialization, and ``specialization_key``
+    leaves it out.
+    """
+
+    kind: str = ""  # "contiguous" | "masked"
+    packing: str | None = None  # "tight" | "aligned"; None for masked
+    metadata_kind: str | None = None  # "physical_psum" | "per_row"; None for masked
+    alignment: int = 1  # 1 unless packing == "aligned"
+    max_m: int | None = None  # masked only
+    ab_dtype: torch.dtype | None = None
+    cd_dtype: torch.dtype | None = None
+    num_groups: int = 0
+    m: int = 0
     n: int = 0
     k: int = 0
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        # The layout fields are one layout spec flattened; hold them to the
+        # combinations a spec can express so a candidate never has to. The
+        # all-defaults record (``CallSpec.__str__`` builds one to diff against)
+        # names no layout and is left alone.
+        if self.kind == "":
+            return
+        if self.kind == "contiguous":
+            if self.packing not in ("tight", "aligned"):
+                raise ValueError(
+                    f"contiguous layouts pack 'tight' or 'aligned', got {self.packing!r}"
+                )
+            if self.metadata_kind not in ("physical_psum", "per_row"):
+                raise ValueError(
+                    f"contiguous metadata is 'physical_psum' or 'per_row', got {self.metadata_kind!r}"
+                )
+            if self.max_m is not None:
+                raise ValueError("contiguous layouts have no max_m")
+            if self.packing == "tight" and self.alignment != 1:
+                raise ValueError("tight packing has alignment 1")
+            if self.packing == "aligned" and self.alignment < 2:
+                raise ValueError("aligned packing has alignment > 1")
+        elif self.kind == "masked":
+            if self.packing is not None or self.metadata_kind is not None or self.alignment != 1:
+                raise ValueError("masked layouts carry no packing, metadata_kind or alignment")
+            if self.max_m is None or self.max_m < 0:
+                raise ValueError("masked layouts need a non-negative max_m")
+        else:
+            raise ValueError(f"kind is 'contiguous' or 'masked', got {self.kind!r}")
+
+    @property
+    def specialization_key(self) -> tuple:
+        """What a built kernel is specialized on: everything but the row count."""
+        return (
+            self.kind,
+            self.packing,
+            self.metadata_kind,
+            self.alignment,
+            self.max_m,
+            self.ab_dtype,
+            self.cd_dtype,
+            self.num_groups,
+            self.n,
+            self.k,
+        )
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/tileops/manifest/moe.yaml
+++ b/src/tileops/manifest/moe.yaml
@@ -378,7 +378,7 @@ MoeGroupedGemmFwdOp:
       output: {dtype: "same_as(a) | float32"}
     params:
       layout: {type: MGroupedLayoutSpec}
-      out_dtype: {type: "torch.dtype | None", default: null, kw_only: true}
+      out_dtype: {type: "torch.float32 | None", default: null, kw_only: true}
       out: {type: "tensor | None", default: null}
     shape_rules:
     - "a.ndim == 2 or a.ndim == 3"
@@ -387,11 +387,9 @@ MoeGroupedGemmFwdOp:
     - "layout_metadata.ndim == 1"
     - "output.shape == (*a.shape[:-1], b.shape[1])"
   workloads: []
-  # Bytes count the output at the operand width; an fp32 ``out_dtype`` writes twice
-  # that, and the op's eval_roofline reports the exact figure.
+  # bytes depend on out_dtype as well as the operand dtype: not expressible inline.
   roofline:
-    flops: "2 * a.numel() * b.shape[1]"
-    bytes: "(a.numel() + b.numel() + output.numel()) * elem_bytes + layout_metadata.numel() * 4"
+    func: "tileops.perf.formulas.moe_grouped_gemm_roofline"
   source:
     kernel: tileops/ops/moe/staged.py
     op: tileops/ops/moe/staged.py
@@ -425,8 +423,7 @@ MoeExpertMLPFwdOp:
     - "output.shape == (*expert_input.shape[:-1], w_down.shape[1])"
   workloads: []
   roofline:
-    flops: "(expert_input.numel() // expert_input.shape[-1]) * (2 * w_gate_up.shape[1] * w_gate_up.shape[2] + 6 * w_down.shape[2] + 2 * w_down.shape[1] * w_down.shape[2])"
-    bytes: "(expert_input.numel() + w_gate_up.numel() + w_down.numel() + output.numel()) * elem_bytes + layout_metadata.numel() * 4"
+    func: "tileops.perf.formulas.moe_expert_mlp_roofline"
   source:
     kernel: tileops/ops/moe/staged.py
     op: tileops/ops/moe/staged.py

--- a/src/tileops/manifest/moe.yaml
+++ b/src/tileops/manifest/moe.yaml
@@ -371,22 +371,27 @@ MoeGroupedGemmFwdOp:
   status: spec-only
   signature:
     inputs:
-      a: {dtype: "bfloat16"}
+      a: {dtype: "float16 | bfloat16"}
       b: {dtype: "same_as(a)"}
+      layout_metadata: {dtype: "int32"}
     outputs:
-      output: {dtype: "bfloat16"}
+      output: {dtype: "same_as(a) | float32"}
     params:
-      compute: {type: "NoScaleComputeSpec | None", default: null}
-      expert_layout: {type: MaterializedExpertLayout}
-      scales: {type: "object | None", default: null}
+      layout: {type: MGroupedLayoutSpec}
+      out_dtype: {type: "torch.dtype | None", default: null, kw_only: true}
       out: {type: "tensor | None", default: null}
     shape_rules:
     - "a.ndim == 2 or a.ndim == 3"
     - "b.ndim == 3"
     - "a.shape[-1] == b.shape[-1]"
+    - "layout_metadata.ndim == 1"
     - "output.shape == (*a.shape[:-1], b.shape[1])"
   workloads: []
-  roofline: {flops: "2 * a.numel() * b.shape[1]", bytes: "(a.numel() + b.numel() + output.numel()) * elem_bytes"}
+  # Bytes count the output at the operand width; an fp32 ``out_dtype`` writes twice
+  # that, and the op's eval_roofline reports the exact figure.
+  roofline:
+    flops: "2 * a.numel() * b.shape[1]"
+    bytes: "(a.numel() + b.numel() + output.numel()) * elem_bytes + layout_metadata.numel() * 4"
   source:
     kernel: tileops/ops/moe/staged.py
     op: tileops/ops/moe/staged.py
@@ -399,27 +404,29 @@ MoeExpertMLPFwdOp:
   status: spec-only
   signature:
     inputs:
-      expert_input: {dtype: "bfloat16"}
+      expert_input: {dtype: "float16 | bfloat16"}
       w_gate_up: {dtype: "same_as(expert_input)"}
       w_down: {dtype: "same_as(expert_input)"}
+      layout_metadata: {dtype: "int32"}
     outputs:
       output: {dtype: "same_as(expert_input)"}
     params:
+      layout: {type: MGroupedLayoutSpec}
       activation: {type: str, default: silu_and_mul}
-      compute: {type: "NoScaleComputeSpec | None", default: null}
-      expert_layout: {type: MaterializedExpertLayout}
       out: {type: "tensor | None", default: null}
     shape_rules:
     - "expert_input.ndim == 2 or expert_input.ndim == 3"
     - "w_gate_up.ndim == 3"
     - "w_down.ndim == 3"
+    - "w_gate_up.shape[0] == w_down.shape[0]"
     - "w_gate_up.shape[1] == 2 * w_down.shape[2]"
     - "expert_input.shape[-1] == w_gate_up.shape[-1]"
+    - "layout_metadata.ndim == 1"
     - "output.shape == (*expert_input.shape[:-1], w_down.shape[1])"
   workloads: []
   roofline:
     flops: "(expert_input.numel() // expert_input.shape[-1]) * (2 * w_gate_up.shape[1] * w_gate_up.shape[2] + 6 * w_down.shape[2] + 2 * w_down.shape[1] * w_down.shape[2])"
-    bytes: "(expert_input.numel() + w_gate_up.numel() + w_down.numel() + output.numel()) * elem_bytes"
+    bytes: "(expert_input.numel() + w_gate_up.numel() + w_down.numel() + output.numel()) * elem_bytes + layout_metadata.numel() * 4"
   source:
     kernel: tileops/ops/moe/staged.py
     op: tileops/ops/moe/staged.py

--- a/src/tileops/ops/moe/__init__.py
+++ b/src/tileops/ops/moe/__init__.py
@@ -11,8 +11,6 @@ from .abc import (
 from .contracts import (
     ContiguousLayoutSpec,
     MaskedLayoutSpec,
-    MaterializedExpertLayout,
-    NoScaleComputeSpec,
     RoutingEpilogueSpec,
 )
 from .fused_moe import FusedMoe, FusedMoeFwdOp
@@ -42,7 +40,6 @@ __all__ = [
     "FusedMoeFwdOp",
     "FusedTopKOp",
     "MaskedLayoutSpec",
-    "MaterializedExpertLayout",
     "MoEPrepareAndFinalizeNoDPEP",
     "MoeExpertMLPFwdOp",
     "MoeGateUpFwdOp",
@@ -51,7 +48,6 @@ __all__ = [
     "MoePermuteAlignFwdOp",
     "MoePostPermuteFwdOp",
     "MoePrePermuteFwdOp",
-    "NoScaleComputeSpec",
     "PrepareResult",
     "RoutingEpilogueSpec",
     "SharedFusedMoE",

--- a/src/tileops/ops/moe/contracts.py
+++ b/src/tileops/ops/moe/contracts.py
@@ -13,15 +13,14 @@ __all__ = [
     "ContiguousMetadata",
     "ContiguousPacking",
     "ContiguousLayoutSpec",
-    "ExpertLayoutMetadata",
     "MGroupedLayoutSpec",
     "MaskedLayoutSpec",
     "MaskedMetadata",
-    "MaterializedExpertLayout",
-    "NoScaleComputeSpec",
     "PerRowExpertMetadata",
     "PhysicalPsumMetadata",
     "RoutingEpilogueSpec",
+    "layout_from_preset",
+    "layout_value_guard",
 ]
 
 
@@ -78,19 +77,35 @@ class ContiguousLayoutSpec:
         """Use aligned expert segments described by one expert ID per row."""
         return cls(ContiguousPacking.ALIGNED, ContiguousMetadata.PER_ROW, alignment)
 
+    @classmethod
+    def aligned_physical_psum(cls, alignment: int) -> "ContiguousLayoutSpec":
+        """Use aligned expert segments described by per-expert physical segment ends."""
+        return cls(ContiguousPacking.ALIGNED, ContiguousMetadata.PHYSICAL_PSUM, alignment)
+
     @property
     def selection_key(self) -> str:
         """Return the concrete specialization key recorded in CallSpecs."""
         return f"{self.packing.value}_{self.metadata_kind.value}"
 
     @property
+    def kind(self) -> str:
+        """The layout family a kernel candidate reads first: ``"contiguous"``."""
+        return "contiguous"
+
+    @property
     def max_m(self) -> None:
         """Contiguous layouts have no fixed per-expert capacity."""
         return None
 
+    def metadata_length(self, *, rows: int, num_experts: int) -> int:
+        """Rows of ``layout_metadata`` this layout describes ``rows`` rows with."""
+        if self.metadata_kind is ContiguousMetadata.PER_ROW:
+            return rows
+        return num_experts
+
     def __repr__(self) -> str:
         if self.packing is ContiguousPacking.ALIGNED:
-            return f"ContiguousLayoutSpec.aligned_per_row({self.alignment})"
+            return f"ContiguousLayoutSpec.{self.selection_key}({self.alignment})"
         return f"ContiguousLayoutSpec.{self.selection_key}()"
 
 
@@ -109,17 +124,42 @@ class MaskedLayoutSpec:
         """Return the concrete specialization key recorded in CallSpecs."""
         return _LayoutKind.MASKED_PREDICATED.value
 
+    @property
+    def kind(self) -> str:
+        """The layout family a kernel candidate reads first: ``"masked"``."""
+        return "masked"
+
+    def metadata_length(self, *, rows: int, num_experts: int) -> int:
+        """Masked metadata carries one valid-row count per expert."""
+        return num_experts
+
 
 MGroupedLayoutSpec: TypeAlias = ContiguousLayoutSpec | MaskedLayoutSpec
 
 
-def _validate_metadata_tensor(tensor: torch.Tensor, *, name: str, length: int) -> None:
-    if tensor.dtype is not torch.int32:
-        raise TypeError(f"{name} must have dtype torch.int32")
-    if tensor.ndim != 1 or tensor.shape[0] != length:
-        raise ValueError(f"{name} must have shape ({length},), got {tuple(tensor.shape)}")
-    if not tensor.is_contiguous():
-        raise ValueError(f"{name} must be contiguous")
+def layout_from_preset(
+    name: str, *, alignment: int | None = None, max_m: int | None = None
+) -> MGroupedLayoutSpec:
+    """Resolve a manifest workload's ``layout`` preset name into a layout spec.
+
+    ``tight_physical_psum`` and ``tight_per_row`` take nothing else;
+    ``aligned_per_row`` and ``aligned_physical_psum`` take ``alignment``;
+    ``masked`` takes ``max_m``. A missing or surplus argument is an error, so a
+    workload row cannot silently mean a different layout than it names.
+    """
+    if name in ("tight_physical_psum", "tight_per_row"):
+        if alignment is not None or max_m is not None:
+            raise ValueError(f"{name} takes neither alignment nor max_m")
+        return getattr(ContiguousLayoutSpec, name)()
+    if name in ("aligned_per_row", "aligned_physical_psum"):
+        if alignment is None or max_m is not None:
+            raise ValueError(f"{name} takes alignment and no max_m")
+        return getattr(ContiguousLayoutSpec, name)(alignment)
+    if name == "masked":
+        if max_m is None or alignment is not None:
+            raise ValueError("masked takes max_m and no alignment")
+        return MaskedLayoutSpec(max_m=max_m)
+    raise ValueError(f"unknown layout preset {name!r}")
 
 
 @dataclasses.dataclass(frozen=True)
@@ -127,12 +167,6 @@ class PhysicalPsumMetadata:
     """Physical segment ends for tightly materialized compute experts."""
 
     physical_ends: torch.Tensor
-
-    def validate_structure(self, *, num_experts: int, device: torch.device) -> None:
-        """Validate facts available without reading device-resident values."""
-        _validate_metadata_tensor(self.physical_ends, name="physical_ends", length=num_experts)
-        if self.physical_ends.device != device:
-            raise ValueError("physical_ends must be on the activation device")
 
     def device_value_guard(self, *, materialized_rows: int) -> torch.Tensor:
         """Return an asynchronous guard for tight PSUM ordering and capacity."""
@@ -148,12 +182,6 @@ class PerRowExpertMetadata:
     """Expert ID for every materialized contiguous row."""
 
     expert_ids: torch.Tensor
-
-    def validate_structure(self, *, materialized_rows: int, device: torch.device) -> None:
-        """Validate facts available without reading device-resident values."""
-        _validate_metadata_tensor(self.expert_ids, name="expert_ids", length=materialized_rows)
-        if self.expert_ids.device != device:
-            raise ValueError("expert_ids must be on the activation device")
 
     def device_value_guard(
         self, *, num_experts: int, allow_capacity_sentinel: bool = False
@@ -174,154 +202,9 @@ class MaskedMetadata:
 
     masked_m: torch.Tensor
 
-    def validate_structure(self, *, num_experts: int, device: torch.device) -> None:
-        """Validate facts available without reading device-resident values."""
-        _validate_metadata_tensor(self.masked_m, name="masked_m", length=num_experts)
-        if self.masked_m.device != device:
-            raise ValueError("masked_m must be on the activation device")
-
     def device_value_guard(self, *, max_m: int) -> torch.Tensor:
         """Return an asynchronous guard for masked valid lengths."""
         return torch.all((self.masked_m >= 0) & (self.masked_m <= max_m))
-
-
-ExpertLayoutMetadata: TypeAlias = PhysicalPsumMetadata | PerRowExpertMetadata | MaskedMetadata
-
-
-@dataclasses.dataclass(frozen=True)
-class MaterializedExpertLayout:
-    """One materialization's layout semantic, metadata, and physical capacity."""
-
-    layout: MGroupedLayoutSpec
-    metadata: ExpertLayoutMetadata
-    num_experts: int
-    materialized_rows: int
-    _materialization_token: object = dataclasses.field(
-        default_factory=object,
-        init=False,
-        repr=False,
-        compare=False,
-    )
-
-    def __post_init__(self) -> None:
-        if self.num_experts < 0 or self.materialized_rows < 0:
-            raise ValueError("num_experts and materialized_rows must be non-negative")
-        if isinstance(self.layout, MaskedLayoutSpec):
-            if not isinstance(self.metadata, MaskedMetadata):
-                raise TypeError("masked layout requires MaskedMetadata")
-            _validate_metadata_tensor(
-                self.metadata.masked_m,
-                name="masked_m",
-                length=self.num_experts,
-            )
-            expected_rows = self.num_experts * self.layout.max_m
-            if self.materialized_rows != expected_rows:
-                raise ValueError(
-                    f"masked materialization requires {expected_rows} rows, "
-                    f"got {self.materialized_rows}"
-                )
-            return
-        expected_type = {
-            ContiguousMetadata.PHYSICAL_PSUM: PhysicalPsumMetadata,
-            ContiguousMetadata.PER_ROW: PerRowExpertMetadata,
-        }[self.layout.metadata_kind]
-        if not isinstance(self.metadata, expected_type):
-            raise TypeError(f"{self.layout.selection_key} layout requires {expected_type.__name__}")
-        if isinstance(self.metadata, PhysicalPsumMetadata):
-            _validate_metadata_tensor(
-                self.metadata.physical_ends,
-                name="physical_ends",
-                length=self.num_experts,
-            )
-        else:
-            _validate_metadata_tensor(
-                self.metadata.expert_ids,
-                name="expert_ids",
-                length=self.materialized_rows,
-            )
-
-    @classmethod
-    def from_physical_psum(
-        cls,
-        physical_ends: torch.Tensor,
-        *,
-        materialized_rows: int,
-        num_experts: int | None = None,
-    ) -> "MaterializedExpertLayout":
-        """Build a tight Physical-PSUM binding for external materialization."""
-        experts = physical_ends.numel() if num_experts is None else num_experts
-        return cls(
-            layout=ContiguousLayoutSpec.tight_physical_psum(),
-            metadata=PhysicalPsumMetadata(physical_ends),
-            num_experts=experts,
-            materialized_rows=materialized_rows,
-        )
-
-    @classmethod
-    def from_per_row_ids(
-        cls,
-        expert_ids: torch.Tensor,
-        *,
-        num_experts: int,
-    ) -> "MaterializedExpertLayout":
-        """Build a tight per-row-ID binding for external materialization."""
-        return cls(
-            layout=ContiguousLayoutSpec.tight_per_row(),
-            metadata=PerRowExpertMetadata(expert_ids),
-            num_experts=num_experts,
-            materialized_rows=expert_ids.numel(),
-        )
-
-    @classmethod
-    def from_masked_m(
-        cls,
-        masked_m: torch.Tensor,
-        *,
-        max_m: int,
-        num_experts: int | None = None,
-    ) -> "MaterializedExpertLayout":
-        """Build a predicated masked binding for external materialization."""
-        experts = masked_m.numel() if num_experts is None else num_experts
-        return cls(
-            layout=MaskedLayoutSpec(max_m=max_m),
-            metadata=MaskedMetadata(masked_m),
-            num_experts=experts,
-            materialized_rows=experts * max_m,
-        )
-
-    @property
-    def selection_key(self) -> str:
-        """Return the concrete specialization key recorded in CallSpecs."""
-        return self.layout.selection_key
-
-    @property
-    def max_m(self) -> int | None:
-        """Return masked capacity per expert, or ``None`` for contiguous layouts."""
-        return self.layout.max_m
-
-    def validate_structure(self, expert_input: torch.Tensor) -> None:
-        """Validate activation shape/device and its metadata binding."""
-        if not expert_input.is_contiguous():
-            raise ValueError("expert_input must be contiguous")
-        if isinstance(self.layout, ContiguousLayoutSpec):
-            if expert_input.ndim != 2 or expert_input.shape[0] != self.materialized_rows:
-                raise ValueError("contiguous expert_input row count does not match layout")
-        else:
-            expected = (self.num_experts, self.layout.max_m)
-            if expert_input.ndim != 3 or tuple(expert_input.shape[:2]) != expected:
-                raise ValueError("masked expert_input leading dimensions do not match layout")
-        if isinstance(self.metadata, PhysicalPsumMetadata):
-            self.metadata.validate_structure(
-                num_experts=self.num_experts, device=expert_input.device
-            )
-        elif isinstance(self.metadata, PerRowExpertMetadata):
-            self.metadata.validate_structure(
-                materialized_rows=self.materialized_rows, device=expert_input.device
-            )
-        else:
-            self.metadata.validate_structure(
-                num_experts=self.num_experts, device=expert_input.device
-            )
 
 
 @dataclasses.dataclass(frozen=True)
@@ -346,14 +229,51 @@ class RoutingEpilogueSpec:
         return input_dtype if self.output_dtype is None else self.output_dtype
 
 
-@dataclasses.dataclass(frozen=True)
-class NoScaleComputeSpec:
-    """SM90 BF16 grouped GEMM with FP32 accumulation and BF16 output."""
+def layout_value_guard(
+    layout: MGroupedLayoutSpec,
+    layout_metadata: torch.Tensor,
+    *,
+    rows: int,
+    num_experts: int,
+) -> torch.Tensor:
+    """Return an asynchronous bool tensor: does ``layout_metadata`` satisfy ``layout``?
 
-    @property
-    def accumulation_dtype(self) -> torch.dtype:
-        return torch.float32
+    These are the invariants only the device-resident values can answer — a host
+    check would synchronise, so ``forward`` never runs this. Tests and benchmarks
+    consume it through ``torch._assert_async``. ``rows`` is the materialized row
+    count of the activation (``E * max_m`` for masked layouts).
 
-    @property
-    def output_dtype(self) -> torch.dtype:
-        return torch.bfloat16
+    * tight physical psum: ends non-decreasing, first end non-negative, last end
+      equal to ``rows``.
+    * aligned physical psum: ends non-decreasing; each end at or after its
+      segment start, the previous end rounded up to ``alignment``; last end at
+      most ``rows``.
+    * tight per-row: ids non-decreasing in ``[0, num_experts)``.
+    * aligned per-row: ids non-decreasing in ``[0, num_experts]`` (``num_experts``
+      is the padding sentinel); every id change lands on a multiple of
+      ``alignment``.
+    * masked: every valid count in ``[0, max_m]``.
+    """
+    meta = layout_metadata
+    if isinstance(layout, MaskedLayoutSpec):
+        return MaskedMetadata(meta).device_value_guard(max_m=layout.max_m)
+    if layout.metadata_kind is ContiguousMetadata.PER_ROW:
+        ordered = PerRowExpertMetadata(meta).device_value_guard(
+            num_experts=num_experts,
+            allow_capacity_sentinel=layout.packing is ContiguousPacking.ALIGNED,
+        )
+        if layout.packing is ContiguousPacking.TIGHT or meta.numel() < 2:
+            return ordered
+        change = meta[1:] != meta[:-1]
+        position = torch.arange(1, meta.numel(), device=meta.device)
+        on_boundary = (position % layout.alignment) == 0
+        return ordered & torch.all(~change | on_boundary)
+    if layout.packing is ContiguousPacking.TIGHT:
+        return PhysicalPsumMetadata(meta).device_value_guard(materialized_rows=rows)
+    ends = meta
+    if ends.numel() == 0:
+        return torch.tensor(rows == 0, dtype=torch.bool, device=ends.device)
+    alignment = layout.alignment
+    prev = torch.cat((ends.new_zeros(1), ends[:-1]))
+    starts = (prev + alignment - 1) // alignment * alignment
+    return torch.all(ends >= starts) & (ends[0] >= 0) & (ends[-1] <= rows)

--- a/src/tileops/ops/moe/staged.py
+++ b/src/tileops/ops/moe/staged.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 from typing import ClassVar, Mapping
 
 import torch
@@ -11,6 +12,7 @@ from tileops.kernels.moe import MoePrePermuteContiguousKernel, MoeUnpermuteKerne
 from tileops.kernels.moe.call_spec import MGroupedGemmCall, PostPermuteCall, PrePermuteCall
 from tileops.ops.compile_boundary import get_instance
 from tileops.ops.op_base import Op
+from tileops.perf.formulas import moe_expert_mlp_roofline, moe_grouped_gemm_roofline
 from tileops.utils import get_sm_version, is_h200
 
 from ..elementwise import SiluAndMulFwdOp
@@ -123,9 +125,8 @@ class MoePrePermuteFwdOp(_StagedOpBase):
         local_expert_ids_shape: tuple[int, ...],
     ) -> dict[str, tuple[int, ...]]:
         rows = hidden_states_shape[0] * local_expert_ids_shape[1]
-        # The manifest validator's parity check builds the op without __init__ and
-        # hands a placeholder for ``layout``; read its axes with getattr so that
-        # placeholder resolves to the tight shapes instead of raising.
+        # The manifest validator's parity probe builds the op without __init__ and
+        # binds a placeholder for ``layout``; getattr resolves it to the tight shapes.
         layout = self.layout
         if isinstance(layout, MaskedLayoutSpec):
             expert_input = (self.num_local_experts, layout.max_m, hidden_states_shape[1])
@@ -299,16 +300,8 @@ class MoeGroupedGemmFwdOp(_StagedOpBase):
         return {"output": (*tuple(a_shape)[:-1], b_shape[1])}
 
     def eval_roofline(self) -> tuple[int, int]:
-        if self.input_shapes is None or self.dtype is None:
-            raise RuntimeError("eval_roofline requires a prior forward call")
-        a_shape, b_shape, meta_shape = self.input_shapes
-        rows = _rows_of(self.layout, a_shape)
-        num_experts, n, k = b_shape
-        flops = 2 * rows * n * k
-        out_dtype = self.resolve_output_dtype(self.dtype)
-        nbytes = (rows * k + num_experts * n * k) * self.dtype.itemsize
-        nbytes += rows * n * out_dtype.itemsize + meta_shape[0] * 4
-        return int(flops), int(nbytes)
+        # What codegen emits for ``roofline.func``; a spec-only entry gets no codegen.
+        return moe_grouped_gemm_roofline(self)
 
     def make_call(
         self,
@@ -450,11 +443,14 @@ class MoeGroupedGemmFwdOp(_StagedOpBase):
         self.dtype = a.dtype
         self.input_shapes = [tuple(a.shape), tuple(b.shape), tuple(layout_metadata.shape)]
         name = self.select_kernel_key(tuple((self.kernel_map or {}).keys()), call)
+        # ``m`` is a fact of the call, not of the built kernel. The builder is handed
+        # the record the cache is keyed on, so it cannot specialize on a row count.
+        build_call = dataclasses.replace(call, m=0)
         kernel = self.get_or_build_kernel(
             name,
             inputs=(a, b, layout_metadata),
-            key=call.specialization_key,
-            build=lambda: self.kernel_map[name](call),
+            key=build_call,
+            build=lambda: self.kernel_map[name](build_call),
         )
         return kernel(a, b, layout_metadata, out=out)
 
@@ -514,17 +510,8 @@ class MoeExpertMLPFwdOp(_StagedOpBase):
         return {"output": (*tuple(expert_input_shape)[:-1], w_down_shape[1])}
 
     def eval_roofline(self) -> tuple[int, int]:
-        if self.input_shapes is None or self.dtype is None:
-            raise RuntimeError("eval_roofline requires a prior forward call")
-        x_shape, gate_shape, down_shape, meta_shape = self.input_shapes
-        rows = _rows_of(self.layout, x_shape)
-        num_experts, two_ffn, hidden = gate_shape
-        ffn = down_shape[2]
-        flops = rows * (2 * two_ffn * hidden + 6 * ffn + 2 * hidden * ffn)
-        elem = self.dtype.itemsize
-        nbytes = (rows * hidden + num_experts * two_ffn * hidden) * elem
-        nbytes += (num_experts * hidden * ffn + rows * hidden) * elem + meta_shape[0] * 4
-        return int(flops), int(nbytes)
+        # What codegen emits for ``roofline.func``; a spec-only entry gets no codegen.
+        return moe_expert_mlp_roofline(self)
 
     @staticmethod
     def _check_widths(w_gate_up: torch.Tensor, w_down: torch.Tensor) -> None:

--- a/src/tileops/ops/moe/staged.py
+++ b/src/tileops/ops/moe/staged.py
@@ -15,13 +15,13 @@ from tileops.utils import get_sm_version, is_h200
 
 from ..elementwise import SiluAndMulFwdOp
 from .contracts import (
+    ContiguousLayoutSpec,
     ContiguousMetadata,
     ContiguousPacking,
     MaskedLayoutSpec,
-    MaterializedExpertLayout,
     MGroupedLayoutSpec,
-    NoScaleComputeSpec,
     RoutingEpilogueSpec,
+    layout_value_guard,
 )
 
 __all__ = [
@@ -78,20 +78,14 @@ class _ContiguousPostPermuteKernel(Kernel):
 
 
 class _StagedOpBase(Op):
-    """Common behavior for a staged boundary with no shipped implementation yet."""
+    """Common behavior of the staged boundary ops: no default candidates, dtypes checked per call."""
 
     @property
     def default_kernel_map(self) -> dict[str, Kernel]:
         return {}
 
-    def _infer_output_shapes(self, **shape_kwargs: tuple[int, ...]) -> dict[str, tuple[int, ...]]:
-        raise NotImplementedError("staged output shape depends on materialized layout metadata")
-
     def _validate_dtypes(self, *args: torch.Tensor) -> None:
         raise NotImplementedError("staged dtype validation requires family-specific call data")
-
-    def eval_roofline(self) -> tuple[int, int]:
-        raise NotImplementedError("staged roofline evaluation requires materialized runtime data")
 
 
 class MoePrePermuteFwdOp(_StagedOpBase):
@@ -114,7 +108,7 @@ class MoePrePermuteFwdOp(_StagedOpBase):
         """Configure a pre-permute boundary for one layout and expert domain."""
         if num_local_experts <= 0:
             raise ValueError("num_local_experts must be positive")
-        self.layout = layout
+        self.layout = _check_layout(layout)
         self.num_local_experts = num_local_experts
         self.target = target
         self.dispatch_kernel(kernel_map)
@@ -129,29 +123,20 @@ class MoePrePermuteFwdOp(_StagedOpBase):
         local_expert_ids_shape: tuple[int, ...],
     ) -> dict[str, tuple[int, ...]]:
         rows = hidden_states_shape[0] * local_expert_ids_shape[1]
-        layout_key = getattr(self.layout, "selection_key", self.layout)
-        if isinstance(self.layout, MaskedLayoutSpec):
-            expert_input = (
-                self.num_local_experts,
-                self.layout.max_m,
-                hidden_states_shape[1],
-            )
+        # The manifest validator's parity check builds the op without __init__ and
+        # hands a placeholder for ``layout``; read its axes with getattr so that
+        # placeholder resolves to the tight shapes instead of raising.
+        layout = self.layout
+        if isinstance(layout, MaskedLayoutSpec):
+            expert_input = (self.num_local_experts, layout.max_m, hidden_states_shape[1])
             metadata_rows = self.num_local_experts
-        elif (
-            getattr(self.layout, "packing", None) is ContiguousPacking.ALIGNED
-            and getattr(self.layout, "metadata_kind", None) is ContiguousMetadata.PER_ROW
-        ):
-            capacity = rows + self.num_local_experts * (self.layout.alignment - 1)
-            expert_input = (capacity, hidden_states_shape[1])
-            metadata_rows = capacity
         else:
-            expert_input = (rows, hidden_states_shape[1])
-            metadata_rows = (
-                rows
-                if getattr(self.layout, "metadata_kind", None) is ContiguousMetadata.PER_ROW
-                or layout_key == "tight_per_row"
-                else self.num_local_experts
-            )
+            per_row = getattr(layout, "metadata_kind", None) is ContiguousMetadata.PER_ROW
+            capacity = rows
+            if per_row and getattr(layout, "packing", None) is ContiguousPacking.ALIGNED:
+                capacity += self.num_local_experts * (layout.alignment - 1)
+            expert_input = (capacity, hidden_states_shape[1])
+            metadata_rows = capacity if per_row else self.num_local_experts
         return {
             "expert_input": expert_input,
             "layout_metadata": (metadata_rows,),
@@ -235,108 +220,274 @@ class MoePrePermuteFwdOp(_StagedOpBase):
         return kernel(hidden_states, local_expert_ids)
 
 
+def _check_layout(layout: object) -> MGroupedLayoutSpec:
+    if not isinstance(layout, (ContiguousLayoutSpec, MaskedLayoutSpec)):
+        raise TypeError("layout must be ContiguousLayoutSpec or MaskedLayoutSpec")
+    return layout
+
+
+def _rows_of(layout: MGroupedLayoutSpec, a_shape: tuple[int, ...]) -> int:
+    """Materialized rows of ``a``: ``M`` for contiguous, ``E * max_m`` for masked."""
+    if isinstance(layout, MaskedLayoutSpec):
+        return a_shape[0] * a_shape[1]
+    return a_shape[0]
+
+
 class MoeGroupedGemmFwdOp(_StagedOpBase):
-    """Independently callable typed M-grouped GEMM boundary."""
+    """M-grouped GEMM over expert-materialized rows: ``out[rows of g] = a[rows of g] @ b[g]^T``.
+
+    ``layout`` fixes how the rows of ``a`` are organised by expert and what the
+    ``layout_metadata`` tensor means; ``E`` is read off ``b``, ``M``/``N``/``K`` off
+    the operands. Accumulation is fp32; the output is written in the operand dtype
+    unless ``out_dtype`` asks for fp32.
+
+    Per layout the operands are (``trans``-free, ``b`` is ``[E, N, K]``):
+
+    | layout                      | ``a``             | ``layout_metadata``          | ``out``           |
+    | --------------------------- | ----------------- | ---------------------------- | ----------------- |
+    | contiguous · physical_psum  | ``[M, K]``        | ``[E]`` segment end rows     | ``[M, N]``        |
+    | contiguous · per_row        | ``[M, K]``        | ``[M]`` expert id per row    | ``[M, N]``        |
+    | masked                      | ``[E, max_m, K]`` | ``[E]`` valid rows per expert| ``[E, max_m, N]`` |
+
+    Rows an aligned layout pads with, and a masked slab's rows past its valid
+    count, hold unspecified values in ``out``. The metadata's value-level
+    invariants (ordering, segment ends, ranges) are not checked here — doing so
+    would synchronise — but ``layout_guard`` returns them as an asynchronous
+    tensor for tests and benchmarks.
+    """
+
+    compile_op_names: ClassVar[tuple[str, ...]] = (
+        "tileops::moe_grouped_gemm_fwd",
+        "tileops::moe_grouped_gemm_fwd_inplace",
+    )
 
     def __init__(
         self,
-        compute: NoScaleComputeSpec | None = None,
+        layout: MGroupedLayoutSpec,
         *,
+        out_dtype: torch.dtype | None = None,
         kernel_map: dict[str, Kernel] | None = None,
         target: object = None,
     ) -> None:
-        """Configure the current BF16/NoScale M-grouped GEMM semantic."""
-        compute = NoScaleComputeSpec() if compute is None else compute
-        if not isinstance(compute, NoScaleComputeSpec):
-            raise TypeError("the current public manifest supports only NoScaleComputeSpec")
-        self.compute = compute
+        """Fix the expert layout and the output dtype policy.
+
+        Args:
+            layout: Manifest ``params.layout``; how ``a``'s rows are grouped by expert.
+            out_dtype: Manifest ``params.out_dtype``; ``None`` writes the operand dtype,
+                ``torch.float32`` keeps the fp32 accumulator.
+            kernel_map: Optional kernel override dict.
+            target: Which backend serves this instance; detected from the tensors when
+                ``None``.
+        """
+        self.layout = _check_layout(layout)
+        if out_dtype is not None and out_dtype is not torch.float32:
+            raise ValueError("out_dtype must be None (operand dtype) or torch.float32")
+        self.out_dtype = out_dtype
         self.target = target
         self.dispatch_kernel(kernel_map)
+
+    def resolve_output_dtype(self, input_dtype: torch.dtype) -> torch.dtype:
+        """The dtype ``out`` is written in for operands of ``input_dtype``."""
+        return input_dtype if self.out_dtype is None else self.out_dtype
+
+    def _infer_output_shapes(
+        self,
+        a_shape: tuple[int, ...],
+        b_shape: tuple[int, ...],
+        layout_metadata_shape: tuple[int, ...],
+    ) -> dict[str, tuple[int, ...]]:
+        return {"output": (*tuple(a_shape)[:-1], b_shape[1])}
+
+    def eval_roofline(self) -> tuple[int, int]:
+        if self.input_shapes is None or self.dtype is None:
+            raise RuntimeError("eval_roofline requires a prior forward call")
+        a_shape, b_shape, meta_shape = self.input_shapes
+        rows = _rows_of(self.layout, a_shape)
+        num_experts, n, k = b_shape
+        flops = 2 * rows * n * k
+        out_dtype = self.resolve_output_dtype(self.dtype)
+        nbytes = (rows * k + num_experts * n * k) * self.dtype.itemsize
+        nbytes += rows * n * out_dtype.itemsize + meta_shape[0] * 4
+        return int(flops), int(nbytes)
 
     def make_call(
         self,
         a: torch.Tensor,
         b: torch.Tensor,
-        expert_layout: MaterializedExpertLayout,
-        scales: object | None = None,
+        layout_metadata: torch.Tensor,
         out: torch.Tensor | None = None,
     ) -> MGroupedGemmCall:
-        """Validate operands/spec/layout and construct the selection record."""
-        tensors = {"a": a, "b": b}
+        """Validate the operands against the layout and build the selection record."""
+        tensors = {"a": a, "b": b, "layout_metadata": layout_metadata}
         if out is not None:
             tensors["out"] = out
         device = _same_device(tensors)
         if device.type != "cuda":
             raise ValueError("staged grouped GEMM currently requires CUDA tensors")
-        expert_layout.validate_structure(a)
-        if b.ndim != 3 or b.shape[0] != expert_layout.num_experts:
+        if a.dtype not in (torch.bfloat16, torch.float16):
+            raise TypeError("the staged grouped-GEMM contract accepts BF16 or FP16 operands")
+        if b.dtype is not a.dtype:
+            raise TypeError("a and b must share one dtype")
+        if layout_metadata.dtype is not torch.int32:
+            raise TypeError("layout_metadata must have dtype torch.int32")
+        for name, tensor in tensors.items():
+            if not tensor.is_contiguous():
+                raise ValueError(f"{name} must be contiguous")
+        if b.ndim != 3:
             raise ValueError("b must have shape [num_experts, n, k]")
-        if not b.is_contiguous():
-            raise ValueError("b must be contiguous")
-        if a.shape[-1] != b.shape[-1]:
+        num_experts, n, k = b.shape
+        layout = self.layout
+        if isinstance(layout, MaskedLayoutSpec):
+            if a.ndim != 3 or a.shape[0] != num_experts or a.shape[1] != layout.max_m:
+                raise ValueError(
+                    f"masked a must have shape [{num_experts}, {layout.max_m}, k] to match "
+                    f"b and the layout's max_m"
+                )
+        else:
+            if a.ndim != 2:
+                raise ValueError("contiguous a must have shape [rows, k]")
+            if layout.packing is ContiguousPacking.ALIGNED and a.shape[0] % layout.alignment:
+                raise ValueError(
+                    f"aligned rows ({a.shape[0]}) must be a multiple of the layout's "
+                    f"alignment ({layout.alignment})"
+                )
+        if a.shape[-1] != k:
             raise ValueError("a and b must have the same reduction dimension")
-        arch = get_sm_version(device.index)
-        if scales is not None:
-            raise ValueError("NoScaleComputeSpec forbids scales")
-        if arch != 90 or a.dtype is not torch.bfloat16 or b.dtype is not torch.bfloat16:
-            raise ValueError("NoScale currently supports only SM90 BF16 operands")
-        output_shape = (*a.shape[:-1], b.shape[1])
-        if out is not None and not out.is_contiguous():
-            raise ValueError("out must be contiguous")
-        if out is not None and (
-            tuple(out.shape) != output_shape or out.dtype != self.compute.output_dtype
-        ):
-            raise ValueError("out shape and dtype must match the resolved grouped-GEMM output")
+        rows = _rows_of(layout, tuple(a.shape))
+        expected_meta = layout.metadata_length(rows=rows, num_experts=num_experts)
+        if layout_metadata.ndim != 1 or layout_metadata.shape[0] != expected_meta:
+            raise ValueError(
+                f"layout_metadata must have shape ({expected_meta},) for this layout, "
+                f"got {tuple(layout_metadata.shape)}"
+            )
+        cd_dtype = self.resolve_output_dtype(a.dtype)
+        output_shape = self._infer_output_shapes(
+            tuple(a.shape), tuple(b.shape), tuple(layout_metadata.shape)
+        )["output"]
+        if out is not None and (tuple(out.shape) != output_shape or out.dtype != cd_dtype):
+            raise ValueError(
+                f"out must be a {list(output_shape)} tensor of dtype {cd_dtype}, "
+                f"got {list(out.shape)} {out.dtype}"
+            )
+        packing = None if isinstance(layout, MaskedLayoutSpec) else layout.packing.value
+        metadata_kind = None if isinstance(layout, MaskedLayoutSpec) else layout.metadata_kind.value
         return MGroupedGemmCall(
-            arch=arch,
-            layout_key=expert_layout.selection_key,
-            max_m=expert_layout.max_m,
-            device_type=a.device.type,
-            input_dtype=a.dtype,
-            weight_dtype=b.dtype,
-            output_dtype=self.compute.output_dtype,
-            materialized_rows=expert_layout.materialized_rows,
-            num_experts=expert_layout.num_experts,
-            n=b.shape[1],
-            k=b.shape[2],
+            arch=get_sm_version(device.index),
+            h200=is_h200(device.index),
+            kind=layout.kind,
+            packing=packing,
+            metadata_kind=metadata_kind,
+            alignment=getattr(layout, "alignment", 1),
+            max_m=layout.max_m,
+            ab_dtype=a.dtype,
+            cd_dtype=cd_dtype,
+            num_groups=num_experts,
+            m=rows,
+            n=n,
+            k=k,
+        )
+
+    def layout_guard(
+        self,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        layout_metadata: torch.Tensor,
+    ) -> torch.Tensor:
+        """Asynchronous bool: ``layout_metadata``'s values satisfy the layout for ``a``/``b``.
+
+        The metadata's shape is checked here on the host, its values on the device;
+        never a host sync. Consume with ``torch._assert_async`` or ``.item()`` in
+        tests and benchmarks, never in ``forward``.
+
+        Raises:
+            ValueError: ``layout_metadata`` is not the int32 vector the layout expects.
+        """
+        rows = _rows_of(self.layout, tuple(a.shape))
+        expected = self.layout.metadata_length(rows=rows, num_experts=b.shape[0])
+        if layout_metadata.dtype is not torch.int32 or tuple(layout_metadata.shape) != (expected,):
+            raise ValueError(
+                f"layout_metadata must be an int32 vector of length {expected}, "
+                f"got {layout_metadata.dtype} {tuple(layout_metadata.shape)}"
+            )
+        return layout_value_guard(
+            self.layout,
+            layout_metadata,
+            rows=rows,
+            num_experts=b.shape[0],
         )
 
     def forward(
         self,
         a: torch.Tensor,
         b: torch.Tensor,
-        expert_layout: MaterializedExpertLayout,
-        scales: object | None = None,
+        layout_metadata: torch.Tensor,
         out: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        """Run one grouped GEMM using the supplied materialized expert layout."""
-        call = self.make_call(a, b, expert_layout, scales, out)
+        """Run one GEMM per expert over the rows the layout assigns it.
+
+        Args:
+            a: Expert-materialized activations, ``[M, K]`` or ``[E, max_m, K]`` per the layout.
+            b: Per-expert weights, ``[E, N, K]``.
+            layout_metadata: ``int32`` metadata whose shape and meaning the layout fixes.
+            out: Optional preallocated output in the resolved output dtype.
+
+        Returns:
+            ``[M, N]`` or ``[E, max_m, N]`` in the operand dtype, or fp32 when asked for.
+        """
+        if out is None:
+            return _moe_grouped_gemm_fwd(a, b, layout_metadata, self._instance_key)
+        _moe_grouped_gemm_fwd_inplace(a, b, layout_metadata, out, self._instance_key)
+        return out
+
+    def _eager_forward(
+        self,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        layout_metadata: torch.Tensor,
+        out: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        call = self.make_call(a, b, layout_metadata, out)
+        self.dtype = a.dtype
+        self.input_shapes = [tuple(a.shape), tuple(b.shape), tuple(layout_metadata.shape)]
         name = self.select_kernel_key(tuple((self.kernel_map or {}).keys()), call)
         kernel = self.get_or_build_kernel(
             name,
-            inputs=(a, b),
-            key=call,
+            inputs=(a, b, layout_metadata),
+            key=call.specialization_key,
             build=lambda: self.kernel_map[name](call),
         )
-        return kernel(a, b, expert_layout, scales=scales, out=out)
+        return kernel(a, b, layout_metadata, out=out)
 
 
 class MoeExpertMLPFwdOp(_StagedOpBase):
-    """Compose two typed grouped GEMMs around a gated activation."""
+    """Two grouped GEMMs around a gated activation on one expert layout.
+
+    ``out = (act(expert_input @ w_gate_up[g]^T)) @ w_down[g]^T`` per expert ``g``, where
+    ``act`` is the gated activation: ``w_gate_up`` stacks the gate and up projections
+    along ``N`` and the activation halves it. A composite: it registers no operator
+    of its own, its graph is its three leaves'.
+    """
 
     def __init__(
         self,
+        layout: MGroupedLayoutSpec,
         activation: str = "silu_and_mul",
         *,
-        compute: NoScaleComputeSpec | None = None,
         kernel_map: dict[str, Kernel] | None = None,
         target: object = None,
     ) -> None:
-        """Configure two grouped GEMMs around the selected gated activation."""
+        """Configure two grouped GEMMs on ``layout`` around the selected gated activation.
+
+        Args:
+            layout: Manifest ``params.layout``; shared by both GEMMs and the metadata.
+            activation: Manifest ``params.activation``; ``"silu_and_mul"`` only for now.
+            kernel_map: Optional overrides, forwarded to the delegate whose key they name.
+            target: Which backend serves the delegates.
+        """
         if activation != "silu_and_mul":
             raise ValueError("the staged Expert MLP currently supports only silu_and_mul")
+        self.layout = _check_layout(layout)
         self.activation = activation
-        self.compute = NoScaleComputeSpec() if compute is None else compute
         self.target = target
         self.dispatch_kernel(kernel_map)
         overrides = self.forwarded_overrides()
@@ -345,50 +496,80 @@ class MoeExpertMLPFwdOp(_StagedOpBase):
             if overrides
             else None
         )
-        self.gate_up = MoeGroupedGemmFwdOp(
-            self.compute, kernel_map=grouped_overrides, target=target
-        )
+        self.gate_up = MoeGroupedGemmFwdOp(layout, kernel_map=grouped_overrides, target=target)
         self.activation_op = SiluAndMulFwdOp(kernel_map=overrides)
         self.activation_op.target = target
-        self.down = MoeGroupedGemmFwdOp(self.compute, kernel_map=grouped_overrides, target=target)
+        self.down = MoeGroupedGemmFwdOp(layout, kernel_map=grouped_overrides, target=target)
 
     def kernel_delegates(self) -> tuple[Op, Op, Op]:
         return self.gate_up, self.activation_op, self.down
 
-    def make_calls(
+    def _infer_output_shapes(
         self,
-        expert_input: torch.Tensor,
-        w_gate_up: torch.Tensor,
-        w_down: torch.Tensor,
-        expert_layout: MaterializedExpertLayout,
-        out: torch.Tensor | None = None,
-    ) -> tuple[MGroupedGemmCall, MGroupedGemmCall]:
-        """Build both GEMM calls while preserving one layout binding."""
-        gate_call = self.gate_up.make_call(expert_input, w_gate_up, expert_layout)
+        expert_input_shape: tuple[int, ...],
+        w_gate_up_shape: tuple[int, ...],
+        w_down_shape: tuple[int, ...],
+        layout_metadata_shape: tuple[int, ...],
+    ) -> dict[str, tuple[int, ...]]:
+        return {"output": (*tuple(expert_input_shape)[:-1], w_down_shape[1])}
+
+    def eval_roofline(self) -> tuple[int, int]:
+        if self.input_shapes is None or self.dtype is None:
+            raise RuntimeError("eval_roofline requires a prior forward call")
+        x_shape, gate_shape, down_shape, meta_shape = self.input_shapes
+        rows = _rows_of(self.layout, x_shape)
+        num_experts, two_ffn, hidden = gate_shape
+        ffn = down_shape[2]
+        flops = rows * (2 * two_ffn * hidden + 6 * ffn + 2 * hidden * ffn)
+        elem = self.dtype.itemsize
+        nbytes = (rows * hidden + num_experts * two_ffn * hidden) * elem
+        nbytes += (num_experts * hidden * ffn + rows * hidden) * elem + meta_shape[0] * 4
+        return int(flops), int(nbytes)
+
+    @staticmethod
+    def _check_widths(w_gate_up: torch.Tensor, w_down: torch.Tensor) -> None:
+        if w_gate_up.ndim != 3 or w_down.ndim != 3:
+            raise ValueError("w_gate_up and w_down must have shape [num_experts, n, k]")
         if w_gate_up.shape[1] % 2:
             raise ValueError("w_gate_up output dimension must be even")
-        intermediate_shape = (*expert_input.shape[:-1], w_gate_up.shape[1] // 2)
-        if w_down.shape[-1] != intermediate_shape[-1]:
+        if w_down.shape[-1] != w_gate_up.shape[1] // 2:
             raise ValueError("w_down reduction dimension must match the gated width")
-        intermediate = expert_input.new_empty(intermediate_shape)
-        down_call = self.down.make_call(intermediate, w_down, expert_layout, out=out)
-        return gate_call, down_call
+        if w_down.shape[0] != w_gate_up.shape[0]:
+            raise ValueError("w_gate_up and w_down must hold the same experts")
 
     def forward(
         self,
         expert_input: torch.Tensor,
         w_gate_up: torch.Tensor,
         w_down: torch.Tensor,
-        expert_layout: MaterializedExpertLayout,
+        layout_metadata: torch.Tensor,
         out: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        """Run gate/up GEMM, gated activation, and down GEMM on one layout."""
-        self.make_calls(expert_input, w_gate_up, w_down, expert_layout, out)
-        gate_up = self.gate_up(expert_input, w_gate_up, expert_layout)
+        """Run gate/up GEMM, gated activation, and down GEMM on one layout.
+
+        Args:
+            expert_input: ``[M, hidden]`` or ``[E, max_m, hidden]`` per the layout.
+            w_gate_up: ``[E, 2 * ffn, hidden]``, gate and up stacked along the output axis.
+            w_down: ``[E, hidden, ffn]``.
+            layout_metadata: ``int32`` metadata the layout fixes; shared by both GEMMs.
+            out: Optional preallocated ``[.., hidden]`` output in the operand dtype.
+
+        Returns:
+            ``[M, hidden]`` or ``[E, max_m, hidden]`` in the operand dtype.
+        """
+        self._check_widths(w_gate_up, w_down)
+        self.dtype = expert_input.dtype
+        self.input_shapes = [
+            tuple(expert_input.shape),
+            tuple(w_gate_up.shape),
+            tuple(w_down.shape),
+            tuple(layout_metadata.shape),
+        ]
+        gate_up = self.gate_up(expert_input, w_gate_up, layout_metadata)
         flat_gate_up = gate_up.reshape(-1, gate_up.shape[-1])
         activated = self.activation_op(flat_gate_up)
         activated = activated.reshape(*gate_up.shape[:-1], gate_up.shape[-1] // 2)
-        return self.down(activated, w_down, expert_layout, out=out)
+        return self.down(activated, w_down, layout_metadata, out=out)
 
 
 class MoePostPermuteFwdOp(_StagedOpBase):
@@ -411,7 +592,7 @@ class MoePostPermuteFwdOp(_StagedOpBase):
         epilogue = RoutingEpilogueSpec() if epilogue is None else epilogue
         if not isinstance(epilogue, RoutingEpilogueSpec):
             raise TypeError("epilogue must be RoutingEpilogueSpec")
-        self.layout = layout
+        self.layout = _check_layout(layout)
         self.epilogue = epilogue
         self.target = target
         self.dispatch_kernel(kernel_map)
@@ -607,3 +788,36 @@ def _moe_post_permute_fwd_inplace(
     instance_key: str,
 ) -> None:
     get_instance(instance_key)._eager_forward(expert_output, inverse_indices, topk_weights, out=out)
+
+
+@torch.library.custom_op("tileops::moe_grouped_gemm_fwd", mutates_args=())
+def _moe_grouped_gemm_fwd(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    layout_metadata: torch.Tensor,
+    instance_key: str,
+) -> torch.Tensor:
+    return get_instance(instance_key)._eager_forward(a, b, layout_metadata)
+
+
+@_moe_grouped_gemm_fwd.register_fake
+def _moe_grouped_gemm_fwd_fake(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    layout_metadata: torch.Tensor,
+    instance_key: str,
+) -> torch.Tensor:
+    op = get_instance(instance_key)
+    shape = op._infer_output_shapes(tuple(a.shape), tuple(b.shape), tuple(layout_metadata.shape))
+    return torch.empty(shape["output"], dtype=op.resolve_output_dtype(a.dtype), device=a.device)
+
+
+@torch.library.custom_op("tileops::moe_grouped_gemm_fwd_inplace", mutates_args=("out",))
+def _moe_grouped_gemm_fwd_inplace(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    layout_metadata: torch.Tensor,
+    out: torch.Tensor,
+    instance_key: str,
+) -> None:
+    get_instance(instance_key)._eager_forward(a, b, layout_metadata, out=out)

--- a/src/tileops/perf/formulas.py
+++ b/src/tileops/perf/formulas.py
@@ -67,6 +67,8 @@ __all__ = [
     "mhc_post_roofline",
     "mhc_pre_roofline",
     "minimum_fwd_roofline",
+    "moe_expert_mlp_roofline",
+    "moe_grouped_gemm_roofline",
     "mul_fwd_roofline",
     "ne_fwd_roofline",
     "pow_fwd_roofline",
@@ -1047,6 +1049,45 @@ def grouped_gemm_roofline(op: "Op") -> tuple[int, int]:
         memory_c = batch_count * n * k
         memory_b = k * batch_sum if bool(op.transpose_b) else batch_sum * k
     return int(flops), int((memory_a + memory_b + memory_c) * elem)
+
+
+def _staged_moe_input_shapes(op: "Op") -> tuple:
+    if getattr(op, "input_shapes", None) is None or getattr(op, "dtype", None) is None:
+        raise RuntimeError(f"{type(op).__name__}.eval_roofline requires a prior forward call")
+    return tuple(op.input_shapes)
+
+
+def _staged_moe_rows(a_shape: tuple) -> int:
+    # Contiguous layouts hand over [M, K], masked ones [E, max_m, K].
+    rows = 1
+    for dim in a_shape[:-1]:
+        rows *= int(dim)
+    return rows
+
+
+def moe_grouped_gemm_roofline(op: "Op") -> tuple[int, int]:
+    a_shape, b_shape, meta_shape = _staged_moe_input_shapes(op)
+    rows = _staged_moe_rows(a_shape)
+    num_experts, n, k = (int(dim) for dim in b_shape)
+    elem = op.dtype.itemsize
+    # The output width is the op's, not the operands': out_dtype may keep fp32.
+    out_elem = op.resolve_output_dtype(op.dtype).itemsize
+    flops = 2 * rows * n * k
+    nbytes = (rows * k + num_experts * n * k) * elem + rows * n * out_elem
+    nbytes += int(meta_shape[0]) * 4
+    return int(flops), int(nbytes)
+
+
+def moe_expert_mlp_roofline(op: "Op") -> tuple[int, int]:
+    x_shape, gate_shape, down_shape, meta_shape = _staged_moe_input_shapes(op)
+    rows = _staged_moe_rows(x_shape)
+    num_experts, two_ffn, hidden = (int(dim) for dim in gate_shape)
+    ffn = int(down_shape[2])
+    elem = op.dtype.itemsize
+    flops = rows * (2 * two_ffn * hidden + 6 * ffn + 2 * hidden * ffn)
+    weights = num_experts * two_ffn * hidden + num_experts * hidden * ffn
+    nbytes = (2 * rows * hidden + weights) * elem + int(meta_shape[0]) * 4
+    return int(flops), int(nbytes)
 
 
 def rope_roofline(op: "Op") -> tuple[int, int]:

--- a/tests/ops/test_moe_staged_contracts.py
+++ b/tests/ops/test_moe_staged_contracts.py
@@ -181,11 +181,12 @@ def test_family_call_specs_are_frozen_and_keep_selection_axes_separate() -> None
     assert aligned_pre != pre
     assert len({pre, aligned_pre}) == 2
     assert post.layout_key == "tight_physical_psum"
-    # The row count is a fact of the call, not of the built kernel.
+    # The op keys its cache on this record with ``m`` reset; every other field survives.
     taller = dataclasses.replace(gemm, m=4096)
     assert taller != gemm
-    assert taller.specialization_key == gemm.specialization_key
-    assert dataclasses.replace(gemm, n=8).specialization_key != gemm.specialization_key
+    assert dataclasses.replace(taller, m=0) == dataclasses.replace(gemm, m=0)
+    assert dataclasses.replace(gemm, n=8, m=0) != dataclasses.replace(gemm, m=0)
+    assert dataclasses.replace(gemm, arch=100, m=0) != dataclasses.replace(gemm, m=0)
     # The flattened layout fields admit only what a layout spec can express.
     with pytest.raises(ValueError, match="no max_m"):
         dataclasses.replace(gemm, max_m=4)
@@ -195,6 +196,10 @@ def test_family_call_specs_are_frozen_and_keep_selection_axes_separate() -> None
         MGroupedGemmCall(arch=90, sm_count=1, kind="masked", packing="tight", max_m=4)
     with pytest.raises(ValueError, match="kind is"):
         MGroupedGemmCall(arch=90, sm_count=1, kind="padded")
+    # Only the record that names no layout skips the checks.
+    assert MGroupedGemmCall(arch=90, sm_count=1).kind == ""
+    with pytest.raises(ValueError, match="kind is"):
+        MGroupedGemmCall(arch=90, sm_count=1, max_m=4)
 
 
 def _layout_key_of(call: MGroupedGemmCall) -> str | None:

--- a/tests/ops/test_moe_staged_contracts.py
+++ b/tests/ops/test_moe_staged_contracts.py
@@ -12,32 +12,23 @@ from tileops.ops import moe as public_moe
 from tileops.ops.moe import (
     ContiguousLayoutSpec,
     MaskedLayoutSpec,
-    MaterializedExpertLayout,
     MoeExpertMLPFwdOp,
     MoeGroupedGemmFwdOp,
     MoePostPermuteFwdOp,
     MoePrePermuteFwdOp,
-    NoScaleComputeSpec,
     RoutingEpilogueSpec,
 )
 from tileops.ops.moe.contracts import (
     MaskedMetadata,
     PerRowExpertMetadata,
     PhysicalPsumMetadata,
+    layout_from_preset,
+    layout_value_guard,
 )
 
 pytestmark = pytest.mark.smoke
 
-
-def _physical_layout(rows: int = 2, experts: int = 2) -> MaterializedExpertLayout:
-    ends = torch.arange(1, experts + 1, dtype=torch.int32)
-    if experts:
-        ends[-1] = rows
-    return MaterializedExpertLayout.from_physical_psum(
-        ends,
-        materialized_rows=rows,
-        num_experts=experts,
-    )
+_TIGHT = ContiguousLayoutSpec.tight_physical_psum()
 
 
 def test_layout_presets_expose_only_supported_semantics() -> None:
@@ -54,6 +45,13 @@ def test_layout_presets_expose_only_supported_semantics() -> None:
     assert repr(physical) == "ContiguousLayoutSpec.tight_physical_psum()"
     assert repr(per_row) == "ContiguousLayoutSpec.tight_per_row()"
     assert repr(aligned) == "ContiguousLayoutSpec.aligned_per_row(128)"
+    aligned_psum = ContiguousLayoutSpec.aligned_physical_psum(64)
+    assert aligned_psum.selection_key == "aligned_physical_psum"
+    assert repr(aligned_psum) == "ContiguousLayoutSpec.aligned_physical_psum(64)"
+    assert (physical.kind, masked.kind) == ("contiguous", "masked")
+    assert physical.metadata_length(rows=10, num_experts=3) == 3
+    assert per_row.metadata_length(rows=10, num_experts=3) == 10
+    assert masked.metadata_length(rows=12, num_experts=3) == 3
     with pytest.raises(ValueError, match="alignment > 1"):
         ContiguousLayoutSpec.aligned_per_row(1)
     with pytest.raises(ValueError, match="non-negative"):
@@ -61,6 +59,23 @@ def test_layout_presets_expose_only_supported_semantics() -> None:
 
     with pytest.raises(ValueError, match="num_local_experts must be positive"):
         MoePrePermuteFwdOp(physical, num_local_experts=0)
+
+
+def test_layout_presets_resolve_from_manifest_rows() -> None:
+    """A workload row names a preset and carries only the argument that preset takes."""
+    assert layout_from_preset("tight_physical_psum") == _TIGHT
+    assert layout_from_preset(
+        "aligned_per_row", alignment=128
+    ) == ContiguousLayoutSpec.aligned_per_row(128)
+    assert layout_from_preset("masked", max_m=64) == MaskedLayoutSpec(max_m=64)
+    with pytest.raises(ValueError, match="neither alignment nor max_m"):
+        layout_from_preset("tight_physical_psum", alignment=8)
+    with pytest.raises(ValueError, match="takes alignment"):
+        layout_from_preset("aligned_per_row")
+    with pytest.raises(ValueError, match="takes max_m"):
+        layout_from_preset("masked", alignment=8, max_m=4)
+    with pytest.raises(ValueError, match="unknown layout preset"):
+        layout_from_preset("padded")
 
 
 def test_default_public_surface_hides_kernel_author_and_metadata_types() -> None:
@@ -71,48 +86,10 @@ def test_default_public_surface_hides_kernel_author_and_metadata_types() -> None
         "PhysicalPsumMetadata",
         "PerRowExpertMetadata",
         "MaskedMetadata",
-        "ComputeFamilyKey",
-        "ResolvedContiguousLayout",
+        "MaterializedExpertLayout",
+        "NoScaleComputeSpec",
     ):
         assert not hasattr(public_moe, name)
-
-
-def test_materialized_layout_rejects_incompatible_metadata() -> None:
-    with pytest.raises(TypeError, match="PhysicalPsumMetadata"):
-        MaterializedExpertLayout(
-            layout=ContiguousLayoutSpec.tight_physical_psum(),
-            metadata=PerRowExpertMetadata(torch.empty(4, dtype=torch.int32)),
-            num_experts=2,
-            materialized_rows=4,
-        )
-    with pytest.raises(TypeError, match="MaskedMetadata"):
-        MaterializedExpertLayout(
-            layout=MaskedLayoutSpec(max_m=4),
-            metadata=PhysicalPsumMetadata(torch.empty(2, dtype=torch.int32)),
-            num_experts=2,
-            materialized_rows=8,
-        )
-
-
-def test_external_materialization_factories_derive_concrete_contracts() -> None:
-    physical = MaterializedExpertLayout.from_physical_psum(
-        torch.tensor([1, 3], dtype=torch.int32), materialized_rows=3
-    )
-    assert physical.selection_key == "tight_physical_psum"
-    assert physical.num_experts == 2
-
-    per_row = MaterializedExpertLayout.from_per_row_ids(
-        torch.tensor([0, 0, 1], dtype=torch.int32), num_experts=2
-    )
-    assert per_row.selection_key == "tight_per_row"
-    assert per_row.materialized_rows == 3
-
-    masked = MaterializedExpertLayout.from_masked_m(
-        torch.tensor([2, 1], dtype=torch.int32), max_m=4
-    )
-    assert masked.selection_key == "masked_predicated"
-    assert masked.materialized_rows == 8
-    assert masked.max_m == 4
 
 
 def test_device_value_guards_cover_empty_experts_ordering_and_ranges() -> None:
@@ -161,11 +138,8 @@ def test_device_value_validation_returns_a_device_guard_without_host_readback() 
     assert guard.shape == ()
 
 
-def test_compute_and_epilogue_specs_are_minimal_and_frozen() -> None:
-    compute = NoScaleComputeSpec()
+def test_epilogue_spec_is_minimal_and_frozen_and_ops_type_check_their_layout() -> None:
     epilogue = RoutingEpilogueSpec()
-    assert compute.accumulation_dtype is torch.float32
-    assert compute.output_dtype is torch.bfloat16
     assert epilogue.accumulation_dtype is torch.float32
     assert epilogue.output_dtype is None
     assert epilogue.resolve_output_dtype(torch.bfloat16) is torch.bfloat16
@@ -175,18 +149,30 @@ def test_compute_and_epilogue_specs_are_minimal_and_frozen() -> None:
         RoutingEpilogueSpec(routed_scaling_factor=0.0)
     with pytest.raises(dataclasses.FrozenInstanceError):
         epilogue.routed_scaling_factor = 2.0
-    with pytest.raises(TypeError, match="NoScaleComputeSpec"):
-        MoeGroupedGemmFwdOp(compute=0)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="ContiguousLayoutSpec or MaskedLayoutSpec"):
+        MoeGroupedGemmFwdOp(0)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="ContiguousLayoutSpec or MaskedLayoutSpec"):
+        MoeExpertMLPFwdOp("tight_physical_psum")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="out_dtype must be None"):
+        MoeGroupedGemmFwdOp(_TIGHT, out_dtype=torch.float16)
+    assert MoeGroupedGemmFwdOp(_TIGHT).resolve_output_dtype(torch.float16) is torch.float16
+    assert (
+        MoeGroupedGemmFwdOp(_TIGHT, out_dtype=torch.float32).resolve_output_dtype(torch.bfloat16)
+        is torch.float32
+    )
     with pytest.raises(TypeError, match="RoutingEpilogueSpec"):
         MoePostPermuteFwdOp(ContiguousLayoutSpec.tight_physical_psum(), epilogue=0)  # type: ignore[arg-type]
 
 
 def test_family_call_specs_are_frozen_and_keep_selection_axes_separate() -> None:
-    pre = PrePermuteCall(arch=90, layout=ContiguousLayoutSpec.tight_physical_psum())
+    pre = PrePermuteCall(arch=90, sm_count=1, layout=ContiguousLayoutSpec.tight_physical_psum())
     aligned_pre = dataclasses.replace(pre, layout=ContiguousLayoutSpec.aligned_per_row(128))
-    gemm = MGroupedGemmCall(arch=90, layout_key="tight_physical_psum")
+    gemm = MGroupedGemmCall(
+        arch=90, sm_count=1, kind="contiguous", packing="tight", metadata_kind="physical_psum"
+    )
     post = PostPermuteCall(
         arch=90,
+        sm_count=1,
         layout_key="tight_physical_psum",
         epilogue=RoutingEpilogueSpec(),
     )
@@ -194,7 +180,28 @@ def test_family_call_specs_are_frozen_and_keep_selection_axes_separate() -> None
         pre.arch = 100
     assert aligned_pre != pre
     assert len({pre, aligned_pre}) == 2
-    assert gemm.layout_key == post.layout_key
+    assert post.layout_key == "tight_physical_psum"
+    # The row count is a fact of the call, not of the built kernel.
+    taller = dataclasses.replace(gemm, m=4096)
+    assert taller != gemm
+    assert taller.specialization_key == gemm.specialization_key
+    assert dataclasses.replace(gemm, n=8).specialization_key != gemm.specialization_key
+    # The flattened layout fields admit only what a layout spec can express.
+    with pytest.raises(ValueError, match="no max_m"):
+        dataclasses.replace(gemm, max_m=4)
+    with pytest.raises(ValueError, match="alignment"):
+        dataclasses.replace(gemm, packing="aligned")
+    with pytest.raises(ValueError, match="carry no packing"):
+        MGroupedGemmCall(arch=90, sm_count=1, kind="masked", packing="tight", max_m=4)
+    with pytest.raises(ValueError, match="kind is"):
+        MGroupedGemmCall(arch=90, sm_count=1, kind="padded")
+
+
+def _layout_key_of(call: MGroupedGemmCall) -> str | None:
+    """The contiguous-layout key a test candidate claims, off the GEMM call."""
+    if call.kind != "contiguous":
+        return None
+    return f"{call.packing}_{call.metadata_kind}"
 
 
 class _PhysicalPsumCandidate(Kernel):
@@ -202,11 +209,7 @@ class _PhysicalPsumCandidate(Kernel):
 
     @classmethod
     def applies(cls, call: object) -> bool:
-        key = getattr(call, "layout_key", None)
-        if key is None:
-            layout = getattr(call, "layout", None)
-            key = getattr(layout, "selection_key", None)
-        return key == "tight_physical_psum"
+        return _layout_key_of(call) == "tight_physical_psum"
 
     def forward(self, *args: object, **kwargs: object) -> None:
         return None
@@ -217,11 +220,7 @@ class _PerRowCandidate(Kernel):
 
     @classmethod
     def applies(cls, call: object) -> bool:
-        key = getattr(call, "layout_key", None)
-        if key is None:
-            layout = getattr(call, "layout", None)
-            key = getattr(layout, "selection_key", None)
-        return key == "tight_per_row"
+        return _layout_key_of(call) == "tight_per_row"
 
     def forward(self, *args: object, **kwargs: object) -> None:
         return None
@@ -244,6 +243,12 @@ class _NeverCandidate(Kernel):
         return None
 
 
+def _zero_output(a: torch.Tensor, b: torch.Tensor, out: torch.Tensor | None, dtype=None):
+    """What an executable fake writes: zeros of the GEMM's output shape."""
+    result = a.new_zeros((*a.shape[:-1], b.shape[1]), dtype=dtype)
+    return result if out is None else out.copy_(result)
+
+
 class _ExecutableGroupedCandidate(Kernel):
     builds = 0
 
@@ -252,20 +257,8 @@ class _ExecutableGroupedCandidate(Kernel):
         type(self).builds += 1
         self.call = call
 
-    def forward(
-        self,
-        a: torch.Tensor,
-        b: torch.Tensor,
-        expert_layout: MaterializedExpertLayout,
-        *,
-        scales: object | None = None,
-        out: torch.Tensor | None = None,
-    ) -> torch.Tensor:
-        result = a.new_zeros((*a.shape[:-1], b.shape[1]))
-        if out is not None:
-            out.copy_(result)
-            return out
-        return result
+    def forward(self, a, b, layout_metadata, *, out=None):
+        return _zero_output(a, b, out, dtype=self.call.cd_dtype)
 
 
 def _grouped_op_with_declared_candidates(**candidates: type[Kernel]) -> MoeGroupedGemmFwdOp:
@@ -274,12 +267,23 @@ def _grouped_op_with_declared_candidates(**candidates: type[Kernel]) -> MoeGroup
         def default_kernel_map(self) -> dict[str, Kernel]:
             return dict(candidates)
 
-    return DeclaringGroupedGemmOp()
+    return DeclaringGroupedGemmOp(_TIGHT)
+
+
+def _tight_call(metadata_kind: str = "physical_psum", **fields: object) -> MGroupedGemmCall:
+    return MGroupedGemmCall(
+        arch=90,
+        sm_count=1,
+        kind="contiguous",
+        packing="tight",
+        metadata_kind=metadata_kind,
+        **fields,
+    )
 
 
 def test_grouped_gemm_selection_behavior_table() -> None:
-    physical_call = MGroupedGemmCall(arch=90, layout_key="tight_physical_psum")
-    per_row_call = MGroupedGemmCall(arch=90, layout_key="tight_per_row")
+    physical_call = _tight_call()
+    per_row_call = _tight_call("per_row")
     op = _grouped_op_with_declared_candidates(
         physical=_PhysicalPsumCandidate,
         per_row=_PerRowCandidate,
@@ -295,7 +299,7 @@ def test_grouped_gemm_selection_behavior_table() -> None:
 
 
 def test_grouped_gemm_ambiguous_and_incompatible_override_fail_explicitly() -> None:
-    call = MGroupedGemmCall(arch=90, layout_key="tight_physical_psum")
+    call = _tight_call()
     ambiguous = _grouped_op_with_declared_candidates(
         first=_PhysicalPsumCandidate,
         second=_PhysicalPsumCandidate,
@@ -308,7 +312,7 @@ def test_grouped_gemm_ambiguous_and_incompatible_override_fail_explicitly() -> N
         def default_kernel_map(self) -> dict[str, Kernel]:
             return {"special": _PhysicalPsumCandidate, "general": _GeneralCandidate}
 
-    overridden = OverrideableOp(kernel_map={"special": _NeverCandidate})
+    overridden = OverrideableOp(_TIGHT, kernel_map={"special": _NeverCandidate})
     with pytest.raises(ValueError, match="does not fall back"):
         overridden.select_kernel_key(("special", "general"), call)
 
@@ -327,19 +331,18 @@ def test_public_ops_build_complete_calls_before_selection() -> None:
         pre_call.top_k,
     ) == (2, 2, 8, 1)
 
-    layout = MaterializedExpertLayout.from_physical_psum(
-        torch.tensor([1, 2], dtype=torch.int32, device="cuda"), materialized_rows=2
-    )
+    ends = torch.tensor([1, 2], dtype=torch.int32, device="cuda")
     a = torch.empty(2, 8, dtype=torch.bfloat16, device="cuda")
     b = torch.empty(2, 4, 8, dtype=torch.bfloat16, device="cuda")
-    gemm_call = MoeGroupedGemmFwdOp().make_call(a, b, layout)
-    assert (gemm_call.materialized_rows, gemm_call.num_experts, gemm_call.n, gemm_call.k) == (
-        2,
-        2,
-        4,
-        8,
+    gemm_call = MoeGroupedGemmFwdOp(_TIGHT).make_call(a, b, ends)
+    assert (gemm_call.m, gemm_call.num_groups, gemm_call.n, gemm_call.k) == (2, 2, 4, 8)
+    assert (gemm_call.kind, gemm_call.packing, gemm_call.metadata_kind) == (
+        "contiguous",
+        "tight",
+        "physical_psum",
     )
-    assert gemm_call.layout_key == "tight_physical_psum"
+    assert (gemm_call.alignment, gemm_call.max_m) == (1, None)
+    assert gemm_call.ab_dtype is gemm_call.cd_dtype is torch.bfloat16
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CallSpec records CUDA architecture")
@@ -352,13 +355,10 @@ def test_call_architecture_comes_from_the_input_device(monkeypatch: pytest.Monke
         return 90
 
     monkeypatch.setattr(staged_module, "get_sm_version", fake_sm_version)
-    layout = MaterializedExpertLayout.from_physical_psum(
-        torch.tensor([1], dtype=torch.int32, device=device), materialized_rows=1
-    )
-    MoeGroupedGemmFwdOp().make_call(
+    MoeGroupedGemmFwdOp(_TIGHT).make_call(
         torch.empty(1, 4, dtype=torch.bfloat16, device=device),
         torch.empty(1, 2, 4, dtype=torch.bfloat16, device=device),
-        layout,
+        torch.tensor([1], dtype=torch.int32, device=device),
     )
 
     assert observed_indices == [device.index]
@@ -367,22 +367,27 @@ def test_call_architecture_comes_from_the_input_device(monkeypatch: pytest.Monke
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CallSpec records CUDA architecture")
 def test_staged_wiring_builds_all_family_calls_without_an_executable_candidate() -> None:
     device = torch.device("cuda")
-    layout = MaterializedExpertLayout.from_physical_psum(
-        torch.tensor([1, 2], dtype=torch.int32, device=device), materialized_rows=2
-    )
+    ends = torch.tensor([1, 2], dtype=torch.int32, device=device)
     expert_input = torch.empty(2, 8, dtype=torch.bfloat16, device=device)
     w_gate_up = torch.empty(2, 12, 8, dtype=torch.bfloat16, device=device)
     w_down = torch.empty(2, 8, 6, dtype=torch.bfloat16, device=device)
-    mlp = MoeExpertMLPFwdOp()
+    mlp = MoeExpertMLPFwdOp(_TIGHT)
 
-    gate_call, down_call = mlp.make_calls(expert_input, w_gate_up, w_down, layout)
+    gate_call = mlp.gate_up.make_call(expert_input, w_gate_up, ends)
+    activated = torch.empty(2, 6, dtype=torch.bfloat16, device=device)
+    down_call = mlp.down.make_call(activated, w_down, ends)
 
-    assert gate_call.layout_key == down_call.layout_key == "tight_physical_psum"
+    assert gate_call.kind == down_call.kind == "contiguous"
+    assert gate_call.packing == down_call.packing == "tight"
     assert (gate_call.k, gate_call.n, down_call.k, down_call.n) == (8, 12, 6, 8)
     assert tuple(mlp.kernel_delegates()) == (mlp.gate_up, mlp.activation_op, mlp.down)
+    with pytest.raises(ValueError, match="gated width"):
+        mlp(
+            expert_input, w_gate_up, torch.empty(2, 8, 5, dtype=torch.bfloat16, device=device), ends
+        )
 
     inverse_indices = torch.tensor([0, 1], dtype=torch.int32, device=device)
-    post_call = MoePostPermuteFwdOp(layout.layout, RoutingEpilogueSpec()).make_call(
+    post_call = MoePostPermuteFwdOp(_TIGHT, RoutingEpilogueSpec()).make_call(
         torch.empty(2, 8, dtype=torch.bfloat16, device=device),
         torch.ones(2, 1, dtype=torch.float32, device=device),
         inverse_indices,
@@ -395,14 +400,12 @@ def test_staged_wiring_builds_all_family_calls_without_an_executable_candidate()
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CallSpec records CUDA architecture")
 def test_post_permute_rejects_wrong_masked_geometry_with_same_row_count() -> None:
     device = torch.device("cuda")
-    layout = MaterializedExpertLayout.from_masked_m(
-        torch.tensor([2, 1], dtype=torch.int32, device=device), max_m=4
-    )
+    layout = MaskedLayoutSpec(max_m=4)
     inverse_indices = torch.tensor([0], dtype=torch.int32, device=device)
     wrong_geometry = torch.empty(1, 8, 4, dtype=torch.bfloat16, device=device)
 
     with pytest.raises(ValueError, match="masked expert_output"):
-        MoePostPermuteFwdOp(layout.layout).make_call(
+        MoePostPermuteFwdOp(layout).make_call(
             wrong_geometry,
             torch.ones(1, 1, dtype=torch.float32, device=device),
             inverse_indices,
@@ -412,28 +415,36 @@ def test_post_permute_rejects_wrong_masked_geometry_with_same_row_count() -> Non
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="candidate test uses CUDA calls")
 def test_injected_candidate_uses_common_selection_and_call_spec_cache() -> None:
     device = torch.device("cuda")
-    layout = MaterializedExpertLayout.from_physical_psum(
-        torch.tensor([1], dtype=torch.int32, device=device), materialized_rows=1
-    )
+    ends = torch.tensor([1], dtype=torch.int32, device=device)
     a = torch.ones(1, 4, dtype=torch.bfloat16, device=device)
     b = torch.ones(1, 2, 4, dtype=torch.bfloat16, device=device)
     _ExecutableGroupedCandidate.builds = 0
-    op = MoeGroupedGemmFwdOp(kernel_map={"grouped": _ExecutableGroupedCandidate})
+    op = MoeGroupedGemmFwdOp(_TIGHT, kernel_map={"grouped": _ExecutableGroupedCandidate})
 
-    first = op(a, b, layout)
-    second = op(a, b, layout)
+    first = op(a, b, ends)
+    second = op(a, b, ends)
+    # More rows for the same experts is the same specialization.
+    taller = op(torch.ones(3, 4, dtype=torch.bfloat16, device=device), b, ends * 3)
 
     assert first.shape == second.shape == (1, 2)
+    assert taller.shape == (3, 2)
     assert _ExecutableGroupedCandidate.builds == 1
     assert len(op.built_kernels("grouped")) == 1
+    assert op.eval_roofline() == (2 * 3 * 2 * 4, (3 * 4 + 1 * 2 * 4 + 3 * 2) * 2 + 4)
+
+    out = torch.empty(1, 2, dtype=torch.bfloat16, device=device)
+    assert op(a, b, ends, out=out) is out
+    with pytest.raises(ValueError, match="out must be"):
+        op(a, b, ends, out=torch.empty(1, 2, dtype=torch.float32, device=device))
 
 
 def test_expert_mlp_forwards_only_caller_replacements_to_matching_delegates() -> None:
     mlp = MoeExpertMLPFwdOp(
+        _TIGHT,
         kernel_map={
             "grouped": _ExecutableGroupedCandidate,
             "silu_and_mul": _NeverCandidate,
-        }
+        },
     )
     assert mlp.gate_up.forwarded_overrides() == {"grouped": _ExecutableGroupedCandidate}
     assert mlp.down.forwarded_overrides() == {"grouped": _ExecutableGroupedCandidate}
@@ -511,3 +522,141 @@ def test_staged_aligned_per_row_pre_post_round_trip(dtype: torch.dtype) -> None:
     output = post(expert_input, weights, inverse)
     expected = x.float() * weights.sum(dim=1, keepdim=True)
     torch.testing.assert_close(output.float(), expected, rtol=2e-2, atol=2e-2)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="make_call records CUDA architecture")
+def test_grouped_gemm_make_call_checks_geometry_against_the_layout() -> None:
+    """Shapes are validated against the declared layout, never used to guess it."""
+    device = torch.device("cuda")
+    b = torch.empty(2, 4, 8, dtype=torch.bfloat16, device=device)
+    a = torch.empty(6, 8, dtype=torch.bfloat16, device=device)
+    ends = torch.tensor([2, 6], dtype=torch.int32, device=device)
+
+    with pytest.raises(ValueError, match=r"layout_metadata must have shape \(2,\)"):
+        MoeGroupedGemmFwdOp(_TIGHT).make_call(
+            a, b, torch.zeros(6, dtype=torch.int32, device=device)
+        )
+    with pytest.raises(ValueError, match=r"layout_metadata must have shape \(6,\)"):
+        MoeGroupedGemmFwdOp(ContiguousLayoutSpec.tight_per_row()).make_call(a, b, ends)
+    with pytest.raises(ValueError, match="multiple of the layout's alignment"):
+        MoeGroupedGemmFwdOp(ContiguousLayoutSpec.aligned_per_row(4)).make_call(
+            a, b, torch.zeros(6, dtype=torch.int32, device=device)
+        )
+    with pytest.raises(ValueError, match=r"masked a must have shape \[2, 4, k\]"):
+        MoeGroupedGemmFwdOp(MaskedLayoutSpec(max_m=4)).make_call(a, b, ends)
+    with pytest.raises(ValueError, match="contiguous a must have shape"):
+        MoeGroupedGemmFwdOp(_TIGHT).make_call(a.reshape(2, 3, 8), b, ends)
+    with pytest.raises(ValueError, match="same reduction dimension"):
+        MoeGroupedGemmFwdOp(_TIGHT).make_call(
+            torch.empty(6, 4, dtype=torch.bfloat16, device=device), b, ends
+        )
+    with pytest.raises(TypeError, match="BF16 or FP16"):
+        MoeGroupedGemmFwdOp(_TIGHT).make_call(a.float(), b.float(), ends)
+    with pytest.raises(TypeError, match="layout_metadata must have dtype torch.int32"):
+        MoeGroupedGemmFwdOp(_TIGHT).make_call(a, b, ends.long())
+
+    masked = MoeGroupedGemmFwdOp(MaskedLayoutSpec(max_m=3), out_dtype=torch.float32).make_call(
+        a.reshape(2, 3, 8), b, ends
+    )
+    assert (masked.kind, masked.packing, masked.metadata_kind, masked.max_m) == (
+        "masked",
+        None,
+        None,
+        3,
+    )
+    assert (masked.m, masked.cd_dtype) == (6, torch.float32)
+
+    aligned = MoeGroupedGemmFwdOp(ContiguousLayoutSpec.aligned_per_row(2)).make_call(
+        a, b, torch.zeros(6, dtype=torch.int32, device=device)
+    )
+    assert (aligned.packing, aligned.metadata_kind, aligned.alignment) == ("aligned", "per_row", 2)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="selection records CUDA architecture")
+def test_grouped_gemm_without_a_shipped_candidate_reports_no_implementation() -> None:
+    """The boundary is public before any kernel serves it; a call says so, not a crash."""
+    device = torch.device("cuda")
+    op = MoeGroupedGemmFwdOp(_TIGHT)
+    assert op.kernel_map == {}
+    with pytest.raises(ValueError, match="no implementation serves this call"):
+        op(
+            torch.empty(2, 8, dtype=torch.bfloat16, device=device),
+            torch.empty(2, 4, 8, dtype=torch.bfloat16, device=device),
+            torch.tensor([1, 2], dtype=torch.int32, device=device),
+        )
+
+
+def _ids(values: list[int]) -> torch.Tensor:
+    return torch.tensor(values, dtype=torch.int32)
+
+
+@pytest.mark.parametrize(
+    ("layout", "metadata", "rows", "expected"),
+    [
+        pytest.param(_TIGHT, [2, 2, 5], 5, True, id="tight-psum-ok"),
+        pytest.param(_TIGHT, [2, 2, 4], 5, False, id="tight-psum-short"),
+        pytest.param(
+            ContiguousLayoutSpec.aligned_physical_psum(4),
+            [2, 6, 12],
+            12,
+            True,
+            id="aligned-psum-ok",
+        ),
+        pytest.param(
+            ContiguousLayoutSpec.aligned_physical_psum(4),
+            [2, 3, 12],
+            12,
+            False,
+            id="aligned-psum-start-inside-tile",
+        ),
+        pytest.param(
+            ContiguousLayoutSpec.aligned_physical_psum(4),
+            [2, 6, 13],
+            12,
+            False,
+            id="aligned-psum-past-capacity",
+        ),
+        pytest.param(
+            ContiguousLayoutSpec.aligned_per_row(2),
+            [0, 0, 1, 1, 3, 3],
+            6,
+            True,
+            id="aligned-per-row-ok",
+        ),
+        pytest.param(
+            ContiguousLayoutSpec.aligned_per_row(2),
+            [0, 1, 1, 1, 3, 3],
+            6,
+            False,
+            id="aligned-per-row-change-mid-tile",
+        ),
+        pytest.param(
+            ContiguousLayoutSpec.tight_per_row(), [0, 0, 1, 2, 2], 5, True, id="tight-per-row-ok"
+        ),
+        pytest.param(
+            ContiguousLayoutSpec.tight_per_row(),
+            [0, 0, 1, 3, 3],
+            5,
+            False,
+            id="tight-per-row-sentinel-not-allowed",
+        ),
+        pytest.param(MaskedLayoutSpec(max_m=4), [4, 0, 2], 12, True, id="masked-ok"),
+        pytest.param(MaskedLayoutSpec(max_m=4), [5, 0, 2], 12, False, id="masked-over-capacity"),
+    ],
+)
+def test_layout_value_guard_table(layout, metadata: list[int], rows: int, expected: bool) -> None:
+    """Every layout's device-side invariants, answered without a host readback."""
+    guard = layout_value_guard(layout, _ids(metadata), rows=rows, num_experts=3)
+    assert guard.dtype is torch.bool and guard.shape == ()
+    assert guard.item() is expected
+
+
+def test_grouped_gemm_layout_guard_reads_rows_and_experts_off_the_operands() -> None:
+    """The op's guard needs no call and no device: rows and experts come off ``a`` and ``b``."""
+    op = MoeGroupedGemmFwdOp(MaskedLayoutSpec(max_m=4))
+    a = torch.empty(3, 4, 8, dtype=torch.bfloat16)
+    b = torch.empty(3, 2, 8, dtype=torch.bfloat16)
+    assert op.layout_guard(a, b, _ids([4, 0, 2])).item()
+    assert not op.layout_guard(a, b, _ids([4, 0, 5])).item()
+    with pytest.raises(ValueError, match="length 3"):
+        op.layout_guard(a, b, _ids([4, 0]))


### PR DESCRIPTION
## Summary

- `MoeGroupedGemmFwdOp(layout, *, out_dtype=None)` fixes the layout at construction like its Pre/PostPermute siblings, and `forward(a, b, layout_metadata, out=None)` takes the `int32` metadata tensor PrePermute already emits, so the op registers `tileops::moe_grouped_gemm_fwd` and `_inplace` on the compile boundary.
- `E`, `M`, `N`, `K` are read off the operands and checked against the layout: metadata length, `a`'s rank, an aligned layout's `M % alignment`, a masked layout's `max_m`.
- Gone: `compute` and `scales` (fp8 placeholders with one legal value each), `MaterializedExpertLayout` with the metadata classes' `validate_structure`, and the op-layer `arch == 90` / bf16-only checks — architecture is each kernel's `supported_archs`, fp16 is declared in the manifest.
- `MGroupedGemmCall` carries the layout flattened (`kind`, `packing`, `metadata_kind`, `alignment`, `max_m`), so a candidate's `applies()` claims a region rather than a string, and the record rejects combinations no layout spec can express.
- The op keys its kernel cache on the call record with `m` reset and hands the builder that same record: a decode step with a new row count reuses the instance, and no kernel can specialize on a row count the key ignores.
- `layout_guard(a, b, layout_metadata)` returns the value-level invariants (psum ends monotone and equal to `M`, per-row ids ordered with changes on tile boundaries, masked counts within `max_m`) as one asynchronous `bool` tensor; `forward` never reads it.
- `layout_from_preset` resolves a manifest workload's `layout` name plus `alignment` or `max_m` into a spec, for the benchmark the next PR adds.
- `MoeExpertMLPFwdOp(layout, activation)` composes two grouped GEMMs on one metadata tensor and no longer allocates a stand-in intermediate per call.
- Manifest: `float16` operands, an `float32` output beside the operand dtype, `layout_metadata` as an input, two more shape rules, and both roofline blocks in `func` mode over `tileops.perf.formulas` — `bytes` depend on `out_dtype` as well as the operand dtype, which inline arithmetic cannot express.
- No kernel is wired: both entries stay `spec-only`, `default_kernel_map` is empty, a call reports "no implementation serves this call", and there is nothing to benchmark yet.

## Regression

- The kernel cache key dropped `arch`, `h200` and `sm_count` along with `m`, so one op instance reused the first device's kernel; `test_family_call_specs_are_frozen_and_keep_selection_axes_separate` now asserts `arch` still separates two records.
- `MGroupedGemmCall.__post_init__` skipped every layout check whenever `kind` was empty; the same test asserts a half-filled record such as `MGroupedGemmCall(max_m=4)` is rejected.
