### PR TITLE
[Feat][MoE] Add an SM90 GEMM template over dense, batched and expert-grouped layouts with per-call tile selection

### DIFF
--- a/src/tileops/kernels/moe/__init__.py
+++ b/src/tileops/kernels/moe/__init__.py
@@ -8,6 +8,7 @@ from .moe_grouped_gemm_separate_act import MoeGroupedGemmSeparateActKernel
 from .permute_align import MoePermuteAlignKernel
 from .permute_contiguous import MoePrePermuteContiguousKernel
 from .shared_expert_mlp import SharedExpertMLPKernel
+from .sm90_gemm import SM90GemmFwdKernel
 from .unpermute import MoeUnpermuteKernel
 
 __all__ = [
@@ -21,5 +22,6 @@ __all__ = [
     "MoeUnpermuteKernel",
     "PostPermuteCall",
     "PrePermuteCall",
+    "SM90GemmFwdKernel",
     "SharedExpertMLPKernel",
 ]

--- a/src/tileops/kernels/moe/__init__.py
+++ b/src/tileops/kernels/moe/__init__.py
@@ -8,11 +8,12 @@ from .moe_grouped_gemm_separate_act import MoeGroupedGemmSeparateActKernel
 from .permute_align import MoePermuteAlignKernel
 from .permute_contiguous import MoePrePermuteContiguousKernel
 from .shared_expert_mlp import SharedExpertMLPKernel
-from .sm90_gemm import SM90GemmFwdKernel
+from .sm90_gemm import GemmType, SM90GemmFwdKernel
 from .unpermute import MoeUnpermuteKernel
 
 __all__ = [
     "FusedTopKKernel",
+    "GemmType",
     "MGroupedGemmCall",
     "MoeGroupedGemmNopadKernel",
     "MoeGroupedGemmPersistent3WGFusedActKernel",

--- a/src/tileops/kernels/moe/sm90_gemm.py
+++ b/src/tileops/kernels/moe/sm90_gemm.py
@@ -325,23 +325,30 @@ def _make_prim_func(
 
     @T.macro
     def store_tile(C, C_src, C_s, group, row0, col0, rows, wg):
-        """TMA-store one warp-group's rows; a tight group's ragged tail is masked."""
+        """Store one warp-group's rows of a tile from its shared staging buffer.
+
+        Every tile is staged fragment -> shared first; the previous tile's TMA store
+        may still be reading ``C_s``, hence the barrier before. A full tile then
+        goes out through TMA. A tight group's ragged last tile cannot: TMA clips
+        against the tensor, not the group, and would overwrite the next group's
+        rows, so its valid rows are written back with row-predicated vector stores.
+        (Writing the accumulator fragment straight from registers scattered 4-byte
+        stores across the tile and cost 12% to 24% on short-K grouped GEMMs.)
+        """
+        T.sync_threads(barrier_id=_EPILOGUE_BARRIER_BASE + wg, arrive_count=128)
+        T.copy(C_src, C_s)
         if tight_psum:
             if rows < T.int32(wg_rows):
+                T.sync_threads(barrier_id=_EPILOGUE_BARRIER_BASE + wg, arrive_count=128)
                 if rows > 0:
                     for i, j in T.Parallel(wg_rows, block_n):
                         if i < rows:
-                            C[row0 + i, col0 + j] = C_src[i, j]
+                            C[row0 + i, col0 + j] = C_s[i, j]
             else:
-                T.sync_threads(barrier_id=_EPILOGUE_BARRIER_BASE + wg, arrive_count=128)
-                T.copy(C_src, C_s)
                 T.fence_proxy_async()
                 T.sync_threads(barrier_id=_EPILOGUE_BARRIER_BASE + wg, arrive_count=128)
                 T.copy(C_s, C[row0, col0])
         else:
-            # The previous tile's TMA store may still be reading C_s.
-            T.sync_threads(barrier_id=_EPILOGUE_BARRIER_BASE + wg, arrive_count=128)
-            T.copy(C_src, C_s)
             T.fence_proxy_async()
             T.sync_threads(barrier_id=_EPILOGUE_BARRIER_BASE + wg, arrive_count=128)
             if a_has_group:

--- a/src/tileops/kernels/moe/sm90_gemm.py
+++ b/src/tileops/kernels/moe/sm90_gemm.py
@@ -1,0 +1,905 @@
+"""SM90 GEMM template, a TileLang port of DeepGEMM's ``sm90_bf16_gemm_impl``.
+
+One kernel body, specialised by ``SM90GemmSpec`` the way the CUDA template
+is specialised by its parameter pack: the GEMM type, the majorness of ``A``
+and ``B``, the output dtype, which dims are compiled in, the tile, the pipeline
+depth, one or two math warp-groups, and TMA multicast across a 2-CTA cluster.
+Python-level ``if`` on spec fields plays the role of ``if constexpr``; every
+branch not taken is absent from the compiled kernel.
+
+Structure, as in DeepGEMM:
+
+* a persistent grid of ``num_sms`` CTAs, each walking tile ids
+  ``iter * num_sms + blockIdx.x`` through a scheduler that swizzles the tile
+  order in groups of 8 or 16 along one dim for L2 reuse;
+* one TMA warp-group filling a ``num_stages``-deep ring of ``A``/``B`` tiles,
+  and one (``block_m <= 64``) or two (``block_m >= 128``) math warp-groups
+  draining it, the two splitting the tile's rows;
+* one WGMMA group stays in flight: a k-step drains the previous one with
+  ``wgmma.wait_group 1`` and releases that stage, arriving at both CTAs of the
+  cluster when multicasting;
+* the epilogue casts to the output dtype, stages through shared memory and
+  TMA-stores the tile, so ragged edges are clipped by the descriptor.
+
+The GEMM types fall into three scheduler families:
+
+* ``flat``: ``NORMAL`` and ``M_GROUPED_ALIGNED_PER_ROW`` enumerate the
+  ``M x N`` tile grid once; the grouped one reads a tile's group off its first
+  row.
+* ``batched``: ``BATCHED`` repeats the tile grid per batch.
+* ``per_group``: ``M_GROUPED_MASKED``, ``M_GROUPED_ALIGNED_PSUM`` and
+  ``M_GROUPED_TIGHT_PSUM`` enumerate tiles group by group from a per-group
+  row count, through a tile-count prefix sum built in shared memory at
+  kernel start. Only the tight variant can end a group mid-tile, so only it
+  masks the store of a group's last tile.
+"""
+
+import functools
+from typing import Optional
+
+import tilelang
+import tilelang.language as T
+import torch
+
+from tileops.kernels.kernel_base import Kernel
+from tileops.utils import get_sm_count
+
+from .sm90_gemm_heuristics import (
+    PER_GROUP_TYPES,
+    GemmDesc,
+    GemmType,
+    Major,
+    SM90GemmSpec,
+    get_best_config,
+    spec_from_config,
+)
+
+__all__ = [
+    "GemmDesc",
+    "GemmType",
+    "Major",
+    "SM90GemmFwdKernel",
+    "SM90GemmSpec",
+]
+
+# Register budgets after `setmaxnreg`, DeepGEMM's numbers.
+_TMA_REGS = 48
+_MATH_REGS_ONE_WG = 248
+_MATH_REGS_TWO_WG = 224
+# Named barriers private to each math warp-group's epilogue.
+_EPILOGUE_BARRIER_BASE = 8
+# Both CTAs of the cluster; TMA multicast is only ever 2-wide on SM90.
+_CLUSTER_MASK = 0b11
+
+
+def _num_1d_blocks_per_group(block_m: int, block_n: int, num_sms: int, multicast_on_a: bool) -> int:
+    """How many tiles along the primary dim share one L2 group; DeepGEMM's rule."""
+    best, best_usage = 0, None
+    for candidate in (8, 16):
+        if multicast_on_a:
+            usage = candidate * block_n + -(-num_sms // candidate) * block_m
+        else:
+            usage = candidate * block_m + -(-num_sms // candidate) * block_n
+        if best_usage is None or usage < best_usage:
+            best, best_usage = candidate, usage
+    return best
+
+
+def _make_prim_func(
+    gemm_type: str,
+    a_k_major: bool,
+    b_k_major: bool,
+    ab_dtype: str,
+    cd_dtype: str,
+    num_groups: int,
+    shape_m: int,
+    shape_n: int,
+    shape_k: int,
+    block_m: int,
+    block_n: int,
+    block_k: int,
+    num_stages: int,
+    num_math_wgs: int,
+    num_multicast: int,
+    multicast_on_a: bool,
+    num_sms: int,
+):
+    """Build the ``@T.prim_func`` for one spec; parameters are the spec's scalars."""
+    dtype = ab_dtype
+    accum_dtype = "float"
+    gtype = GemmType(gemm_type)
+    tma_threads = 128
+    math_threads = 128 * num_math_wgs
+    threads = tma_threads + math_threads
+    wg_rows = block_m // num_math_wgs
+    math_warps = math_threads // 32
+    blocks_per_group = _num_1d_blocks_per_group(block_m, block_n, num_sms, multicast_on_a)
+    math_regs = _MATH_REGS_ONE_WG if num_math_wgs == 1 else _MATH_REGS_TWO_WG
+    cast_output = cd_dtype != "float32"
+
+    # Scheduler family and what each operand looks like.
+    contiguous = gtype is GemmType.M_GROUPED_ALIGNED_PER_ROW
+    masked = gtype is GemmType.M_GROUPED_MASKED
+    aligned_psum = gtype is GemmType.M_GROUPED_ALIGNED_PSUM
+    tight_psum = gtype is GemmType.M_GROUPED_TIGHT_PSUM
+    batched = gtype is GemmType.BATCHED
+    per_group = gtype in PER_GROUP_TYPES
+    b_has_group = gtype is not GemmType.NORMAL
+    a_has_group = masked or batched  # A and C carry a leading group dim
+    search_steps = max(1, (num_groups - 1).bit_length())
+
+    m = T.dynamic("m") if shape_m == 0 else shape_m
+    n = T.dynamic("n") if shape_n == 0 else shape_n
+    k = T.dynamic("k") if shape_k == 0 else shape_k
+
+    a_2d = (m, k) if a_k_major else (k, m)
+    a_shape = (num_groups,) + a_2d if a_has_group else a_2d
+    b_2d = (n, k) if b_k_major else (k, n)
+    b_shape = (num_groups,) + b_2d if b_has_group else b_2d
+    c_shape = (num_groups, m, n) if a_has_group else (m, n)
+    if contiguous:
+        layout_shape = (m,)
+    elif per_group:
+        layout_shape = (num_groups,)
+    else:
+        layout_shape = (1,)
+    a_tile = (wg_rows, block_k) if a_k_major else (block_k, wg_rows)
+    b_tile = (block_n, block_k) if b_k_major else (block_k, block_n)
+
+    def a_region(A, group, row0, k0):
+        if a_has_group:
+            if a_k_major:
+                return A[group, row0 : row0 + wg_rows, k0 : k0 + block_k]
+            return A[group, k0 : k0 + block_k, row0 : row0 + wg_rows]
+        if a_k_major:
+            return A[row0 : row0 + wg_rows, k0 : k0 + block_k]
+        return A[k0 : k0 + block_k, row0 : row0 + wg_rows]
+
+    def b_region(B, group, n0, k0):
+        if b_has_group:
+            if b_k_major:
+                return B[group, n0 : n0 + block_n, k0 : k0 + block_k]
+            return B[group, k0 : k0 + block_k, n0 : n0 + block_n]
+        if b_k_major:
+            return B[n0 : n0 + block_n, k0 : k0 + block_k]
+        return B[k0 : k0 + block_k, n0 : n0 + block_n]
+
+    def align_up(x):
+        return ((x + T.int32(block_m - 1)) // T.int32(block_m)) * T.int32(block_m)
+
+    @T.macro
+    def swizzle_block(block_idx, num_m_blocks, num_n_blocks, out_m, out_n, out_in_group):
+        """Tile id -> (m block, n block, tiles in this L2 group), DeepGEMM's swizzle.
+
+        Groups ``blocks_per_group`` tiles along the primary dim (N when
+        multicasting A, M otherwise) so the CTAs of one wave share the other
+        operand in L2. With a cluster, an odd-sized group is split so the
+        peer of every multicast pair is in the same group.
+        """
+        primary = num_n_blocks if multicast_on_a else num_m_blocks
+        secondary = num_m_blocks if multicast_on_a else num_n_blocks
+        num_blocks_per_group = secondary * T.int32(blocks_per_group)
+        group_idx = block_idx // num_blocks_per_group
+        first = T.alloc_var("int32", init=group_idx * T.int32(blocks_per_group))
+        in_group = T.alloc_var("int32", init=block_idx % num_blocks_per_group)
+        in_group_blocks = T.alloc_var(
+            "int32", init=T.min(T.int32(blocks_per_group), primary - first)
+        )
+        if num_multicast > 1:  # noqa: SIM102 -- compile-time guard around a runtime test
+            if in_group_blocks % 2 != 0:
+                if in_group < (in_group_blocks ^ 1) * secondary:
+                    in_group_blocks = in_group_blocks ^ 1
+                else:
+                    in_group = in_group - (in_group_blocks ^ 1) * secondary
+                    first = first + (in_group_blocks ^ 1)
+                    in_group_blocks = T.int32(1)
+        if multicast_on_a:
+            out_m[0] = in_group // in_group_blocks
+            out_n[0] = first + in_group % in_group_blocks
+        else:
+            out_m[0] = first + in_group % in_group_blocks
+            out_n[0] = in_group // in_group_blocks
+        out_in_group[0] = in_group_blocks
+
+    @T.macro
+    def tile_cumsum(grouped_layout, s_cum, s_total, num_n_blocks):
+        """Per-group tile-count prefix sum; ``s_total`` is the tile count of the call.
+
+        Masked groups are ``masked_m[g]`` rows from row 0 of their slab; psum
+        groups run from the previous end (aligned up for the aligned variant)
+        to ``psum[g]``.
+        """
+        s_cum[0] = T.int32(0)
+        prev_end = T.alloc_var("int32", init=0)
+        for g in T.serial(num_groups):
+            if masked:
+                rows = T.max(T.min(grouped_layout[g], m), T.int32(0))
+            elif aligned_psum:
+                rows = T.max(grouped_layout[g] - align_up(prev_end), T.int32(0))
+            else:
+                rows = T.max(grouped_layout[g] - prev_end, T.int32(0))
+            s_cum[g + 1] = s_cum[g] + (rows + T.int32(block_m - 1)) // T.int32(block_m)
+            prev_end = grouped_layout[g]
+        s_total[0] = s_cum[num_groups] * num_n_blocks
+
+    @T.macro
+    def resolve_tile(
+        block_idx,
+        grouped_layout,
+        s_cum,
+        num_m_blocks,
+        num_n_blocks,
+        t_group,
+        t_row0,
+        t_col0,
+        t_rows,
+        t_in_group,
+    ):
+        """Tile id -> group, first row, first column, valid rows, L2-group size.
+
+        ``t_row0`` indexes the A/C slab the tile belongs to: the whole tensor
+        for the flat and psum families, the group's slab for masked and
+        batched. ``t_rows`` is ``block_m`` except on a tight group's last tile.
+        """
+        m_blk = T.alloc_local((1,), "int32")
+        n_blk = T.alloc_local((1,), "int32")
+        if batched:
+            per_batch = num_m_blocks * num_n_blocks
+            rem = block_idx % per_batch
+            t_group[0] = block_idx // per_batch
+            if multicast_on_a:
+                m_blk[0] = rem // num_n_blocks
+                n_blk[0] = rem % num_n_blocks
+            else:
+                m_blk[0] = rem % num_m_blocks
+                n_blk[0] = rem // num_m_blocks
+            t_in_group[0] = T.int32(1)
+            t_row0[0] = m_blk[0] * T.int32(block_m)
+            t_rows[0] = T.int32(block_m)
+        elif per_group:
+            lo = T.alloc_var("int32", init=0)
+            hi = T.alloc_var("int32", init=num_groups - 1)
+            for _ in T.serial(search_steps):
+                mid = (lo + hi) >> T.int32(1)
+                if s_cum[mid + 1] * num_n_blocks <= block_idx:
+                    lo = mid + T.int32(1)
+                else:
+                    hi = mid
+            t_group[0] = lo
+            rel = block_idx - s_cum[lo] * num_n_blocks
+            swizzle_block(rel, s_cum[lo + 1] - s_cum[lo], num_n_blocks, m_blk, n_blk, t_in_group)
+            if masked:
+                t_row0[0] = m_blk[0] * T.int32(block_m)
+                t_rows[0] = T.int32(block_m)
+            else:
+                prev_end = T.if_then_else(lo > 0, grouped_layout[T.max(lo - 1, 0)], T.int32(0))
+                if aligned_psum:
+                    t_row0[0] = align_up(prev_end) + m_blk[0] * T.int32(block_m)
+                    t_rows[0] = T.int32(block_m)
+                else:
+                    t_row0[0] = prev_end + m_blk[0] * T.int32(block_m)
+                    t_rows[0] = T.min(T.int32(block_m), grouped_layout[lo] - t_row0[0])
+        else:
+            swizzle_block(block_idx, num_m_blocks, num_n_blocks, m_blk, n_blk, t_in_group)
+            t_row0[0] = m_blk[0] * T.int32(block_m)
+            t_rows[0] = T.int32(block_m)
+            if contiguous:
+                # Rows past the last group carry `num_groups`; clamp so a tile of
+                # padding reads a real B and its rows are ignored.
+                t_group[0] = T.min(
+                    T.max(grouped_layout[t_row0[0]], T.int32(0)), T.int32(num_groups - 1)
+                )
+            else:
+                t_group[0] = T.int32(0)
+        t_col0[0] = n_blk[0] * T.int32(block_n)
+
+    @T.macro
+    def load_a(A, dst, full, slot, group, row0, k0, use_mc):
+        if multicast_on_a:
+            if use_mc != 0:
+                T.tma_copy(
+                    a_region(A, group, row0, k0),
+                    dst[slot, :, :],
+                    barrier=full[slot],
+                    annotations={"cluster_mask": _CLUSTER_MASK},
+                )
+            else:
+                T.tma_copy(a_region(A, group, row0, k0), dst[slot, :, :], barrier=full[slot])
+        else:
+            T.tma_copy(a_region(A, group, row0, k0), dst[slot, :, :], barrier=full[slot])
+
+    @T.macro
+    def load_b(B, dst, full, slot, group, n0, k0, use_mc):
+        if num_multicast > 1 and not multicast_on_a:
+            if use_mc != 0:
+                T.tma_copy(
+                    b_region(B, group, n0, k0),
+                    dst[slot, :, :],
+                    barrier=full[slot],
+                    annotations={"cluster_mask": _CLUSTER_MASK},
+                )
+            else:
+                T.tma_copy(b_region(B, group, n0, k0), dst[slot, :, :], barrier=full[slot])
+        else:
+            T.tma_copy(b_region(B, group, n0, k0), dst[slot, :, :], barrier=full[slot])
+
+    @T.macro
+    def store_tile(C, C_src, C_s, group, row0, col0, rows, wg):
+        """TMA-store one warp-group's rows; a tight group's ragged tail is masked."""
+        if tight_psum:
+            if rows < T.int32(wg_rows):
+                if rows > 0:
+                    for i, j in T.Parallel(wg_rows, block_n):
+                        if i < rows:
+                            C[row0 + i, col0 + j] = C_src[i, j]
+            else:
+                T.sync_threads(barrier_id=_EPILOGUE_BARRIER_BASE + wg, arrive_count=128)
+                T.copy(C_src, C_s)
+                T.fence_proxy_async()
+                T.sync_threads(barrier_id=_EPILOGUE_BARRIER_BASE + wg, arrive_count=128)
+                T.copy(C_s, C[row0, col0])
+        else:
+            # The previous tile's TMA store may still be reading C_s.
+            T.sync_threads(barrier_id=_EPILOGUE_BARRIER_BASE + wg, arrive_count=128)
+            T.copy(C_src, C_s)
+            T.fence_proxy_async()
+            T.sync_threads(barrier_id=_EPILOGUE_BARRIER_BASE + wg, arrive_count=128)
+            if a_has_group:
+                T.copy(C_s, C[group, row0, col0])
+            else:
+                T.copy(C_s, C[row0, col0])
+
+    @T.macro
+    def release_stage(empty, slot, lane, rank, peer_alive):
+        """Lane 0 of each math warp arrives on the stage's empty barrier, at both CTAs of a cluster."""
+        if num_multicast > 1:
+            if lane < num_multicast:
+                T.mbarrier_arrive(empty[slot], T.if_then_else(peer_alive, lane, rank))
+        else:
+            if lane == 0:
+                T.mbarrier_arrive(empty[slot])
+
+    @T.macro
+    def math_warpgroup(
+        A_s,
+        B_s,
+        C,
+        full,
+        empty,
+        grouped_layout,
+        s_cum,
+        C_l,
+        C_cast,
+        C_s,
+        wg,
+        pid,
+        num_m_blocks,
+        num_n_blocks,
+        num_blocks,
+        num_waves,
+        k_iters,
+    ):
+        """One math warp-group: drain the ring over K for each tile, then store."""
+        T.inc_max_nreg(math_regs)
+        tx = T.get_thread_binding()
+        lane = tx % 32
+        rank = T.block_rank_in_cluster() if num_multicast > 1 else T.int32(0)
+        gi = T.alloc_var("int32", init=0)
+        prev_slot = T.alloc_local((1,), "int32")
+        t_group = T.alloc_local((1,), "int32")
+        t_row0 = T.alloc_local((1,), "int32")
+        t_col0 = T.alloc_local((1,), "int32")
+        t_rows = T.alloc_local((1,), "int32")
+        t_in_group = T.alloc_local((1,), "int32")
+
+        for w in T.serial(num_waves):
+            block_idx = w * T.int32(num_sms) + pid
+            if block_idx < num_blocks:
+                resolve_tile(
+                    block_idx,
+                    grouped_layout,
+                    s_cum,
+                    num_m_blocks,
+                    num_n_blocks,
+                    t_group,
+                    t_row0,
+                    t_col0,
+                    t_rows,
+                    t_in_group,
+                )
+                peer_alive = (
+                    (num_n_blocks % T.int32(num_multicast) == 0)
+                    | (num_m_blocks % T.int32(num_multicast) == 0)
+                    | ((block_idx ^ 1) < num_blocks)
+                )
+                for ki in T.serial(k_iters):
+                    slot = gi % num_stages
+                    phase = (gi // num_stages) & 1
+                    T.barrier_wait(full[slot], phase)
+                    T.wgmma_gemm(
+                        A_s[slot, :, :],
+                        B_s[slot, :, :],
+                        C_l,
+                        transpose_A=not a_k_major,
+                        transpose_B=b_k_major,
+                        policy=T.GemmWarpPolicy.FullRow,
+                        clear_accum=(ki == 0),
+                    )
+                    # One WGMMA group stays in flight: drain the previous k-step
+                    # and release its stage while this one runs. DeepGEMM drains
+                    # every step (`warpgroup_wait<0>`) and merges stages instead,
+                    # which it only does for a dense single-warp-group NT GEMM;
+                    # the 1-deep pipeline is what TileOPs' grouped kernels use
+                    # and is worth 4% to 7% on Mixtral-shaped grouped GEMMs here.
+                    if ki > 0:
+                        T.wait_wgmma(1)
+                        release_stage(empty, prev_slot[0], lane, rank, peer_alive)
+                    prev_slot[0] = slot
+                    gi = gi + 1
+                T.wait_wgmma(0)
+                release_stage(empty, prev_slot[0], lane, rank, peer_alive)
+                T.warpgroup_fence_operand(C_l, num_regs=(wg_rows * block_n) // 128)
+
+                row0 = t_row0[0] + T.int32(wg * wg_rows)
+                rows = t_rows[0] - T.int32(wg * wg_rows)
+                if cast_output:
+                    T.copy(C_l, C_cast)
+                    store_tile(C, C_cast, C_s, t_group[0], row0, t_col0[0], rows, wg)
+                else:
+                    store_tile(C, C_l, C_s, t_group[0], row0, t_col0[0], rows, wg)
+
+    @T.prim_func
+    def sm90_gemm(
+        A: T.Tensor(a_shape, dtype),  # type: ignore
+        B: T.Tensor(b_shape, dtype),  # type: ignore
+        C: T.Tensor(c_shape, cd_dtype),  # type: ignore
+        grouped_layout: T.Tensor(layout_shape, "int32"),  # type: ignore
+    ):
+        with T.ClusterKernel(num_sms, threads=threads, cluster_dims=(num_multicast, 1, 1)) as (
+            pid,
+        ):
+            A_s0 = T.alloc_shared((num_stages,) + a_tile, dtype)
+            if num_math_wgs > 1:
+                A_s1 = T.alloc_shared((num_stages,) + a_tile, dtype)
+            B_s = T.alloc_shared((num_stages,) + b_tile, dtype)
+            C_l0 = T.alloc_fragment((wg_rows, block_n), accum_dtype)
+            C_cast0 = T.alloc_fragment((wg_rows, block_n), cd_dtype)
+            C_s0 = T.alloc_shared((wg_rows, block_n), cd_dtype)
+            if num_math_wgs > 1:
+                C_l1 = T.alloc_fragment((wg_rows, block_n), accum_dtype)
+                C_cast1 = T.alloc_fragment((wg_rows, block_n), cd_dtype)
+                C_s1 = T.alloc_shared((wg_rows, block_n), cd_dtype)
+            # Per-group tile prefix sum and the call's tile count (per_group family).
+            s_cum = T.alloc_shared((num_groups + 1,), "int32")
+            s_total = T.alloc_shared((1,), "int32")
+
+            if num_math_wgs > 1:
+                T.annotate_layout(
+                    {
+                        A_s0: tilelang.layout.make_swizzled_layout(A_s0),
+                        A_s1: tilelang.layout.make_swizzled_layout(A_s1),
+                        B_s: tilelang.layout.make_swizzled_layout(B_s),
+                        C_s0: tilelang.layout.make_swizzled_layout(C_s0),
+                        C_s1: tilelang.layout.make_swizzled_layout(C_s1),
+                    }
+                )
+            else:
+                T.annotate_layout(
+                    {
+                        A_s0: tilelang.layout.make_swizzled_layout(A_s0),
+                        B_s: tilelang.layout.make_swizzled_layout(B_s),
+                        C_s0: tilelang.layout.make_swizzled_layout(C_s0),
+                    }
+                )
+
+            # full: the TMA warp-group arrives once per thread after issuing a
+            # stage. empty: lane 0 of every math warp arrives, at both CTAs of
+            # the cluster when multicasting (DeepGEMM's arrive counts).
+            full = T.alloc_barrier([tma_threads] * num_stages)
+            if num_multicast > 1:
+                empty = T.alloc_cluster_barrier([math_warps * num_multicast] * num_stages)
+            else:
+                empty = T.alloc_barrier([math_warps] * num_stages)
+
+            num_m_blocks = T.ceildiv(m, block_m)
+            num_n_blocks = T.ceildiv(n, block_n)
+            k_iters = T.ceildiv(k, block_k)
+
+            tx = T.get_thread_binding()
+
+            if per_group:  # noqa: SIM102 -- compile-time guard around a runtime test
+                if tx == 0:
+                    tile_cumsum(grouped_layout, s_cum, s_total, num_n_blocks)
+
+            if num_multicast > 1:
+                # Barrier init must be visible cluster-wide before any remote arrive.
+                T.cluster_sync()
+            else:
+                T.sync_threads()
+
+            if per_group:
+                num_blocks = s_total[0]
+            elif batched:
+                num_blocks = num_m_blocks * num_n_blocks * T.int32(num_groups)
+            else:
+                num_blocks = num_m_blocks * num_n_blocks
+            num_waves = T.ceildiv(num_blocks, num_sms)
+
+            if tx < tma_threads:
+                # ── TMA warp-group ──
+                T.dec_max_nreg(_TMA_REGS)
+                gi = T.alloc_var("int32", init=0)
+                t_group = T.alloc_local((1,), "int32")
+                t_row0 = T.alloc_local((1,), "int32")
+                t_col0 = T.alloc_local((1,), "int32")
+                t_rows = T.alloc_local((1,), "int32")
+                t_in_group = T.alloc_local((1,), "int32")
+                use_mc = T.alloc_var("int32", init=1)
+
+                for w in T.serial(num_waves):
+                    block_idx = w * T.int32(num_sms) + pid
+                    if block_idx < num_blocks:
+                        resolve_tile(
+                            block_idx,
+                            grouped_layout,
+                            s_cum,
+                            num_m_blocks,
+                            num_n_blocks,
+                            t_group,
+                            t_row0,
+                            t_col0,
+                            t_rows,
+                            t_in_group,
+                        )
+                        if num_multicast > 1:
+                            if contiguous and not multicast_on_a:
+                                # The peer's tile must read the same B.
+                                peer_row = (t_row0[0] // T.int32(block_m) ^ 1) * T.int32(block_m)
+                                use_mc = T.if_then_else(
+                                    (t_in_group[0] != 1)
+                                    & (grouped_layout[t_row0[0]] == grouped_layout[peer_row]),
+                                    T.int32(1),
+                                    T.int32(0),
+                                )
+                            else:
+                                use_mc = T.if_then_else(t_in_group[0] != 1, T.int32(1), T.int32(0))
+                        for ki in T.serial(k_iters):
+                            slot = gi % num_stages
+                            phase = (gi // num_stages) & 1
+                            k0 = ki * T.int32(block_k)
+                            T.barrier_wait(empty[slot], phase ^ 1)
+                            load_a(A, A_s0, full, slot, t_group[0], t_row0[0], k0, use_mc)
+                            if num_math_wgs > 1:
+                                load_a(
+                                    A,
+                                    A_s1,
+                                    full,
+                                    slot,
+                                    t_group[0],
+                                    t_row0[0] + T.int32(wg_rows),
+                                    k0,
+                                    use_mc,
+                                )
+                            load_b(B, B_s, full, slot, t_group[0], t_col0[0], k0, use_mc)
+                            T.barrier_arrive(full[slot])
+                            gi = gi + 1
+                if num_multicast > 1:
+                    # Let every remote empty-arrive land before this CTA exits.
+                    for i in T.serial(num_stages):
+                        slot = (gi + i) % num_stages
+                        phase = ((gi + i) // num_stages) & 1
+                        T.barrier_wait(empty[slot], phase ^ 1)
+            elif tx < tma_threads + 128:
+                math_warpgroup(
+                    A_s0,
+                    B_s,
+                    C,
+                    full,
+                    empty,
+                    grouped_layout,
+                    s_cum,
+                    C_l0,
+                    C_cast0,
+                    C_s0,
+                    0,
+                    pid,
+                    num_m_blocks,
+                    num_n_blocks,
+                    num_blocks,
+                    num_waves,
+                    k_iters,
+                )
+            else:
+                if num_math_wgs > 1:
+                    math_warpgroup(
+                        A_s1,
+                        B_s,
+                        C,
+                        full,
+                        empty,
+                        grouped_layout,
+                        s_cum,
+                        C_l1,
+                        C_cast1,
+                        C_s1,
+                        1,
+                        pid,
+                        num_m_blocks,
+                        num_n_blocks,
+                        num_blocks,
+                        num_waves,
+                        k_iters,
+                    )
+
+    return sm90_gemm
+
+
+# maxsize=None: an entry is one compiled kernel, so evicting it would only
+# force a recompile. The key space is the specs the selector emits, a few
+# hundred layouts per (gemm_type, majors, dtypes, static n and k), plus any
+# explicit config a caller pins.
+@functools.lru_cache(maxsize=None)
+def _sm90_gemm_kernel(spec: SM90GemmSpec):
+    """JIT factory for one ``spec``; ``_sm90_gemm_kernel(spec)()`` compiles it.
+
+    The builder closes over the spec's scalars only, so TileLang's cache key
+    is exactly the template parameter pack.
+    """
+    gemm_type = spec.gemm_type.value
+    a_k_major = spec.major_a is Major.K
+    b_k_major = spec.major_b is Major.K
+    ab_dtype = spec.ab_dtype
+    cd_dtype = spec.cd_dtype
+    num_groups = spec.num_groups
+    shape_m, shape_n, shape_k = spec.shape_m, spec.shape_n, spec.shape_k
+    block_m, block_n, block_k = spec.block_m, spec.block_n, spec.block_k
+    num_stages = spec.num_stages
+    num_math_wgs = spec.num_math_warpgroups
+    num_multicast = spec.num_tma_multicast
+    multicast_on_a = spec.is_tma_multicast_on_a
+    num_sms = spec.num_sms
+
+    @tilelang.jit(
+        out_idx=[],
+        pass_configs={
+            tilelang.PassConfigKey.TL_DISABLE_THREAD_STORAGE_SYNC: True,
+            "tl.disable_warp_specialized": True,
+        },
+        compile_flags=["-O3", "-DENABLE_BF16"],
+    )
+    def _func():
+        return _make_prim_func(
+            gemm_type,
+            a_k_major,
+            b_k_major,
+            ab_dtype,
+            cd_dtype,
+            num_groups,
+            shape_m,
+            shape_n,
+            shape_k,
+            block_m,
+            block_n,
+            block_k,
+            num_stages,
+            num_math_wgs,
+            num_multicast,
+            multicast_on_a,
+            num_sms,
+        )
+
+    return _func
+
+
+def _major_of(t: torch.Tensor, k_dim: int) -> Major:
+    """K-major when the K dim is the contiguous one, MN-major when the other is."""
+    if t.stride(k_dim) == 1:
+        return Major.K
+    other = t.ndim - 1 if k_dim == t.ndim - 2 else t.ndim - 2
+    if t.stride(other) == 1:
+        return Major.MN
+    raise ValueError(f"neither of the last two dims of a {tuple(t.shape)} tensor is contiguous")
+
+
+def _torch_dtype_str(dtype: torch.dtype) -> str:
+    return str(dtype).split(".")[-1]
+
+
+class SM90GemmFwdKernel(Kernel):
+    """DeepGEMM-style 16-bit GEMM on Hopper: dense, batched, or m-grouped.
+
+    ``C = A @ B^T`` on bf16 or fp16 operands with fp32 accumulation and a ``C``
+    in the operand dtype or fp32. Any of the four layouts is accepted and read off the operands'
+    strides. Operand shapes per ``gemm_type`` (logical; an MN-major operand is
+    a transposed view):
+
+    | ``gemm_type``               | ``a``            | ``b``          | ``c``            | ``grouped_layout``           |
+    | --------------------------- | ---------------- | -------------- | ---------------- | ---------------------------- |
+    | ``NORMAL``                  | ``[M, K]``       | ``[N, K]``     | ``[M, N]``       | none                         |
+    | ``M_GROUPED_ALIGNED_PER_ROW`` | ``[M, K]``     | ``[G, N, K]``  | ``[M, N]``       | ``[M]`` group of each row    |
+    | ``M_GROUPED_ALIGNED_PSUM``  | ``[M, K]``       | ``[G, N, K]``  | ``[M, N]``       | ``[G]`` psum row ends        |
+    | ``M_GROUPED_TIGHT_PSUM``    | ``[M, K]``       | ``[G, N, K]``  | ``[M, N]``       | ``[G]`` psum row ends        |
+    | ``M_GROUPED_MASKED``        | ``[G, max_m, K]``| ``[G, N, K]``  | ``[G, max_m, N]``| ``[G]`` valid rows per group |
+    | ``BATCHED``                 | ``[G, M, K]``    | ``[G, N, K]``  | ``[G, M, N]``    | none                         |
+
+    The kernel is selected per call by DeepGEMM's cost model over the legal
+    tile/cluster layouts, so a config never has to be authored; ``config``
+    pins one for tuning. Dims not named in ``static_dims`` stay dynamic, and a
+    call with a new value of a dynamic dim reuses the compiled kernel.
+
+    Example:
+        ```python linenums="1"
+        kernel = SM90GemmFwdKernel(GemmType.NORMAL)
+        c = kernel(a, b)                       # a: [M, K], b: [N, K], both bf16
+        kernel = SM90GemmFwdKernel(GemmType.M_GROUPED_TIGHT_PSUM, num_groups=E)
+        c = kernel(a, b, grouped_layout=ends)  # b: [E, N, K], ends: [E] int32
+        ```
+    """
+
+    supported_archs: list[int] = [90]
+
+    def __init__(
+        self,
+        gemm_type: GemmType = GemmType.NORMAL,
+        *,
+        num_groups: int = 1,
+        cd_dtype: Optional[torch.dtype] = None,
+        static_dims: str = "nk",
+        m_alignment: int = 128,
+        expected_m: int = 0,
+        sm_count: Optional[int] = None,
+        config: Optional[dict] = None,
+        tune: bool = False,
+        device_index: Optional[int] = None,
+    ) -> None:
+        """Fix the template's operand-side parameters; the schedule is chosen per call.
+
+        Args:
+            gemm_type: Which rows of ``a`` and which ``b`` a tile reads.
+            num_groups: Groups, experts or batches; 1 for ``NORMAL``.
+            cd_dtype: Output dtype: the operand dtype (default) or ``torch.float32``.
+            static_dims: Dims compiled into the kernel, a subset of ``"mnk"``.
+            m_alignment: Segment alignment of the aligned grouped layouts; it fixes ``block_m``.
+            expected_m: Rows per group the cost model should plan for in the masked and
+                psum layouts; the slab height, or the mean over groups, when 0. A caller
+                whose routing is skewed passes the large experts' row count here.
+            sm_count: Persistent grid size; the device's SM count when ``None``.
+            config: Pins ``block_m``, ``block_n`` and optionally ``block_k``, ``num_stages``,
+                ``cluster_m``, ``cluster_n`` instead of running the selector.
+            tune: Kernel-protocol flag; this kernel has no autotune space, the selector
+                stands in for it, so ``True`` only warns.
+            device_index: Device the kernel is built for; the current one when ``None``.
+        """
+        super().__init__(device_index=device_index)
+        self.gemm_type = GemmType(gemm_type)
+        self.num_groups = num_groups
+        self.cd_dtype = cd_dtype
+        self.static_dims = static_dims
+        self.m_alignment = m_alignment
+        self.expected_m = expected_m
+        self.sm_count = get_sm_count(device_index) if sm_count is None else sm_count
+        self.explicit_config = config
+        self.init_config(config, tune)
+
+    @property
+    def default_config(self) -> dict:
+        # The selector picks per call; nothing to author here.
+        return {}
+
+    @property
+    def _a_has_group(self) -> bool:
+        return self.gemm_type in (GemmType.M_GROUPED_MASKED, GemmType.BATCHED)
+
+    def describe(self, a: torch.Tensor, b: torch.Tensor) -> GemmDesc:
+        """The selector's view of a call; see the class docstring for the shapes."""
+        a_ndim = 3 if self._a_has_group else 2
+        if a.ndim != a_ndim:
+            raise ValueError(f"{self.gemm_type.value} takes a {a_ndim}-D A, got {a.ndim}-D")
+        if self.gemm_type is GemmType.NORMAL:
+            if b.ndim != 2:
+                raise ValueError("a normal GEMM takes a 2-D B")
+        elif b.ndim != 3 or b.shape[0] != self.num_groups:
+            raise ValueError(f"{self.gemm_type.value} takes B as [{self.num_groups}, N, K]")
+        if self._a_has_group and a.shape[0] != self.num_groups:
+            raise ValueError(f"{self.gemm_type.value} takes A as [{self.num_groups}, M, K]")
+        m, k = a.shape[-2], a.shape[-1]
+        n, k_b = b.shape[-2], b.shape[-1]
+        if k != k_b:
+            raise ValueError(f"A and B disagree on K: {k} vs {k_b}")
+        return GemmDesc(
+            gemm_type=self.gemm_type,
+            m=m,
+            n=n,
+            k=k,
+            num_groups=self.num_groups,
+            major_a=_major_of(a, a.ndim - 1),
+            major_b=_major_of(b, b.ndim - 1),
+            ab_dtype=_torch_dtype_str(a.dtype),
+            cd_dtype=_torch_dtype_str(self.output_dtype(a)),
+            num_sms=self.sm_count,
+            static_dims=self.static_dims,
+            m_alignment=self.m_alignment,
+            expected_m=self.expected_m,
+        )
+
+    def spec_for(self, a: torch.Tensor, b: torch.Tensor) -> SM90GemmSpec:
+        """The template instantiation this call runs."""
+        return self._spec_of(self.describe(a, b))
+
+    def _spec_of(self, desc: GemmDesc) -> SM90GemmSpec:
+        if self.explicit_config:
+            return spec_from_config(desc, self.explicit_config)
+        return get_best_config(desc)
+
+    def output_dtype(self, a: torch.Tensor) -> torch.dtype:
+        """The dtype ``C`` is written in: ``cd_dtype`` when set, else the operand dtype."""
+        return a.dtype if self.cd_dtype is None else self.cd_dtype
+
+    @staticmethod
+    def refusal_for(a: torch.Tensor, b: torch.Tensor) -> Optional[str]:
+        """Why TMA cannot address these operands, or ``None`` when it can."""
+        if a.dtype not in (torch.bfloat16, torch.float16) or b.dtype != a.dtype:
+            return f"bf16 or fp16 operands of one dtype only, got {a.dtype} and {b.dtype}"
+        for name, t in (("a", a), ("b", b)):
+            inner = t.shape[-1] if t.stride(-1) == 1 else t.shape[-2]
+            if inner % 8:
+                return f"{name}'s contiguous extent {inner} is not a multiple of 8 elements"
+        return None
+
+    def _check_layout(self, desc: GemmDesc, grouped_layout: Optional[torch.Tensor]) -> None:
+        gtype = self.gemm_type
+        if gtype in (GemmType.NORMAL, GemmType.BATCHED):
+            if grouped_layout is not None:
+                raise ValueError(f"{gtype.value} takes no grouped_layout")
+            return
+        if grouped_layout is None:
+            raise ValueError(f"{gtype.value} needs grouped_layout")
+        length = desc.m if gtype is GemmType.M_GROUPED_ALIGNED_PER_ROW else self.num_groups
+        if grouped_layout.dtype != torch.int32 or grouped_layout.shape != (length,):
+            raise ValueError(f"grouped_layout must be [{length}] int32")
+        if gtype is GemmType.M_GROUPED_ALIGNED_PER_ROW and desc.m % self.m_alignment:
+            raise ValueError(
+                f"aligned_per_row rows ({desc.m}) must be a multiple of m_alignment "
+                f"({self.m_alignment})"
+            )
+
+    def forward(
+        self,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        grouped_layout: Optional[torch.Tensor] = None,
+        out: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Run ``C = A @ B^T`` (per group or batch when grouped) and return ``C``.
+
+        Args:
+            a: Logical ``[M, K]`` bf16 or fp16, ``[G, M, K]`` for masked and batched; a
+                transposed view of contiguous storage is MN-major.
+            b: Logical ``[N, K]`` in ``a``'s dtype, with a leading ``G`` dim for every type but
+                ``NORMAL``; a transposed view of ``[K, N]`` storage is MN-major.
+            grouped_layout: int32 layout metadata per the class table; ``None`` for
+                ``NORMAL`` and ``BATCHED``.
+            out: Optional preallocated output in ``cd_dtype``.
+        """
+        self._require_cuda(a=a, b=b, grouped_layout=grouped_layout, out=out)
+        why = self.refusal_for(a, b)
+        if why is not None:
+            raise ValueError(f"{type(self).__name__}: {why}")
+        desc = self.describe(a, b)
+        self._check_layout(desc, grouped_layout)
+        if grouped_layout is None:
+            grouped_layout = torch.zeros(1, dtype=torch.int32, device=a.device)
+        c_shape = (self.num_groups, desc.m, desc.n) if self._a_has_group else (desc.m, desc.n)
+        cd_dtype = self.output_dtype(a)
+        if out is None:
+            out = torch.empty(c_shape, dtype=cd_dtype, device=a.device)
+        elif tuple(out.shape) != c_shape or out.dtype != cd_dtype or not out.is_contiguous():
+            raise ValueError(f"out must be a contiguous {list(c_shape)} {cd_dtype}")
+        spec = self._spec_of(desc)
+        # The kernel takes the physical storage: an MN-major operand's
+        # contiguous tensor is the transpose of its logical view.
+        a_phys = a if desc.major_a is Major.K else a.transpose(-2, -1)
+        b_phys = b if desc.major_b is Major.K else b.transpose(-2, -1)
+        fn = _sm90_gemm_kernel(spec)()
+        fn(a_phys, b_phys, out, grouped_layout)
+        return out

--- a/src/tileops/kernels/moe/sm90_gemm.py
+++ b/src/tileops/kernels/moe/sm90_gemm.py
@@ -342,7 +342,7 @@ def _make_prim_func(
                 T.sync_threads(barrier_id=_EPILOGUE_BARRIER_BASE + wg, arrive_count=128)
                 if rows > 0:
                     for i, j in T.Parallel(wg_rows, block_n):
-                        if i < rows:
+                        if i < rows and col0 + j < n:
                             C[row0 + i, col0 + j] = C_s[i, j]
             else:
                 T.fence_proxy_async()
@@ -561,7 +561,12 @@ def _make_prim_func(
                         if num_multicast > 1:
                             if contiguous and not multicast_on_a:
                                 # The peer's tile must read the same B.
-                                peer_row = (t_row0[0] // T.int32(block_m) ^ 1) * T.int32(block_m)
+                                # The lone last tile's peer row is past M; its use_mc is
+                                # 0 either way, so clamp the read rather than the branch.
+                                peer_row = T.min(
+                                    (t_row0[0] // T.int32(block_m) ^ 1) * T.int32(block_m),
+                                    m - T.int32(1),
+                                )
                                 use_mc = T.if_then_else(
                                     (t_in_group[0] != 1)
                                     & (grouped_layout[t_row0[0]] == grouped_layout[peer_row]),
@@ -716,9 +721,10 @@ class SM90GemmFwdKernel(Kernel):
     """DeepGEMM-style 16-bit GEMM on Hopper: dense, batched, or m-grouped.
 
     ``C = A @ B^T`` on bf16 or fp16 operands with fp32 accumulation and a ``C``
-    in the operand dtype or fp32. Any of the four layouts is accepted and read off the operands'
-    strides. Operand shapes per ``gemm_type`` (logical; an MN-major operand is
-    a transposed view):
+    in the operand dtype or fp32. Majorness is read off the operands' strides;
+    ``NORMAL`` and ``BATCHED`` take either for both operands, the grouped types
+    need a K-major ``A``. Operand shapes per ``gemm_type`` (logical; an MN-major
+    operand is a transposed view):
 
     | ``gemm_type``               | ``a``            | ``b``          | ``c``            | ``grouped_layout``           |
     | --------------------------- | ---------------- | -------------- | ---------------- | ---------------------------- |
@@ -778,6 +784,10 @@ class SM90GemmFwdKernel(Kernel):
             device_index: Device the kernel is built for; the current one when ``None``.
         """
         super().__init__(device_index=device_index)
+        if num_groups < 1:
+            raise ValueError(f"num_groups must be positive, got {num_groups}")
+        if m_alignment < 1:
+            raise ValueError(f"m_alignment must be positive, got {m_alignment}")
         self.gemm_type = GemmType(gemm_type)
         self.num_groups = num_groups
         self.cd_dtype = cd_dtype
@@ -844,13 +854,23 @@ class SM90GemmFwdKernel(Kernel):
 
     @staticmethod
     def refusal_for(a: torch.Tensor, b: torch.Tensor) -> Optional[str]:
-        """Why TMA cannot address these operands, or ``None`` when it can."""
+        """Why TMA cannot address these operands or the output, or ``None`` when it can.
+
+        Every TMA-addressed row pitch must be a multiple of 16 bytes: the contiguous
+        extent of each operand, and ``N`` for the output row. ``K`` must be positive.
+        """
         if a.dtype not in (torch.bfloat16, torch.float16) or b.dtype != a.dtype:
             return f"bf16 or fp16 operands of one dtype only, got {a.dtype} and {b.dtype}"
+        if a.ndim < 2 or b.ndim < 2:
+            return f"operands need at least two dims, got {a.ndim}-D and {b.ndim}-D"
+        if a.shape[-1] == 0:
+            return "K must be positive"
         for name, t in (("a", a), ("b", b)):
             inner = t.shape[-1] if t.stride(-1) == 1 else t.shape[-2]
             if inner % 8:
                 return f"{name}'s contiguous extent {inner} is not a multiple of 8 elements"
+        if b.shape[-2] % 8:
+            return f"N={b.shape[-2]} is not a multiple of 8 elements (the output row pitch)"
         return None
 
     def _check_layout(self, desc: GemmDesc, grouped_layout: Optional[torch.Tensor]) -> None:
@@ -864,6 +884,8 @@ class SM90GemmFwdKernel(Kernel):
         length = desc.m if gtype is GemmType.M_GROUPED_ALIGNED_PER_ROW else self.num_groups
         if grouped_layout.dtype != torch.int32 or grouped_layout.shape != (length,):
             raise ValueError(f"grouped_layout must be [{length}] int32")
+        if not grouped_layout.is_contiguous():
+            raise ValueError("grouped_layout must be contiguous")
         if gtype is GemmType.M_GROUPED_ALIGNED_PER_ROW and desc.m % self.m_alignment:
             raise ValueError(
                 f"aligned_per_row rows ({desc.m}) must be a multiple of m_alignment "
@@ -889,11 +911,21 @@ class SM90GemmFwdKernel(Kernel):
             out: Optional preallocated output in ``cd_dtype``.
         """
         self._require_cuda(a=a, b=b, grouped_layout=grouped_layout, out=out)
+        for name, t in (("b", b), ("grouped_layout", grouped_layout), ("out", out)):
+            if t is not None and t.device != a.device:
+                raise ValueError(f"{name} must be on {a.device}, got {t.device}")
         why = self.refusal_for(a, b)
         if why is not None:
             raise ValueError(f"{type(self).__name__}: {why}")
         desc = self.describe(a, b)
         self._check_layout(desc, grouped_layout)
+        # The kernel takes the physical storage: an MN-major operand's contiguous
+        # tensor is the transpose of its logical view. A dynamic dim hides a stride
+        # from TileLang's ABI check, so require contiguity here.
+        a_phys = a if desc.major_a is Major.K else a.transpose(-2, -1)
+        b_phys = b if desc.major_b is Major.K else b.transpose(-2, -1)
+        if not a_phys.is_contiguous() or not b_phys.is_contiguous():
+            raise ValueError("a and b must be contiguous in their physical (K- or MN-major) layout")
         if grouped_layout is None:
             grouped_layout = torch.zeros(1, dtype=torch.int32, device=a.device)
         c_shape = (self.num_groups, desc.m, desc.n) if self._a_has_group else (desc.m, desc.n)
@@ -902,11 +934,14 @@ class SM90GemmFwdKernel(Kernel):
             out = torch.empty(c_shape, dtype=cd_dtype, device=a.device)
         elif tuple(out.shape) != c_shape or out.dtype != cd_dtype or not out.is_contiguous():
             raise ValueError(f"out must be a contiguous {list(c_shape)} {cd_dtype}")
+        if out.numel() == 0:  # no rows or no columns: nothing to launch
+            return out
+        if out.data_ptr() in (
+            a.data_ptr(),
+            b.data_ptr(),
+        ):  # same start; offset overlap is not caught
+            raise ValueError("out must not alias an operand: tiles store while others still load")
         spec = self._spec_of(desc)
-        # The kernel takes the physical storage: an MN-major operand's
-        # contiguous tensor is the transpose of its logical view.
-        a_phys = a if desc.major_a is Major.K else a.transpose(-2, -1)
-        b_phys = b if desc.major_b is Major.K else b.transpose(-2, -1)
         fn = _sm90_gemm_kernel(spec)()
         fn(a_phys, b_phys, out, grouped_layout)
         return out

--- a/src/tileops/kernels/moe/sm90_gemm_heuristics.py
+++ b/src/tileops/kernels/moe/sm90_gemm_heuristics.py
@@ -98,7 +98,11 @@ PER_GROUP_TYPES = (
     GemmType.M_GROUPED_TIGHT_PSUM,
 )
 _FLAT_LIKE_TYPES = (GemmType.NORMAL, GemmType.BATCHED)
-# Only a dense GEMM may take a 2-CTA cluster; see _MIN_WAVES_FOR_CLUSTER. Offering
+# The schedulers a 2-CTA cluster is legal on: the flat ones pair consecutive tile
+# ids inside one swizzle group, and the per-row kernel checks the pair shares a
+# group. A per-group range can start at an odd tile, so pairs would straddle groups.
+_MULTICAST_TYPES = (GemmType.NORMAL, GemmType.M_GROUPED_ALIGNED_PER_ROW)
+# Only a dense GEMM is *offered* one by the selector; see _MIN_WAVES_FOR_CLUSTER. Offering
 # one to a per-group type would also need the CTA pair kept inside one group,
 # i.e. an even ceil(N / block_n), the prune DeepGEMM applies there.
 _CLUSTER_TYPES = (GemmType.NORMAL,)
@@ -160,14 +164,24 @@ class SM90GemmSpec:
             )
         if self.num_tma_multicast not in (1, 2):
             raise ValueError("num_tma_multicast must be 1 or 2")
+        if self.is_tma_multicast_on_a and self.num_tma_multicast == 1:
+            raise ValueError("is_tma_multicast_on_a needs a 2-CTA cluster")
+        if self.num_stages < 1:
+            raise ValueError("num_stages must be positive")
+        if self.num_sms < 1 or min(self.shape_m, self.shape_n, self.shape_k) < 0:
+            raise ValueError("num_sms must be positive and static dims non-negative")
         if self.num_tma_multicast > 1 and self.num_sms % 2:
             raise ValueError("TMA multicast needs an even persistent grid")
         if self.gemm_type not in _FLAT_LIKE_TYPES and self.major_a is not Major.K:
             raise ValueError("m-grouped GEMM requires a K-major A")
         if self.gemm_type is GemmType.NORMAL and self.num_groups != 1:
             raise ValueError("a normal GEMM has exactly one group")
-        if self.gemm_type is GemmType.BATCHED and self.num_tma_multicast > 1:
-            raise ValueError("the batched scheduler does not multicast")
+        if self.num_tma_multicast > 1 and self.gemm_type not in _MULTICAST_TYPES:
+            raise ValueError(
+                "TMA multicast is offered to the flat schedulers only (NORMAL, aligned per-row): "
+                "a per-group tile range can start at an odd tile, so a hardware CTA pair may "
+                "straddle two groups; the batched scheduler does not multicast"
+            )
         if self.block_m > 128 and self.block_n > 128:
             raise ValueError("block_m and block_n cannot both exceed 128 (register budget)")
         if self.block_m > 128 and self.cd_dtype == "float32":
@@ -319,6 +333,8 @@ def _num_cycles(desc: GemmDesc, layout: _Layout) -> tuple[int, int]:
         * (desc.num_groups if desc.gemm_type is GemmType.BATCHED else 1)
     )
     num_waves = math.ceil(num_blocks / desc.num_sms)
+    if num_blocks == 0:  # a call with no rows or no columns runs nothing
+        return 0, 0
 
     l2_bandwidth_per_cycle = int(min(64.0 * desc.num_sms, 8e6 / 1.3e3))
     l1_bandwidth_per_cycle = 128 * desc.num_sms
@@ -435,6 +451,12 @@ def spec_from_config(desc: GemmDesc, config: dict) -> SM90GemmSpec:
         config.get("cluster_m", 1),
         config.get("cluster_n", 1),
     )
+    if desc.gemm_type in _ALIGNED_TYPES and layout.block_m != desc.m_alignment:
+        raise ValueError(
+            f"an aligned layout's block_m is its segment alignment: the kernel rounds group "
+            f"starts up to block_m and reads a tile's group off its first row, so a block_m of "
+            f"{layout.block_m} does not fit m_alignment={desc.m_alignment}"
+        )
     stages = config.get("num_stages")
     if stages is None:
         stages = _num_stages(desc, dataclasses.replace(layout, block_k=_BLOCK_K))

--- a/src/tileops/kernels/moe/sm90_gemm_heuristics.py
+++ b/src/tileops/kernels/moe/sm90_gemm_heuristics.py
@@ -1,0 +1,442 @@
+"""Template parameters and config selection for the SM90 GEMM template.
+
+Ported from DeepGEMM: the kernel template ``sm90_bf16_gemm_impl`` takes every
+structural choice as a template parameter, and the host side (``SM90ArchSpec``
++ ``get_best_config``) enumerates the legal layouts for a call and scores them
+with an L1/L2 cycle model instead of benchmarking. ``SM90GemmSpec`` is the
+TileOPs counterpart of that template parameter pack, and ``get_best_config`` is
+the counterpart of the selector.
+
+Deviations from DeepGEMM, all deliberate:
+
+* ``block_m`` in {16, 32} is not offered. TileLang's WGMMA lowering is only
+  exercised at 64-row multiples here.
+* ``with_accumulation`` (TMA reduce-add into C) is absent: TileLang's TMA store
+  lowering hard-codes ``need_reduce = 0``.
+* Swizzle modes are not spec fields. TileLang derives the swizzle from the
+  shared tile's inner extent, the same rule DeepGEMM applies, and with 64-wide
+  ``block_n`` steps every inner extent is a whole 128-byte atom, so DeepGEMM's
+  swizzle prune has nothing to reject and is not carried.
+"""
+
+import dataclasses
+import enum
+import functools
+import math
+
+__all__ = [
+    "PER_GROUP_TYPES",
+    "GemmDesc",
+    "GemmType",
+    "Major",
+    "SM90GemmSpec",
+    "get_best_config",
+    "layout_candidates",
+    "spec_from_config",
+]
+
+# Hopper opt-in shared memory per block, in bytes.
+_SMEM_CAPACITY = 232448
+_MAX_STAGES = 16
+_BARRIER_BYTES = _MAX_STAGES * 8 * 2
+# What TileLang lays out beyond DeepGEMM's accounting: 1024-byte alignment of
+# each swizzled buffer (A per math warp-group, B, C per math warp-group) and
+# the per-group tile prefix sum. Without it a budget within a few hundred
+# bytes of the cap fails at launch ("Failed to set the allowed dynamic shared
+# memory size").
+_SMEM_ALIGN_SLACK = 6 * 1024
+_WGMMA_M = 64
+_ELEM_BYTES = 2  # bf16 / fp16 operands
+_BLOCK_K = 128 // _ELEM_BYTES
+# H200 calibration, 2026-09: block_n must hold whole 128-byte swizzle atoms.
+_BLOCK_N_STEP = 64
+# H200 calibration, 2026-09: a 2-CTA cluster (TMA multicast of one operand) is
+# added to the tile the plain model picked, only for a dense GEMM, and only
+# when that tile runs at least this many waves. DeepGEMM lets clusters compete
+# for the tile choice and rejects them below 2 waves. Measured on H200, a
+# cluster on the best plain dense tile gained 0.6% to 5% at 16 waves and more
+# and lost 1% to 6% at 8 waves and fewer; letting it pick the tile instead
+# moved the choice to 128x128 tiles whose halved L2 traffic the model
+# overvalues, 8% to 15% behind. On grouped GEMMs, which stream every expert's
+# B from HBM, the pairing gained at most 1.5% and lost 8.5% on an 8-expert
+# 4096-row case, so they never take one.
+_MIN_WAVES_FOR_CLUSTER = 16
+
+
+class GemmType(str, enum.Enum):
+    """Which rows of ``A`` and which ``B`` a tile reads.
+
+    * ``NORMAL``: one dense GEMM.
+    * ``M_GROUPED_ALIGNED_PER_ROW``: DeepGEMM's ``MGroupedContiguous``. Rows are
+      packed per group into segments whose length is a multiple of ``block_m``,
+      ``grouped_layout[row]`` names the group of each row, and rows past the
+      last group carry ``num_groups``.
+    * ``M_GROUPED_ALIGNED_PSUM``: DeepGEMM's ``MGroupedContiguousWithPsumLayout``.
+      ``grouped_layout[g]`` is the prefix-sum end row of group ``g``, and each
+      group starts at the previous end rounded up to ``block_m``.
+    * ``M_GROUPED_TIGHT_PSUM``: TileOPs' ``tight_physical_psum``. As the aligned
+      psum layout but each group starts exactly at the previous end, so a
+      group's last tile is stored with a row mask.
+    * ``M_GROUPED_MASKED``: DeepGEMM's ``MGroupedMasked``. ``A`` and ``C`` carry a
+      leading group dim of ``max_m`` rows each and ``grouped_layout[g]`` is the
+      valid row count.
+    * ``BATCHED``: independent GEMMs on a leading batch dim of ``A``, ``B``, ``C``.
+    """
+
+    NORMAL = "normal"
+    M_GROUPED_ALIGNED_PER_ROW = "m_grouped_aligned_per_row"
+    M_GROUPED_ALIGNED_PSUM = "m_grouped_aligned_psum"
+    M_GROUPED_TIGHT_PSUM = "m_grouped_tight_psum"
+    M_GROUPED_MASKED = "m_grouped_masked"
+    BATCHED = "batched"
+
+
+_ALIGNED_TYPES = (GemmType.M_GROUPED_ALIGNED_PER_ROW, GemmType.M_GROUPED_ALIGNED_PSUM)
+PER_GROUP_TYPES = (
+    GemmType.M_GROUPED_MASKED,
+    GemmType.M_GROUPED_ALIGNED_PSUM,
+    GemmType.M_GROUPED_TIGHT_PSUM,
+)
+_FLAT_LIKE_TYPES = (GemmType.NORMAL, GemmType.BATCHED)
+# Only a dense GEMM may take a 2-CTA cluster; see _MIN_WAVES_FOR_CLUSTER. Offering
+# one to a per-group type would also need the CTA pair kept inside one group,
+# i.e. an even ceil(N / block_n), the prune DeepGEMM applies there.
+_CLUSTER_TYPES = (GemmType.NORMAL,)
+
+
+class Major(str, enum.Enum):
+    """Which logical dim is contiguous in memory for an operand."""
+
+    K = "k"
+    MN = "mn"
+
+
+@dataclasses.dataclass(frozen=True)
+class SM90GemmSpec:
+    """One instantiation of the kernel template.
+
+    Every field is a compile-time parameter of the kernel; two specs that
+    differ in any field are two distinct compiled kernels. ``shape_m`` /
+    ``shape_n`` / ``shape_k`` are ``0`` for a dim left dynamic, which is
+    DeepGEMM's ``SHAPE_* == 0`` convention.
+    """
+
+    gemm_type: GemmType
+    major_a: Major
+    major_b: Major
+    ab_dtype: str
+    cd_dtype: str
+    num_groups: int
+    shape_m: int
+    shape_n: int
+    shape_k: int
+    block_m: int
+    block_n: int
+    block_k: int
+    num_stages: int
+    num_math_threads: int
+    num_tma_multicast: int
+    is_tma_multicast_on_a: bool
+    num_sms: int
+
+    def __post_init__(self) -> None:
+        if self.ab_dtype not in ("bfloat16", "float16"):
+            raise ValueError(f"ab_dtype must be bfloat16 or float16, got {self.ab_dtype!r}")
+        if self.cd_dtype not in (self.ab_dtype, "float32"):
+            raise ValueError(
+                f"cd_dtype must be the operand dtype or float32, got {self.cd_dtype!r} "
+                f"for {self.ab_dtype} operands"
+            )
+        if self.block_m not in (64, 128, 256):
+            raise ValueError(f"block_m must be 64, 128 or 256, got {self.block_m}")
+        if self.block_n % 8 or not 8 <= self.block_n <= 256:
+            raise ValueError(f"block_n must be a multiple of 8 in [8, 256], got {self.block_n}")
+        if self.block_k % 64:
+            raise ValueError(f"block_k must be a multiple of 64, got {self.block_k}")
+        if self.num_math_threads != (128 if self.block_m <= 64 else 256):
+            raise ValueError(
+                "num_math_threads is 128 for block_m <= 64 and 256 otherwise, "
+                f"got {self.num_math_threads} for block_m={self.block_m}"
+            )
+        if self.num_tma_multicast not in (1, 2):
+            raise ValueError("num_tma_multicast must be 1 or 2")
+        if self.num_tma_multicast > 1 and self.num_sms % 2:
+            raise ValueError("TMA multicast needs an even persistent grid")
+        if self.gemm_type not in _FLAT_LIKE_TYPES and self.major_a is not Major.K:
+            raise ValueError("m-grouped GEMM requires a K-major A")
+        if self.gemm_type is GemmType.NORMAL and self.num_groups != 1:
+            raise ValueError("a normal GEMM has exactly one group")
+        if self.gemm_type is GemmType.BATCHED and self.num_tma_multicast > 1:
+            raise ValueError("the batched scheduler does not multicast")
+        if self.block_m > 128 and self.block_n > 128:
+            raise ValueError("block_m and block_n cannot both exceed 128 (register budget)")
+        if self.block_m > 128 and self.cd_dtype == "float32":
+            raise ValueError("block_m=256 is only offered for a 16-bit output")
+
+    @property
+    def num_math_warpgroups(self) -> int:
+        return self.num_math_threads // 128
+
+
+@dataclasses.dataclass(frozen=True)
+class GemmDesc:
+    """What a call asks for; the selector's input.
+
+    ``static_dims`` names the dims baked into the kernel (DeepGEMM's
+    ``compiled_dims``); the others stay dynamic. ``expected_m`` feeds the cost
+    model only and defaults to the call's own ``m``; for the per-group layouts
+    it is the rows per group the model should plan for, which a caller who
+    knows the routing is skewed sets to the large experts' size rather than
+    the mean. ``m_alignment`` is the segment alignment of an m-grouped layout
+    and fixes ``block_m`` for it.
+    """
+
+    gemm_type: GemmType
+    m: int
+    n: int
+    k: int
+    num_groups: int
+    major_a: Major
+    major_b: Major
+    cd_dtype: str
+    num_sms: int
+    static_dims: str = "nk"
+    ab_dtype: str = "bfloat16"
+    m_alignment: int = 128
+    expected_m: int = 0
+
+    def __post_init__(self) -> None:
+        if any(c not in "mnk" for c in self.static_dims):
+            raise ValueError(f"static_dims may only name m, n, k; got {self.static_dims!r}")
+        if self.num_sms % 2:
+            raise ValueError("the persistent grid must have an even SM count")
+
+    def get_expected_m(self) -> int:
+        return self.expected_m if self.expected_m > 0 else self.m
+
+
+@dataclasses.dataclass(frozen=True)
+class _Layout:
+    block_m: int
+    block_n: int
+    block_k: int
+    cluster_m: int
+    cluster_n: int
+
+    @property
+    def cluster_size(self) -> int:
+        return self.cluster_m * self.cluster_n
+
+
+def _align(x: int, a: int) -> int:
+    return (x + a - 1) // a * a
+
+
+def _num_stages(desc: GemmDesc, layout: _Layout) -> int:
+    cd_bytes = 4 if desc.cd_dtype == "float32" else 2
+    smem_cd = _align(layout.block_m * layout.block_n * cd_bytes, 1024)
+    smem_prefix = _align((desc.num_groups + 2) * 4, 128)
+    per_stage = (layout.block_m + layout.block_n) * layout.block_k * _ELEM_BYTES
+    budget = _SMEM_CAPACITY - smem_cd - _BARRIER_BYTES - _SMEM_ALIGN_SLACK - smem_prefix
+    return min(budget // per_stage, _MAX_STAGES)
+
+
+def _num_math_threads(block_m: int) -> int:
+    return 128 if block_m <= 64 else 256
+
+
+def layout_candidates(desc: GemmDesc) -> list[_Layout]:
+    """Every tile/cluster layout the template accepts for ``desc``.
+
+    Mirrors ``SM90ArchSpec::get_layout_candidates``, minus the 16/32-row tiles.
+    """
+    if desc.gemm_type in _FLAT_LIKE_TYPES:
+        block_m_candidates = [64, 128]
+        if desc.cd_dtype != "float32":
+            block_m_candidates.append(256)
+    elif desc.gemm_type in _ALIGNED_TYPES:
+        if desc.m_alignment not in (64, 128, 256):
+            raise ValueError(
+                f"m-grouped block_m follows the segment alignment, which must be 64, 128 or "
+                f"256; got {desc.m_alignment}"
+            )
+        block_m_candidates = [desc.m_alignment]
+    else:
+        # Masked and tight rows have no alignment to honour; short groups want 64.
+        block_m_candidates = [64, 128]
+
+    # DeepGEMM steps block_n by 16. Measured on H200 (see docs), every block_n
+    # that is not a multiple of 64 runs 1.5x or more behind the best tile in
+    # this TileLang epilogue, so those widths are not offered.
+    block_n_candidates = list(range(_BLOCK_N_STEP, 256 + 1, _BLOCK_N_STEP))
+    block_k = _BLOCK_K
+    max_cluster = 2 if desc.gemm_type in _CLUSTER_TYPES else 1
+
+    candidates = []
+    for cluster_m in (1, 2):
+        for cluster_n in (1, 2):
+            cluster = cluster_m * cluster_n
+            if cluster > max_cluster or desc.num_sms % cluster:
+                continue
+            for block_m in block_m_candidates:
+                for block_n in block_n_candidates:
+                    if block_m > 128 and block_n > 128:
+                        continue
+                    layout = _Layout(block_m, block_n, block_k, cluster_m, cluster_n)
+                    stages = _num_stages(desc, layout)
+                    if stages < 3 or (block_m * block_n < 128 * 192 and stages < 4):
+                        continue
+                    candidates.append(layout)
+    if not candidates:
+        raise ValueError(f"no legal layout for {desc}")
+    return candidates
+
+
+def _num_m_blocks(desc: GemmDesc, block_m: int) -> int:
+    """M tiles the schedule will run, counting each group's round-up separately.
+
+    DeepGEMM divides the expected rows by ``block_m`` once. A per-group layout
+    rounds every group up on its own, and for short groups that round-up is
+    most of the work: 32-row groups cost a full 128-row tile each. Counting it
+    is what lets the selector prefer ``block_m=64`` there.
+    """
+    if desc.gemm_type in PER_GROUP_TYPES:
+        if desc.gemm_type is GemmType.M_GROUPED_MASKED or desc.expected_m > 0:
+            rows_per_group = desc.expected_m if desc.expected_m > 0 else desc.m
+        else:
+            rows_per_group = desc.m / max(1, desc.num_groups)
+        return desc.num_groups * math.ceil(rows_per_group / block_m)
+    return math.ceil(desc.get_expected_m() / block_m)
+
+
+def _num_cycles(desc: GemmDesc, layout: _Layout) -> tuple[int, int]:
+    """DeepGEMM's L1/L2 cycle model; returns ``(num_waves, cycles)``."""
+    # Only a batched GEMM runs one full tile grid per group; the grouped
+    # layouts are counted per group by _num_m_blocks instead.
+    num_blocks = (
+        _num_m_blocks(desc, layout.block_m)
+        * math.ceil(desc.n / layout.block_n)
+        * (desc.num_groups if desc.gemm_type is GemmType.BATCHED else 1)
+    )
+    num_waves = math.ceil(num_blocks / desc.num_sms)
+
+    l2_bandwidth_per_cycle = int(min(64.0 * desc.num_sms, 8e6 / 1.3e3))
+    l1_bandwidth_per_cycle = 128 * desc.num_sms
+    elem_ab = _ELEM_BYTES
+    elem_cd = 4 if desc.cd_dtype == "float32" else 2
+
+    k = desc.k
+    bytes_l2_ab = k * (layout.block_m // layout.cluster_n + layout.block_n // layout.cluster_m)
+    bytes_l2_ab *= elem_ab
+    bytes_l1_ab = k * (layout.block_m + layout.block_n) * elem_ab
+    bytes_l1_tc = k * (max(_WGMMA_M, layout.block_m) + layout.block_n) * elem_ab
+    bytes_l1_tc += layout.block_m * layout.block_n * elem_cd
+    bytes_cd = layout.block_m * layout.block_n * elem_cd
+
+    l2_cycles = (bytes_l2_ab + bytes_cd) * num_blocks // l2_bandwidth_per_cycle
+    l1_cycles = (bytes_l1_ab + bytes_l1_tc + bytes_cd) * num_blocks // l1_bandwidth_per_cycle
+    wave_efficiency = num_blocks / (num_waves * desc.num_sms)
+    cycles = int(max(l1_cycles, l2_cycles) / wave_efficiency)
+
+    if layout.cluster_size > 1 and num_waves < _MIN_WAVES_FOR_CLUSTER:
+        cycles = 2**62
+    return num_waves, cycles
+
+
+def _best_layout(desc: GemmDesc, candidates: list[_Layout]) -> _Layout:
+    """The plain (single-CTA) tile the model prefers, with a cluster added on top.
+
+    Tile and cluster are decided in two steps rather than one ranking: the
+    cluster variants of the chosen tile compete among themselves only, so
+    multicast never changes which tile runs.
+    """
+    plain = [lay for lay in candidates if lay.cluster_size == 1]
+    best = min(plain, key=lambda lay: _num_cycles(desc, lay)[1])
+    clustered = [
+        lay
+        for lay in candidates
+        if lay.cluster_size > 1
+        and (lay.block_m, lay.block_n, lay.block_k) == (best.block_m, best.block_n, best.block_k)
+    ]
+    if clustered:
+        with_cluster = min(clustered, key=lambda lay: _num_cycles(desc, lay)[1])
+        if _num_cycles(desc, with_cluster)[1] < _num_cycles(desc, best)[1]:
+            return with_cluster
+    return best
+
+
+def _merge_stages(spec: SM90GemmSpec) -> SM90GemmSpec:
+    """Widen ``block_k`` out of surplus stages, DeepGEMM's ``kDoMergeStages``.
+
+    Fewer, longer stages cut the per-stage barrier traffic of a single math
+    warp-group on a dense NT GEMM; kept as DeepGEMM has it, although this
+    kernel already overlaps a k-step's drain with the next (``wait_group 1``).
+    """
+    merge = (
+        spec.num_stages >= 10
+        and spec.gemm_type is GemmType.NORMAL
+        and spec.major_a is Major.K
+        and spec.major_b is Major.K
+        and spec.num_math_threads == 128
+    )
+    if not merge:
+        return spec
+    per_merge = spec.num_stages // 5
+    return dataclasses.replace(
+        spec, block_k=spec.block_k * per_merge, num_stages=spec.num_stages // per_merge
+    )
+
+
+def _spec(desc: GemmDesc, layout: _Layout, num_stages: int) -> SM90GemmSpec:
+    return SM90GemmSpec(
+        gemm_type=desc.gemm_type,
+        major_a=desc.major_a,
+        major_b=desc.major_b,
+        ab_dtype=desc.ab_dtype,
+        cd_dtype=desc.cd_dtype,
+        num_groups=desc.num_groups,
+        shape_m=desc.m if "m" in desc.static_dims else 0,
+        shape_n=desc.n if "n" in desc.static_dims else 0,
+        shape_k=desc.k if "k" in desc.static_dims else 0,
+        block_m=layout.block_m,
+        block_n=layout.block_n,
+        block_k=layout.block_k,
+        num_stages=num_stages,
+        num_math_threads=_num_math_threads(layout.block_m),
+        num_tma_multicast=layout.cluster_size,
+        is_tma_multicast_on_a=layout.cluster_n > 1,
+        num_sms=desc.num_sms,
+    )
+
+
+@functools.lru_cache(maxsize=1024)
+def get_best_config(desc: GemmDesc) -> SM90GemmSpec:
+    """The spec DeepGEMM's selector would pick for ``desc``.
+
+    Cached per descriptor: the enumeration is a few hundred candidates and a
+    call site typically repeats a handful of shapes.
+    """
+    best = _best_layout(desc, layout_candidates(desc))
+    return _merge_stages(_spec(desc, best, _num_stages(desc, best)))
+
+
+def spec_from_config(desc: GemmDesc, config: dict) -> SM90GemmSpec:
+    """A spec from an explicit ``config`` instead of the selector.
+
+    ``config`` names ``block_m``, ``block_n`` and optionally ``block_k``,
+    ``num_stages``, ``cluster_m``, ``cluster_n``. Missing fields take the
+    selector's derivation for that layout, so a tuning sweep can pin the tile
+    and leave the pipeline depth to the shared-memory budget.
+    """
+    layout = _Layout(
+        config["block_m"],
+        config["block_n"],
+        config.get("block_k", _BLOCK_K),
+        config.get("cluster_m", 1),
+        config.get("cluster_n", 1),
+    )
+    stages = config.get("num_stages")
+    if stages is None:
+        stages = _num_stages(desc, dataclasses.replace(layout, block_k=_BLOCK_K))
+        stages = max(1, stages * _BLOCK_K // layout.block_k)
+    return _spec(desc, layout, stages)

--- a/tests/kernels/test_sm90_gemm.py
+++ b/tests/kernels/test_sm90_gemm.py
@@ -1,0 +1,360 @@
+"""Correctness tests for SM90GemmFwdKernel, the DeepGEMM sm90 bf16 template port."""
+
+import math
+
+import pytest
+import torch
+
+from tileops.kernels.moe.sm90_gemm import GemmType, Major, SM90GemmFwdKernel
+from tileops.kernels.moe.sm90_gemm_heuristics import (
+    GemmDesc,
+    SM90GemmSpec,
+    get_best_config,
+    layout_candidates,
+)
+
+pytestmark = pytest.mark.hopper
+
+
+def _operands(m, n, k, major_a="k", major_b="k"):
+    """Logical ``a[M, K]`` and ``b[N, K]``; an MN-major one is a transposed view."""
+    torch.manual_seed(0)
+    a = torch.randn(m, k, device="cuda", dtype=torch.bfloat16)
+    if major_a == "mn":
+        a = a.T.contiguous().T
+    b = torch.randn(n, k, device="cuda", dtype=torch.bfloat16)
+    if major_b == "mn":
+        b = b.T.contiguous().T
+    return a, b
+
+
+def _assert_gemm(out, ref):
+    torch.testing.assert_close(out.float(), ref.float(), rtol=2e-2, atol=1e-1)
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "m,n,k,config",
+    [
+        pytest.param(512, 512, 512, dict(block_m=64, block_n=128), id="one-math-warpgroup"),
+        pytest.param(1024, 1024, 1024, dict(block_m=128, block_n=128), id="two-math-warpgroups"),
+        pytest.param(2048, 2048, 1024, dict(block_m=256, block_n=128), id="block-m-256"),
+    ],
+)
+def test_dense_tile_shapes(m, n, k, config):
+    """Each math warp-group arrangement the template offers."""
+    a, b = _operands(m, n, k)
+    kernel = SM90GemmFwdKernel(GemmType.NORMAL, config=config)
+    _assert_gemm(kernel(a, b), a.float() @ b.float().T)
+
+
+@pytest.mark.parametrize(
+    "m,n,cluster",
+    [
+        pytest.param(4096, 4096, dict(cluster_m=2), id="multicast-b"),
+        pytest.param(4096, 4096, dict(cluster_n=2), id="multicast-a"),
+        pytest.param(4096 + 3 * 128, 4096 + 5 * 128, dict(cluster_m=2), id="odd-groups-split"),
+        pytest.param(1000, 1000, dict(cluster_n=2), id="ragged-with-dead-peer"),
+    ],
+)
+@pytest.mark.full
+def test_dense_tma_multicast(m, n, cluster):
+    """A 2-CTA cluster shares one operand; odd block counts exercise the peer checks."""
+    a, b = _operands(m, n, 1024)
+    kernel = SM90GemmFwdKernel(GemmType.NORMAL, config=dict(block_m=128, block_n=128, **cluster))
+    _assert_gemm(kernel(a, b), a.float() @ b.float().T)
+
+
+@pytest.mark.parametrize(
+    "major_a,major_b",
+    [
+        pytest.param("mn", "k", id="tn"),
+        pytest.param("k", "mn", id="nn"),
+        pytest.param("mn", "mn", id="tt"),
+    ],
+)
+@pytest.mark.full
+def test_dense_layouts_from_strides(major_a, major_b):
+    """Majorness is read off the operands and picks the transposed TMA/WGMMA path."""
+    a, b = _operands(1024, 1024, 1024, major_a, major_b)
+    kernel = SM90GemmFwdKernel(GemmType.NORMAL)
+    spec = kernel.spec_for(a, b)
+    assert spec.major_a is Major(major_a) and spec.major_b is Major(major_b)
+    _assert_gemm(kernel(a, b), a.float() @ b.float().T)
+
+
+@pytest.mark.full
+def test_dense_fp32_output():
+    a, b = _operands(1024, 1024, 1024)
+    kernel = SM90GemmFwdKernel(GemmType.NORMAL, cd_dtype=torch.float32)
+    out = kernel(a, b)
+    assert out.dtype == torch.float32
+    torch.testing.assert_close(out, a.float() @ b.float().T, rtol=1e-3, atol=1e-2)
+
+
+@pytest.mark.full
+def test_dynamic_m_shares_one_spec():
+    """M is dynamic by default: two row counts resolve to one spec, hence one compiled kernel."""
+    kernel = SM90GemmFwdKernel(GemmType.NORMAL, config=dict(block_m=128, block_n=128))
+    a1, b = _operands(1024, 1024, 1024)
+    a2 = torch.randn(1000, 1024, device="cuda", dtype=torch.bfloat16)
+    spec1, spec2 = kernel.spec_for(a1, b), kernel.spec_for(a2, b)
+    assert spec1 == spec2 and spec1.shape_m == 0
+    _assert_gemm(kernel(a1, b), a1.float() @ b.float().T)
+    _assert_gemm(kernel(a2, b), a2.float() @ b.float().T)
+
+
+def _grouped_operands(sizes, n, k, layout, *, alignment=128, major_b="k", dtype=torch.bfloat16):
+    """Per-group rows of ``a`` and their metadata for one grouped layout.
+
+    ``per_row``: each group's segment padded to ``alignment``, a sentinel tail of one
+    tile, metadata is the expert id per row. ``tight``: rows packed, metadata is the
+    physical end per group. ``aligned``: each group starts at the previous end rounded
+    up to ``alignment``, metadata is the physical end per group. Returns
+    ``(a, b, metadata, ref, valid)``; ``ref`` is fp32 and defined on ``valid`` rows.
+    """
+    torch.manual_seed(0)
+    groups = len(sizes)
+    starts, ends, row = [], [], 0
+    for size in sizes:
+        start = row if layout == "tight" else math.ceil(row / alignment) * alignment
+        starts.append(start)
+        ends.append(start + size)
+        row = start + (math.ceil(size / alignment) * alignment if layout == "per_row" else size)
+    total = row + alignment if layout == "per_row" else row
+    if layout == "aligned":
+        total = math.ceil(total / alignment) * alignment
+    a = torch.randn(total, k, device="cuda", dtype=dtype)
+    b = torch.randn(groups, n, k, device="cuda", dtype=dtype)
+    if major_b == "mn":
+        b = b.transpose(1, 2).contiguous().transpose(1, 2)
+    ref = torch.zeros(total, n, dtype=torch.float32, device="cuda")
+    valid = torch.zeros(total, dtype=torch.bool, device="cuda")
+    for g in range(groups):
+        ref[starts[g] : ends[g]] = a[starts[g] : ends[g]].float() @ b[g].float().T
+        valid[starts[g] : ends[g]] = True
+    if layout == "per_row":
+        metadata = torch.full((total,), groups, dtype=torch.int32)
+        for g in range(groups):
+            metadata[starts[g] : starts[g] + math.ceil(sizes[g] / alignment) * alignment] = g
+    else:
+        metadata = torch.tensor(ends, dtype=torch.int32)
+    return a, b, metadata.cuda(), ref, valid
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "sizes,n,k,major_b,config",
+    [
+        pytest.param(
+            [100, 0, 300, 128, 7],
+            512,
+            512,
+            "k",
+            dict(block_m=128, block_n=128),
+            id="empty-and-partial-groups",
+        ),
+        pytest.param([300] * 32, 2048, 1024, "mn", None, id="mn-major-b"),
+        pytest.param(
+            [100, 200, 300, 400, 500, 600, 700, 800],
+            2048,
+            1024,
+            "k",
+            dict(block_m=128, block_n=128, cluster_m=2),
+            id="multicast-b-group-boundary",
+        ),
+    ],
+)
+def test_m_grouped_aligned_per_row(sizes, n, k, major_b, config):
+    """Rows follow their group's B; padding rows and the sentinel tail are never read back."""
+    a, b, ids, ref, valid = _grouped_operands(sizes, n, k, "per_row", major_b=major_b)
+    kernel = SM90GemmFwdKernel(
+        GemmType.M_GROUPED_ALIGNED_PER_ROW, num_groups=len(sizes), m_alignment=128, config=config
+    )
+    out = kernel(a, b, grouped_layout=ids)
+    _assert_gemm(out[valid], ref[valid])
+
+
+@pytest.mark.full
+def test_grouped_requires_layout_and_alignment():
+    a, b, ids, _, _ = _grouped_operands([64, 64], 256, 256, "per_row")
+    kernel = SM90GemmFwdKernel(GemmType.M_GROUPED_ALIGNED_PER_ROW, num_groups=2)
+    with pytest.raises(ValueError, match="grouped_layout"):
+        kernel(a, b)
+    with pytest.raises(ValueError, match="m_alignment"):
+        kernel(a[:-64], b, grouped_layout=ids[:-64])
+
+
+@pytest.mark.full
+def test_refuses_operands_tma_cannot_address():
+    a = torch.randn(64, 60, device="cuda", dtype=torch.bfloat16)
+    b = torch.randn(64, 60, device="cuda", dtype=torch.bfloat16)
+    assert "multiple of 8" in SM90GemmFwdKernel.refusal_for(a, b)
+    with pytest.raises(ValueError, match="multiple of 8"):
+        SM90GemmFwdKernel(GemmType.NORMAL)(a, b)
+
+
+def _desc(m, n, k, **kw):
+    fields = dict(
+        gemm_type=GemmType.NORMAL,
+        m=m,
+        n=n,
+        k=k,
+        num_groups=1,
+        major_a=Major.K,
+        major_b=Major.K,
+        cd_dtype="bfloat16",
+        num_sms=132,
+    )
+    fields.update(kw)
+    return GemmDesc(**fields)
+
+
+@pytest.mark.full
+def test_selector_prunes_like_deepgemm():
+    """Every candidate satisfies the register, block_n step and stage-count rules."""
+    for layout in layout_candidates(_desc(4096, 4096, 4096)):
+        assert not (layout.block_m > 128 and layout.block_n > 128)
+        assert layout.block_n % 64 == 0
+    fp32 = layout_candidates(_desc(4096, 4096, 4096, cd_dtype="float32"))
+    assert all(layout.block_m <= 128 for layout in fp32)
+
+
+@pytest.mark.full
+def test_selector_merges_surplus_stages_for_one_warpgroup():
+    """A dense NT GEMM with a single math warp-group trades stages for a wider block_k."""
+    spec = get_best_config(_desc(8, 4096, 7168))
+    assert spec.num_math_threads == 128
+    assert spec.block_k > 64 and spec.num_stages >= 5
+
+
+@pytest.mark.full
+def test_spec_rejects_inconsistent_template_parameters():
+    fields = dict(
+        gemm_type=GemmType.NORMAL,
+        major_a=Major.K,
+        major_b=Major.K,
+        ab_dtype="bfloat16",
+        cd_dtype="bfloat16",
+        num_groups=1,
+        shape_m=0,
+        shape_n=4096,
+        shape_k=4096,
+        block_m=128,
+        block_n=128,
+        block_k=64,
+        num_stages=4,
+        num_math_threads=256,
+        num_tma_multicast=1,
+        is_tma_multicast_on_a=False,
+        num_sms=132,
+    )
+    SM90GemmSpec(**fields)
+    with pytest.raises(ValueError, match="num_math_threads"):
+        SM90GemmSpec(**{**fields, "block_m": 64})
+    with pytest.raises(ValueError, match="both exceed 128"):
+        SM90GemmSpec(**{**fields, "block_m": 256, "block_n": 256})
+    with pytest.raises(ValueError, match="K-major A"):
+        SM90GemmSpec(
+            **{
+                **fields,
+                "gemm_type": GemmType.M_GROUPED_ALIGNED_PER_ROW,
+                "num_groups": 4,
+                "major_a": Major.MN,
+            }
+        )
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "sizes,config",
+    [
+        pytest.param([100, 0, 300, 128, 7, 64], dict(block_m=128, block_n=128), id="two-wgs"),
+        pytest.param([100, 0, 300, 128, 7, 64], dict(block_m=64, block_n=128), id="one-wg"),
+    ],
+)
+def test_m_grouped_tight_psum_masks_each_groups_last_tile(sizes, config):
+    """Tight rows: a group's ragged last tile is stored under a row mask, not over its neighbour."""
+    a, b, ends, ref, _ = _grouped_operands(sizes, 2048, 1024, "tight")
+    kernel = SM90GemmFwdKernel(GemmType.M_GROUPED_TIGHT_PSUM, num_groups=len(sizes), config=config)
+    out = torch.full_like(ref, 1e4, dtype=torch.bfloat16)  # poison: every row must be written
+    kernel(a, b, grouped_layout=ends, out=out)
+    _assert_gemm(out, ref)
+
+
+@pytest.mark.full
+@pytest.mark.parametrize(
+    "sizes,config",
+    [
+        pytest.param([100, 0, 300, 128, 7, 64], dict(block_m=128, block_n=128), id="padded-groups"),
+        pytest.param([300] * 32, None, id="selected"),
+    ],
+)
+def test_m_grouped_aligned_psum(sizes, config):
+    """Aligned psum rows: each group starts at the previous end rounded up to block_m."""
+    a, b, ends, ref, valid = _grouped_operands(sizes, 2048, 1024, "aligned")
+    kernel = SM90GemmFwdKernel(
+        GemmType.M_GROUPED_ALIGNED_PSUM, num_groups=len(sizes), m_alignment=128, config=config
+    )
+    out = kernel(a, b, grouped_layout=ends)
+    _assert_gemm(out[valid], ref[valid])
+
+
+@pytest.mark.full
+@pytest.mark.parametrize(
+    "masked,max_m,config",
+    [
+        pytest.param([100, 0, 256, 33], 256, dict(block_m=64, block_n=128), id="one-wg"),
+        pytest.param([100, 200, 300, 400], 512, dict(block_m=128, block_n=128), id="two-wgs"),
+    ],
+)
+def test_m_grouped_masked(masked, max_m, config):
+    """Masked slabs: only the first ``masked_m[g]`` rows of each group are meaningful."""
+    torch.manual_seed(0)
+    groups = len(masked)
+    a = torch.randn(groups, max_m, 512, device="cuda", dtype=torch.bfloat16)
+    b = torch.randn(groups, 1024, 512, device="cuda", dtype=torch.bfloat16)
+    kernel = SM90GemmFwdKernel(GemmType.M_GROUPED_MASKED, num_groups=groups, config=config)
+    out = kernel(a, b, grouped_layout=torch.tensor(masked, dtype=torch.int32).cuda())
+    assert out.shape == (groups, max_m, 1024)
+    for g, mm in enumerate(masked):
+        if mm:
+            _assert_gemm(out[g, :mm], a[g, :mm].float() @ b[g].float().T)
+
+
+@pytest.mark.full
+@pytest.mark.parametrize(
+    "major_a,major_b,config",
+    [
+        pytest.param("k", "k", dict(block_m=128, block_n=128), id="nt"),
+        pytest.param("mn", "mn", None, id="tt-selected"),
+    ],
+)
+def test_batched(major_a, major_b, config):
+    """Batched: one tile grid per batch, no scheduler swizzle, no multicast."""
+    torch.manual_seed(0)
+    a = torch.randn(4, 1000, 512, device="cuda", dtype=torch.bfloat16)
+    b = torch.randn(4, 1000, 512, device="cuda", dtype=torch.bfloat16)
+    if major_a == "mn":
+        a = a.transpose(1, 2).contiguous().transpose(1, 2)
+    if major_b == "mn":
+        b = b.transpose(1, 2).contiguous().transpose(1, 2)
+    kernel = SM90GemmFwdKernel(GemmType.BATCHED, num_groups=4, config=config)
+    _assert_gemm(kernel(a, b), torch.bmm(a.float(), b.float().transpose(1, 2)))
+
+
+@pytest.mark.smoke
+def test_fp16_operands_dense_and_tight():
+    """fp16 operands take the same kernel; the output follows the operand dtype."""
+    a, b = _operands(1024, 1024, 1024)
+    a, b = a.half(), b.half()
+    out = SM90GemmFwdKernel(GemmType.NORMAL)(a, b)
+    assert out.dtype is torch.float16
+    _assert_gemm(out, a.float() @ b.float().T)
+    ta, tb, ends, ref, _ = _grouped_operands(
+        [100, 0, 300, 128, 7, 64], 512, 512, "tight", dtype=torch.float16
+    )
+    kernel = SM90GemmFwdKernel(GemmType.M_GROUPED_TIGHT_PSUM, num_groups=6)
+    _assert_gemm(kernel(ta, tb, grouped_layout=ends), ref)
+    with pytest.raises(ValueError, match="one dtype"):
+        SM90GemmFwdKernel(GemmType.NORMAL)(a, b.bfloat16())

--- a/tests/kernels/test_sm90_gemm.py
+++ b/tests/kernels/test_sm90_gemm.py
@@ -1,4 +1,4 @@
-"""Correctness tests for SM90GemmFwdKernel, the DeepGEMM sm90 bf16 template port."""
+"""Correctness tests for SM90GemmFwdKernel, the DeepGEMM ``sm90_bf16_gemm_impl`` port."""
 
 import math
 
@@ -54,7 +54,7 @@ def test_dense_tile_shapes(m, n, k, config):
         pytest.param(4096, 4096, dict(cluster_m=2), id="multicast-b"),
         pytest.param(4096, 4096, dict(cluster_n=2), id="multicast-a"),
         pytest.param(4096 + 3 * 128, 4096 + 5 * 128, dict(cluster_m=2), id="odd-groups-split"),
-        pytest.param(1000, 1000, dict(cluster_n=2), id="ragged-with-dead-peer"),
+        pytest.param(1000, 1000, dict(cluster_n=2), id="ragged-tma-clip"),
     ],
 )
 @pytest.mark.full


### PR DESCRIPTION
## Problem

TileOPs' Hopper GEMMs are one hand-written kernel per layout. The MoE grouped GEMMs (`GroupedGemmPersistent3WGKernel`) serve one tight layout, bind their shape at construction, and pick a schedule from a fixed regime table rather than from the shape at hand; there is no masked or batched variant, and the dense kernel shares nothing with them. Adding a layout meant another kernel body, and there was no model to say which tile a new shape should run.

This PR adds one SM90 GEMM template, `SM90GemmFwdKernel`, whose single kernel body is specialised by a spec and whose tile is chosen per call by a calibrated cost model. It covers dense, batched and four expert-grouped layouts with the same mainloop and epilogue, takes bf16 or fp16 operands with fp32 accumulation, and keeps `M` dynamic so one compiled kernel serves every row count of a shape.

No op calls it yet: the staged grouped-GEMM op interface it will sit behind is a separate PR, and the adapter, manifest `kernel_map` and 3WG replacement follow both.

## Changes

- `src/tileops/kernels/moe/sm90_gemm.py` (re-exported with `GemmType` from `kernels/moe/__init__.py`): one `@T.prim_func` body specialised by `SM90GemmSpec` — GEMM type, operand majorness (read off the strides, so a transposed view is a layout, not a copy), `ab_dtype` bf16/fp16, `cd_dtype` operand or fp32, static vs dynamic dims, tile, stages, one or two math warp-groups, 2-CTA TMA multicast. Persistent grid, L2-swizzled tile order, TMA/WGMMA pipeline, TMA-store epilogue.
- Six GEMM types over three schedulers: `NORMAL` and `M_GROUPED_ALIGNED_PER_ROW` (flat grid); `BATCHED` (grid per batch); `M_GROUPED_MASKED`, `M_GROUPED_ALIGNED_PSUM` and `M_GROUPED_TIGHT_PSUM` (per-group prefix sum in shared memory, binary search, in-group swizzle). The tight layout stores a group's ragged last tile under a row mask so it never overwrites the next group. K-grouped types, `with_accumulation` and small M (`block_m` 16/32) are out of scope by decision.
- The math warp-groups keep one WGMMA group in flight (`wgmma.wait_group 1`, release the previous stage) instead of draining every k-step. Draining cost Mixtral-shaped grouped GEMMs 4–7% against the 3WG kernel at the same tile (CUPTI); with one group in flight they are level.
- `sm90_gemm_heuristics.py`: the candidate enumeration and an L1/L2 cycle model, calibrated on H200 against a sweep of ~600 of its own candidates over 15 shapes. Findings that went into the rules: `block_n` in multiples of 64 (other widths are 1.46x+ slower through TileLang's epilogue swizzle); per-group tile round-up in the tile count, so 32-row experts pick `block_m` 64; a 2-CTA cluster only for dense GEMMs and only from 16 waves (1–6% slower at 8 waves and fewer, 0.6–5% faster from 16); shared-memory slack for TileLang's 1024-byte buffer alignment (a stress case asked for 231680 of 232448 bytes and failed to launch). Selector gap to the measured best: mean 0.7%, max 2.3%.
- `tests/kernels/test_sm90_gemm.py`: 29 cases, one per code path (six types, four operand layouts, fp16 operands, fp32 output, dynamic M, both multicast directions and odd tile groups, a cluster across a group boundary, tight ragged tiles, selector rules, spec validation). A 200-case randomised stress over types, layouts, dtypes, unaligned shapes and off-selector tiles found one bug — a shared-memory budget a few hundred bytes under the 227 KB cap failing at launch, fixed by the alignment slack above — and nothing else.

## Performance

Idle H200, one GPU, `do_bench` 100 iterations, outputs compared element-wise against torch fp32.

Dense bf16 NT, cuBLAS time / this kernel's time (>1 is faster):

| Weight (N x K)             | M=2048 | 4096 | 8192 | 16384 |
| -------------------------- | -----: | ---: | ---: | ----: |
| llama7b qkvo 4096x4096     |   0.97 | 1.01 | 0.97 |  1.03 |
| llama70b qkvo 8192x8192    |   1.02 | 1.03 | 1.09 |  0.98 |
| llama70b gate 28672x8192   |   1.00 | 1.02 | 1.19 |  1.19 |
| dsv3 dense gate 18432x7168 |   1.01 | 1.03 | 1.04 |  1.08 |
| dsv3 dense down 7168x18432 |   0.92 | 0.99 | 0.98 |  1.00 |

Grouped tight psum on gate_up shapes with skewed routing, vs `GroupedGemmPersistent3WGKernel` and `torch._grouped_mm` (>1 is faster):

| Model     | tokens | experts |     N |    K | vs 3WG | vs grouped_mm |
| --------- | -----: | ------: | ----: | ---: | -----: | ------------: |
| dsv3      |    256 |     256 |  4096 | 7168 |  1.05x |         1.29x |
| dsv3      |   1024 |     256 |  4096 | 7168 |  1.22x |         1.22x |
| dsv3      |   4096 |     256 |  4096 | 7168 |  1.00x |         1.39x |
| mixtral   |    256 |       8 | 28672 | 4096 |  0.97x |         1.36x |
| mixtral   |   4096 |       8 | 28672 | 4096 |  0.98x |         1.03x |
| qwen2-moe |   1024 |      64 |  2816 | 2048 |  1.00x |         1.33x |
| qwen2-moe |   4096 |      64 |  2816 | 2048 |  1.21x |         0.96x |

Masked and batched match `torch.bmm` within 1–2% on weight-bandwidth-bound DeepSeek-V3 shapes.

Where this kernel is not good enough: small M on a weight that does not fill the machine. Its smallest tile is `block_m` 64 and it has no split-K, so when `M × N` yields fewer tiles than SMs the GEMM runs one partial wave and nothing hides the K loop. Measured on the same H200 (cuBLAS time / this kernel's time, >1 is faster):

| Weight (N x K)             | M=16 | M=64 | M=128 | M=256 | M=512 |
| -------------------------- | ---: | ---: | ----: | ----: | ----: |
| llama7b qkvo 4096x4096     | 0.35 | 0.89 |  0.91 |  0.52 |  0.52 |
| llama70b gate 28672x8192   | 0.94 | 0.96 |  0.98 |  0.94 |  0.88 |
| dsv3 dense down 7168x18432 | 0.68 | 1.05 |  0.92 |  0.86 |  1.00 |

On the narrow 4096² weight the kernel is half of cuBLAS from M=256 up to M=512 (128 tiles on 132 SMs, one wave); on the wide 28672-column weight, where even M=16 fills the machine, it stays within 2–12%. Small N (N=2112, which only 64-wide tiles divide) is the same problem from the other side. Grouped small token counts are not affected the same way: tight psum at 8–128 tokens with skewed routing is 1.02–1.27x the 3WG kernel and 1.3–1.5x `torch._grouped_mm` on DeepSeek-V3 and Mixtral gate_up shapes, because the per-expert scheduler already runs the ragged tiles the shape has. Below the wave boundary this kernel should not be selected for dense shapes: a dedicated small-M kernel (split-K or a swapped-operand schedule with `block_m` 16/32) is a follow-up rather than a tuning of this one, and the short-group 3WG fused-activation kernel keeps the MoE decode regime.

Second commit, after the staged grouped-GEMM wiring measured the template inside the experts pipeline: a tight group's ragged last tile was written straight from the accumulator fragment under a row predicate (TMA cannot clip it against the group). On DeepSeek-V3's down projection (N 7168, K 2048) under random routing that cost 12–24% against `GroupedGemmPersistent3WGKernel`; the tile now stages through the warp-group's shared buffer like a full tile and writes back with row-predicated vector stores. Interleaved on H200, E=128, 32768 rows, random routing: down 2.19–2.28 → 1.89–1.91 ms, gate_up 3.78–3.83 → 3.67 ms; the template is now 1.02–1.05x the 3WG kernel on both projections. Only the tight type compiles this branch; the tables above were measured before it, so the tight rows there are conservative.

Third commit, from a boundary audit of the kernel (52 offline cases: ragged N and K, 0- and 1-row groups, 1000 groups, masked counts past `max_m`, clusters with odd tile counts, every host refusal): a zero-row call divided by zero in the selector and now returns the empty output; three inputs that computed a wrong answer or failed at TMA descriptor encode are refused with a message — a pinned `block_m` that differs from an aligned layout's `m_alignment` (the kernel rounds group starts to `block_m`), a cluster pinned on a per-group type (a CTA pair straddled two groups), and `N` not a multiple of 8 or `K = 0`. Also refused: `num_groups` or `m_alignment` below 1, operands under two dims, `out` aliasing an operand, operands on different devices, operands or `grouped_layout` not contiguous in their physical layout. The aligned per-row peer-row read is clamped inside the metadata, and the tight ragged store carries an explicit column guard. No selector-chosen spec was affected; every refusal names its reason.

## Follow-ups

- Third PR, after this and the interface PR: an adapter class over the staged op's `MGroupedGemmCall` (its `applies` claims the grouped layouts this kernel has a type for — tight psum, aligned psum, aligned per-row, masked — its constructor looks the layout up into a `gemm_type` and builds this kernel, its `forward` passes the metadata as `grouped_layout`), the manifest `kernel_map` and workloads, a benchmark, and the replacement of `GroupedGemmPersistent3WGKernel` where this kernel covers it (the fused-activation variant stays: it needs a gate/up epilogue this kernel does not have, and small M is out of scope).
- A small-M kernel for the decode regime (M ≤ 128 dense, short groups in MoE): split-K or a swapped-operand schedule with `block_m` 16/32. Out of this template's scope by decision; until it exists the 3WG fused-activation kernel and `GemmKernel`'s small-batch paths keep those shapes.
- `GemmFwdOp` dense adapter, after a measured comparison against `GemmKernel` on the dense workloads.
- Mid-batch `BATCHED` einsum layout; re-run the calibration sweep on other devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
