### PR TITLE
[BugFix][Kernels] Keep every jit builder's closure scalar, and lint for it

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -1,6 +1,7 @@
 Rules a reader has to apply by hand. The deprecated `T.Buffer` annotation, a dtype-first
-`T.reinterpret`, a literal cast to a narrow float, and a file-level `noqa` are checked by
-`scripts/lint/tilelang_idioms_lint.py`; that file states why each one is wrong.
+`T.reinterpret`, a literal cast to a narrow float, a `@tilelang.jit` builder closing over a
+non-scalar, and a file-level `noqa` are checked by `scripts/lint/tilelang_idioms_lint.py`;
+that file states why each one is wrong.
 
 - Every `src/tileops/kernels/*` subpackage MUST have an `__init__.py` with explicit `__all__` and `from .module import Symbol` re-exports.
 

--- a/scripts/lint/tilelang_idioms_lint.py
+++ b/scripts/lint/tilelang_idioms_lint.py
@@ -14,6 +14,10 @@ Each rule below is a form the compiler accepts, so nothing downstream reports it
   loses its low bits. Reference ``x.dtype``, or compute wider and cast at the
   boundary. A narrow *integer* cast is not this: a uint8 mask compared against 0
   or 1 loses nothing.
+- A ``@tilelang.jit`` builder closing over a value that is not a scalar. The
+  autotuner folds a jit function's free variables into its cache key and accepts
+  only ``int``, ``float``, ``str``, ``bool`` and ``None``; anything else raises
+  only once that kernel is autotuned, which no correctness test does.
 - A file-level lint suppression (``# ruff: noqa``, ``# flake8: noqa``). It hides
   every future finding in the file, not the one being waived.
 
@@ -26,8 +30,10 @@ import argparse
 import ast
 import io
 import re
+import symtable
 import sys
 import tokenize
+from collections.abc import Iterator
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -144,6 +150,155 @@ def _arg(call: ast.Call, pos: int, name: str) -> ast.AST | None:
     return next((k.value for k in call.keywords if k.arg == name), None)
 
 
+_NONSCALAR_KINDS = {
+    ast.List: "list",
+    ast.ListComp: "list",
+    ast.Dict: "dict",
+    ast.DictComp: "dict",
+    ast.Set: "set",
+    ast.SetComp: "set",
+    ast.Tuple: "tuple",
+    ast.GeneratorExp: "generator",
+    ast.Lambda: "function",
+}
+
+_SCOPE = (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+
+_Func = ast.FunctionDef | ast.AsyncFunctionDef
+
+
+def _jit_names(tree: ast.Module) -> tuple[set[str], set[str]]:
+    """What this file binds to ``tilelang.jit``: module aliases, then bare names.
+
+    The package re-exports ``jit`` over its own submodule, so ``import tilelang.jit as
+    tj`` binds the decorator and the same import unaliased binds the package.
+    """
+    aliases, bare = set(), set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for a in node.names:
+                if a.name == "tilelang":
+                    aliases.add(a.asname or a.name)
+                elif a.name == "tilelang.jit":
+                    bare.add(a.asname) if a.asname else aliases.add("tilelang")
+        elif isinstance(node, ast.ImportFrom) and node.module == "tilelang":
+            bare |= {a.asname or a.name for a in node.names if a.name == "jit"}
+    return aliases, bare
+
+
+def _is_jit_builder(func: _Func, aliases: set[str], bare: set[str]) -> bool:
+    """Whether ``tilelang.jit`` decorates this function, called or bare."""
+    for dec in func.decorator_list:
+        node = dec.func if isinstance(dec, ast.Call) else dec
+        if isinstance(node, ast.Name) and node.id in bare:
+            return True
+        path = _attr_path(node)
+        if path:
+            base, _, attr = path.rpartition(".")
+            if attr == "jit" and base in aliases:
+                return True
+    return False
+
+
+def _nested_functions(tree: ast.Module) -> list[tuple[_Func, tuple[_Func, ...]]]:
+    """Each function defined inside another, with every function enclosing it.
+
+    A cell comes from any enclosing scope, so the chain is ordered innermost first — the
+    order in which a name resolves.
+    """
+    pairs, stack = [], [(tree, ())]
+    while stack:
+        node, outer = stack.pop()
+        for child in ast.iter_child_nodes(node):
+            nested = isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+            if nested and outer:
+                pairs.append((child, outer))
+            stack.append((child, (child, *outer) if nested else outer))
+    return pairs
+
+
+def _own_scope(func: _Func) -> Iterator[ast.AST]:
+    """Nodes belonging to this function's own scope, not to one nested inside it."""
+    stack: list[ast.AST] = list(func.body)
+    while stack:
+        node = stack.pop()
+        yield node
+        if not isinstance(node, _SCOPE):
+            stack.extend(ast.iter_child_nodes(node))
+
+
+def _function_tables(top: symtable.SymbolTable) -> dict[tuple[str, int], symtable.SymbolTable]:
+    """Every function scope in the file, keyed by its name and ``def`` line."""
+    tables: dict[tuple[str, int], symtable.SymbolTable] = {}
+    stack = [top]
+    while stack:
+        table = stack.pop()
+        if table.get_type() == "function":
+            tables.setdefault((table.get_name(), table.get_lineno()), table)
+        stack.extend(table.get_children())
+    return tables
+
+
+def _nonscalar_kind(value: ast.AST, classes: set[str]) -> str | None:
+    """What kind of non-scalar this expression provably builds, or None.
+
+    One-sided on purpose: an expression this cannot classify is left alone, so a
+    factory call returning an object passes.
+    """
+    for node_type, kind in _NONSCALAR_KINDS.items():
+        if isinstance(value, node_type):
+            return kind
+    if isinstance(value, ast.Call):
+        func = value.func
+        name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", "")
+        if name in classes:
+            return f"{name} instance"
+    return None
+
+
+def _nonscalar_closures(path: Path, text: str, tree: ast.Module) -> list[str]:
+    """Free variables of a jit builder that provably hold something other than a scalar."""
+    try:
+        tables = _function_tables(symtable.symtable(text, str(path), "exec"))
+    except (SyntaxError, ValueError):
+        return []
+
+    aliases, bare = _jit_names(tree)
+    classes = {node.name for node in ast.walk(tree) if isinstance(node, ast.ClassDef)}
+    out = []
+
+    for func, outers in _nested_functions(tree):
+        table = tables.get((func.name, func.lineno))
+        if table is None or not _is_jit_builder(func, aliases, bare):
+            continue
+        free = {sym.get_name() for sym in table.get_symbols() if sym.is_free()}
+        # The innermost scope binding a name holds the cell the builder closes over. An
+        # outer scope binding the same name is shadowed and says nothing about that cell,
+        # so every name this scope binds leaves the search whether or not it is reported.
+        for outer in outers:
+            # The cell holds what the last assignment left, so a name bound more than
+            # once in a scope is classified by its final binding, not its first.
+            last: dict[str, tuple[int, str | None]] = {}
+            for node in _own_scope(outer):
+                if not isinstance(node, (ast.Assign, ast.AnnAssign)) or node.value is None:
+                    continue
+                targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+                for target in targets:
+                    if not isinstance(target, ast.Name) or target.id not in free:
+                        continue
+                    if node.lineno >= last.get(target.id, (-1, None))[0]:
+                        last[target.id] = (node.lineno, _nonscalar_kind(node.value, classes))
+            out += [
+                f"{path}:{lineno}: {func.name} closes over `{name}` ({kind}) — a jit "
+                "builder's free variables enter the autotune cache key, which takes "
+                "only int, float, str, bool and None"
+                for name, (lineno, kind) in last.items()
+                if kind
+            ]
+            free -= set(last)
+    return sorted(out)
+
+
 def check(path: Path) -> list[str]:
     """Violations in one file, each rendered as ``path:line: message``."""
     raw = path.read_bytes()
@@ -163,6 +318,8 @@ def check(path: Path) -> list[str]:
         tree = ast.parse(text)
     except SyntaxError:
         return out  # check-ast reports it; nothing here to add
+
+    out += _nonscalar_closures(path, text, tree)
 
     aliases, bare = _tilelang_names(tree)
 

--- a/src/tileops/kernels/attention/deepseek_nsa_cmp_fwd.py
+++ b/src/tileops/kernels/attention/deepseek_nsa_cmp_fwd.py
@@ -32,15 +32,6 @@ def _nsa_cmp_fwd_varlen_kernel(
     bk = dim_k
     bv = dim_v
 
-    q_shape = [c_seq_len, heads, dim_k]
-    k_cmp_shape = [chunk_num, head_kv, dim_k]
-    v_cmp_shape = [chunk_num, head_kv, dim_v]
-    lse_shape = [c_seq_len, heads]
-    offsets_shape = [seq_num + 1]
-    token_indices_shape = [c_seq_len, 2]
-    chunk_offsets_shape = [seq_num + 1]
-    o_shape = [c_seq_len, heads, dim_v]
-
     @tilelang.jit(
         out_idx=[-2, -1],
         pass_configs={
@@ -52,14 +43,14 @@ def _nsa_cmp_fwd_varlen_kernel(
     def _nsa_cmp_fwd_varlen_func(threads: int):
         @T.prim_func
         def _parallel_nsa_cmp_fwd_varlen_main(
-            q: T.Tensor(q_shape, dtype),
-            k_cmp: T.Tensor(k_cmp_shape, dtype),
-            v_cmp: T.Tensor(v_cmp_shape, dtype),
-            offsets: T.Tensor(offsets_shape, T.int32),
-            chunk_offsets: T.Tensor(chunk_offsets_shape, T.int32),
-            token_indices: T.Tensor(token_indices_shape, T.int32),
-            output: T.Tensor(o_shape, dtype),
-            temp_lse: T.Tensor(lse_shape, dtype),
+            q: T.Tensor((c_seq_len, heads, dim_k), dtype),
+            k_cmp: T.Tensor((chunk_num, head_kv, dim_k), dtype),
+            v_cmp: T.Tensor((chunk_num, head_kv, dim_v), dtype),
+            offsets: T.Tensor((seq_num + 1,), T.int32),
+            chunk_offsets: T.Tensor((seq_num + 1,), T.int32),
+            token_indices: T.Tensor((c_seq_len, 2), T.int32),
+            output: T.Tensor((c_seq_len, heads, dim_v), dtype),
+            temp_lse: T.Tensor((c_seq_len, heads), dtype),
         ):
             with T.Kernel(c_seq_len, head_kv, threads=threads) as (bx, by):
                 q_shared = T.alloc_shared([group, bk], dtype)

--- a/src/tileops/kernels/attention/deepseek_nsa_topk.py
+++ b/src/tileops/kernels/attention/deepseek_nsa_topk.py
@@ -31,14 +31,6 @@ def _nsa_topk_varlen_kernel(
     # would silently truncate the QK contraction.
     bk = dim
 
-    q_shape = [c_seq_len, heads, dim]
-    k_cmp_shape = [chunk_num, head_kv, dim]
-    lse_shape = [c_seq_len, heads]
-    offsets_shape = [seq_num + 1]
-    token_indices_shape = [c_seq_len, 2]
-    chunk_offsets_shape = [seq_num + 1]
-    block_indices_shape = [c_seq_len, head_kv, selected_block_num]
-
     @tilelang.jit(
         out_idx=[-1],
         pass_configs={
@@ -77,13 +69,13 @@ def _nsa_topk_varlen_kernel(
 
         @T.prim_func
         def _parallel_nsa_topk_varlen_main(
-            q: T.Tensor(q_shape, dtype),
-            k_cmp: T.Tensor(k_cmp_shape, dtype),
-            lse_in: T.Tensor(lse_shape, dtype),  # todo: lse_in is none.
-            offsets: T.Tensor(offsets_shape, T.int32),
-            chunk_offsets: T.Tensor(chunk_offsets_shape, T.int32),
-            token_indices: T.Tensor(token_indices_shape, T.int32),
-            block_indices: T.Tensor(block_indices_shape, T.int32),
+            q: T.Tensor((c_seq_len, heads, dim), dtype),
+            k_cmp: T.Tensor((chunk_num, head_kv, dim), dtype),
+            lse_in: T.Tensor((c_seq_len, heads), dtype),  # todo: lse_in is none.
+            offsets: T.Tensor((seq_num + 1,), T.int32),
+            chunk_offsets: T.Tensor((seq_num + 1,), T.int32),
+            token_indices: T.Tensor((c_seq_len, 2), T.int32),
+            block_indices: T.Tensor((c_seq_len, head_kv, selected_block_num), T.int32),
         ):
             _ = lse_in
             with T.Kernel(c_seq_len, head_kv, threads=threads) as (bx, by):

--- a/tests/test_tilelang_idioms_lint.py
+++ b/tests/test_tilelang_idioms_lint.py
@@ -91,6 +91,229 @@ def test_accepted(tmp_path, source):
     assert result.returncode == 0, result.stdout
 
 
+# One builder per fixture; the rule reads scopes, so the nesting is the fixture.
+CLOSES_OVER_A_LIST = """
+import tilelang
+
+
+def build(n):
+    shape = [n, 4]
+
+    @tilelang.jit(out_idx=[1])
+    def _func(threads: int):
+        return shape
+"""
+
+ANNOTATED_LIST = """
+import tilelang
+
+
+def build(n):
+    shape: list[int] = [n, 4]
+
+    @tilelang.jit(out_idx=[1])
+    def _func(threads: int):
+        return shape
+"""
+
+CLOSES_OVER_AN_INSTANCE = """
+from tilelang import jit as tjit
+
+
+class Policy:
+    pass
+
+
+def build(n):
+    policy = Policy()
+
+    @tjit
+    def _func(threads: int):
+        return policy.pick(n)
+"""
+
+FROM_A_GRANDPARENT_SCOPE = """
+import tilelang
+
+
+def outer(n):
+    shape = [n, 4]
+
+    def build():
+        @tilelang.jit(out_idx=[1])
+        def _func(threads: int):
+            return shape
+"""
+
+SUBMODULE_IMPORT = """
+import tilelang.jit
+
+
+def build(n):
+    shape = [n, 4]
+
+    @tilelang.jit(out_idx=[1])
+    def _func(threads: int):
+        return shape
+"""
+
+SHADOWED_BY_THE_PARENT = """
+import tilelang
+
+
+def outer(n):
+    shape = [n, 4]
+    record(shape)
+
+    def build():
+        shape = n * 2
+
+        @tilelang.jit(out_idx=[1])
+        def _func(threads: int):
+            return shape
+"""
+
+SUBMODULE_IMPORT_ALIASED = """
+import tilelang.jit as tj
+
+
+def build(n):
+    shape = [n, 4]
+
+    @tj(out_idx=[1])
+    def _func(threads: int):
+        return shape
+"""
+
+REBOUND_SCALAR_LAST = """
+import tilelang
+
+
+def build(n):
+    shape = [n, 4]
+    shape = n * 2
+
+    @tilelang.jit(out_idx=[1])
+    def _func(threads: int):
+        return shape
+"""
+
+CLOSES_OVER_A_SCALAR = """
+import tilelang
+
+
+def build(n):
+    rows = n * 2
+
+    @tilelang.jit(out_idx=[1])
+    def _func(threads: int):
+        return rows
+"""
+
+PLAIN_NESTED_FUNCTION = """
+def build(n):
+    shape = [n, 4]
+
+    def _helper():
+        return shape
+"""
+
+ANOTHER_LIBRARYS_JIT = """
+import numba
+
+
+def build(n):
+    shape = [n, 4]
+
+    @numba.jit
+    def _func(threads):
+        return shape
+"""
+
+REBOUND_INSIDE_THE_BUILDER = """
+import tilelang
+
+
+def build(n):
+    tile = [n, 4]
+    record(tile)
+
+    @tilelang.jit(out_idx=[1])
+    def _func(threads: int):
+        tile = [threads, 4]
+        return tile
+"""
+
+SAME_NAME_IN_A_SIBLING_HELPER = """
+import tilelang
+
+
+def build(n):
+    rows = n * 2
+
+    def _describe():
+        rows = [n, 4]
+        return rows
+
+    @tilelang.jit(out_idx=[1])
+    def _func(threads: int):
+        return rows, _describe
+"""
+
+CALLS_A_FACTORY = """
+import tilelang
+
+
+def build(n):
+    policy = make_policy(n)
+
+    @tilelang.jit(out_idx=[1])
+    def _func(threads: int):
+        return policy.pick(n)
+"""
+
+
+@pytest.mark.parametrize(
+    "source, expected",
+    [
+        (CLOSES_OVER_A_LIST, "closes over `shape` (list)"),
+        (ANNOTATED_LIST, "closes over `shape` (list)"),
+        # An aliased bare import names the same decorator.
+        (CLOSES_OVER_AN_INSTANCE, "closes over `policy` (Policy instance)"),
+        (FROM_A_GRANDPARENT_SCOPE, "closes over `shape` (list)"),
+        (SUBMODULE_IMPORT, "closes over `shape` (list)"),
+        # Aliased, the same import binds the decorator rather than the package.
+        (SUBMODULE_IMPORT_ALIASED, "closes over `shape` (list)"),
+    ],
+)
+def test_nonscalar_closure_rejected(tmp_path, source, expected):
+    result = run_lint(tmp_path, source)
+    assert result.returncode == 1
+    assert expected in result.stdout
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        CLOSES_OVER_A_SCALAR,
+        # The nearest binding holds the cell; an outer one of the same name is shadowed.
+        SHADOWED_BY_THE_PARENT,
+        # The cell holds what the last assignment left.
+        REBOUND_SCALAR_LAST,
+        PLAIN_NESTED_FUNCTION,
+        ANOTHER_LIBRARYS_JIT,
+        # Assigned inside the builder, the name is local there and never a cell.
+        REBOUND_INSIDE_THE_BUILDER,
+        SAME_NAME_IN_A_SIBLING_HELPER,
+        # The blind spot, held deliberately: an unclassifiable call is left alone.
+        CALLS_A_FACTORY,
+    ],
+)
+def test_nonscalar_closure_accepted(tmp_path, source):
+    result = run_lint(tmp_path, source)
+    assert result.returncode == 0, result.stdout
+
+
 def test_bom_does_not_hide_the_rules(tmp_path):
     """A byte-order mark is valid Python; decoding past it must not skip the parse."""
     target = tmp_path / "fixture.py"


### PR DESCRIPTION
## Summary

- The autotuner folds a jit function's free variables into its cache key and asserts each is `int`, `float`, `str`, `bool` or `None` (`tilelang/autotuner/tuner.py`).
- `deepseek_nsa_topk.py` and `deepseek_nsa_cmp_fwd.py` held their tensor shapes in list locals, so 15 free variables were lists. Each shape moves into its `T.Tensor` annotation, leaving scalars only. No kernel behaviour changes.
- `scripts/lint/tilelang_idioms_lint.py` gains the constraint as a rule: `symtable` resolves the free variables, and a list, dict, set, tuple, comprehension, lambda or same-file class instance is reported. Everything else passes, so an unclassifiable call is missed and nothing is reported that is not a violation.
- The rule inspects 226 jit builders across 99 files, reports nothing on `main`, and reports the 9 real violations on the two pre-fix files.

## Regression

- 1500 generated programs — nested scopes, repeated and shadowing bindings, control flow, six decorator spellings — were checked against the free variables the interpreter actually builds: no false positive, and every miss a factory call.
- The assert lives only in `AutoTuner.run()`, so a correctness test never reaches it and PR CI stays green — #2103's bug took a full nightly cycle to surface. A walrus binding, a tuple-unpacking target, and a free variable holding the return of an unclassifiable call still get through.
