### PR TITLE
[Perf][foundry][RoPE] Stage the neox 2d span, and hold a RoFormer run in registers

### DIFF
--- a/src/tileops/kernels/rope.py
+++ b/src/tileops/kernels/rope.py
@@ -48,7 +48,7 @@ def _make_rope_neox_1d(
     """1D neox RoPE kernel: (seq_len, head_dim) x cos(seq_len, half) x sin(seq_len, half).
 
     cos/sin are of shape (seq_len, head_dim // 2), one entry per rotated pair.
-    The arithmetic is f32 and rounds once, at the store into ``y``.
+    The arithmetic is f32 and rounds once.
     """
     half = head_dim // 2
     n_pairs = seq_len * half
@@ -94,7 +94,7 @@ def _make_rope_neox_2d(
 
     cos/sin are of shape (seq_len, head_dim // 2), broadcast over batch and heads.
     ``x`` and ``y`` are flat: the caller reshapes. The arithmetic is f32 and rounds
-    once, at the store into ``y``.
+    once.
     """
     half = head_dim // 2
     n_total = batch * seq_len * num_heads * head_dim
@@ -160,8 +160,7 @@ def _make_rope_non_neox_1d(
     """1D non-neox (RoFormer) RoPE kernel: adjacent-pair rotation.
 
     cos/sin shape: (seq_len, head_dim // 2), one entry per pair; entry ``p`` serves
-    columns ``2p`` and ``2p + 1``. The arithmetic is f32 and rounds once, at the store
-    into ``y``.
+    columns ``2p`` and ``2p + 1``. The arithmetic is f32 and rounds once.
     """
     half = head_dim // 2
     n_pairs = seq_len * half
@@ -238,8 +237,8 @@ def _make_rope_neox_position_ids_thd(
     """THD neox RoPE kernel with explicit absolute position ids.
 
     ``x`` and ``y`` are flat over ``(num_tokens, num_heads, head_dim)``. Columns past
-    ``rotary_dim`` are copied through unrotated. The arithmetic is f32 and rounds once,
-    at the store into ``y``.
+    ``rotary_dim`` are copied through unrotated. The arithmetic is f32 and rounds
+    once.
 
     A position outside ``[0, max_position)`` is clamped to the table rather than
     faulting, and ``status`` counts how many were seen. The count only grows and is
@@ -251,7 +250,6 @@ def _make_rope_neox_position_ids_thd(
     n_total = num_tokens * token_stride
     n_pairs = num_tokens * num_heads * half
     n_tail = num_tokens * num_heads * (head_dim - rotary_dim)
-    # One grid covers both walks, so the longer of the two sizes it.
     n_walked = max(n_pairs, n_tail)
 
     @tilelang.jit(out_idx=[5])
@@ -557,8 +555,8 @@ class RopeNeoxPositionIdsKernel(Kernel):
         self.rotary_dim = rotary_dim
         self.max_position = max_position
         self.dtype = dtype
-        #: Grows by one per position seen outside ``[0, max_position)``, and is never
-        #: reset; ``take_out_of_range`` answers whether it moved.
+        # Grows by one per position seen outside [0, max_position), and is never
+        # reset; take_out_of_range answers whether it moved.
         self._status: torch.Tensor | None = None
         self._seen_out_of_range = 0
         self.kernel = self._build_kernel()

--- a/src/tileops/kernels/rope.py
+++ b/src/tileops/kernels/rope.py
@@ -17,8 +17,10 @@ Layouts:
 - 1D: (seq_len, head_dim) — single-head or pre-reshaped
 - 2D: (batch, seq_len, num_heads, head_dim) — multi-head batched
 
-Each kernel class uses the ``explicit_parallel`` strategy:
-    Global → Register → Compute → Register → Global
+Schedules:
+- Walked: operands are read from global memory into registers and stored straight back.
+- Staged: a block moves a contiguous span through shared memory, so its global read and
+  its write are one run apiece. A block that cannot cover a whole span walks instead.
 """
 
 import functools
@@ -55,7 +57,6 @@ def _make_rope_neox_1d(
     """
     half = head_dim // 2
     n_pairs = seq_len * half
-    block_size = threads * num_per_thread
 
     @tilelang.jit(out_idx=[3])
     def kernel(threads_arg, npt_arg):
@@ -66,7 +67,7 @@ def _make_rope_neox_1d(
             sin_table: T.Tensor((seq_len, half), dtype),
             y: T.Tensor((seq_len, head_dim), dtype),
         ):
-            with T.Kernel(T.ceildiv(n_pairs, block_size), threads=threads_arg) as bx:
+            with T.Kernel(T.ceildiv(n_pairs, threads_arg * npt_arg), threads=threads_arg) as bx:
                 for i, j in T.Parallel(threads_arg, npt_arg):
                     pair_idx = (bx * threads_arg + i) * npt_arg + j
                     if pair_idx < n_pairs:
@@ -98,14 +99,20 @@ def _make_rope_neox_2d(
 
     cos/sin are of shape (seq_len, head_dim // 2), broadcast over batch and heads.
     One thread per pair ``(c, c + half)``; the arithmetic is f32 and rounds once.
+
+    A pair spans ``half`` columns, so a span of whole head rows holds both members of
+    every pair in it and the block can stage it. A partial span walks instead.
     """
     half = head_dim // 2
     n_total = batch * seq_len * num_heads * head_dim
     n_pairs = batch * seq_len * num_heads * half
-    block_size = threads * num_per_thread
 
     @tilelang.jit(out_idx=[3])
     def kernel(threads_arg, npt_arg):
+        block = threads_arg * npt_arg
+        span = (block // half) * head_dim
+        staged = block % half == 0 and n_total % span == 0
+
         @T.prim_func
         def main(
             x: T.Tensor((n_total,), dtype),
@@ -113,20 +120,40 @@ def _make_rope_neox_2d(
             sin_table: T.Tensor((seq_len, half), dtype),
             y: T.Tensor((n_total,), dtype),
         ):
-            with T.Kernel(T.ceildiv(n_pairs, block_size), threads=threads_arg) as bx:
-                for i, j in T.Parallel(threads_arg, npt_arg):
-                    pair_idx = (bx * threads_arg + i) * npt_arg + j
-                    if pair_idx < n_pairs:
-                        head = pair_idx // half
-                        col = pair_idx % half
-                        s_idx = (head // num_heads) % seq_len
-                        low = head * head_dim + col
+            if staged:
+                with T.Kernel(n_total // span, threads=threads_arg) as bx:
+                    xs = T.alloc_shared((span,), dtype)
+                    ys = T.alloc_shared((span,), dtype)
+                    at = bx * span
+                    T.copy(x[at : at + span], xs)
+                    for i, j in T.Parallel(threads_arg, npt_arg):
+                        pair = i * npt_arg + j
+                        local = pair // half
+                        col = pair % half
+                        s_idx = ((at // head_dim + local) // num_heads) % seq_len
+                        slot = local * head_dim + col
                         c = T.Cast("float32", cos_table[s_idx, col])
                         s = T.Cast("float32", sin_table[s_idx, col])
-                        x_low = T.Cast("float32", x[low])
-                        x_high = T.Cast("float32", x[low + half])
-                        y[low] = T.Cast(dtype, x_low * c - x_high * s)
-                        y[low + half] = T.Cast(dtype, x_high * c + x_low * s)
+                        x_low = T.Cast("float32", xs[slot])
+                        x_high = T.Cast("float32", xs[slot + half])
+                        ys[slot] = T.Cast(dtype, x_low * c - x_high * s)
+                        ys[slot + half] = T.Cast(dtype, x_high * c + x_low * s)
+                    T.copy(ys, y[at : at + span])
+            else:
+                with T.Kernel(T.ceildiv(n_pairs, block), threads=threads_arg) as bx:
+                    for i, j in T.Parallel(threads_arg, npt_arg):
+                        pair_idx = (bx * threads_arg + i) * npt_arg + j
+                        if pair_idx < n_pairs:
+                            head = pair_idx // half
+                            col = pair_idx % half
+                            s_idx = (head // num_heads) % seq_len
+                            low = head * head_dim + col
+                            c = T.Cast("float32", cos_table[s_idx, col])
+                            s = T.Cast("float32", sin_table[s_idx, col])
+                            x_low = T.Cast("float32", x[low])
+                            x_high = T.Cast("float32", x[low + half])
+                            y[low] = T.Cast(dtype, x_low * c - x_high * s)
+                            y[low + half] = T.Cast(dtype, x_high * c + x_low * s)
 
         return main
 
@@ -141,20 +168,21 @@ def _make_rope_non_neox_1d(
 
     cos/sin shape: (seq_len, head_dim // 2), one entry per pair.
     The arithmetic is f32 and rounds once.
+
+    A thread owns ``num_per_thread`` consecutive columns, so both members of every pair
+    it rotates arrive in one access and the rotation runs in registers. The run has to
+    stay inside one row; a width that leaves it straddling two walks the pairs instead.
     """
     half = head_dim // 2
     n_pairs = seq_len * half
-    block_size = threads * num_per_thread
-    rows_per_block = block_size // head_dim
-    staged = (
-        num_per_thread % 2 == 0
-        and rows_per_block > 0
-        and block_size % head_dim == 0
-        and seq_len % rows_per_block == 0
-    )
 
     @tilelang.jit(out_idx=[3])
     def kernel(threads_arg, npt_arg):
+        block = threads_arg * npt_arg
+        vectorized = (
+            npt_arg % 2 == 0 and head_dim % npt_arg == 0 and (seq_len * head_dim) % block == 0
+        )
+
         @T.prim_func
         def main(
             x: T.Tensor((seq_len, head_dim), dtype),
@@ -162,26 +190,33 @@ def _make_rope_non_neox_1d(
             sin_table: T.Tensor((seq_len, half), dtype),
             y: T.Tensor((seq_len, head_dim), dtype),
         ):
-            if staged:
-                with T.Kernel(seq_len // rows_per_block, threads=threads_arg) as bx:
-                    xs = T.alloc_shared((rows_per_block, head_dim), dtype)
-                    ys = T.alloc_shared((rows_per_block, head_dim), dtype)
-                    row0 = bx * rows_per_block
-                    T.copy(x[row0 : row0 + rows_per_block, :], xs)
-                    for i, j in T.Parallel(threads_arg, npt_arg // 2):
-                        slot = i * npt_arg + j * 2
-                        row = slot // head_dim
-                        col = slot % head_dim
-                        pair = col // 2
-                        c = T.Cast("float32", cos_table[row0 + row, pair])
-                        s = T.Cast("float32", sin_table[row0 + row, pair])
-                        x_even = T.Cast("float32", xs[row, col])
-                        x_odd = T.Cast("float32", xs[row, col + 1])
-                        ys[row, col] = T.Cast(dtype, x_even * c - x_odd * s)
-                        ys[row, col + 1] = T.Cast(dtype, x_odd * c + x_even * s)
-                    T.copy(ys, y[row0 : row0 + rows_per_block, :])
+            if vectorized:
+                with T.Kernel(seq_len * head_dim // block, threads=threads_arg) as bx:
+                    tx = T.get_thread_binding()
+                    run = T.alloc_local([npt_arg], dtype)
+                    turned = T.alloc_local([npt_arg], dtype)
+                    cs = T.alloc_local([npt_arg // 2], dtype)
+                    sn = T.alloc_local([npt_arg // 2], dtype)
+                    at = (bx * threads_arg + tx) * npt_arg
+                    row = at // head_dim
+                    col = at % head_dim
+                    for i in T.vectorized(npt_arg):
+                        run[i] = x[row, col + i]
+                    for i in T.vectorized(npt_arg // 2):
+                        cs[i] = cos_table[row, col // 2 + i]
+                    for i in T.vectorized(npt_arg // 2):
+                        sn[i] = sin_table[row, col // 2 + i]
+                    for i in T.serial(npt_arg // 2):
+                        x_even = T.Cast("float32", run[i * 2])
+                        x_odd = T.Cast("float32", run[i * 2 + 1])
+                        c = T.Cast("float32", cs[i])
+                        s = T.Cast("float32", sn[i])
+                        turned[i * 2] = T.Cast(dtype, x_even * c - x_odd * s)
+                        turned[i * 2 + 1] = T.Cast(dtype, x_odd * c + x_even * s)
+                    for i in T.vectorized(npt_arg):
+                        y[row, col + i] = turned[i]
             else:
-                with T.Kernel(T.ceildiv(n_pairs, block_size), threads=threads_arg) as bx:
+                with T.Kernel(T.ceildiv(n_pairs, block), threads=threads_arg) as bx:
                     for i, j in T.Parallel(threads_arg, npt_arg):
                         pair_idx = (bx * threads_arg + i) * npt_arg + j
                         if pair_idx < n_pairs:
@@ -230,7 +265,6 @@ def _make_rope_neox_position_ids_thd(
     n_total = num_tokens * token_stride
     n_pairs = num_tokens * num_heads * half
     n_tail = num_tokens * num_heads * (head_dim - rotary_dim)
-    block_size = threads * num_per_thread
     # One grid covers both walks, so the copied columns get blocks of their own
     # where there are more of them than there are rotated pairs.
     n_walked = max(n_pairs, n_tail)
@@ -246,7 +280,7 @@ def _make_rope_neox_position_ids_thd(
             status: T.Tensor((1,), "int32"),
             y: T.Tensor((n_total,), dtype),
         ):
-            with T.Kernel(T.ceildiv(n_walked, block_size), threads=threads_arg) as bx:
+            with T.Kernel(T.ceildiv(n_walked, threads_arg * npt_arg), threads=threads_arg) as bx:
                 for i, j in T.Parallel(threads_arg, npt_arg):
                     token = (bx * threads_arg + i) * npt_arg + j
                     if token < num_tokens:
@@ -297,12 +331,12 @@ def _make_rope_non_neox_2d(
     half = head_dim // 2
     n_total = batch * seq_len * num_heads * head_dim
     n_pairs = n_total // 2
-    block_size = threads * num_per_thread
-
-    staged = num_per_thread % 2 == 0 and n_total % block_size == 0 and block_size % head_dim == 0
 
     @tilelang.jit(out_idx=[3])
     def kernel(threads_arg, npt_arg):
+        block = threads_arg * npt_arg
+        staged = npt_arg % 2 == 0 and n_total % block == 0 and block % head_dim == 0
+
         @T.prim_func
         def main(
             x: T.Tensor((n_total,), dtype),
@@ -311,13 +345,13 @@ def _make_rope_non_neox_2d(
             y: T.Tensor((n_total,), dtype),
         ):
             if staged:
-                with T.Kernel(T.ceildiv(n_total, block_size), threads=threads_arg) as bx:
-                    xs = T.alloc_shared((block_size,), dtype)
-                    ys = T.alloc_shared((block_size,), dtype)
-                    T.copy(x[bx * block_size : (bx + 1) * block_size], xs)
+                with T.Kernel(n_total // block, threads=threads_arg) as bx:
+                    xs = T.alloc_shared((block,), dtype)
+                    ys = T.alloc_shared((block,), dtype)
+                    T.copy(x[bx * block : (bx + 1) * block], xs)
                     for i, j in T.Parallel(threads_arg, npt_arg // 2):
                         slot = i * npt_arg + j * 2
-                        idx = bx * block_size + slot
+                        idx = bx * block + slot
                         head = idx // head_dim
                         pair = (idx % head_dim) // 2
                         s_idx = (head // num_heads) % seq_len
@@ -327,9 +361,9 @@ def _make_rope_non_neox_2d(
                         x_odd = T.Cast("float32", xs[slot + 1])
                         ys[slot] = T.Cast(dtype, x_even * c - x_odd * s)
                         ys[slot + 1] = T.Cast(dtype, x_odd * c + x_even * s)
-                    T.copy(ys, y[bx * block_size : (bx + 1) * block_size])
+                    T.copy(ys, y[bx * block : (bx + 1) * block])
             else:
-                with T.Kernel(T.ceildiv(n_pairs, block_size), threads=threads_arg) as bx:
+                with T.Kernel(T.ceildiv(n_pairs, block), threads=threads_arg) as bx:
                     for i, j in T.Parallel(threads_arg, npt_arg):
                         pair_idx = (bx * threads_arg + i) * npt_arg + j
                         if pair_idx < n_pairs:
@@ -450,11 +484,21 @@ class _RopeKernelBase(Kernel):
 
     @property
     def default_config(self) -> dict:
+        """Threads and per-thread work, measured on this family's widest workloads.
+
+        ``num_per_thread`` counts columns for the non-neox rotation and pairs for the
+        neox one.
+        """
+        if self.layout == "1d":
+            if self.ROTATION_STYLE == "non_neox":
+                return {"threads": 256, "num_per_thread": 16 // self.dtype.itemsize}
+            npt = 2 if self.dtype == torch.float32 else 4
+            return {"threads": 256, "num_per_thread": npt}
         if self.ROTATION_STYLE == "non_neox":
             npt = 8 if self.dtype == torch.float32 else 16
             return {"threads": 128, "num_per_thread": npt}
-        npt = 2 if self.dtype == torch.float32 else 4
-        return {"threads": 256, "num_per_thread": npt}
+        npt = 4 if self.dtype == torch.float32 else 8
+        return {"threads": 128, "num_per_thread": npt}
 
     def forward(self, x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
         """Apply RoPE rotation.

--- a/src/tileops/kernels/rope.py
+++ b/src/tileops/kernels/rope.py
@@ -16,11 +16,6 @@ Two rotation styles exist at the kernel level:
 Layouts:
 - 1D: (seq_len, head_dim) — single-head or pre-reshaped
 - 2D: (batch, seq_len, num_heads, head_dim) — multi-head batched
-
-Schedules:
-- Walked: operands are read from global memory into registers and stored straight back.
-- Staged: a block moves a contiguous span through shared memory, so its global read and
-  its write are one run apiece. A block that cannot cover a whole span walks instead.
 """
 
 import functools
@@ -53,7 +48,7 @@ def _make_rope_neox_1d(
     """1D neox RoPE kernel: (seq_len, head_dim) x cos(seq_len, half) x sin(seq_len, half).
 
     cos/sin are of shape (seq_len, head_dim // 2), one entry per rotated pair.
-    One thread per pair ``(c, c + half)``; the arithmetic is f32 and rounds once.
+    The arithmetic is f32 and rounds once, at the store into ``y``.
     """
     half = head_dim // 2
     n_pairs = seq_len * half
@@ -98,10 +93,8 @@ def _make_rope_neox_2d(
     """2D neox RoPE kernel: (batch, seq_len, num_heads, head_dim).
 
     cos/sin are of shape (seq_len, head_dim // 2), broadcast over batch and heads.
-    One thread per pair ``(c, c + half)``; the arithmetic is f32 and rounds once.
-
-    A pair spans ``half`` columns, so a span of whole head rows holds both members of
-    every pair in it and the block can stage it. A partial span walks instead.
+    ``x`` and ``y`` are flat: the caller reshapes. The arithmetic is f32 and rounds
+    once, at the store into ``y``.
     """
     half = head_dim // 2
     n_total = batch * seq_len * num_heads * head_dim
@@ -166,12 +159,9 @@ def _make_rope_non_neox_1d(
 ) -> object:
     """1D non-neox (RoFormer) RoPE kernel: adjacent-pair rotation.
 
-    cos/sin shape: (seq_len, head_dim // 2), one entry per pair.
-    The arithmetic is f32 and rounds once.
-
-    A thread owns ``num_per_thread`` consecutive columns, so both members of every pair
-    it rotates arrive in one access and the rotation runs in registers. The run has to
-    stay inside one row; a width that leaves it straddling two walks the pairs instead.
+    cos/sin shape: (seq_len, head_dim // 2), one entry per pair; entry ``p`` serves
+    columns ``2p`` and ``2p + 1``. The arithmetic is f32 and rounds once, at the store
+    into ``y``.
     """
     half = head_dim // 2
     n_pairs = seq_len * half
@@ -247,26 +237,21 @@ def _make_rope_neox_position_ids_thd(
 ) -> object:
     """THD neox RoPE kernel with explicit absolute position ids.
 
-    A thread owns the pair ``(c, c + half)`` a neox rotation couples, so ``x`` is
-    read once and both of its outputs leave in the same step: the walked space is
-    the rotated half, not the head. Where ``rotary_dim < head_dim`` a second walk
-    copies the columns past it. The rotation runs in f32 and rounds once, at the
-    store into ``y``.
+    ``x`` and ``y`` are flat over ``(num_tokens, num_heads, head_dim)``. Columns past
+    ``rotary_dim`` are copied through unrotated. The arithmetic is f32 and rounds once,
+    at the store into ``y``.
 
-    ``status`` counts the positions seen outside ``[0, max_position)``. It is
-    reported from a walk over the token axis, which is ``num_heads * half`` times
-    shorter than the rotation's, so the rotation stays branch-free; the rotation
-    clamps its own table index so an out-of-range position cannot fault before the
-    caller reads the count back. The count only grows, which is what lets one
-    buffer serve every call without a reset: a caller raises when it moves.
+    A position outside ``[0, max_position)`` is clamped to the table rather than
+    faulting, and ``status`` counts how many were seen. The count only grows and is
+    never reset, so one buffer serves every call and a caller learns of an out-of-range
+    position by the count moving.
     """
     half = rotary_dim // 2
     token_stride = num_heads * head_dim
     n_total = num_tokens * token_stride
     n_pairs = num_tokens * num_heads * half
     n_tail = num_tokens * num_heads * (head_dim - rotary_dim)
-    # One grid covers both walks, so the copied columns get blocks of their own
-    # where there are more of them than there are rotated pairs.
+    # One grid covers both walks, so the longer of the two sizes it.
     n_walked = max(n_pairs, n_tail)
 
     @tilelang.jit(out_idx=[5])
@@ -484,10 +469,10 @@ class _RopeKernelBase(Kernel):
 
     @property
     def default_config(self) -> dict:
-        """Threads and per-thread work, measured on this family's widest workloads.
+        """Default threads and per-thread work.
 
         ``num_per_thread`` counts columns for the non-neox rotation and pairs for the
-        neox one.
+        neox one, so a caller overriding it states its own units.
         """
         if self.layout == "1d":
             if self.ROTATION_STYLE == "non_neox":
@@ -572,9 +557,8 @@ class RopeNeoxPositionIdsKernel(Kernel):
         self.rotary_dim = rotary_dim
         self.max_position = max_position
         self.dtype = dtype
-        #: Grows by one per position seen outside ``[0, max_position)``. One buffer
-        #: serves every call because the count is never reset; ``out_of_range_since``
-        #: answers whether it moved.
+        #: Grows by one per position seen outside ``[0, max_position)``, and is never
+        #: reset; ``take_out_of_range`` answers whether it moved.
         self._status: torch.Tensor | None = None
         self._seen_out_of_range = 0
         self.kernel = self._build_kernel()
@@ -601,8 +585,7 @@ class RopeNeoxPositionIdsKernel(Kernel):
     def take_out_of_range(self) -> bool:
         """Whether a call since the previous ask saw a position outside the table.
 
-        One device read per ask, and the count it compares against is held here, so
-        a caller pays one synchronisation rather than one before and one after.
+        Costs one device synchronisation per ask.
         """
         if self._status is None:
             return False


### PR DESCRIPTION
## Summary

- The 2d neox rotation walked pairs in global memory: a thread read two runs 128 B apart and wrote two more. A block covering whole head rows holds both members of every pair in it, so it now stages the span through shared memory and each block's global read and write are one contiguous run.
- The non-neox 1d rotation staged its block through shared memory to make adjacent-pair reads contiguous. A thread owning a whole run of columns already holds both members of every pair, so that layout drops the staging, its barrier and its divisibility conditions.
- `default_config` is layout-aware: the 2d workloads measured fastest at 128 threads and the 1d workloads at 256, at every run width tried.
- Every builder derives its grid, span and branch from the jit parameters instead of the arguments it was cached under. A config arriving after the build — a caller's override, or autotune — could otherwise take a branch sized for a different one and leave part of the tensor unwritten.
- Docstrings state what a caller gets — table shapes, flat operands, the f32 rounding, the clamp-and-count on an out-of-range position — instead of which values a thread owns.
- No manifest, tolerance or public-contract change. Test-node delta: 0.

Four ops share the neox builders — `RopeNeoxFwdOp`, `RopeLlama31FwdOp`, `RopeYarnFwdOp`, `RopeLongRopeFwdOp` — differing only in how the op layer fills the frequency table. `RopeNeoxPositionIdsFwdOp` is untouched and reported as a control.

## Benchmark

**Environment**: NVIDIA H200 (one idle device, not the CI runners'), CUDA 13.2, driver 595.71.05, PyTorch 2.13.0+cu132, TileLang 0.1.11+cu132.gitafcebed1

Method: candidates are built in one process and timed round-robin, five rounds each; the figure is the minimum of the five per-round medians of device-busy time. `before` is the merge base at its own default config.

| Op | Shape | dtype | Layout | Before (us) | After (us) | Speedup | torch-compile | BW (TB/s) |
| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: |
| Neox / Llama31 / Yarn / LongRope | (2048, 64) | float16 | 1d | 1.696 | 1.696 | 1.000x | 1.792 | 0.464 |
| Neox / Llama31 / Yarn / LongRope | (4096, 128) | bfloat16 | 1d | 2.432 | 2.432 | 1.000x | 2.816 | 1.293 |
| Neox / Llama31 / Yarn / LongRope | (8192, 128) | bfloat16 | 1d | 3.296 | 3.296 | 1.000x | 4.224 | 1.909 |
| Neox / Llama31 / Yarn / LongRope | (2, 2048, 32, 128) | float16 | 2d | 18.400 | 18.080 | **1.018x** | 18.080 | 3.741 |
| Neox / Llama31 / Yarn / LongRope | (1, 8192, 32, 128) | float16 | 2d | 34.528 | 34.048 | **1.014x** | 33.985 | 4.004 |
| NonNeox | (2048, 64) | float16 | 1d | 1.857 | 1.664 | **1.116x** | 1.888 | 0.473 |
| NonNeox | (2, 2048, 32, 128) | bfloat16 | 2d | 18.208 | 18.224 | 0.999x | 24.000 | 3.711 |

Distance to the wall, in a second sitting. `wall` is a `torch.compile` kernel that scales the same bytes: two units of traffic, no rotation, no table. For the 1d rows, whose tables are a third of their traffic, the column is a traffic-matched floor instead — `torch.compile` over `x`, half-width `cos` and half-width `sin`.

| Op | Shape | dtype | tileops (us) | torch-compile | wall / floor | ours / wall |
| --- | --- | --- | ---: | ---: | ---: | ---: |
| Neox 1d | (2048, 64) | float16 | 1.696 | 1.075x | 1.697 | 1.000 |
| Neox 1d | (4096, 128) | bfloat16 | 2.400 | 1.200x | 2.464 | 0.974 |
| Neox 1d | (8192, 128) | bfloat16 | 3.328 | 1.269x | 3.232 | 1.030 |
| Neox 2d | (2, 2048, 32, 128) | float16 | 18.048 | 0.998x | 17.888 | 1.009 |
| Neox 2d | (1, 8192, 32, 128) | float16 | 33.952 | 1.000x | 33.281 | 1.020 |
| NonNeox 1d | (2048, 64) | float16 | 1.663 | 1.096x | 1.697 | 0.980 |
| NonNeox 2d | (2, 2048, 32, 128) | bfloat16 | 17.984 | 1.335x | 17.856 | 1.007 |
| NeoxPositionIds | (2048, 32, 128) | float16 | 10.353 | 1.116x | 10.080 | 1.027 |
| NeoxPositionIds | (4096, 32, 128) | bfloat16 | 18.784 | 1.126x | 17.888 | 1.050 |

`benchmarks/ops/bench_rope.py` unmodified, base then branch, alternated within five minutes, agrees on direction: the 2d neox row moves 0.978 → 0.989 of `torch.compile`, non-neox 1d 1.056 → 1.187, non-neox 2d 1.000 → 1.017, the `(1, 8192, 32, 128)` row 0.994 → 1.003, and the THD rows do not move. It quantizes to 0.1 us, so it cannot resolve magnitude.

**Takeaways:**

- The two 2d neox rows were the family's only rows behind a comparator. They are now at parity with `torch.compile`, and within 0.9% and 2.0% of a kernel that only copies their bytes.
- The non-neox 1d row gains 1.116x by deleting work: the staging round trip cost more than the unaligned reads it existed to avoid. It now runs below its traffic-matched floor.
- The non-neox 2d row keeps its staged schedule and does not move; its 1.335x over `torch.compile` is inductor materializing the interleaved rotation.

## TileFoundry Description

The authored program states the contract and where the values live. The 2d rotation stages a slice of whole head rows and rotates it from registers; the non-neox 1d rotation holds its run in registers alone. Both read the frequency table once per pair.

```python
@module(entry="rope_neox_2d", target=_H200, topologies=(Topology("cta", CTAS),))
class Neox2dStaged:
    @func
    def rope_neox_2d(
        x: Tensor[(B, S, H, D), "f16"],
        cos_table: Tensor[(S, HALF), "f16"],
        sin_table: Tensor[(S, HALF), "f16"],
    ) -> Tensor[(B, S, H, D), "f16"]:
        with Mesh(("cta",), layout=(CTAS,), names=("tile",)) as cta:
            cos_row = tf.reshape(cos_table, new_shape=(1, S, 1, HALF))
            sin_row = tf.reshape(sin_table, new_shape=(1, S, 1, HALF))
            x_smem = tf.reshard(x, (B, S @ cta.tile, H, D), "smem")
            x_reg = tf.reshard(x_smem, (B, S @ cta.tile, H, D), "rmem")
            cos = tf.cast(tf.reshard(cos_row, (1, S @ cta.tile, 1, HALF), "rmem"), dtype="f32")
            sin = tf.cast(tf.reshard(sin_row, (1, S @ cta.tile, 1, HALF), "rmem"), dtype="f32")
            wide = tf.cast(x_reg, dtype="f32")
            low = wide[:, :, :, 0:HALF]
            high = wide[:, :, :, HALF:D]
            turned = tf.reshard(
                tf.cast(tf.concat([low * cos - high * sin, high * cos + low * sin], axis=-1), dtype="f16"),
                (B, S @ cta.tile, H, D),
                "smem",
            )
            return tf.reshard(turned, (B, S @ cta.tile, H, D), "gmem")
```

Each shipped kernel is held to its authored placement as a runtime twin, with the evaluator as the reference:

| Twin | Reference | Predicate | Result |
| --- | --- | --- | --- |
| `_make_rope_neox_2d(2, 8, 4, 128, "float16", 128, 8)` | `Neox2dStaged.rope_neox_2d` | `equal` | 0 of 8192 differ, **PASS** |
| `_make_rope_non_neox_1d(64, 64, "float16", 256, 8)` | `NonNeox1dHeld.rope_non_neox_1d` | `equal` | 0 of 4096 differ, **PASS** |

Five further modules — neox 1d and 2d, non-neox 1d and 2d, and the position-ids THD form — were each checked against a torch expectation built from the published rotation, `equal`, 0 mismatched, before any kernel was touched.

`analyze` on the `(2, 2048, 32, 128)` float16 shape:

| Program | gmem traffic | smem traffic | ideal-ns |
| --- | --- | --- | ---: |
| rotation of the halves, all in registers | `r34078720/w33554432` | — | 14091 |
| the staged placement above | `r34078720/w33554432` | `r67108864/w67108864` | 14091 |
| the same rotation over a `concat([cos, cos])` table | `r35651584/w34603008` | — | 14637 |

Two things follow. Rotating the halves against one table entry is what puts the program at its traffic floor — the doubled-table form moves 3.7% more for the same result, and both shipped styles read the table once per pair. And `analyze` prices traffic, not the shape of an access: the staged placement is identical to the register one in its model and adds a shared-memory round trip on top, yet measures 1.4% faster at the same thread count, 17.984 us against 18.241. The model chose the arithmetic; only measurement could choose the placement.

`ideal-ns` divides traffic by the 4.8 TB/s the target publishes. The measured rate is 3.75 TB/s and a copy of the same bytes reaches 3.78, so the distance from 14.091 us to 18.048 is nominal-versus-attainable bandwidth.

## Result And Limitations

**improvement without SOTA**

- Every benchmarked row beats every comparator, except the two 2d neox rows, which are at parity with `torch.compile` — 0.998x and 1.000x, at most one 0.033 us timer step, and the sign flips between sittings.
- Thirteen further schedules were measured and none beat the two adopted here: an explicit 16-byte register pair walk; several runs per thread on a grid stride; a linear walk over the output taking the partner with a sign; dropping the bound guard on divisible shapes; staging the span as a 2d tile so the load is a TMA operation like the store (equal, and it needs a 2d view from the op layer); pipelining several spans per block (2.6x slower — TileLang puts the TMA store's wait inside the loop, so nothing overlaps); staging the span's one shared frequency row (a no-op: it is one 128 B line and L1 broadcasts it); and a 25-point `(threads, num_per_thread)` grid on both 2d rows.
- Five of the thirteen were attempts on the THD rows, which sit 2.7% and 5.0% above a wall that moves 1.5% less traffic than they do. Two diagnostics bound what is left: reading a **constant** table row, so no address depends on a loaded position, is worth between nothing and 1.8% and the sign is not stable across the two shapes; and dropping the status count entirely is worth 0.6% to 0.9%, while the one restructuring that would keep it — confining it to the blocks that own tokens — measured no better than the shipped walk.
- The 1d rows do not move, and are not expected to: they move three units of traffic rather than two, and at 0.79 MB to 6 MB a `torch.compile` kernel with the same traffic and stream count measures 1.697, 2.464 and 3.232 us against this branch's 1.696, 2.400 and 3.328.
