### PR TITLE
[Perf][foundry][Pool] Stage an AvgPool1d row once, and read every tap from shared memory

### DIFF
--- a/src/tileops/kernels/pool/avg_pool1d.py
+++ b/src/tileops/kernels/pool/avg_pool1d.py
@@ -28,6 +28,29 @@ class _Span(NamedTuple):
         return self.span // self.vector_elems
 
 
+def _round_up(value: int, step: int) -> int:
+    return ((value + step - 1) // step) * step
+
+
+def _span(
+    tile_outputs: int, l_in: int, kernel_l: int, stride_l: int, pad_l: int, dtype: str
+) -> _Span:
+    """The stretch of a row a block stages to cover ``tile_outputs`` outputs.
+
+    Every staging load is a whole group of ``vector_elems``, and a group is loaded or
+    zeroed as one, so each has to sit either wholly inside the row or wholly outside it.
+    The width is narrowed until the three things that move a group boundary all divide
+    it: the block step, the head, and the row end.
+    """
+    vector_elems = VECTOR_ACCESS_BYTES // dtype_itemsize(dtype)
+    step = tile_outputs * stride_l
+    while vector_elems > 1 and (l_in % vector_elems or step % vector_elems):
+        vector_elems //= 2
+    head = _round_up(pad_l, vector_elems)
+    reach = head + (tile_outputs - 1) * stride_l + kernel_l
+    return _Span(vector_elems, head, _round_up(reach, vector_elems))
+
+
 class _WindowStaging:
     """What one block stages, and the launch shapes worth offering for it.
 
@@ -65,25 +88,10 @@ class _WindowStaging:
         self._pad_l = pad_l
         self._dtype = dtype
 
-    @staticmethod
-    def _round_up(value: int, step: int) -> int:
-        return ((value + step - 1) // step) * step
-
-    def span(self, tile_outputs: int) -> _Span:
-        """The stretch covering ``tile_outputs`` consecutive outputs.
-
-        Every staging load is a whole group of ``vector_elems``, and a group is loaded or
-        zeroed as one, so each has to sit either wholly inside the row or wholly outside
-        it. The width is narrowed until the three things that move a group boundary all
-        divide it: the block step, the head, and the row end.
-        """
-        vector_elems = VECTOR_ACCESS_BYTES // dtype_itemsize(self._dtype)
-        step = tile_outputs * self._stride_l
-        while vector_elems > 1 and (self._l_in % vector_elems or step % vector_elems):
-            vector_elems //= 2
-        head = self._round_up(self._pad_l, vector_elems)
-        reach = head + (tile_outputs - 1) * self._stride_l + self._kernel_l
-        return _Span(vector_elems, head, self._round_up(reach, vector_elems))
+    def _span(self, tile_outputs: int) -> _Span:
+        return _span(
+            tile_outputs, self._l_in, self._kernel_l, self._stride_l, self._pad_l, self._dtype
+        )
 
     def widths(self) -> list[int]:
         """The tile widths whose span fits the static shared budget, widest first.
@@ -93,9 +101,9 @@ class _WindowStaging:
                 size in the tens of thousands.
         """
         budget = STATIC_SHARED_BYTES // dtype_itemsize(self._dtype)
-        fitting = [width for width in self._TILE_CHOICES if self.span(width).span <= budget]
+        fitting = [width for width in self._TILE_CHOICES if self._span(width).span <= budget]
         if not fitting:
-            need = self.span(1).span * dtype_itemsize(self._dtype)
+            need = self._span(1).span * dtype_itemsize(self._dtype)
             raise ValueError(
                 f"avg_pool1d stages the pooling window in shared memory: kernel_size="
                 f"{self._kernel_l} needs {need} B for a single output, over the "
@@ -125,7 +133,7 @@ class _WindowStaging:
         unfilled.
         """
         width = self.width()
-        vectors = self.span(width).vectors
+        vectors = self._span(width).vectors
         blocks = self._rows * ((self._out_l + width - 1) // width)
         return [
             {"block_ol": width, "threads": threads}
@@ -161,11 +169,7 @@ def _avg_pool1d_kernel(
         # Outputs `stride_l` apart share taps, so a warp taking one output each reads one
         # short stretch of the row `kernel_l` times over, a narrow load each time. A block
         # stages that stretch with full-width loads and takes every tap from it.
-        #
-        # Built here rather than closed over: TileLang reads every free variable of a jit
-        # builder into the autotune cache key and asserts on anything but a scalar.
-        staging = _WindowStaging(rows, l_in, out_l, kernel_l, stride_l, pad_l, dtype)
-        vector_elems, head, span = staging.span(block_ol)
+        vector_elems, head, span = _span(block_ol, l_in, kernel_l, stride_l, pad_l, dtype)
         vectors = span // vector_elems
         # The tile holds zeros where it reaches outside the row, so no tap carries a test
         # and its index into the tile is this same constant in every block.

--- a/src/tileops/kernels/pool/avg_pool1d.py
+++ b/src/tileops/kernels/pool/avg_pool1d.py
@@ -1,15 +1,123 @@
 import functools
-import itertools
-from typing import Optional
+from typing import NamedTuple, Optional
 
 import tilelang
 import tilelang.language as T
 import torch
 
+from tileops.kernels.constants import STATIC_SHARED_BYTES, VECTOR_ACCESS_BYTES
 from tileops.kernels.kernel_base import Kernel
-from tileops.kernels.pool.common import fits_static_shared, pool_output_dim
+from tileops.kernels.pool.common import pool_output_dim
 
 __all__ = ["AvgPool1dKernel", "AvgPool1dSpatialKernel"]
+
+# Tile widths a launch may take, widest first. The tail below 128 is what keeps a window
+# too wide to stage at 128 outputs from having no width at all.
+_BLOCK_OL_CHOICES = (2048, 1024, 512, 256, 128, 64, 32, 16, 8, 4, 2, 1)
+# Two warps per block measured fastest only on the widest workload, and is what
+# the autotuner mispicks on a launch too short for it to tell candidates apart.
+_THREAD_CHOICES = (128, 256)
+# Measured best, or within one timer quantum of best, at all three manifest workloads.
+_DEFAULT_BLOCK_OL = 512
+_DEFAULT_THREADS = 128
+
+
+def _itemsize(dtype: str) -> int:
+    return 4 if dtype in ("float", "float32") else 2
+
+
+def _round_up(value: int, step: int) -> int:
+    return ((value + step - 1) // step) * step
+
+
+class _Staging(NamedTuple):
+    """Where one block's staged span sits in the row, and how wide its loads are."""
+
+    # Elements one full-width access covers.
+    vector_elems: int
+    # Elements staged in front of the block's leftmost window.
+    head: int
+    # Elements the block stages.
+    span: int
+
+    @property
+    def vectors(self) -> int:
+        """Full-width loads the staging pass issues."""
+        return self.span // self.vector_elems
+
+
+def _staging(
+    block_ol: int, l_in: int, kernel_l: int, stride_l: int, pad_l: int, dtype: str
+) -> _Staging:
+    """The staged span covering ``block_ol`` consecutive outputs.
+
+    The staging load is vectorized and unguarded, so every span start has to sit on a
+    multiple of the access width. Two things move a start: the block index, in steps of
+    ``block_ol * stride_l``, and the slide back inside the row at the end of a row, which
+    lands it on ``l_in - span``. The width is narrowed until it divides both. The head
+    then absorbs the left padding, and a span wider than the row is the whole row.
+    """
+    vector_elems = VECTOR_ACCESS_BYTES // _itemsize(dtype)
+    while vector_elems > 1 and (l_in % vector_elems or (block_ol * stride_l) % vector_elems):
+        vector_elems //= 2
+    head = _round_up(pad_l, vector_elems)
+    reach = head + (block_ol - 1) * stride_l + kernel_l
+    return _Staging(vector_elems, head, min(_round_up(reach, vector_elems), l_in))
+
+
+def _block_ol_choices(l_in: int, kernel_l: int, stride_l: int, pad_l: int, dtype: str) -> list[int]:
+    """The tile widths whose staged span fits the static shared budget, widest first.
+
+    Raises:
+        ValueError: When not even one output's window fits, which takes a kernel size
+            in the tens of thousands.
+    """
+    budget = STATIC_SHARED_BYTES // _itemsize(dtype)
+    fitting = [
+        block_ol
+        for block_ol in _BLOCK_OL_CHOICES
+        if _staging(block_ol, l_in, kernel_l, stride_l, pad_l, dtype).span <= budget
+    ]
+    if not fitting:
+        span = _staging(1, l_in, kernel_l, stride_l, pad_l, dtype).span
+        raise ValueError(
+            f"avg_pool1d stages the pooling window in shared memory: kernel_size="
+            f"{kernel_l} needs {span * _itemsize(dtype)} B for a single output, over "
+            f"the {STATIC_SHARED_BYTES} B a block gets"
+        )
+    return fitting
+
+
+def _thread_configs(
+    block_ol: int, l_in: int, kernel_l: int, stride_l: int, pad_l: int, dtype: str
+) -> list[dict]:
+    """Candidate configs at a fixed tile width: the block sizes worth timing on it.
+
+    The width is not a candidate. Two widths a factor of two apart differ by a few
+    percent here, which is under what the autotuner can resolve on a launch this short,
+    so it is settled by :func:`_default_block_ol` instead. A block with more threads than
+    the staging pass has full-width loads idles threads on the read this kernel is bound
+    by, which leaves at most one candidate on a narrow tile.
+    """
+    staged = _staging(block_ol, l_in, kernel_l, stride_l, pad_l, dtype)
+    return [
+        {"block_ol": block_ol, "threads": threads}
+        for threads in _THREAD_CHOICES
+        if staged.vectors >= threads
+    ] or [{"block_ol": block_ol, "threads": _DEFAULT_THREADS}]
+
+
+def _default_block_ol(
+    l_in: int, out_l: int, kernel_l: int, stride_l: int, pad_l: int, dtype: str
+) -> int:
+    """``_DEFAULT_BLOCK_OL``, narrowed twice.
+
+    Narrowed to what the static shared budget holds, and to what the output row is
+    wide enough to fill: a tile wider than the row only idles threads.
+    """
+    choices = _block_ol_choices(l_in, kernel_l, stride_l, pad_l, dtype)
+    wanted = min(_DEFAULT_BLOCK_OL, max(out_l, choices[-1]))
+    return next(block_ol for block_ol in choices if block_ol <= wanted)
 
 
 @functools.lru_cache(maxsize=64)
@@ -27,72 +135,128 @@ def _avg_pool1d_kernel(
     accum_dtype = "float"
     out_l = pool_output_dim(l_in, kernel_l, stride_l, pad_l, ceil_mode)
     rows = n * c_in
-    total = rows * out_l
     window_inside = pad_l == 0 and (out_l - 1) * stride_l + kernel_l <= l_in
     # Otherwise a window can overhang, and the divisor comes from its own extent.
     whole_window_divides = window_inside or (count_include_pad and not ceil_mode)
 
     @tilelang.jit(out_idx=[1], compile_flags=["-O3", "-DENABLE_BF16"])
-    def _avg_pool1d_func(block_m: int, threads: int):
-        tile_full = total % block_m == 0
-        # Neighbouring outputs read windows `stride_l` apart, so a warp's taps span
-        # several lines; a block holding a whole row reads it once instead.
-        stage_row = fits_static_shared(l_in, dtype)
+    def _avg_pool1d_func(block_ol: int, threads: int):
+        # Outputs `stride_l` apart share taps, so a warp taking one output each reads
+        # one short stretch of the row `kernel_l` times over, a narrow load each time. A
+        # block stages that stretch with full-width loads and takes every tap from it.
+        staged = _staging(block_ol, l_in, kernel_l, stride_l, pad_l, dtype)
+        vector_elems, head, span = staged
+        blocks_per_row = (out_l + block_ol - 1) // block_ol
+        tail_free = out_l % block_ol == 0
+        # Only the first and the last block of a row hold an overhanging window, so the
+        # blocks between them need neither the tap select nor a per-output divisor.
+        interior_split = (
+            not window_inside
+            and blocks_per_row >= 3
+            and block_ol * stride_l - pad_l >= 0
+            and ((blocks_per_row - 1) * block_ol - 1) * stride_l - pad_l + kernel_l <= l_in
+        )
+        # Inside those two blocks the overhang is a handful of outputs at the row ends.
+        clean_lo = -(-pad_l // stride_l)
+        clean_hi = min((l_in + pad_l - kernel_l) // stride_l, out_l - 1)
+
+        def _window_store(inside: bool):
+            """A macro storing one output's mean, reading the taps from the tile.
+
+            Args:
+                inside: Whether every tap of this output is known to be in the row.
+                    When it is not, the tap is read anyway and a select discards it,
+                    so an overhanging window costs no branch.
+            """
+
+            @T.macro
+            def _store(tile, offset, j, ol, out, out_row):
+                total = T.alloc_var(T.float32)
+                total = T.cast(0.0, accum_dtype)
+                if inside:
+                    # Written out rather than held in a var: bound analysis cannot
+                    # place a var inside the tile, and guards the tap load in 64-bit
+                    # addressing when it cannot.
+                    for k in T.serial(kernel_l):
+                        total += T.cast(tile[offset + j * stride_l + k], accum_dtype)
+                else:
+                    # A guard is emitted here whatever the index looks like, so the var
+                    # keeps the address arithmetic from repeating per tap. The clamp
+                    # keeps the discarded read inside the tile.
+                    at = T.alloc_var(T.int32)
+                    at = offset + j * stride_l
+                    for k in T.serial(kernel_l):
+                        tap = T.cast(tile[T.max(0, T.min(at + k, span - 1))], accum_dtype)
+                        src = ol * stride_l - pad_l + k
+                        total += T.if_then_else(
+                            (src >= 0) and (src < l_in), tap, T.cast(0.0, accum_dtype)
+                        )
+                if inside or whole_window_divides:
+                    out[out_row, ol] = T.cast(total * T.cast(1.0 / kernel_l, accum_dtype), dtype)
+                else:
+                    start = ol * stride_l - pad_l
+                    if count_include_pad:
+                        divisor = T.max(
+                            T.min(start + kernel_l, l_in + pad_l) - T.max(start, -pad_l), 1
+                        )
+                    else:
+                        divisor = T.max(T.min(start + kernel_l, l_in) - T.max(start, 0), 1)
+                    out[out_row, ol] = T.cast(total / T.cast(divisor, accum_dtype), dtype)
+
+            return _store
+
+        _interior = _window_store(True)
+        _boundary = _window_store(window_inside)
 
         @T.macro
-        def _mean_window(src, src_row, ol, out, out_row):
-            """Store the mean of one window of ``src[src_row]``.
-
-            ``src`` is indexed with a leading axis so the staged tile and ``x`` are
-            read the same way.
-            """
-            start = ol * stride_l - pad_l
-            total_val = T.alloc_var(T.float32)
-            total_val = T.cast(0.0, accum_dtype)
-            for k in T.serial(kernel_l):
-                il = start + k
-                if window_inside:
-                    total_val += T.cast(src[src_row, il], accum_dtype)
-                else:
-                    # A select, not a branch, so every thread walks the same window.
-                    # The clamp only keeps the discarded read in range.
-                    total_val += T.if_then_else(
-                        (il >= 0) and (il < l_in),
-                        T.cast(src[src_row, T.max(0, T.min(il, l_in - 1))], accum_dtype),
-                        T.cast(0.0, accum_dtype),
-                    )
-            if whole_window_divides:
-                divisor = T.cast(kernel_l, accum_dtype)
-            elif count_include_pad:
-                divisor = T.cast(
-                    T.max(T.min(start + kernel_l, l_in + pad_l) - T.max(start, -pad_l), 1),
-                    accum_dtype,
-                )
+        def _edge_split(tile, offset, j, ol, out, out_row):
+            """One edge block, testing each output for the clean path."""
+            if (ol >= clean_lo) and (ol <= clean_hi):
+                _interior(tile, offset, j, ol, out, out_row)
             else:
-                divisor = T.cast(
-                    T.max(T.min(start + kernel_l, l_in) - T.max(start, 0), 1),
-                    accum_dtype,
-                )
-            out[out_row, ol] = T.cast(total_val / divisor, dtype)
+                if ol < out_l:
+                    _boundary(tile, offset, j, ol, out, out_row)
+
+        @T.macro
+        def _edge_plain(tile, offset, j, ol, out, out_row):
+            """One edge block, on the overhang path throughout."""
+            if ol < out_l:
+                _boundary(tile, offset, j, ol, out, out_row)
+
+        # Testing each output costs two comparisons and buys the constant divisor, which
+        # pays only where a window's divisor is its own extent.
+        _edge = _edge_plain if whole_window_divides else _edge_split
 
         @T.prim_func
         def _avg_pool1d_main(
             x: T.Tensor((rows, l_in), dtype),  # type: ignore
             out: T.Tensor((rows, out_l), dtype),  # type: ignore
         ):
-            grid = rows if stage_row else T.ceildiv(total, block_m)
-            with T.Kernel(grid, threads=threads) as bx:
-                if stage_row:
-                    tile = T.alloc_shared((1, l_in), dtype)
-                    T.copy(x[bx, 0:l_in], tile[0, 0:l_in])
-                    for ol in T.Parallel(out_l):
-                        _mean_window(tile, 0, ol, out, bx)
-                else:
-                    for i in T.Parallel(block_m):
-                        idx = bx * block_m + i
-                        if tile_full or idx < total:
-                            row = idx // out_l
-                            _mean_window(x, row, idx % out_l, out, row)
+            with T.Kernel(blocks_per_row, rows, threads=threads) as (bx, by):
+                tile = T.alloc_shared((span,), dtype)
+                # Sliding the span back inside the row costs a few already-staged
+                # elements at the two ends and keeps every staging load unguarded.
+                start = T.max(0, T.min(bx * (block_ol * stride_l) - head, l_in - span))
+                for i in T.Parallel(staged.vectors):
+                    for v in T.vectorized(vector_elems):
+                        tile[i * vector_elems + v] = x[by, start + i * vector_elems + v]
+                offset = bx * (block_ol * stride_l) - pad_l - start
+                for j in T.Parallel(block_ol):
+                    ol = bx * block_ol + j
+                    if window_inside:
+                        if tail_free:
+                            _interior(tile, offset, j, ol, out, by)
+                        else:
+                            if ol < out_l:
+                                _interior(tile, offset, j, ol, out, by)
+                    else:
+                        if interior_split:
+                            if (bx > 0) and (bx < blocks_per_row - 1):
+                                _interior(tile, offset, j, ol, out, by)
+                            else:
+                                _edge(tile, offset, j, ol, out, by)
+                        else:
+                            _edge(tile, offset, j, ol, out, by)
 
         return _avg_pool1d_main
 
@@ -126,7 +290,7 @@ def _launch_avg_pool1d(
     ceil_mode: bool,
     count_include_pad: bool,
     dtype: str,
-    block_m: int,
+    block_ol: int,
     threads: int,
     x: torch.Tensor,
 ) -> torch.Tensor:
@@ -141,7 +305,7 @@ def _launch_avg_pool1d(
         ceil_mode,
         count_include_pad,
         dtype,
-    )(block_m, threads)
+    )(block_ol, threads)
 
     return kernel(x.contiguous().view(n * c_in, l_in)).view(n, c_in, out_l)
 
@@ -154,17 +318,22 @@ def _launch_avg_pool1d_spatial(
     stride_l: int,
     pad_l: int,
     dtype: str,
-    block_m: int,
+    block_ol: int,
     threads: int,
     x: torch.Tensor,
 ) -> torch.Tensor:
     return _launch_avg_pool1d(
-        n, c_in, l_in, kernel_l, stride_l, pad_l, False, True, dtype, block_m, threads, x
+        n, c_in, l_in, kernel_l, stride_l, pad_l, False, True, dtype, block_ol, threads, x
     )
 
 
 class AvgPool1dSpatialKernel(Kernel):
-    """Fast path for common NCL avg_pool1d workloads."""
+    """Fast path for common NCL avg_pool1d workloads.
+
+    Raises:
+        ValueError: When one pooling window does not fit the shared memory a block
+            stages it in, which takes a ``kernel_size`` in the tens of thousands.
+    """
 
     supported_archs: list[int] = [80, 86, 89, 90]
 
@@ -204,16 +373,27 @@ class AvgPool1dSpatialKernel(Kernel):
     @property
     def default_config(self) -> dict:
         return {
-            "block_m": 256,
-            "threads": 256,
+            "block_ol": _default_block_ol(
+                self.l_in,
+                self.out_l,
+                self.kernel_l,
+                self.stride_l,
+                self.pad_l,
+                self.dtype_str,
+            ),
+            "threads": _DEFAULT_THREADS,
         }
 
     @property
     def autotune_configs(self) -> list[dict]:
-        return [
-            {"block_m": block_m, "threads": threads}
-            for block_m, threads in itertools.product([128, 256, 512], [128, 256, 512])
-        ]
+        return _thread_configs(
+            self.default_config["block_ol"],
+            self.l_in,
+            self.kernel_l,
+            self.stride_l,
+            self.pad_l,
+            self.dtype_str,
+        )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         self._require_cuda(x=x)
@@ -225,13 +405,20 @@ class AvgPool1dSpatialKernel(Kernel):
             self.stride_l,
             self.pad_l,
             self.dtype_str,
-            self.config["block_m"],
+            self.config["block_ol"],
             self.config["threads"],
             x,
         )
 
 
 class AvgPool1dKernel(Kernel):
+    """Average pooling over an NCL row, with every PyTorch flag combination.
+
+    Raises:
+        ValueError: When one pooling window does not fit the shared memory a block
+            stages it in, which takes a ``kernel_size`` in the tens of thousands.
+    """
+
     supported_archs: list[int] = [80, 86, 89, 90]
 
     def __init__(
@@ -276,16 +463,27 @@ class AvgPool1dKernel(Kernel):
     @property
     def default_config(self) -> dict:
         return {
-            "block_m": 256,
-            "threads": 256,
+            "block_ol": _default_block_ol(
+                self.l_in,
+                self.out_l,
+                self.kernel_l,
+                self.stride_l,
+                self.pad_l,
+                self.dtype_str,
+            ),
+            "threads": _DEFAULT_THREADS,
         }
 
     @property
     def autotune_configs(self) -> list[dict]:
-        return [
-            {"block_m": block_m, "threads": threads}
-            for block_m, threads in itertools.product([128, 256, 512], [128, 256, 512])
-        ]
+        return _thread_configs(
+            self.default_config["block_ol"],
+            self.l_in,
+            self.kernel_l,
+            self.stride_l,
+            self.pad_l,
+            self.dtype_str,
+        )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         self._require_cuda(x=x)
@@ -299,7 +497,7 @@ class AvgPool1dKernel(Kernel):
             self.ceil_mode,
             self.count_include_pad,
             self.dtype_str,
-            self.config["block_m"],
+            self.config["block_ol"],
             self.config["threads"],
             x,
         )

--- a/src/tileops/kernels/pool/avg_pool1d.py
+++ b/src/tileops/kernels/pool/avg_pool1d.py
@@ -1,5 +1,5 @@
 import functools
-from typing import NamedTuple, Optional
+from typing import ClassVar, NamedTuple, Optional, Tuple
 
 import tilelang
 import tilelang.language as T
@@ -7,33 +7,13 @@ import torch
 
 from tileops.kernels.constants import STATIC_SHARED_BYTES, VECTOR_ACCESS_BYTES
 from tileops.kernels.kernel_base import Kernel
-from tileops.kernels.pool.common import pool_output_dim
+from tileops.kernels.pool.common import dtype_itemsize, pool_output_dim
 
 __all__ = ["AvgPool1dKernel", "AvgPool1dSpatialKernel"]
 
-# Tile widths a launch may take, widest first. The tail below 128 is what keeps a window
-# too wide to stage at 128 outputs from having no width at all.
-_BLOCK_OL_CHOICES = (2048, 1024, 512, 256, 128, 64, 32, 16, 8, 4, 2, 1)
-# The best block size is not a function of the shape any rule here fits, so it is tuned.
-_THREAD_CHOICES = (64, 128, 256)
-# Threads a launch needs before a narrow block is worth offering: below this the blocks
-# do not fill the device, and giving each thread more outputs only lengthens the tail.
-_MIN_LAUNCH_THREADS = 1 << 16
-# Measured best, or within one timer quantum of best, at all three manifest workloads.
-_DEFAULT_BLOCK_OL = 512
-_DEFAULT_THREADS = 128
 
-
-def _itemsize(dtype: str) -> int:
-    return 4 if dtype in ("float", "float32") else 2
-
-
-def _round_up(value: int, step: int) -> int:
-    return ((value + step - 1) // step) * step
-
-
-class _Staging(NamedTuple):
-    """Where one block's staged span sits in the row, and how wide its loads are."""
+class _Span(NamedTuple):
+    """The stretch of a row one block stages, in the row's own coordinates."""
 
     # Elements one full-width access covers.
     vector_elems: int
@@ -48,88 +28,110 @@ class _Staging(NamedTuple):
         return self.span // self.vector_elems
 
 
-def _staging(
-    block_ol: int, l_in: int, kernel_l: int, stride_l: int, pad_l: int, dtype: str
-) -> _Staging:
-    """The staged span covering ``block_ol`` consecutive outputs.
+class _WindowStaging:
+    """What one block stages, and the launch shapes worth offering for it.
 
-    The tile is a window on the row's own coordinates, starting `head` elements before
-    the block's leftmost window and holding zeros wherever it reaches outside the row.
-    Every staging load is a whole group of `vector_elems`, so each group is either
-    entirely inside the row or entirely outside it, and the width is narrowed until the
-    three things that move a group boundary all divide it: the block step
-    ``block_ol * stride_l``, the head, and the row end ``l_in``.
+    These figures describe this kernel's access pattern, not the device, and are held
+    here so that a later kernel does not read them as general truths.
     """
-    vector_elems = VECTOR_ACCESS_BYTES // _itemsize(dtype)
-    while vector_elems > 1 and (l_in % vector_elems or (block_ol * stride_l) % vector_elems):
-        vector_elems //= 2
-    head = _round_up(pad_l, vector_elems)
-    reach = head + (block_ol - 1) * stride_l + kernel_l
-    return _Staging(vector_elems, head, _round_up(reach, vector_elems))
 
+    # Tile widths a launch may take, widest first. The tail below 128 is what keeps a
+    # window too wide to stage at 128 outputs from having no width at all.
+    _TILE_CHOICES: ClassVar[Tuple[int, ...]] = (2048, 1024, 512, 256, 128, 64, 32, 16, 8, 4, 2, 1)
+    # Outputs a block covers before the shared budget or the output row narrows it.
+    _TILE_OUTPUTS: ClassVar[int] = 512
+    _THREAD_CHOICES: ClassVar[Tuple[int, ...]] = (64, 128, 256)
+    # Taken when every block size is ruled out, which needs a tile of a few outputs.
+    _FALLBACK_THREADS: ClassVar[int] = 128
+    # Threads a launch needs before a narrow block is worth offering: under this the
+    # blocks do not fill the device, and widening each thread's run only lengthens it.
+    _MIN_LAUNCH_THREADS: ClassVar[int] = 1 << 16
 
-def _block_ol_choices(l_in: int, kernel_l: int, stride_l: int, pad_l: int, dtype: str) -> list[int]:
-    """The tile widths whose staged span fits the static shared budget, widest first.
+    def __init__(
+        self,
+        rows: int,
+        l_in: int,
+        out_l: int,
+        kernel_l: int,
+        stride_l: int,
+        pad_l: int,
+        dtype: str,
+    ) -> None:
+        self._rows = rows
+        self._l_in = l_in
+        self._out_l = out_l
+        self._kernel_l = kernel_l
+        self._stride_l = stride_l
+        self._pad_l = pad_l
+        self._dtype = dtype
 
-    Raises:
-        ValueError: When not even one output's window fits, which takes a kernel size
-            in the tens of thousands.
-    """
-    budget = STATIC_SHARED_BYTES // _itemsize(dtype)
-    fitting = [
-        block_ol
-        for block_ol in _BLOCK_OL_CHOICES
-        if _staging(block_ol, l_in, kernel_l, stride_l, pad_l, dtype).span <= budget
-    ]
-    if not fitting:
-        span = _staging(1, l_in, kernel_l, stride_l, pad_l, dtype).span
-        raise ValueError(
-            f"avg_pool1d stages the pooling window in shared memory: kernel_size="
-            f"{kernel_l} needs {span * _itemsize(dtype)} B for a single output, over "
-            f"the {STATIC_SHARED_BYTES} B a block gets"
-        )
-    return fitting
+    @staticmethod
+    def _round_up(value: int, step: int) -> int:
+        return ((value + step - 1) // step) * step
 
+    def span(self, tile_outputs: int) -> _Span:
+        """The stretch covering ``tile_outputs`` consecutive outputs.
 
-def _thread_configs(
-    block_ol: int,
-    rows: int,
-    l_in: int,
-    out_l: int,
-    kernel_l: int,
-    stride_l: int,
-    pad_l: int,
-    dtype: str,
-) -> list[dict]:
-    """Candidate configs at a fixed tile width: the block sizes worth timing on it.
+        Every staging load is a whole group of ``vector_elems``, and a group is loaded or
+        zeroed as one, so each has to sit either wholly inside the row or wholly outside
+        it. The width is narrowed until the three things that move a group boundary all
+        divide it: the block step, the head, and the row end.
+        """
+        vector_elems = VECTOR_ACCESS_BYTES // dtype_itemsize(self._dtype)
+        step = tile_outputs * self._stride_l
+        while vector_elems > 1 and (self._l_in % vector_elems or step % vector_elems):
+            vector_elems //= 2
+        head = self._round_up(self._pad_l, vector_elems)
+        reach = head + (tile_outputs - 1) * self._stride_l + self._kernel_l
+        return _Span(vector_elems, head, self._round_up(reach, vector_elems))
 
-    The width is not a candidate. Two widths a factor of two apart differ by a few
-    percent here, which is under what the autotuner can resolve on a launch this short,
-    so it is settled by :func:`_default_block_ol` instead. Two block sizes are dropped:
-    one with more threads than the staging pass has full-width loads idles threads on the
-    read this kernel is bound by, and one whose launch falls short of
-    ``_MIN_LAUNCH_THREADS`` leaves the device unfilled.
-    """
-    staged = _staging(block_ol, l_in, kernel_l, stride_l, pad_l, dtype)
-    blocks = rows * ((out_l + block_ol - 1) // block_ol)
-    return [
-        {"block_ol": block_ol, "threads": threads}
-        for threads in _THREAD_CHOICES
-        if staged.vectors >= threads and blocks * threads >= _MIN_LAUNCH_THREADS
-    ] or [{"block_ol": block_ol, "threads": _DEFAULT_THREADS}]
+    def widths(self) -> list[int]:
+        """The tile widths whose span fits the static shared budget, widest first.
 
+        Raises:
+            ValueError: When not even one output's window fits, which takes a kernel
+                size in the tens of thousands.
+        """
+        budget = STATIC_SHARED_BYTES // dtype_itemsize(self._dtype)
+        fitting = [width for width in self._TILE_CHOICES if self.span(width).span <= budget]
+        if not fitting:
+            need = self.span(1).span * dtype_itemsize(self._dtype)
+            raise ValueError(
+                f"avg_pool1d stages the pooling window in shared memory: kernel_size="
+                f"{self._kernel_l} needs {need} B for a single output, over the "
+                f"{STATIC_SHARED_BYTES} B a block gets"
+            )
+        return fitting
 
-def _default_block_ol(
-    l_in: int, out_l: int, kernel_l: int, stride_l: int, pad_l: int, dtype: str
-) -> int:
-    """``_DEFAULT_BLOCK_OL``, narrowed twice.
+    def width(self) -> int:
+        """``_TILE_OUTPUTS``, narrowed to the shared budget and to the output row.
 
-    Narrowed to what the static shared budget holds, and to what the output row is
-    wide enough to fill: a tile wider than the row only idles threads.
-    """
-    choices = _block_ol_choices(l_in, kernel_l, stride_l, pad_l, dtype)
-    wanted = min(_DEFAULT_BLOCK_OL, max(out_l, choices[-1]))
-    return next(block_ol for block_ol in choices if block_ol <= wanted)
+        A tile wider than the row only idles threads.
+        """
+        fitting = self.widths()
+        wanted = min(self._TILE_OUTPUTS, max(self._out_l, fitting[-1]))
+        return next(width for width in fitting if width <= wanted)
+
+    def default(self) -> dict:
+        return {"block_ol": self.width(), "threads": self._FALLBACK_THREADS}
+
+    def tuned(self) -> list[dict]:
+        """Block sizes worth timing at the chosen width, which is not itself a candidate.
+
+        Two widths a factor of two apart differ by less than the autotuner resolves on a
+        launch this short. Two block sizes are dropped: one holding more threads than the
+        staging pass has full-width loads idles them on the read this kernel is bound by,
+        and one whose launch falls short of ``_MIN_LAUNCH_THREADS`` leaves the device
+        unfilled.
+        """
+        width = self.width()
+        vectors = self.span(width).vectors
+        blocks = self._rows * ((self._out_l + width - 1) // width)
+        return [
+            {"block_ol": width, "threads": threads}
+            for threads in self._THREAD_CHOICES
+            if vectors >= threads and blocks * threads >= self._MIN_LAUNCH_THREADS
+        ] or [{"block_ol": width, "threads": self._FALLBACK_THREADS}]
 
 
 @functools.lru_cache(maxsize=64)
@@ -156,13 +158,17 @@ def _avg_pool1d_kernel(
 
     @tilelang.jit(out_idx=[1], compile_flags=["-O3", "-DENABLE_BF16"])
     def _avg_pool1d_func(block_ol: int, threads: int):
-        # Outputs `stride_l` apart share taps, so a warp taking one output each reads
-        # one short stretch of the row `kernel_l` times over, a narrow load each time. A
-        # block stages that stretch with full-width loads and takes every tap from it.
-        staged = _staging(block_ol, l_in, kernel_l, stride_l, pad_l, dtype)
-        vector_elems, head, span = staged
-        # The tile holds zeros where it reaches outside the row, so a tap needs no test
-        # of its own and its index into the tile is the same in every block.
+        # Outputs `stride_l` apart share taps, so a warp taking one output each reads one
+        # short stretch of the row `kernel_l` times over, a narrow load each time. A block
+        # stages that stretch with full-width loads and takes every tap from it.
+        #
+        # Built here rather than closed over: TileLang reads every free variable of a jit
+        # builder into the autotune cache key and asserts on anything but a scalar.
+        staging = _WindowStaging(rows, l_in, out_l, kernel_l, stride_l, pad_l, dtype)
+        vector_elems, head, span = staging.span(block_ol)
+        vectors = span // vector_elems
+        # The tile holds zeros where it reaches outside the row, so no tap carries a test
+        # and its index into the tile is this same constant in every block.
         base = head - pad_l
         blocks_per_row = (out_l + block_ol - 1) // block_ol
         tail_free = out_l % block_ol == 0
@@ -172,7 +178,7 @@ def _avg_pool1d_kernel(
         @T.macro
         def _stage_inside(tile, x, origin, row):
             """Every group is in the row: one unguarded full-width load each."""
-            for i in T.Parallel(staged.vectors):
+            for i in T.Parallel(vectors):
                 for v in T.vectorized(vector_elems):
                     tile[i * vector_elems + v] = x[row, origin + i * vector_elems + v]
 
@@ -180,14 +186,13 @@ def _avg_pool1d_kernel(
         def _stage_edge(tile, x, origin, row):
             """Zero the tile, then load the groups the row covers.
 
-            The row covers whole groups only, so the second pass tests one per group and
-            its load stays unguarded. Predicating the load itself instead, in one pass,
-            measured slower than doing two.
+            The row covers whole groups, so the second pass tests one per group and its
+            load stays unguarded.
             """
-            for i in T.Parallel(staged.vectors):
+            for i in T.Parallel(vectors):
                 for v in T.vectorized(vector_elems):
                     tile[i * vector_elems + v] = T.cast(0.0, dtype)
-            for i in T.Parallel(staged.vectors):
+            for i in T.Parallel(vectors):
                 if (origin + i * vector_elems >= 0) and (origin + (i + 1) * vector_elems <= l_in):
                     for v in T.vectorized(vector_elems):
                         tile[i * vector_elems + v] = x[row, origin + i * vector_elems + v]
@@ -215,7 +220,6 @@ def _avg_pool1d_kernel(
             if whole_window_divides:
                 _store(tile, j, ol, out, out_row, True)
             else:
-                # A window's divisor is its own extent only where it overhangs the row.
                 if (ol >= clean_lo) and (ol <= clean_hi):
                     _store(tile, j, ol, out, out_row, True)
                 else:
@@ -254,165 +258,18 @@ def _avg_pool1d_kernel(
     return _avg_pool1d_func
 
 
-def _avg_pool1d_spatial_kernel(
-    n: int,
-    c_in: int,
-    l_in: int,
-    kernel_l: int,
-    stride_l: int,
-    pad_l: int,
-    dtype: str = "float16",
-):
-    """Zero-padded, floor-mode 1d average pooling.
+class _AvgPool1dKernelBase(Kernel):
+    """Shape, launch planning and dispatch shared by the two avg_pool1d kernels.
 
-    Every window then spans the full kernel once the padding is counted, which is
-    what ``_avg_pool1d_kernel`` emits for these two flags.
-    """
-    return _avg_pool1d_kernel(n, c_in, l_in, kernel_l, stride_l, pad_l, False, True, dtype)
-
-
-def _launch_avg_pool1d(
-    n: int,
-    c_in: int,
-    l_in: int,
-    kernel_l: int,
-    stride_l: int,
-    pad_l: int,
-    ceil_mode: bool,
-    count_include_pad: bool,
-    dtype: str,
-    block_ol: int,
-    threads: int,
-    x: torch.Tensor,
-) -> torch.Tensor:
-    out_l = pool_output_dim(l_in, kernel_l, stride_l, pad_l, ceil_mode)
-    kernel = _avg_pool1d_kernel(
-        n,
-        c_in,
-        l_in,
-        kernel_l,
-        stride_l,
-        pad_l,
-        ceil_mode,
-        count_include_pad,
-        dtype,
-    )(block_ol, threads)
-
-    return kernel(x.contiguous().view(n * c_in, l_in)).view(n, c_in, out_l)
-
-
-def _launch_avg_pool1d_spatial(
-    n: int,
-    c_in: int,
-    l_in: int,
-    kernel_l: int,
-    stride_l: int,
-    pad_l: int,
-    dtype: str,
-    block_ol: int,
-    threads: int,
-    x: torch.Tensor,
-) -> torch.Tensor:
-    return _launch_avg_pool1d(
-        n, c_in, l_in, kernel_l, stride_l, pad_l, False, True, dtype, block_ol, threads, x
-    )
-
-
-class AvgPool1dSpatialKernel(Kernel):
-    """Fast path for common NCL avg_pool1d workloads.
+    The two differ only in which PyTorch flags a caller may set; the staged span and the
+    configs worth offering follow from the shape alone.
 
     Raises:
         ValueError: When one pooling window does not fit the shared memory a block
             stages it in, which takes a ``kernel_size`` in the tens of thousands.
     """
 
-    supported_archs: list[int] = [80, 86, 89, 90]
-
-    def __init__(
-        self,
-        n: int,
-        c_in: int,
-        l_in: int,
-        kernel_l: int,
-        stride_l: int,
-        pad_l: int,
-        dtype: torch.dtype,
-        config: Optional[dict] = None,
-        tune: bool = False,
-    ) -> None:
-        super().__init__()
-        self.n = n
-        self.c_in = c_in
-        self.l_in = l_in
-        self.kernel_l = kernel_l
-        self.stride_l = stride_l
-        self.pad_l = pad_l
-        self.dtype = dtype
-        self.out_l = pool_output_dim(l_in, kernel_l, stride_l, pad_l, False)
-
-        self.kernel = _avg_pool1d_spatial_kernel(
-            n,
-            c_in,
-            l_in,
-            kernel_l,
-            stride_l,
-            pad_l,
-            self.dtype_str,
-        )
-        self.init_config(config, tune)
-
-    @property
-    def default_config(self) -> dict:
-        return {
-            "block_ol": _default_block_ol(
-                self.l_in,
-                self.out_l,
-                self.kernel_l,
-                self.stride_l,
-                self.pad_l,
-                self.dtype_str,
-            ),
-            "threads": _DEFAULT_THREADS,
-        }
-
-    @property
-    def autotune_configs(self) -> list[dict]:
-        return _thread_configs(
-            self.default_config["block_ol"],
-            self.n * self.c_in,
-            self.l_in,
-            self.out_l,
-            self.kernel_l,
-            self.stride_l,
-            self.pad_l,
-            self.dtype_str,
-        )
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        self._require_cuda(x=x)
-        return _launch_avg_pool1d_spatial(
-            self.n,
-            self.c_in,
-            self.l_in,
-            self.kernel_l,
-            self.stride_l,
-            self.pad_l,
-            self.dtype_str,
-            self.config["block_ol"],
-            self.config["threads"],
-            x,
-        )
-
-
-class AvgPool1dKernel(Kernel):
-    """Average pooling over an NCL row, with every PyTorch flag combination.
-
-    Raises:
-        ValueError: When one pooling window does not fit the shared memory a block
-            stages it in, which takes a ``kernel_size`` in the tens of thousands.
-    """
-
-    supported_archs: list[int] = [80, 86, 89, 90]
+    supported_archs: ClassVar[list[int]] = [80, 86, 89, 90]
 
     def __init__(
         self,
@@ -453,24 +310,8 @@ class AvgPool1dKernel(Kernel):
         )
         self.init_config(config, tune)
 
-    @property
-    def default_config(self) -> dict:
-        return {
-            "block_ol": _default_block_ol(
-                self.l_in,
-                self.out_l,
-                self.kernel_l,
-                self.stride_l,
-                self.pad_l,
-                self.dtype_str,
-            ),
-            "threads": _DEFAULT_THREADS,
-        }
-
-    @property
-    def autotune_configs(self) -> list[dict]:
-        return _thread_configs(
-            self.default_config["block_ol"],
+    def _staging(self) -> _WindowStaging:
+        return _WindowStaging(
             self.n * self.c_in,
             self.l_in,
             self.out_l,
@@ -480,19 +321,42 @@ class AvgPool1dKernel(Kernel):
             self.dtype_str,
         )
 
+    @property
+    def default_config(self) -> dict:
+        return self._staging().default()
+
+    @property
+    def autotune_configs(self) -> list[dict]:
+        return self._staging().tuned()
+
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         self._require_cuda(x=x)
-        return _launch_avg_pool1d(
-            self.n,
-            self.c_in,
-            self.l_in,
-            self.kernel_l,
-            self.stride_l,
-            self.pad_l,
-            self.ceil_mode,
-            self.count_include_pad,
-            self.dtype_str,
-            self.config["block_ol"],
-            self.config["threads"],
-            x,
-        )
+        kernel = self.kernel(self.config["block_ol"], self.config["threads"])
+        rows = kernel(x.contiguous().view(self.n * self.c_in, self.l_in))
+        return rows.view(self.n, self.c_in, self.out_l)
+
+
+class AvgPool1dSpatialKernel(_AvgPool1dKernelBase):
+    """Fast path for common NCL avg_pool1d workloads.
+
+    Zero-padded and floor-mode, so every window spans the full kernel once the padding
+    is counted.
+    """
+
+    def __init__(
+        self,
+        n: int,
+        c_in: int,
+        l_in: int,
+        kernel_l: int,
+        stride_l: int,
+        pad_l: int,
+        dtype: torch.dtype,
+        config: Optional[dict] = None,
+        tune: bool = False,
+    ) -> None:
+        super().__init__(n, c_in, l_in, kernel_l, stride_l, pad_l, False, True, dtype, config, tune)
+
+
+class AvgPool1dKernel(_AvgPool1dKernelBase):
+    """Average pooling over an NCL row, with every PyTorch flag combination."""

--- a/src/tileops/kernels/pool/avg_pool1d.py
+++ b/src/tileops/kernels/pool/avg_pool1d.py
@@ -37,10 +37,9 @@ def _span(
 ) -> _Span:
     """The stretch of a row a block stages to cover ``tile_outputs`` outputs.
 
-    Every staging load is a whole group of ``vector_elems``, and a group is loaded or
-    zeroed as one, so each has to sit either wholly inside the row or wholly outside it.
-    The width is narrowed until the three things that move a group boundary all divide
-    it: the block step, the head, and the row end.
+    A group of ``vector_elems`` is loaded or zeroed as one, so it has to sit wholly
+    inside the row or wholly outside it. The width is narrowed until the block step, the
+    head and the row end all divide it.
     """
     vector_elems = VECTOR_ACCESS_BYTES // dtype_itemsize(dtype)
     step = tile_outputs * stride_l
@@ -58,16 +57,16 @@ class _WindowStaging:
     here so that a later kernel does not read them as general truths.
     """
 
-    # Tile widths a launch may take, widest first. The tail below 128 is what keeps a
-    # window too wide to stage at 128 outputs from having no width at all.
+    # Tile widths a launch may take, widest first. The tail below 128 is for a window
+    # too wide to stage at 128 outputs.
     _TILE_CHOICES: ClassVar[Tuple[int, ...]] = (2048, 1024, 512, 256, 128, 64, 32, 16, 8, 4, 2, 1)
     # Outputs a block covers before the shared budget or the output row narrows it.
     _TILE_OUTPUTS: ClassVar[int] = 512
     _THREAD_CHOICES: ClassVar[Tuple[int, ...]] = (64, 128, 256)
-    # Taken when every block size is ruled out, which needs a tile of a few outputs.
+    # Taken when every block size is ruled out.
     _FALLBACK_THREADS: ClassVar[int] = 128
-    # Threads a launch needs before a narrow block is worth offering: under this the
-    # blocks do not fill the device, and widening each thread's run only lengthens it.
+    # Threads a launch needs before a narrow block is offered; under this the blocks
+    # do not fill the device.
     _MIN_LAUNCH_THREADS: ClassVar[int] = 1 << 16
 
     def __init__(
@@ -94,12 +93,7 @@ class _WindowStaging:
         )
 
     def widths(self) -> list[int]:
-        """The tile widths whose span fits the static shared budget, widest first.
-
-        Raises:
-            ValueError: When not even one output's window fits, which takes a kernel
-                size in the tens of thousands.
-        """
+        """The tile widths whose span fits the static shared budget, widest first."""
         budget = STATIC_SHARED_BYTES // dtype_itemsize(self._dtype)
         fitting = [width for width in self._TILE_CHOICES if self._span(width).span <= budget]
         if not fitting:
@@ -112,10 +106,7 @@ class _WindowStaging:
         return fitting
 
     def width(self) -> int:
-        """``_TILE_OUTPUTS``, narrowed to the shared budget and to the output row.
-
-        A tile wider than the row only idles threads.
-        """
+        """``_TILE_OUTPUTS``, narrowed to the shared budget and to the output row."""
         fitting = self.widths()
         wanted = min(self._TILE_OUTPUTS, max(self._out_l, fitting[-1]))
         return next(width for width in fitting if width <= wanted)
@@ -126,11 +117,8 @@ class _WindowStaging:
     def tuned(self) -> list[dict]:
         """Block sizes worth timing at the chosen width, which is not itself a candidate.
 
-        Two widths a factor of two apart differ by less than the autotuner resolves on a
-        launch this short. Two block sizes are dropped: one holding more threads than the
-        staging pass has full-width loads idles them on the read this kernel is bound by,
-        and one whose launch falls short of ``_MIN_LAUNCH_THREADS`` leaves the device
-        unfilled.
+        A block with more threads than the staging pass has loads idles them on the read
+        this kernel is bound by.
         """
         width = self.width()
         vectors = self._span(width).vectors
@@ -166,13 +154,11 @@ def _avg_pool1d_kernel(
 
     @tilelang.jit(out_idx=[1], compile_flags=["-O3", "-DENABLE_BF16"])
     def _avg_pool1d_func(block_ol: int, threads: int):
-        # Outputs `stride_l` apart share taps, so a warp taking one output each reads one
-        # short stretch of the row `kernel_l` times over, a narrow load each time. A block
-        # stages that stretch with full-width loads and takes every tap from it.
+        # A warp taking one output each reads one short stretch of the row `kernel_l`
+        # times over. A block stages that stretch with full-width loads instead.
         vector_elems, head, span = _span(block_ol, l_in, kernel_l, stride_l, pad_l, dtype)
         vectors = span // vector_elems
-        # The tile holds zeros where it reaches outside the row, so no tap carries a test
-        # and its index into the tile is this same constant in every block.
+        # The tile holds zeros outside the row, so a tap needs no test and this offset.
         base = head - pad_l
         blocks_per_row = (out_l + block_ol - 1) // block_ol
         tail_free = out_l % block_ol == 0
@@ -190,8 +176,7 @@ def _avg_pool1d_kernel(
         def _stage_edge(tile, x, origin, row):
             """Zero the tile, then load the groups the row covers.
 
-            The row covers whole groups, so the second pass tests one per group and its
-            load stays unguarded.
+            The row covers whole groups, so the test is per group and the load unguarded.
             """
             for i in T.Parallel(vectors):
                 for v in T.vectorized(vector_elems):
@@ -264,9 +249,6 @@ def _avg_pool1d_kernel(
 
 class _AvgPool1dKernelBase(Kernel):
     """Shape, launch planning and dispatch shared by the two avg_pool1d kernels.
-
-    The two differ only in which PyTorch flags a caller may set; the staged span and the
-    configs worth offering follow from the shape alone.
 
     Raises:
         ValueError: When one pooling window does not fit the shared memory a block
@@ -341,11 +323,7 @@ class _AvgPool1dKernelBase(Kernel):
 
 
 class AvgPool1dSpatialKernel(_AvgPool1dKernelBase):
-    """Fast path for common NCL avg_pool1d workloads.
-
-    Zero-padded and floor-mode, so every window spans the full kernel once the padding
-    is counted.
-    """
+    """Fast path for common NCL avg_pool1d workloads: zero-padded, floor-mode."""
 
     def __init__(
         self,

--- a/src/tileops/kernels/pool/avg_pool1d.py
+++ b/src/tileops/kernels/pool/avg_pool1d.py
@@ -14,9 +14,11 @@ __all__ = ["AvgPool1dKernel", "AvgPool1dSpatialKernel"]
 # Tile widths a launch may take, widest first. The tail below 128 is what keeps a window
 # too wide to stage at 128 outputs from having no width at all.
 _BLOCK_OL_CHOICES = (2048, 1024, 512, 256, 128, 64, 32, 16, 8, 4, 2, 1)
-# Two warps per block measured fastest only on the widest workload, and is what
-# the autotuner mispicks on a launch too short for it to tell candidates apart.
-_THREAD_CHOICES = (128, 256)
+# The best block size is not a function of the shape any rule here fits, so it is tuned.
+_THREAD_CHOICES = (64, 128, 256)
+# Threads a launch needs before a narrow block is worth offering: below this the blocks
+# do not fill the device, and giving each thread more outputs only lengthens the tail.
+_MIN_LAUNCH_THREADS = 1 << 16
 # Measured best, or within one timer quantum of best, at all three manifest workloads.
 _DEFAULT_BLOCK_OL = 512
 _DEFAULT_THREADS = 128
@@ -51,18 +53,19 @@ def _staging(
 ) -> _Staging:
     """The staged span covering ``block_ol`` consecutive outputs.
 
-    The staging load is vectorized and unguarded, so every span start has to sit on a
-    multiple of the access width. Two things move a start: the block index, in steps of
-    ``block_ol * stride_l``, and the slide back inside the row at the end of a row, which
-    lands it on ``l_in - span``. The width is narrowed until it divides both. The head
-    then absorbs the left padding, and a span wider than the row is the whole row.
+    The tile is a window on the row's own coordinates, starting `head` elements before
+    the block's leftmost window and holding zeros wherever it reaches outside the row.
+    Every staging load is a whole group of `vector_elems`, so each group is either
+    entirely inside the row or entirely outside it, and the width is narrowed until the
+    three things that move a group boundary all divide it: the block step
+    ``block_ol * stride_l``, the head, and the row end ``l_in``.
     """
     vector_elems = VECTOR_ACCESS_BYTES // _itemsize(dtype)
     while vector_elems > 1 and (l_in % vector_elems or (block_ol * stride_l) % vector_elems):
         vector_elems //= 2
     head = _round_up(pad_l, vector_elems)
     reach = head + (block_ol - 1) * stride_l + kernel_l
-    return _Staging(vector_elems, head, min(_round_up(reach, vector_elems), l_in))
+    return _Staging(vector_elems, head, _round_up(reach, vector_elems))
 
 
 def _block_ol_choices(l_in: int, kernel_l: int, stride_l: int, pad_l: int, dtype: str) -> list[int]:
@@ -89,21 +92,30 @@ def _block_ol_choices(l_in: int, kernel_l: int, stride_l: int, pad_l: int, dtype
 
 
 def _thread_configs(
-    block_ol: int, l_in: int, kernel_l: int, stride_l: int, pad_l: int, dtype: str
+    block_ol: int,
+    rows: int,
+    l_in: int,
+    out_l: int,
+    kernel_l: int,
+    stride_l: int,
+    pad_l: int,
+    dtype: str,
 ) -> list[dict]:
     """Candidate configs at a fixed tile width: the block sizes worth timing on it.
 
     The width is not a candidate. Two widths a factor of two apart differ by a few
     percent here, which is under what the autotuner can resolve on a launch this short,
-    so it is settled by :func:`_default_block_ol` instead. A block with more threads than
-    the staging pass has full-width loads idles threads on the read this kernel is bound
-    by, which leaves at most one candidate on a narrow tile.
+    so it is settled by :func:`_default_block_ol` instead. Two block sizes are dropped:
+    one with more threads than the staging pass has full-width loads idles threads on the
+    read this kernel is bound by, and one whose launch falls short of
+    ``_MIN_LAUNCH_THREADS`` leaves the device unfilled.
     """
     staged = _staging(block_ol, l_in, kernel_l, stride_l, pad_l, dtype)
+    blocks = rows * ((out_l + block_ol - 1) // block_ol)
     return [
         {"block_ol": block_ol, "threads": threads}
         for threads in _THREAD_CHOICES
-        if staged.vectors >= threads
+        if staged.vectors >= threads and blocks * threads >= _MIN_LAUNCH_THREADS
     ] or [{"block_ol": block_ol, "threads": _DEFAULT_THREADS}]
 
 
@@ -138,6 +150,9 @@ def _avg_pool1d_kernel(
     window_inside = pad_l == 0 and (out_l - 1) * stride_l + kernel_l <= l_in
     # Otherwise a window can overhang, and the divisor comes from its own extent.
     whole_window_divides = window_inside or (count_include_pad and not ceil_mode)
+    # The outputs whose window lies inside the row, and so divides by the kernel width.
+    clean_lo = -(-pad_l // stride_l)
+    clean_hi = min((l_in + pad_l - kernel_l) // stride_l, out_l - 1)
 
     @tilelang.jit(out_idx=[1], compile_flags=["-O3", "-DENABLE_BF16"])
     def _avg_pool1d_func(block_ol: int, threads: int):
@@ -146,86 +161,76 @@ def _avg_pool1d_kernel(
         # block stages that stretch with full-width loads and takes every tap from it.
         staged = _staging(block_ol, l_in, kernel_l, stride_l, pad_l, dtype)
         vector_elems, head, span = staged
+        # The tile holds zeros where it reaches outside the row, so a tap needs no test
+        # of its own and its index into the tile is the same in every block.
+        base = head - pad_l
         blocks_per_row = (out_l + block_ol - 1) // block_ol
         tail_free = out_l % block_ol == 0
-        # Only the first and the last block of a row hold an overhanging window, so the
-        # blocks between them need neither the tap select nor a per-output divisor.
-        interior_split = (
-            not window_inside
-            and blocks_per_row >= 3
-            and block_ol * stride_l - pad_l >= 0
-            and ((blocks_per_row - 1) * block_ol - 1) * stride_l - pad_l + kernel_l <= l_in
-        )
-        # Inside those two blocks the overhang is a handful of outputs at the row ends.
-        clean_lo = -(-pad_l // stride_l)
-        clean_hi = min((l_in + pad_l - kernel_l) // stride_l, out_l - 1)
+        # Only the first and the last block of a row reach outside it.
+        edge_free = pad_l == 0 and (blocks_per_row - 1) * block_ol * stride_l + span <= l_in
 
-        def _window_store(inside: bool):
-            """A macro storing one output's mean, reading the taps from the tile.
+        @T.macro
+        def _stage_inside(tile, x, origin, row):
+            """Every group is in the row: one unguarded full-width load each."""
+            for i in T.Parallel(staged.vectors):
+                for v in T.vectorized(vector_elems):
+                    tile[i * vector_elems + v] = x[row, origin + i * vector_elems + v]
 
-            Args:
-                inside: Whether every tap of this output is known to be in the row.
-                    When it is not, the tap is read anyway and a select discards it,
-                    so an overhanging window costs no branch.
+        @T.macro
+        def _stage_edge(tile, x, origin, row):
+            """Zero the tile, then load the groups the row covers.
+
+            The row covers whole groups only, so the second pass tests one per group and
+            its load stays unguarded. Predicating the load itself instead, in one pass,
+            measured slower than doing two.
             """
-
-            @T.macro
-            def _store(tile, offset, j, ol, out, out_row):
-                total = T.alloc_var(T.float32)
-                total = T.cast(0.0, accum_dtype)
-                if inside:
-                    # Written out rather than held in a var: bound analysis cannot
-                    # place a var inside the tile, and guards the tap load in 64-bit
-                    # addressing when it cannot.
-                    for k in T.serial(kernel_l):
-                        total += T.cast(tile[offset + j * stride_l + k], accum_dtype)
-                else:
-                    # A guard is emitted here whatever the index looks like, so the var
-                    # keeps the address arithmetic from repeating per tap. The clamp
-                    # keeps the discarded read inside the tile.
-                    at = T.alloc_var(T.int32)
-                    at = offset + j * stride_l
-                    for k in T.serial(kernel_l):
-                        tap = T.cast(tile[T.max(0, T.min(at + k, span - 1))], accum_dtype)
-                        src = ol * stride_l - pad_l + k
-                        total += T.if_then_else(
-                            (src >= 0) and (src < l_in), tap, T.cast(0.0, accum_dtype)
-                        )
-                if inside or whole_window_divides:
-                    out[out_row, ol] = T.cast(total * T.cast(1.0 / kernel_l, accum_dtype), dtype)
-                else:
-                    start = ol * stride_l - pad_l
-                    if count_include_pad:
-                        divisor = T.max(
-                            T.min(start + kernel_l, l_in + pad_l) - T.max(start, -pad_l), 1
-                        )
-                    else:
-                        divisor = T.max(T.min(start + kernel_l, l_in) - T.max(start, 0), 1)
-                    out[out_row, ol] = T.cast(total / T.cast(divisor, accum_dtype), dtype)
-
-            return _store
-
-        _interior = _window_store(True)
-        _boundary = _window_store(window_inside)
+            for i in T.Parallel(staged.vectors):
+                for v in T.vectorized(vector_elems):
+                    tile[i * vector_elems + v] = T.cast(0.0, dtype)
+            for i in T.Parallel(staged.vectors):
+                if (origin + i * vector_elems >= 0) and (origin + (i + 1) * vector_elems <= l_in):
+                    for v in T.vectorized(vector_elems):
+                        tile[i * vector_elems + v] = x[row, origin + i * vector_elems + v]
 
         @T.macro
-        def _edge_split(tile, offset, j, ol, out, out_row):
-            """One edge block, testing each output for the clean path."""
-            if (ol >= clean_lo) and (ol <= clean_hi):
-                _interior(tile, offset, j, ol, out, out_row)
+        def _store(tile, j, ol, out, out_row, whole: bool):
+            """Store the mean of the window `tile` holds for output ``ol``."""
+            total = T.alloc_var(T.float32)
+            total = T.cast(0.0, accum_dtype)
+            for k in T.serial(kernel_l):
+                total += T.cast(tile[base + j * stride_l + k], accum_dtype)
+            if whole:
+                out[out_row, ol] = T.cast(total * T.cast(1.0 / kernel_l, accum_dtype), dtype)
             else:
-                if ol < out_l:
-                    _boundary(tile, offset, j, ol, out, out_row)
+                start = ol * stride_l - pad_l
+                if count_include_pad:
+                    divisor = T.max(T.min(start + kernel_l, l_in + pad_l) - T.max(start, -pad_l), 1)
+                else:
+                    divisor = T.max(T.min(start + kernel_l, l_in) - T.max(start, 0), 1)
+                out[out_row, ol] = T.cast(total / T.cast(divisor, accum_dtype), dtype)
 
         @T.macro
-        def _edge_plain(tile, offset, j, ol, out, out_row):
-            """One edge block, on the overhang path throughout."""
-            if ol < out_l:
-                _boundary(tile, offset, j, ol, out, out_row)
+        def _store_output(tile, j, ol, out, out_row):
+            """Store output ``ol``, taking its divisor from the window where it needs to."""
+            if whole_window_divides:
+                _store(tile, j, ol, out, out_row, True)
+            else:
+                # A window's divisor is its own extent only where it overhangs the row.
+                if (ol >= clean_lo) and (ol <= clean_hi):
+                    _store(tile, j, ol, out, out_row, True)
+                else:
+                    _store(tile, j, ol, out, out_row, False)
 
-        # Testing each output costs two comparisons and buys the constant divisor, which
-        # pays only where a window's divisor is its own extent.
-        _edge = _edge_plain if whole_window_divides else _edge_split
+        @T.macro
+        def _reduce(tile, bx, out, out_row):
+            """One output per lane, over the outputs this block owns."""
+            for j in T.Parallel(block_ol):
+                ol = bx * block_ol + j
+                if tail_free:
+                    _store_output(tile, j, ol, out, out_row)
+                else:
+                    if ol < out_l:
+                        _store_output(tile, j, ol, out, out_row)
 
         @T.prim_func
         def _avg_pool1d_main(
@@ -234,29 +239,15 @@ def _avg_pool1d_kernel(
         ):
             with T.Kernel(blocks_per_row, rows, threads=threads) as (bx, by):
                 tile = T.alloc_shared((span,), dtype)
-                # Sliding the span back inside the row costs a few already-staged
-                # elements at the two ends and keeps every staging load unguarded.
-                start = T.max(0, T.min(bx * (block_ol * stride_l) - head, l_in - span))
-                for i in T.Parallel(staged.vectors):
-                    for v in T.vectorized(vector_elems):
-                        tile[i * vector_elems + v] = x[by, start + i * vector_elems + v]
-                offset = bx * (block_ol * stride_l) - pad_l - start
-                for j in T.Parallel(block_ol):
-                    ol = bx * block_ol + j
-                    if window_inside:
-                        if tail_free:
-                            _interior(tile, offset, j, ol, out, by)
-                        else:
-                            if ol < out_l:
-                                _interior(tile, offset, j, ol, out, by)
+                origin = bx * (block_ol * stride_l) - head
+                if edge_free:
+                    _stage_inside(tile, x, origin, by)
+                else:
+                    if (bx > 0) and (bx < blocks_per_row - 1):
+                        _stage_inside(tile, x, origin, by)
                     else:
-                        if interior_split:
-                            if (bx > 0) and (bx < blocks_per_row - 1):
-                                _interior(tile, offset, j, ol, out, by)
-                            else:
-                                _edge(tile, offset, j, ol, out, by)
-                        else:
-                            _edge(tile, offset, j, ol, out, by)
+                        _stage_edge(tile, x, origin, by)
+                _reduce(tile, bx, out, by)
 
         return _avg_pool1d_main
 
@@ -388,7 +379,9 @@ class AvgPool1dSpatialKernel(Kernel):
     def autotune_configs(self) -> list[dict]:
         return _thread_configs(
             self.default_config["block_ol"],
+            self.n * self.c_in,
             self.l_in,
+            self.out_l,
             self.kernel_l,
             self.stride_l,
             self.pad_l,
@@ -478,7 +471,9 @@ class AvgPool1dKernel(Kernel):
     def autotune_configs(self) -> list[dict]:
         return _thread_configs(
             self.default_config["block_ol"],
+            self.n * self.c_in,
             self.l_in,
+            self.out_l,
             self.kernel_l,
             self.stride_l,
             self.pad_l,

--- a/src/tileops/kernels/pool/common.py
+++ b/src/tileops/kernels/pool/common.py
@@ -7,6 +7,11 @@ from tileops.kernels.constants import STATIC_SHARED_BYTES
 from tileops.kernels.kernel_base import Kernel
 
 
+def dtype_itemsize(dtype: str) -> int:
+    """Bytes one element of *dtype* takes, over the dtypes these kernels accept."""
+    return 4 if dtype in ("float", "float32") else 2
+
+
 def fits_static_shared(elements: int, dtype: str) -> bool:
     """Whether a tile of *elements* fits the shared memory a block gets by default.
 
@@ -17,8 +22,7 @@ def fits_static_shared(elements: int, dtype: str) -> bool:
     Returns:
         True when the tile fits :data:`STATIC_SHARED_BYTES`.
     """
-    itemsize = 4 if dtype in ("float", "float32") else 2
-    return elements * itemsize <= STATIC_SHARED_BYTES
+    return elements * dtype_itemsize(dtype) <= STATIC_SHARED_BYTES
 
 
 def pool_output_dim(

--- a/tests/ops/test_pool.py
+++ b/tests/ops/test_pool.py
@@ -24,7 +24,7 @@ from tileops.kernels.pool import (
     MaxPool3dKernel,
     MaxPool3dWithIndicesKernel,
 )
-from tileops.kernels.pool.avg_pool1d import _WindowStaging
+from tileops.kernels.pool.avg_pool1d import _span, _WindowStaging
 from tileops.kernels.pool.common import pool_output_dim
 from tileops.ops import (
     AdaptiveAvgPool2dFwdOp,
@@ -593,7 +593,7 @@ def test_avg_pool1d_staged_span_stays_aligned(
     out_l = pool_output_dim(l_in, kernel_l, stride_l, pad_l, False)
     staging = _WindowStaging(1, l_in, out_l, kernel_l, stride_l, pad_l, dtype)
     for block_ol in staging.widths():
-        staged = staging.span(block_ol)
+        staged = _span(block_ol, l_in, kernel_l, stride_l, pad_l, dtype)
         assert (block_ol * stride_l) % staged.vector_elems == 0
         assert l_in % staged.vector_elems == 0
         assert staged.head % staged.vector_elems == 0

--- a/tests/ops/test_pool.py
+++ b/tests/ops/test_pool.py
@@ -24,7 +24,8 @@ from tileops.kernels.pool import (
     MaxPool3dKernel,
     MaxPool3dWithIndicesKernel,
 )
-from tileops.kernels.pool.avg_pool1d import _block_ol_choices, _staging
+from tileops.kernels.pool.avg_pool1d import _WindowStaging
+from tileops.kernels.pool.common import pool_output_dim
 from tileops.ops import (
     AdaptiveAvgPool2dFwdOp,
     AdaptiveMaxPool2dFwdOp,
@@ -589,8 +590,10 @@ def test_avg_pool1d_staged_span_stays_aligned(
     Only a window too wide to stage at 128 outputs selects a width that can break this,
     which is why no benchmarked shape reaches it.
     """
-    for block_ol in _block_ol_choices(l_in, kernel_l, stride_l, pad_l, dtype):
-        staged = _staging(block_ol, l_in, kernel_l, stride_l, pad_l, dtype)
+    out_l = pool_output_dim(l_in, kernel_l, stride_l, pad_l, False)
+    staging = _WindowStaging(1, l_in, out_l, kernel_l, stride_l, pad_l, dtype)
+    for block_ol in staging.widths():
+        staged = staging.span(block_ol)
         assert (block_ol * stride_l) % staged.vector_elems == 0
         assert l_in % staged.vector_elems == 0
         assert staged.head % staged.vector_elems == 0

--- a/tests/ops/test_pool.py
+++ b/tests/ops/test_pool.py
@@ -24,6 +24,7 @@ from tileops.kernels.pool import (
     MaxPool3dKernel,
     MaxPool3dWithIndicesKernel,
 )
+from tileops.kernels.pool.avg_pool1d import _block_ol_choices, _staging
 from tileops.ops import (
     AdaptiveAvgPool2dFwdOp,
     AdaptiveMaxPool2dFwdOp,
@@ -560,6 +561,41 @@ def test_avg_pool3d(
         dtype,
         tune,
     )
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "l_in, kernel_l, stride_l, pad_l, dtype",
+    [
+        (4096, 3, 2, 1, "float16"),
+        (32000, 5, 4, 2, "float16"),
+        (2048, 4, 2, 1, "bfloat16"),
+        (28000, 12000, 4001, 0, "float16"),
+        (127, 7, 3, 3, "bfloat16"),
+        (30, 4, 4, 2, "bfloat16"),
+        (33, 3, 2, 1, "float16"),
+        (64, 1, 1, 0, "float16"),
+    ],
+)
+def test_avg_pool1d_staged_span_stays_aligned(
+    l_in: int, kernel_l: int, stride_l: int, pad_l: int, dtype: str
+) -> None:
+    """Every span start a launch can take sits on a multiple of the access width.
+
+    The staging load is vectorized and unguarded, so a start off that multiple reads the
+    wrong elements. A start moves by ``block_ol * stride_l`` per block and lands on
+    ``l_in - span`` where the span slides back inside the row, so the width has to divide
+    both. Only a window too wide to stage at 128 outputs selects a width that can break
+    it, which is why no benchmarked shape reaches this.
+    """
+    for block_ol in _block_ol_choices(l_in, kernel_l, stride_l, pad_l, dtype):
+        staged = _staging(block_ol, l_in, kernel_l, stride_l, pad_l, dtype)
+        assert (block_ol * stride_l) % staged.vector_elems == 0
+        assert (l_in - staged.span) % staged.vector_elems == 0
+        assert staged.span % staged.vector_elems == 0
+        assert staged.head % staged.vector_elems == 0
+        assert staged.head >= pad_l
+        assert staged.span >= min(staged.head + (block_ol - 1) * stride_l + kernel_l, l_in)
 
 
 @pytest.mark.smoke

--- a/tests/ops/test_pool.py
+++ b/tests/ops/test_pool.py
@@ -580,22 +580,23 @@ def test_avg_pool3d(
 def test_avg_pool1d_staged_span_stays_aligned(
     l_in: int, kernel_l: int, stride_l: int, pad_l: int, dtype: str
 ) -> None:
-    """Every span start a launch can take sits on a multiple of the access width.
+    """Every group of the staged span lies wholly inside the row or wholly outside it.
 
-    The staging load is vectorized and unguarded, so a start off that multiple reads the
-    wrong elements. A start moves by ``block_ol * stride_l`` per block and lands on
-    ``l_in - span`` where the span slides back inside the row, so the width has to divide
-    both. Only a window too wide to stage at 128 outputs selects a width that can break
-    it, which is why no benchmarked shape reaches this.
+    The staging load is vectorized, and it is the group boundaries that decide whether a
+    group is loaded or zeroed, so a boundary landing mid-row would read the wrong
+    elements for the whole group. Three things move a boundary: the block step
+    ``block_ol * stride_l``, the head in front of the leftmost window, and the row end.
+    Only a window too wide to stage at 128 outputs selects a width that can break this,
+    which is why no benchmarked shape reaches it.
     """
     for block_ol in _block_ol_choices(l_in, kernel_l, stride_l, pad_l, dtype):
         staged = _staging(block_ol, l_in, kernel_l, stride_l, pad_l, dtype)
         assert (block_ol * stride_l) % staged.vector_elems == 0
-        assert (l_in - staged.span) % staged.vector_elems == 0
-        assert staged.span % staged.vector_elems == 0
+        assert l_in % staged.vector_elems == 0
         assert staged.head % staged.vector_elems == 0
+        assert staged.span % staged.vector_elems == 0
         assert staged.head >= pad_l
-        assert staged.span >= min(staged.head + (block_ol - 1) * stride_l + kernel_l, l_in)
+        assert staged.span >= staged.head + (block_ol - 1) * stride_l + kernel_l
 
 
 @pytest.mark.smoke


### PR DESCRIPTION
## Summary

- A block stages the stretch of row its outputs cover into `smem` with 16-byte loads.
- Every tap is read from that tile.
- The tile holds zeros outside the row, so no tap carries a test.
- A tap's tile index is then the same constant in every block.
- The access width is narrowed until the block step, the head and the row end divide it.
- That keeps every load group wholly inside the row or wholly outside it.
- The tile width follows a rule. The block size is tuned.
- Candidates whose launch cannot fill the device are dropped.
- `_WindowStaging` owns the launch policy; both Kernel classes derive from one base.
- The functions the jit builder calls take scalars, following #2103.
- Config key `block_m` -> `block_ol`: it counts outputs per block.
- Unchanged: the op, kernel dispatch, the spatial fast path, output semantics.
- Unchanged: manifest, workload, reference, benchmark path.
- A `kernel_size` in the tens of thousands now raises `ValueError`.
- One window then exceeds `smem`.
- Test-node delta: +8 (264 to 272).

## TileFoundry Description

`LongTemporalDirect` is the placement this PR replaces: five strided views of
the row, each tap read where it lies.

The three `*Staged` modules are the placement it implements. One CTA per row,
the row resharded to `smem` once, each tap to `rmem`, so the window sum never
leaves a register.

The declared parameter is the row already zero-padded, which is what the kernel
now stages.

```python
"""AvgPool1dFwd as HIR, at the three workloads src/tileops/manifest/pool.yaml benchmarks.

The declared parameter is the row already zero-padded on both ends, so the window
arithmetic is the whole content of the program, and it is what the kernel stages: the
tile a block holds carries the padding as zeros. Padding is 4 of 32004 elements at the
widest workload, which leaves the traffic these modules are read for unchanged.
"""

from tilefoundry import func, module
from tilefoundry.dsl import Mesh, Tensor, Topology, tf
from tilefoundry.target import CudaTarget

H200 = CudaTarget("nvidia.h200_sxm")


def long_temporal_direct():
    """[2,256,32000] k5 s4 p2 f16: each tap read where it lies, nothing staged."""
    ROWS, L_IN, KW, SW, PW = 512, 32000, 5, 4, 2
    OUT_L, L_PAD, DT, SCALE = 8000, 32004, "f16", 1.0 / 5

    @module(entry="avg_pool1d", target=H200, topologies=(Topology("cta", 132),))
    class LongTemporalDirect:
        @func
        def avg_pool1d(xpad: Tensor[(ROWS, L_PAD), DT]):
            t0 = tf.slice(xpad, (0, 0), sizes=(ROWS, OUT_L), strides=(1, SW))
            t1 = tf.slice(xpad, (0, 1), sizes=(ROWS, OUT_L), strides=(1, SW))
            t2 = tf.slice(xpad, (0, 2), sizes=(ROWS, OUT_L), strides=(1, SW))
            t3 = tf.slice(xpad, (0, 3), sizes=(ROWS, OUT_L), strides=(1, SW))
            t4 = tf.slice(xpad, (0, 4), sizes=(ROWS, OUT_L), strides=(1, SW))
            acc = tf.cast(t0, "f32") + tf.cast(t1, "f32") + tf.cast(t2, "f32")
            acc = acc + tf.cast(t3, "f32") + tf.cast(t4, "f32")
            return tf.cast(acc * SCALE, DT)

    return LongTemporalDirect


def long_temporal_staged():
    """The same step with the row staged in smem once and the sum held in a register."""
    ROWS, L_IN, KW, SW, PW = 512, 32000, 5, 4, 2
    OUT_L, L_PAD, DT, SCALE = 8000, 32004, "f16", 1.0 / 5
    NT = 800  # threads per CTA; OUT_L // NT = 10 outputs each

    @module(
        entry="avg_pool1d",
        target=H200,
        topologies=(Topology("cta", ROWS), Topology("thread", NT)),
    )
    class LongTemporalStaged:
        @func
        def avg_pool1d(xpad: Tensor[(ROWS, L_PAD), DT]):
            with Mesh(("cta",), layout=(ROWS,), names=("row",)) as cta:
                with Mesh(("thread",), layout=(NT,), names=("t",)) as m:
                    held = tf.reshard(xpad, (ROWS @ cta.row, L_PAD), "smem")
                    s0 = tf.slice(held, (0, 0), sizes=(ROWS, OUT_L), strides=(1, SW))
                    t0 = tf.reshard(s0, (ROWS @ cta.row, OUT_L @ m.t), "rmem")
                    s1 = tf.slice(held, (0, 1), sizes=(ROWS, OUT_L), strides=(1, SW))
                    t1 = tf.reshard(s1, (ROWS @ cta.row, OUT_L @ m.t), "rmem")
                    s2 = tf.slice(held, (0, 2), sizes=(ROWS, OUT_L), strides=(1, SW))
                    t2 = tf.reshard(s2, (ROWS @ cta.row, OUT_L @ m.t), "rmem")
                    s3 = tf.slice(held, (0, 3), sizes=(ROWS, OUT_L), strides=(1, SW))
                    t3 = tf.reshard(s3, (ROWS @ cta.row, OUT_L @ m.t), "rmem")
                    s4 = tf.slice(held, (0, 4), sizes=(ROWS, OUT_L), strides=(1, SW))
                    t4 = tf.reshard(s4, (ROWS @ cta.row, OUT_L @ m.t), "rmem")
                    acc = tf.cast(t0, "f32") + tf.cast(t1, "f32") + tf.cast(t2, "f32")
                    acc = acc + tf.cast(t3, "f32") + tf.cast(t4, "f32")
                    return tf.reshard(tf.cast(acc * SCALE, DT), (ROWS, OUT_L), "gmem")

    return LongTemporalStaged


def audio_downsample_staged():
    """[4,128,4096] k3 s2 p1 f16, same placement at three taps."""
    ROWS, L_IN, KW, SW, PW = 512, 4096, 3, 2, 1
    OUT_L, L_PAD, DT, SCALE = 2048, 4098, "f16", 1.0 / 3
    NT = 256  # threads per CTA; OUT_L // NT = 8 outputs each

    @module(
        entry="avg_pool1d",
        target=H200,
        topologies=(Topology("cta", ROWS), Topology("thread", NT)),
    )
    class AudioDownsampleStaged:
        @func
        def avg_pool1d(xpad: Tensor[(ROWS, L_PAD), DT]):
            with Mesh(("cta",), layout=(ROWS,), names=("row",)) as cta:
                with Mesh(("thread",), layout=(NT,), names=("t",)) as m:
                    held = tf.reshard(xpad, (ROWS @ cta.row, L_PAD), "smem")
                    s0 = tf.slice(held, (0, 0), sizes=(ROWS, OUT_L), strides=(1, SW))
                    t0 = tf.reshard(s0, (ROWS @ cta.row, OUT_L @ m.t), "rmem")
                    s1 = tf.slice(held, (0, 1), sizes=(ROWS, OUT_L), strides=(1, SW))
                    t1 = tf.reshard(s1, (ROWS @ cta.row, OUT_L @ m.t), "rmem")
                    s2 = tf.slice(held, (0, 2), sizes=(ROWS, OUT_L), strides=(1, SW))
                    t2 = tf.reshard(s2, (ROWS @ cta.row, OUT_L @ m.t), "rmem")
                    acc = tf.cast(t0, "f32") + tf.cast(t1, "f32") + tf.cast(t2, "f32")
                    return tf.reshard(tf.cast(acc * SCALE, DT), (ROWS, OUT_L), "gmem")

    return AudioDownsampleStaged


def ceil_staged():
    """[2,128,2048] k4 s2 p1 ceil bf16, count_include_pad off.

    The divisor is the window's overlap with the row: three at the two ends, four
    everywhere between them.
    """
    ROWS, L_IN, KW, SW, PW = 256, 2048, 4, 2, 1
    OUT_L, L_PAD, DT = 1024, 2050, "bf16"
    EDGE, MID = 1.0 / 3.0, 1.0 / 4.0
    NT = 256  # threads per CTA; OUT_L // NT = 4 outputs each

    @module(
        entry="avg_pool1d",
        target=H200,
        topologies=(Topology("cta", ROWS), Topology("thread", NT)),
    )
    class CeilStaged:
        @func
        def avg_pool1d(xpad: Tensor[(ROWS, L_PAD), DT]):
            with Mesh(("cta",), layout=(ROWS,), names=("row",)) as cta:
                with Mesh(("thread",), layout=(NT,), names=("t",)) as m:
                    held = tf.reshard(xpad, (ROWS @ cta.row, L_PAD), "smem")
                    s0 = tf.slice(held, (0, 0), sizes=(ROWS, OUT_L), strides=(1, SW))
                    t0 = tf.reshard(s0, (ROWS @ cta.row, OUT_L @ m.t), "rmem")
                    s1 = tf.slice(held, (0, 1), sizes=(ROWS, OUT_L), strides=(1, SW))
                    t1 = tf.reshard(s1, (ROWS @ cta.row, OUT_L @ m.t), "rmem")
                    s2 = tf.slice(held, (0, 2), sizes=(ROWS, OUT_L), strides=(1, SW))
                    t2 = tf.reshard(s2, (ROWS @ cta.row, OUT_L @ m.t), "rmem")
                    s3 = tf.slice(held, (0, 3), sizes=(ROWS, OUT_L), strides=(1, SW))
                    t3 = tf.reshard(s3, (ROWS @ cta.row, OUT_L @ m.t), "rmem")
                    acc = tf.cast(t0, "f32") + tf.cast(t1, "f32")
                    acc = acc + tf.cast(t2, "f32") + tf.cast(t3, "f32")
                    end = tf.zeros(Tensor[(1, 1), "f32", "rmem"])
                    mid = tf.zeros(Tensor[(1, OUT_L - 2), "f32", "rmem"])
                    recip = tf.concat(
                        [
                            tf.full_like(end, value=EDGE),
                            tf.full_like(mid, value=MID),
                            tf.full_like(end, value=EDGE),
                        ],
                        axis=-1,
                    )
                    return tf.reshard(tf.cast(acc * recip, DT), (ROWS, OUT_L), "gmem")

    return CeilStaged


LongTemporalDirect = long_temporal_direct()
LongTemporalStaged = long_temporal_staged()
AudioDownsampleStaged = audio_downsample_staged()
CeilStaged = ceil_staged()
```

All four pass `allclose` and `nan_inf` against `torch.nn.functional.avg_pool1d`,
at `atol = rtol = 1e-3` for FP16 and `8e-3` for BF16.

`analyze --compute-cost --memory --roofline` reports every module memory-bound:

| module | gmem read / write (B) | ideal-ns |
| --- | ---: | ---: |
| `LongTemporalDirect` | 204800000 / 172032000 | 78507 |
| `LongTemporalStaged` | 32772096 / 8192000 | 8535 |
| `AudioDownsampleStaged` | 4196352 / 2097152 | 1312 |
| `CeilStaged` | 1049600 / 524288 | 328 |

`LongTemporalStaged` reads the row once and writes the output once. `smem` then
carries 40960000 / 32772096: the 1.25x re-read of overlapping windows, moved off
the device bus.

`LongTemporalDirect` declares no mesh, so every intermediate lands in `gmem`. It
prices that placement, not an implementation of it.

Two limitations, neither presented as TileFoundry selecting the shipped
configuration:

- The staged modules give one CTA a whole 64008-byte row.
- The shipped kernel splits the row into `block_ol`-output tiles, which HIR has
  no halo to express.
- `ideal-ns` is the roofline against the target's published rates: a floor, not
  reachable at these launch sizes.
- The table below prices against a measured streaming pass instead.

## Performance

Operator: `AvgPool1dFwdOp`

| Environment | Value |
| --- | --- |
| image | `ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-afcebed1-tilefoundry-latest` |
| digest | `sha256:ca13df9bda340edf248b8b443b88880f36e3190ab9d470f52d66ccc21c15fd59` |
| gpu | `NVIDIA H200` |
| driver | `595.71.05` |
| cuda | `13.2` |
| torch | `2.13.0+cu132` |
| tilelang | `0.1.11+cu132.gitafcebed1` |
| tilefoundry | `0.1.dev146+g2bec6420e` |
| timer | `CUPTI device_busy_ms` |

Method: `benchmarks.timing.bench_kernel`, which clears L2 before every
iteration, on one GPU in one window.

The incumbent is `1d48e1f5` at its own best config. The fifth column is
`torch.neg` over the same byte count, the reachable floor for a memory-bound
pass.

Ratio in comparator columns: implementation / candidate. &#x1F7E2; > 1 means the
candidate is faster; &#x1F534; <= 1 means it is not.

| Workload | Shape, k/s/p | Dtype | candidate (ms) | incumbent<br>/ ratio | torch-compile<br>/ ratio | torch-ref<br>/ ratio | wall<br>/ ratio |
| --- | --- | --- | ---: | ---: | ---: | ---: | ---: |
| audio-downsample | 4x128x4096, 3/2/1 | FP16 | 0.003488 | **0.003808<br>&#x1F7E2;&nbsp;1.091743x** | **0.003712<br>&#x1F7E2;&nbsp;1.064220x** | **0.012032<br>&#x1F7E2;&nbsp;3.449541x** | 0.003232<br>&#x1F534;&nbsp;0.926606x |
| long-temporal | 2x256x32000, 5/4/2 | FP16 | 0.013409 | **0.017504<br>&#x1F7E2;&nbsp;1.305392x** | **0.020223<br>&#x1F7E2;&nbsp;1.508166x** | **0.045664<br>&#x1F7E2;&nbsp;3.405474x** | 0.012224<br>&#x1F534;&nbsp;0.911627x |
| ceil | 2x128x2048, 4/2/1 ceil excl | BF16 | 0.002080 | **0.002144<br>&#x1F7E2;&nbsp;1.030769x** | **0.002752<br>&#x1F7E2;&nbsp;1.323077x** | **0.004288<br>&#x1F7E2;&nbsp;2.061538x** | 0.001824<br>&#x1F534;&nbsp;0.876923x |
| geometric mean |  |  | 0.004599 | **0.005228<br>&#x1F7E2;&nbsp;1.136774x** | **0.005912<br>&#x1F7E2;&nbsp;1.285352x** | **0.013306<br>&#x1F7E2;&nbsp;2.893189x** | 0.004161<br>&#x1F534;&nbsp;0.904811x |

## Result And Limitations

**improvement without SOTA**

- Every workload improves over the incumbent and both torch comparators.
- Incumbent geometric mean 1.136774x.
- The 2026-09-06 nightly flagged two rows under 1.0 against `torch-compile`:
  0.9632 and 0.9468.
- They are now 1.064220x and 1.508166x.
- Largest gain 1.305392x on long-temporal.
- The incumbent ran at 2.34 TB/s there, against a 3.35 TB/s wall.
- The wall column is red on every row: 1.08x, 1.10x, 1.14x.
- It is a floor, not a comparator.
- That gap is inside the +-5% the instrument reproduces on a rerun.
- Seven further rounds measured equal or slower and are not in the diff.
- They were: reciprocal-select for the edge divide, staged wide stores,
  exact-divisor tile widths, inductor's flat one-output-per-thread body,
  per-thread runs read as wide groups, a one-pass predicated staging load, and a
  1024-output default tile.
- `torch-compile` on the ceil row measured 0.002000 to 0.003328 ms across runs.
- That depends on the inductor cache state, and is the least stable figure here.
- The `ValueError` is a behaviour change, not a defect.
- No manifest workload, test case or `shape_rules` clause reaches it.
