### PR TITLE
[Perf][foundry][Quantization] Multiply an fp8-quant row by one reciprocal, and size the block from the row width

### DIFF
--- a/src/tileops/kernels/fp8_quant.py
+++ b/src/tileops/kernels/fp8_quant.py
@@ -15,7 +15,7 @@ _AMAX_FLOOR = 1e-4
 
 
 @functools.lru_cache(maxsize=32)
-def _fp8_quant_kernel(batch, seq_len_kv, kv_group, index_dim, in_dtype: str, threads: int):
+def _fp8_quant_kernel(rows: int, index_dim: int, in_dtype: str, threads: int):
     @tilelang.jit(out_idx=[1, 2])
     def _fp8_quant_fwd_func(block_m):
         if block_m < 1:
@@ -27,15 +27,11 @@ def _fp8_quant_kernel(batch, seq_len_kv, kv_group, index_dim, in_dtype: str, thr
 
         @T.prim_func
         def _fp8_quant_fwd_main(
-            input_tensor: T.Tensor[(batch, seq_len_kv, kv_group, index_dim), in_dtype],
-            scale_tensor: T.Tensor[(batch, seq_len_kv, kv_group), scale_dtype],
-            output_tensor: T.Tensor[(batch, seq_len_kv, kv_group, index_dim), out_dtype],
+            input_tensor: T.Tensor[(rows, index_dim), in_dtype],
+            scale_tensor: T.Tensor[(rows,), scale_dtype],
+            output_tensor: T.Tensor[(rows, index_dim), out_dtype],
         ):
-            with T.Kernel(batch, T.ceildiv(seq_len_kv, block_m), kv_group, threads=threads) as (
-                bx,
-                pid_m,
-                g,
-            ):
+            with T.Kernel(T.ceildiv(rows, block_m), threads=threads) as pid_m:
                 input_local = T.alloc_fragment((block_m, index_dim), in_dtype)
                 output_local = T.alloc_fragment((block_m, index_dim), out_dtype)
                 amax_local = T.alloc_fragment((block_m,), scale_dtype)
@@ -44,9 +40,7 @@ def _fp8_quant_kernel(batch, seq_len_kv, kv_group, index_dim, in_dtype: str, thr
 
                 # A block past the axis re-reads its last row; the stores drop those rows.
                 for i, j in T.Parallel(block_m, index_dim):
-                    input_local[i, j] = input_tensor[
-                        bx, T.min(pid_m * block_m + i, seq_len_kv - 1), g, j
-                    ]
+                    input_local[i, j] = input_tensor[T.min(pid_m * block_m + i, rows - 1), j]
 
                 T.reduce_absmax(input_local, amax_local, dim=1)
                 for i in T.Parallel(block_m):
@@ -61,11 +55,11 @@ def _fp8_quant_kernel(batch, seq_len_kv, kv_group, index_dim, in_dtype: str, thr
                     )
 
                 for i in T.Parallel(block_m):
-                    if pid_m * block_m + i < seq_len_kv:
-                        scale_tensor[bx, pid_m * block_m + i, g] = scale_local[i]
+                    if pid_m * block_m + i < rows:
+                        scale_tensor[pid_m * block_m + i] = scale_local[i]
                 for i, j in T.Parallel(block_m, index_dim):
-                    if pid_m * block_m + i < seq_len_kv:
-                        output_tensor[bx, pid_m * block_m + i, g, j] = output_local[i, j]
+                    if pid_m * block_m + i < rows:
+                        output_tensor[pid_m * block_m + i, j] = output_local[i, j]
 
         return _fp8_quant_fwd_main
 
@@ -83,8 +77,12 @@ def _fp8_quant_wrapped_kernel(
     block_m: int,
     input_tensor: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    return _fp8_quant_kernel(batch, seq_len_kv, kv_group, index_dim, in_dtype, threads)(block_m)(
-        input_tensor
+    rows = batch * seq_len_kv * kv_group
+    scale, quant = _fp8_quant_kernel(rows, index_dim, in_dtype, threads)(block_m)(
+        input_tensor.view(rows, index_dim)
+    )
+    return scale.view(batch, seq_len_kv, kv_group), quant.view(
+        batch, seq_len_kv, kv_group, index_dim
     )
 
 
@@ -100,8 +98,9 @@ def _(batch, seq_len_kv, kv_group, index_dim, in_dtype, threads, block_m, *input
 class FP8QuantKernel(Kernel):
     """Per-group fp8 quantization of a $[B \\times S\\_kv \\times G \\times D]$ index tensor.
 
-    A block owns whole rows and reduces each of them across the threads holding it. Any
-    positive ``block_m`` serves any ``seq_len_kv``.
+    A block owns whole rows, taken along the flattened $[B \\times S\\_kv \\times G]$ row
+    axis so that its rows are adjacent in memory, and reduces each of them across the
+    threads holding it. Any positive ``block_m`` serves any row count.
 
     Args:
         batch: Batch size.
@@ -140,19 +139,15 @@ class FP8QuantKernel(Kernel):
         self.index_dim = index_dim
         self.dtype = dtype
         self.kernel = _fp8_quant_kernel(
-            self.batch,
-            self.seq_len_kv,
-            self.kv_group,
-            self.index_dim,
-            self.dtype_str,
-            self._THREADS,
+            batch * seq_len_kv * kv_group, self.index_dim, self.dtype_str, self._THREADS
         )
         self.init_config(config, tune)
 
     def _block_rows(self) -> int:
         """Rows a block owns: the largest power of two the access budget and the axis allow."""
         row_bytes = self.index_dim * self.dtype.itemsize
-        widest = min(self._THREADS * VECTOR_ACCESS_BYTES // row_bytes, self.seq_len_kv)
+        rows = self.batch * self.seq_len_kv * self.kv_group
+        widest = min(self._THREADS * VECTOR_ACCESS_BYTES // row_bytes, rows)
         block_m = 1
         while block_m * 2 <= widest:
             block_m *= 2

--- a/src/tileops/kernels/fp8_quant.py
+++ b/src/tileops/kernels/fp8_quant.py
@@ -1,5 +1,5 @@
 import functools
-from typing import Optional, Tuple
+from typing import ClassVar, Optional, Tuple
 
 import tilelang
 import tilelang.language as T
@@ -10,28 +10,14 @@ from tileops.kernels.kernel_base import Kernel
 
 __all__ = ["FP8QuantKernel"]
 
-# Lower bound on a row's absolute maximum, so an all-zero row still has a finite scale.
+# This operator's floor on a row's absolute maximum, which leaves an all-zero row a finite
+# scale. It belongs to the quantization rule ``workloads/fp8_quant.py`` states, not to the
+# fp8 format, so no other kernel should read it. Module scope because the body reads it.
 _AMAX_FLOOR = 1e-4
-# Threads a block runs. ``_block_rows`` reads it, so the two are one launch rule.
-_THREADS = 128
-
-
-def _block_rows(seq_len_kv: int, row_bytes: int) -> int:
-    """Rows per block: the most whose bytes fit one vector access per thread.
-
-    A power of two, so a thread's share of the tile is a whole number of elements wherever
-    the row width allows one, and never more rows than the axis holds. Every width serves
-    every ``seq_len_kv``: the body clamps the rows it reads and tests the rows it writes.
-    """
-    widest = min(_THREADS * VECTOR_ACCESS_BYTES // row_bytes, seq_len_kv)
-    block_m = 1
-    while block_m * 2 <= widest:
-        block_m *= 2
-    return block_m
 
 
 @functools.lru_cache(maxsize=32)
-def _fp8_quant_kernel(batch, seq_len_kv, kv_group, index_dim, in_dtype: str):
+def _fp8_quant_kernel(batch, seq_len_kv, kv_group, index_dim, in_dtype: str, threads: int):
     @tilelang.jit(out_idx=[1, 2])
     def _fp8_quant_fwd_func(block_m):
         if block_m < 1:
@@ -47,7 +33,7 @@ def _fp8_quant_kernel(batch, seq_len_kv, kv_group, index_dim, in_dtype: str):
             scale_tensor: T.Tensor[(batch, seq_len_kv, kv_group), scale_dtype],
             output_tensor: T.Tensor[(batch, seq_len_kv, kv_group, index_dim), out_dtype],
         ):
-            with T.Kernel(batch, T.ceildiv(seq_len_kv, block_m), kv_group, threads=_THREADS) as (
+            with T.Kernel(batch, T.ceildiv(seq_len_kv, block_m), kv_group, threads=threads) as (
                 bx,
                 pid_m,
                 g,
@@ -58,15 +44,13 @@ def _fp8_quant_kernel(batch, seq_len_kv, kv_group, index_dim, in_dtype: str):
                 scale_local = T.alloc_fragment((block_m,), scale_dtype)
                 recip_local = T.alloc_fragment((block_m,), scale_dtype)
 
-                # Every read the block makes happens before any of its writes: the row is
-                # read once here, and no output is stored until the scale has settled.
-                #
-                # A block past the end of the axis re-reads its last row rather than
-                # testing the index, which keeps the access provably in range and so
-                # vectorized. The rows it must not produce are dropped at the stores.
+                # Every read the block makes precedes every write it makes. A block reaching
+                # past the axis re-reads its last row, so the load needs no test of the
+                # index; the rows it must not produce are dropped at the stores instead.
                 for i, j in T.Parallel(block_m, index_dim):
-                    row = T.min(pid_m * block_m + i, seq_len_kv - 1)
-                    input_local[i, j] = input_tensor[bx, row, g, j]
+                    input_local[i, j] = input_tensor[
+                        bx, T.min(pid_m * block_m + i, seq_len_kv - 1), g, j
+                    ]
 
                 T.reduce_absmax(input_local, amax_local, dim=1)
                 for i in T.Parallel(block_m):
@@ -74,9 +58,9 @@ def _fp8_quant_kernel(batch, seq_len_kv, kv_group, index_dim, in_dtype: str):
                     scale_local[i] = amax_local[i] / fp8_max
                     recip_local[i] = 1.0 / scale_local[i]
 
-                # Multiplying by the row's reciprocal is not bitwise the reference's divide
-                # by the scale: an element on an fp8 rounding boundary can land one code
-                # away. ``FP8QuantFwdOp`` states the bound this holds to.
+                # This multiply is not the reference's divide by the scale. The two differ
+                # by at most a few float32 ulp, which moves an element at most to the next
+                # fp8 code; ``FP8QuantFwdOp`` publishes that bound.
                 for i, j in T.Parallel(block_m, index_dim):
                     output_local[i, j] = T.clamp(
                         input_local[i, j] * recip_local[i], fp8_min, fp8_max
@@ -101,16 +85,17 @@ def _fp8_quant_wrapped_kernel(
     kv_group: int,
     index_dim: int,
     in_dtype: str,
+    threads: int,
     block_m: int,
     input_tensor: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    return _fp8_quant_kernel(batch, seq_len_kv, kv_group, index_dim, in_dtype)(block_m)(
+    return _fp8_quant_kernel(batch, seq_len_kv, kv_group, index_dim, in_dtype, threads)(block_m)(
         input_tensor
     )
 
 
 @_fp8_quant_wrapped_kernel.register_fake
-def _(batch, seq_len_kv, kv_group, index_dim, in_dtype, block_m, *inputs):
+def _(batch, seq_len_kv, kv_group, index_dim, in_dtype, threads, block_m, *inputs):
     return torch.empty(
         (batch, seq_len_kv, kv_group), dtype=torch.float32, device=inputs[0].device
     ), torch.empty(
@@ -121,10 +106,9 @@ def _(batch, seq_len_kv, kv_group, index_dim, in_dtype, block_m, *inputs):
 class FP8QuantKernel(Kernel):
     """Per-group fp8 quantization of a $[B \\times S\\_kv \\times G \\times D]$ index tensor.
 
-    A block owns whole rows and reduces each of them across the threads holding it. The
-    default ``block_m`` follows from the row width: it is the number of rows whose bytes fit
-    one vector access per thread. Any positive width serves any ``seq_len_kv``, the block
-    that overruns the axis re-reading its last row and writing none of it.
+    A block owns whole rows and reduces each of them across the threads holding it. Any
+    positive ``block_m`` serves any ``seq_len_kv``, the block that reaches past the axis
+    re-reading its last row and writing none of it.
 
     Args:
         batch: Batch size.
@@ -143,6 +127,11 @@ class FP8QuantKernel(Kernel):
 
     supported_archs: list[int] = [90]
 
+    # This kernel's launch, not a property of the device: four warps is the block a row
+    # reduction fills, and ``_block_rows`` sizes the tile against it. Held here so that a
+    # later kernel does not read either as a general truth.
+    _THREADS: ClassVar[int] = 128
+
     def __init__(
         self,
         batch: int,
@@ -160,13 +149,31 @@ class FP8QuantKernel(Kernel):
         self.index_dim = index_dim
         self.dtype = dtype
         self.kernel = _fp8_quant_kernel(
-            self.batch, self.seq_len_kv, self.kv_group, self.index_dim, self.dtype_str
+            self.batch,
+            self.seq_len_kv,
+            self.kv_group,
+            self.index_dim,
+            self.dtype_str,
+            self._THREADS,
         )
         self.init_config(config, tune)
 
+    def _block_rows(self) -> int:
+        """Rows a block owns: the largest power of two the access budget and the axis allow.
+
+        The budget is one ``VECTOR_ACCESS_BYTES`` access per thread. A row wider than the
+        whole block's budget, or an axis shorter than two rows, yields the floor of one.
+        """
+        row_bytes = self.index_dim * self.dtype.itemsize
+        widest = min(self._THREADS * VECTOR_ACCESS_BYTES // row_bytes, self.seq_len_kv)
+        block_m = 1
+        while block_m * 2 <= widest:
+            block_m *= 2
+        return block_m
+
     @property
     def default_config(self) -> dict:
-        return {"block_m": _block_rows(self.seq_len_kv, self.index_dim * self.dtype.itemsize)}
+        return {"block_m": self._block_rows()}
 
     @property
     def autotune_configs(self) -> list[dict]:
@@ -179,6 +186,7 @@ class FP8QuantKernel(Kernel):
             self.kv_group,
             self.index_dim,
             self.dtype_str,
+            self._THREADS,
             self.config["block_m"],
             input_tensor,
         )

--- a/src/tileops/kernels/fp8_quant.py
+++ b/src/tileops/kernels/fp8_quant.py
@@ -10,18 +10,20 @@ from tileops.kernels.kernel_base import Kernel
 
 __all__ = ["FP8QuantKernel"]
 
-# A row whose absolute maximum falls below this quantizes against the floor, which
-# keeps an all-zero row's scale finite. Matches the reference's ``clamp(min=1e-4)``.
+# Lower bound on a row's absolute maximum, so an all-zero row still has a finite scale.
 _AMAX_FLOOR = 1e-4
+# Threads a block runs. ``_block_rows`` reads it, so the two are one launch rule.
+_THREADS = 128
 
 
-def _block_rows(seq_len_kv: int, row_bytes: int, threads: int) -> int:
-    """Rows per block: as many as give each thread one vector access, bounded two ways.
+def _block_rows(seq_len_kv: int, row_bytes: int) -> int:
+    """Rows per block: the most whose bytes fit one vector access per thread.
 
-    A power of two keeps a thread's share of the tile a whole number of elements. Dividing
-    ``seq_len_kv`` is what lets the body read and write whole blocks with no bounds test.
+    The result is a power of two that divides ``seq_len_kv``, which is what makes every
+    block the launch covers a full one. A row width that leaves the tile indivisible by
+    ``_THREADS`` still gets a valid block; it gets one whose threads read unequal shares.
     """
-    widest = threads * VECTOR_ACCESS_BYTES // row_bytes
+    widest = _THREADS * VECTOR_ACCESS_BYTES // row_bytes
     block_m = 1
     while block_m * 2 <= widest and seq_len_kv % (block_m * 2) == 0:
         block_m *= 2
@@ -31,11 +33,12 @@ def _block_rows(seq_len_kv: int, row_bytes: int, threads: int) -> int:
 @functools.lru_cache(maxsize=32)
 def _fp8_quant_kernel(batch, seq_len_kv, kv_group, index_dim, in_dtype: str):
     @tilelang.jit(out_idx=[1, 2])
-    def _fp8_quant_fwd_func(block_m, threads):
-        if seq_len_kv % block_m:
+    def _fp8_quant_fwd_func(block_m):
+        if block_m < 1 or seq_len_kv % block_m:
             raise ValueError(
-                f"block_m={block_m} does not divide seq_len_kv={seq_len_kv}; the body reads "
-                "and writes whole blocks, so a partial one would run past the tensor"
+                f"block_m={block_m} must be a positive divisor of seq_len_kv={seq_len_kv}: "
+                "the body reads and writes whole blocks, so any other width would run past "
+                "the tensor"
             )
         out_dtype = T.float8_e4m3fn
         scale_dtype = T.float32
@@ -48,7 +51,7 @@ def _fp8_quant_kernel(batch, seq_len_kv, kv_group, index_dim, in_dtype: str):
             scale_tensor: T.Tensor[(batch, seq_len_kv, kv_group), scale_dtype],
             output_tensor: T.Tensor[(batch, seq_len_kv, kv_group, index_dim), out_dtype],
         ):
-            with T.Kernel(batch, T.ceildiv(seq_len_kv, block_m), kv_group, threads=threads) as (
+            with T.Kernel(batch, T.ceildiv(seq_len_kv, block_m), kv_group, threads=_THREADS) as (
                 bx,
                 pid_m,
                 g,
@@ -59,8 +62,8 @@ def _fp8_quant_kernel(batch, seq_len_kv, kv_group, index_dim, in_dtype: str):
                 scale_local = T.alloc_fragment((block_m,), scale_dtype)
                 recip_local = T.alloc_fragment((block_m,), scale_dtype)
 
-                # The row is read once and quantized out of registers, and nothing is
-                # written before the reduction has settled.
+                # Every read the block makes happens before any of its writes: the row is
+                # read once here, and no output is stored until the scale has settled.
                 for i, j in T.Parallel(block_m, index_dim):
                     input_local[i, j] = input_tensor[bx, pid_m * block_m + i, g, j]
 
@@ -68,9 +71,11 @@ def _fp8_quant_kernel(batch, seq_len_kv, kv_group, index_dim, in_dtype: str):
                 for i in T.Parallel(block_m):
                     amax_local[i] = T.max(amax_local[i], _AMAX_FLOOR)
                     scale_local[i] = amax_local[i] / fp8_max
-                    # One reciprocal per row, so the elementwise step is a multiply.
                     recip_local[i] = 1.0 / scale_local[i]
 
+                # Multiplying by the row's reciprocal is not bitwise the reference's divide
+                # by the scale: an element on an fp8 rounding boundary can land one code
+                # away. ``FP8QuantFwdOp`` states the bound this holds to.
                 for i, j in T.Parallel(block_m, index_dim):
                     output_local[i, j] = T.clamp(
                         input_local[i, j] * recip_local[i], fp8_min, fp8_max
@@ -94,16 +99,15 @@ def _fp8_quant_wrapped_kernel(
     index_dim: int,
     in_dtype: str,
     block_m: int,
-    threads: int,
     input_tensor: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    return _fp8_quant_kernel(batch, seq_len_kv, kv_group, index_dim, in_dtype)(block_m, threads)(
+    return _fp8_quant_kernel(batch, seq_len_kv, kv_group, index_dim, in_dtype)(block_m)(
         input_tensor
     )
 
 
 @_fp8_quant_wrapped_kernel.register_fake
-def _(batch, seq_len_kv, kv_group, index_dim, in_dtype, block_m, threads, *inputs):
+def _(batch, seq_len_kv, kv_group, index_dim, in_dtype, block_m, *inputs):
     return torch.empty(
         (batch, seq_len_kv, kv_group), dtype=torch.float32, device=inputs[0].device
     ), torch.empty(
@@ -114,9 +118,10 @@ def _(batch, seq_len_kv, kv_group, index_dim, in_dtype, block_m, threads, *input
 class FP8QuantKernel(Kernel):
     """Per-group fp8 quantization of a $[B \\times S\\_kv \\times G \\times D]$ index tensor.
 
-    A block owns whole rows and reduces each of them across the threads holding it, so
-    the launch shape follows from the row width rather than a search: ``block_m`` is the
-    number of rows whose bytes give each of ``threads`` threads one vector access.
+    A block owns whole rows and reduces each of them across the threads holding it. The
+    default ``block_m`` follows from the row width: it is the number of rows whose bytes fit
+    one vector access per thread. A caller may override it with any positive divisor of
+    ``seq_len_kv``.
 
     Args:
         batch: Batch size.
@@ -126,13 +131,13 @@ class FP8QuantKernel(Kernel):
         dtype: Torch dtype of the tensor being quantized. The output element
             type is fixed at ``torch.float8_e4m3fn`` and the scale at
             ``torch.float32``, so this is the kernel's only free dtype.
-        config: Optional dict with "block_m" and "threads".
+        config: Optional dict with "block_m".
         tune: Whether to autotune.
 
     Raises:
-        ValueError: ``block_m`` does not divide ``seq_len_kv``, raised where the kernel is
-            built. The body reads and writes whole blocks, so a partial one would run past
-            the tensor.
+        ValueError: ``block_m`` is not a positive divisor of ``seq_len_kv``, raised where
+            the kernel is built. The body reads and writes whole blocks, so any other width
+            would run past the tensor.
     """
 
     supported_archs: list[int] = [90]
@@ -160,13 +165,10 @@ class FP8QuantKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
-        threads = 128
-        row_bytes = self.index_dim * self.dtype.itemsize
-        return {"block_m": _block_rows(self.seq_len_kv, row_bytes, threads), "threads": threads}
+        return {"block_m": _block_rows(self.seq_len_kv, self.index_dim * self.dtype.itemsize)}
 
     @property
     def autotune_configs(self) -> list[dict]:
-        # ``_block_rows`` determines the launch from the row width, leaving one candidate.
         return [self.default_config]
 
     def forward(self, input_tensor: torch.Tensor):
@@ -177,6 +179,5 @@ class FP8QuantKernel(Kernel):
             self.index_dim,
             self.dtype_str,
             self.config["block_m"],
-            self.config["threads"],
             input_tensor,
         )

--- a/src/tileops/kernels/fp8_quant.py
+++ b/src/tileops/kernels/fp8_quant.py
@@ -19,13 +19,13 @@ _THREADS = 128
 def _block_rows(seq_len_kv: int, row_bytes: int) -> int:
     """Rows per block: the most whose bytes fit one vector access per thread.
 
-    The result is a power of two that divides ``seq_len_kv``, which is what makes every
-    block the launch covers a full one. A row width that leaves the tile indivisible by
-    ``_THREADS`` still gets a valid block; it gets one whose threads read unequal shares.
+    A power of two, so a thread's share of the tile is a whole number of elements wherever
+    the row width allows one, and never more rows than the axis holds. Every width serves
+    every ``seq_len_kv``: the body clamps the rows it reads and tests the rows it writes.
     """
-    widest = _THREADS * VECTOR_ACCESS_BYTES // row_bytes
+    widest = min(_THREADS * VECTOR_ACCESS_BYTES // row_bytes, seq_len_kv)
     block_m = 1
-    while block_m * 2 <= widest and seq_len_kv % (block_m * 2) == 0:
+    while block_m * 2 <= widest:
         block_m *= 2
     return block_m
 
@@ -34,12 +34,8 @@ def _block_rows(seq_len_kv: int, row_bytes: int) -> int:
 def _fp8_quant_kernel(batch, seq_len_kv, kv_group, index_dim, in_dtype: str):
     @tilelang.jit(out_idx=[1, 2])
     def _fp8_quant_fwd_func(block_m):
-        if block_m < 1 or seq_len_kv % block_m:
-            raise ValueError(
-                f"block_m={block_m} must be a positive divisor of seq_len_kv={seq_len_kv}: "
-                "the body reads and writes whole blocks, so any other width would run past "
-                "the tensor"
-            )
+        if block_m < 1:
+            raise ValueError(f"block_m={block_m} must be positive")
         out_dtype = T.float8_e4m3fn
         scale_dtype = T.float32
         fp8_min = -FP8_E4M3_MAX
@@ -64,8 +60,13 @@ def _fp8_quant_kernel(batch, seq_len_kv, kv_group, index_dim, in_dtype: str):
 
                 # Every read the block makes happens before any of its writes: the row is
                 # read once here, and no output is stored until the scale has settled.
+                #
+                # A block past the end of the axis re-reads its last row rather than
+                # testing the index, which keeps the access provably in range and so
+                # vectorized. The rows it must not produce are dropped at the stores.
                 for i, j in T.Parallel(block_m, index_dim):
-                    input_local[i, j] = input_tensor[bx, pid_m * block_m + i, g, j]
+                    row = T.min(pid_m * block_m + i, seq_len_kv - 1)
+                    input_local[i, j] = input_tensor[bx, row, g, j]
 
                 T.reduce_absmax(input_local, amax_local, dim=1)
                 for i in T.Parallel(block_m):
@@ -82,9 +83,11 @@ def _fp8_quant_kernel(batch, seq_len_kv, kv_group, index_dim, in_dtype: str):
                     )
 
                 for i in T.Parallel(block_m):
-                    scale_tensor[bx, pid_m * block_m + i, g] = scale_local[i]
+                    if pid_m * block_m + i < seq_len_kv:
+                        scale_tensor[bx, pid_m * block_m + i, g] = scale_local[i]
                 for i, j in T.Parallel(block_m, index_dim):
-                    output_tensor[bx, pid_m * block_m + i, g, j] = output_local[i, j]
+                    if pid_m * block_m + i < seq_len_kv:
+                        output_tensor[bx, pid_m * block_m + i, g, j] = output_local[i, j]
 
         return _fp8_quant_fwd_main
 
@@ -120,8 +123,8 @@ class FP8QuantKernel(Kernel):
 
     A block owns whole rows and reduces each of them across the threads holding it. The
     default ``block_m`` follows from the row width: it is the number of rows whose bytes fit
-    one vector access per thread. A caller may override it with any positive divisor of
-    ``seq_len_kv``.
+    one vector access per thread. Any positive width serves any ``seq_len_kv``, the block
+    that overruns the axis re-reading its last row and writing none of it.
 
     Args:
         batch: Batch size.
@@ -135,9 +138,7 @@ class FP8QuantKernel(Kernel):
         tune: Whether to autotune.
 
     Raises:
-        ValueError: ``block_m`` is not a positive divisor of ``seq_len_kv``, raised where
-            the kernel is built. The body reads and writes whole blocks, so any other width
-            would run past the tensor.
+        ValueError: ``block_m`` is not positive, raised where the kernel is built.
     """
 
     supported_archs: list[int] = [90]

--- a/src/tileops/kernels/fp8_quant.py
+++ b/src/tileops/kernels/fp8_quant.py
@@ -10,9 +10,7 @@ from tileops.kernels.kernel_base import Kernel
 
 __all__ = ["FP8QuantKernel"]
 
-# This operator's floor on a row's absolute maximum, which leaves an all-zero row a finite
-# scale. It belongs to the quantization rule ``workloads/fp8_quant.py`` states, not to the
-# fp8 format, so no other kernel should read it. Module scope because the body reads it.
+# workloads/fp8_quant.py clamps a row's absolute maximum to this before dividing.
 _AMAX_FLOOR = 1e-4
 
 
@@ -44,9 +42,7 @@ def _fp8_quant_kernel(batch, seq_len_kv, kv_group, index_dim, in_dtype: str, thr
                 scale_local = T.alloc_fragment((block_m,), scale_dtype)
                 recip_local = T.alloc_fragment((block_m,), scale_dtype)
 
-                # Every read the block makes precedes every write it makes. A block reaching
-                # past the axis re-reads its last row, so the load needs no test of the
-                # index; the rows it must not produce are dropped at the stores instead.
+                # A block past the axis re-reads its last row; the stores drop those rows.
                 for i, j in T.Parallel(block_m, index_dim):
                     input_local[i, j] = input_tensor[
                         bx, T.min(pid_m * block_m + i, seq_len_kv - 1), g, j
@@ -58,9 +54,7 @@ def _fp8_quant_kernel(batch, seq_len_kv, kv_group, index_dim, in_dtype: str, thr
                     scale_local[i] = amax_local[i] / fp8_max
                     recip_local[i] = 1.0 / scale_local[i]
 
-                # This multiply is not the reference's divide by the scale. The two differ
-                # by at most a few float32 ulp, which moves an element at most to the next
-                # fp8 code; ``FP8QuantFwdOp`` publishes that bound.
+                # Not the reference's divide by the scale; ``FP8QuantFwdOp`` bounds the gap.
                 for i, j in T.Parallel(block_m, index_dim):
                     output_local[i, j] = T.clamp(
                         input_local[i, j] * recip_local[i], fp8_min, fp8_max
@@ -107,8 +101,7 @@ class FP8QuantKernel(Kernel):
     """Per-group fp8 quantization of a $[B \\times S\\_kv \\times G \\times D]$ index tensor.
 
     A block owns whole rows and reduces each of them across the threads holding it. Any
-    positive ``block_m`` serves any ``seq_len_kv``, the block that reaches past the axis
-    re-reading its last row and writing none of it.
+    positive ``block_m`` serves any ``seq_len_kv``.
 
     Args:
         batch: Batch size.
@@ -127,9 +120,7 @@ class FP8QuantKernel(Kernel):
 
     supported_archs: list[int] = [90]
 
-    # This kernel's launch, not a property of the device: four warps is the block a row
-    # reduction fills, and ``_block_rows`` sizes the tile against it. Held here so that a
-    # later kernel does not read either as a general truth.
+    # This kernel's launch, not the device's.
     _THREADS: ClassVar[int] = 128
 
     def __init__(
@@ -159,11 +150,7 @@ class FP8QuantKernel(Kernel):
         self.init_config(config, tune)
 
     def _block_rows(self) -> int:
-        """Rows a block owns: the largest power of two the access budget and the axis allow.
-
-        The budget is one ``VECTOR_ACCESS_BYTES`` access per thread. A row wider than the
-        whole block's budget, or an axis shorter than two rows, yields the floor of one.
-        """
+        """Rows a block owns: the largest power of two the access budget and the axis allow."""
         row_bytes = self.index_dim * self.dtype.itemsize
         widest = min(self._THREADS * VECTOR_ACCESS_BYTES // row_bytes, self.seq_len_kv)
         block_m = 1

--- a/src/tileops/kernels/fp8_quant.py
+++ b/src/tileops/kernels/fp8_quant.py
@@ -1,26 +1,46 @@
 import functools
-import itertools
 from typing import Optional, Tuple
 
 import tilelang
 import tilelang.language as T
 import torch
 
-from tileops.kernels.constants import FP8_E4M3_MAX
+from tileops.kernels.constants import FP8_E4M3_MAX, VECTOR_ACCESS_BYTES
 from tileops.kernels.kernel_base import Kernel
 
 __all__ = ["FP8QuantKernel"]
+
+# A row whose absolute maximum falls below this quantizes against the floor, which
+# keeps an all-zero row's scale finite. Matches the reference's ``clamp(min=1e-4)``.
+_AMAX_FLOOR = 1e-4
+
+
+def _block_rows(seq_len_kv: int, row_bytes: int, threads: int) -> int:
+    """Rows per block: as many as give each thread one vector access, bounded two ways.
+
+    A power of two keeps a thread's share of the tile a whole number of elements. Dividing
+    ``seq_len_kv`` is what lets the body read and write whole blocks with no bounds test.
+    """
+    widest = threads * VECTOR_ACCESS_BYTES // row_bytes
+    block_m = 1
+    while block_m * 2 <= widest and seq_len_kv % (block_m * 2) == 0:
+        block_m *= 2
+    return block_m
 
 
 @functools.lru_cache(maxsize=32)
 def _fp8_quant_kernel(batch, seq_len_kv, kv_group, index_dim, in_dtype: str):
     @tilelang.jit(out_idx=[1, 2])
-    def _fp8_quant_fwd_func(num_stages, block_m):
+    def _fp8_quant_fwd_func(block_m, threads):
+        if seq_len_kv % block_m:
+            raise ValueError(
+                f"block_m={block_m} does not divide seq_len_kv={seq_len_kv}; the body reads "
+                "and writes whole blocks, so a partial one would run past the tensor"
+            )
         out_dtype = T.float8_e4m3fn
         scale_dtype = T.float32
         fp8_min = -FP8_E4M3_MAX
         fp8_max = FP8_E4M3_MAX
-        fp8_max_inv = 1 / fp8_max
 
         @T.prim_func
         def _fp8_quant_fwd_main(
@@ -28,30 +48,32 @@ def _fp8_quant_kernel(batch, seq_len_kv, kv_group, index_dim, in_dtype: str):
             scale_tensor: T.Tensor[(batch, seq_len_kv, kv_group), scale_dtype],
             output_tensor: T.Tensor[(batch, seq_len_kv, kv_group, index_dim), out_dtype],
         ):
-            with T.Kernel(batch, T.ceildiv(seq_len_kv, block_m), kv_group, threads=128) as (
+            with T.Kernel(batch, T.ceildiv(seq_len_kv, block_m), kv_group, threads=threads) as (
                 bx,
                 pid_m,
                 g,
             ):
                 input_local = T.alloc_fragment((block_m, index_dim), in_dtype)
+                output_local = T.alloc_fragment((block_m, index_dim), out_dtype)
                 amax_local = T.alloc_fragment((block_m,), scale_dtype)
                 scale_local = T.alloc_fragment((block_m,), scale_dtype)
-                output_local = T.alloc_fragment((block_m, index_dim), out_dtype)
+                recip_local = T.alloc_fragment((block_m,), scale_dtype)
 
-                # Load a (block_m, index_dim) tile explicitly to avoid stride bugs with extra dims
+                # The row is read once and quantized out of registers, and nothing is
+                # written before the reduction has settled.
                 for i, j in T.Parallel(block_m, index_dim):
                     input_local[i, j] = input_tensor[bx, pid_m * block_m + i, g, j]
 
-                # Reduce over index_dim to get amax per sequence position
                 T.reduce_absmax(input_local, amax_local, dim=1)
                 for i in T.Parallel(block_m):
-                    amax_local[i] = T.max(amax_local[i], 1e-4)
-                    scale_local[i] = amax_local[i] * fp8_max_inv
+                    amax_local[i] = T.max(amax_local[i], _AMAX_FLOOR)
+                    scale_local[i] = amax_local[i] / fp8_max
+                    # One reciprocal per row, so the elementwise step is a multiply.
+                    recip_local[i] = 1.0 / scale_local[i]
 
-                # Quantize: q = clamp(input / scale, [-448, 448])
                 for i, j in T.Parallel(block_m, index_dim):
                     output_local[i, j] = T.clamp(
-                        input_local[i, j] / scale_local[i], fp8_min, fp8_max
+                        input_local[i, j] * recip_local[i], fp8_min, fp8_max
                     )
 
                 for i in T.Parallel(block_m):
@@ -71,17 +93,17 @@ def _fp8_quant_wrapped_kernel(
     kv_group: int,
     index_dim: int,
     in_dtype: str,
-    num_stages: int,
     block_m: int,
+    threads: int,
     input_tensor: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    return _fp8_quant_kernel(batch, seq_len_kv, kv_group, index_dim, in_dtype)(num_stages, block_m)(
+    return _fp8_quant_kernel(batch, seq_len_kv, kv_group, index_dim, in_dtype)(block_m, threads)(
         input_tensor
     )
 
 
 @_fp8_quant_wrapped_kernel.register_fake
-def _(batch, seq_len_kv, kv_group, index_dim, in_dtype, num_stages, block_m, *inputs):
+def _(batch, seq_len_kv, kv_group, index_dim, in_dtype, block_m, threads, *inputs):
     return torch.empty(
         (batch, seq_len_kv, kv_group), dtype=torch.float32, device=inputs[0].device
     ), torch.empty(
@@ -92,6 +114,10 @@ def _(batch, seq_len_kv, kv_group, index_dim, in_dtype, num_stages, block_m, *in
 class FP8QuantKernel(Kernel):
     """Per-group fp8 quantization of a $[B \\times S\\_kv \\times G \\times D]$ index tensor.
 
+    A block owns whole rows and reduces each of them across the threads holding it, so
+    the launch shape follows from the row width rather than a search: ``block_m`` is the
+    number of rows whose bytes give each of ``threads`` threads one vector access.
+
     Args:
         batch: Batch size.
         seq_len_kv: Key/value sequence length.
@@ -100,8 +126,13 @@ class FP8QuantKernel(Kernel):
         dtype: Torch dtype of the tensor being quantized. The output element
             type is fixed at ``torch.float8_e4m3fn`` and the scale at
             ``torch.float32``, so this is the kernel's only free dtype.
-        config: Optional dict with "num_stages" and "block_m".
+        config: Optional dict with "block_m" and "threads".
         tune: Whether to autotune.
+
+    Raises:
+        ValueError: ``block_m`` does not divide ``seq_len_kv``, raised where the kernel is
+            built. The body reads and writes whole blocks, so a partial one would run past
+            the tensor.
     """
 
     supported_archs: list[int] = [90]
@@ -122,27 +153,21 @@ class FP8QuantKernel(Kernel):
         self.kv_group = kv_group
         self.index_dim = index_dim
         self.dtype = dtype
-        self.config = config or {}
         self.kernel = _fp8_quant_kernel(
             self.batch, self.seq_len_kv, self.kv_group, self.index_dim, self.dtype_str
         )
         self.init_config(config, tune)
 
     @property
-    def dtype_str(self) -> str:
-        return str(self.dtype).replace("torch.", "")
-
-    @property
     def default_config(self) -> dict:
-        return {"num_stages": 0, "block_m": 32}
+        threads = 128
+        row_bytes = self.index_dim * self.dtype.itemsize
+        return {"block_m": _block_rows(self.seq_len_kv, row_bytes, threads), "threads": threads}
 
     @property
     def autotune_configs(self) -> list[dict]:
-        num_stages = [0, 2]
-        block_m = [32, 64]
-        _configs = list(itertools.product(num_stages, block_m))
-
-        return [{"num_stages": c[0], "block_m": c[1]} for c in _configs]
+        # ``_block_rows`` determines the launch from the row width, leaving one candidate.
+        return [self.default_config]
 
     def forward(self, input_tensor: torch.Tensor):
         return _fp8_quant_wrapped_kernel(
@@ -151,7 +176,7 @@ class FP8QuantKernel(Kernel):
             self.kv_group,
             self.index_dim,
             self.dtype_str,
-            self.config["num_stages"],
             self.config["block_m"],
+            self.config["threads"],
             input_tensor,
         )

--- a/src/tileops/kernels/fp8_quant.py
+++ b/src/tileops/kernels/fp8_quant.py
@@ -14,6 +14,14 @@ __all__ = ["FP8QuantKernel"]
 _AMAX_FLOOR = 1e-4
 
 
+def _pow2_floor(n: int) -> int:
+    """The largest power of two at most *n*, and at least one."""
+    p = 1
+    while p * 2 <= n:
+        p *= 2
+    return p
+
+
 @functools.lru_cache(maxsize=32)
 def _fp8_quant_kernel(rows: int, index_dim: int, in_dtype: str, threads: int):
     @tilelang.jit(out_idx=[1, 2])
@@ -100,7 +108,8 @@ class FP8QuantKernel(Kernel):
 
     A block owns whole rows, taken along the flattened $[B \\times S\\_kv \\times G]$ row
     axis so that its rows are adjacent in memory, and reduces each of them across the
-    threads holding it. Any positive ``block_m`` serves any row count.
+    threads holding it, or inside one thread where the row width leaves the reduction no
+    power-of-two group of threads. Any positive ``block_m`` serves any row count.
 
     Args:
         batch: Batch size.
@@ -119,8 +128,10 @@ class FP8QuantKernel(Kernel):
 
     supported_archs: list[int] = [90]
 
-    # This kernel's launch, not the device's.
-    _THREADS: ClassVar[int] = 128
+    # This kernel's launch, not the device's. A block reducing a row across its threads
+    # runs _LANE_THREADS of them; a block reducing a row inside one thread runs _ROW_THREADS.
+    _LANE_THREADS: ClassVar[int] = 128
+    _ROW_THREADS: ClassVar[int] = 64
 
     def __init__(
         self,
@@ -138,24 +149,36 @@ class FP8QuantKernel(Kernel):
         self.kv_group = kv_group
         self.index_dim = index_dim
         self.dtype = dtype
+        self._threads, self._block_m = self._launch()
         self.kernel = _fp8_quant_kernel(
-            batch * seq_len_kv * kv_group, self.index_dim, self.dtype_str, self._THREADS
+            batch * seq_len_kv * kv_group, self.index_dim, self.dtype_str, self._threads
         )
         self.init_config(config, tune)
 
-    def _block_rows(self) -> int:
-        """Rows a block owns: the largest power of two the access budget and the axis allow."""
-        row_bytes = self.index_dim * self.dtype.itemsize
+    def _launch(self) -> tuple[int, int]:
+        """Threads a block runs, and rows it owns.
+
+        A row width that is a power of two times an odd number above one cannot both give
+        each thread a whole number of vector accesses and leave a power-of-two group of
+        threads on each row, which is what the cross-lane reduction takes. Such a row goes
+        to one thread whole, so the reduction stays in registers and no group exists:
+        ``index_dim=96`` float16 measures 2.783 us that way against 7.264 with the row
+        split across threads. Every other width keeps the split, faster where the two
+        demands agree: 2.016 us against 2.369 at ``index_dim=64``.
+        """
         rows = self.batch * self.seq_len_kv * self.kv_group
-        widest = min(self._THREADS * VECTOR_ACCESS_BYTES // row_bytes, rows)
-        block_m = 1
-        while block_m * 2 <= widest:
-            block_m *= 2
-        return block_m
+        odd = self.index_dim
+        while odd % 2 == 0:
+            odd //= 2
+        if odd > 1:
+            return self._ROW_THREADS, min(self._ROW_THREADS, _pow2_floor(rows))
+        row_bytes = self.index_dim * self.dtype.itemsize
+        widest = self._LANE_THREADS * VECTOR_ACCESS_BYTES // row_bytes
+        return self._LANE_THREADS, _pow2_floor(min(widest, rows))
 
     @property
     def default_config(self) -> dict:
-        return {"block_m": self._block_rows()}
+        return {"block_m": self._block_m}
 
     @property
     def autotune_configs(self) -> list[dict]:
@@ -168,7 +191,7 @@ class FP8QuantKernel(Kernel):
             self.kv_group,
             self.index_dim,
             self.dtype_str,
-            self._THREADS,
+            self._threads,
             self.config["block_m"],
             input_tensor,
         )

--- a/src/tileops/ops/fp8_quant.py
+++ b/src/tileops/ops/fp8_quant.py
@@ -13,15 +13,16 @@ __all__ = ["FP8QuantFwdOp"]
 class FP8QuantFwdOp(Op):
     """Quantize each row of an index tensor to ``float8_e4m3fn`` against its own maximum.
 
-    A row's scale is its absolute maximum, floored at ``1e-4``, over 448. For a row of
-    finite values the returned scale is exact, and the quantized tensor is within one
-    ``float8_e4m3fn`` code of ``clamp(input / scale, -448, 448)`` element by element: the
-    row is scaled by the reciprocal of its scale rather than divided by it, so an element
-    on a boundary between two codes can be assigned either one.
+    ``scale_tensor`` is the row's absolute maximum, floored at ``1e-4``, over 448, to
+    within one float32 ulp. ``output_tensor`` is the row multiplied by the reciprocal of
+    that scale rather than divided by it, which for finite rows puts every element within
+    one ``float8_e4m3fn`` code of ``clamp(input / scale, -448, 448)``: the two products
+    differ by a few float32 ulp, too little to cross more than one rounding boundary of a
+    format whose codes are an eighth apart.
 
-    A row holding an infinity or a NaN is not quantized against a propagated scale. The
-    reduction ignores NaN, so such a row takes the maximum of its finite values, and every
-    element that would be NaN saturates to -448 instead.
+    Neither output propagates a non-finite input. A row holding an infinity or a NaN is
+    quantized against the maximum of its finite values, and an element that division would
+    make NaN saturates instead. Callers needing NaN to survive must check for it.
     """
 
     def __init__(self, kernel_map: Optional[Dict[str, Kernel]] = None, tune: bool = False):

--- a/src/tileops/ops/fp8_quant.py
+++ b/src/tileops/ops/fp8_quant.py
@@ -14,15 +14,12 @@ class FP8QuantFwdOp(Op):
     """Quantize each row of an index tensor to ``float8_e4m3fn`` against its own maximum.
 
     ``scale_tensor`` is the row's absolute maximum, floored at ``1e-4``, over 448, to
-    within one float32 ulp. ``output_tensor`` is the row multiplied by the reciprocal of
-    that scale rather than divided by it, which for finite rows puts every element within
-    one ``float8_e4m3fn`` code of ``clamp(input / scale, -448, 448)``: the two products
-    differ by a few float32 ulp, too little to cross more than one rounding boundary of a
-    format whose codes are an eighth apart.
+    within one float32 ulp. ``output_tensor`` is the row scaled by the reciprocal of that
+    scale, so for a finite row every element is within one ``float8_e4m3fn`` code of
+    ``clamp(input / scale, -448, 448)`` rather than equal to it.
 
-    Neither output propagates a non-finite input. A row holding an infinity or a NaN is
-    quantized against the maximum of its finite values, and an element that division would
-    make NaN saturates instead. Callers needing NaN to survive must check for it.
+    Neither output propagates a non-finite input: a row holding an infinity or a NaN is
+    quantized against the maximum of its finite values.
     """
 
     def __init__(self, kernel_map: Optional[Dict[str, Kernel]] = None, tune: bool = False):

--- a/src/tileops/ops/fp8_quant.py
+++ b/src/tileops/ops/fp8_quant.py
@@ -11,6 +11,19 @@ __all__ = ["FP8QuantFwdOp"]
 
 
 class FP8QuantFwdOp(Op):
+    """Quantize each row of an index tensor to ``float8_e4m3fn`` against its own maximum.
+
+    A row's scale is its absolute maximum, floored at ``1e-4``, over 448. For a row of
+    finite values the returned scale is exact, and the quantized tensor is within one
+    ``float8_e4m3fn`` code of ``clamp(input / scale, -448, 448)`` element by element: the
+    row is scaled by the reciprocal of its scale rather than divided by it, so an element
+    on a boundary between two codes can be assigned either one.
+
+    A row holding an infinity or a NaN is not quantized against a propagated scale. The
+    reduction ignores NaN, so such a row takes the maximum of its finite values, and every
+    element that would be NaN saturates to -448 instead.
+    """
+
     def __init__(self, kernel_map: Optional[Dict[str, Kernel]] = None, tune: bool = False):
         """Build the op. Shapes and dtype are taken from the first call.
 


### PR DESCRIPTION
## Summary

- Every element used to be divided by its row's scale. The row's reciprocal is now computed once and the elementwise step is a multiply. That is the whole gain on all three rows: the incumbent emitted 16 `div.rn.f32` per thread.
- The launch follows from the row width instead of a search over `{32, 64}`. Where the width is a power of two, a row is split across threads and `block_m` is the largest power of two whose bytes fit one 16-byte access per thread: `16` at the two d64 16-bit workloads, `4` at d128 float32. Where the width carries an odd factor above one, no split satisfies both the vectorized access and the power-of-two thread group the reduction takes, so the row goes to one thread whole.
- A block's rows are adjacent in memory whatever `kv_group` is. The kernel declares the flattened `batch * seq_len_kv * kv_group` row axis and a 1-D grid, where it used to take `block_m` consecutive `seq_len_kv` values at one group, a `kv_group * index_dim` stride apart. The wrapper flattens with `view` rather than `reshape`, so an input whose strides cannot carry the flatten is refused rather than silently copied; TileLang's packed ABI already refused it.
- Every `seq_len_kv` gets that width. A block overrunning the axis clamps the rows it reads and tests the rows it writes, where the incumbent read and wrote past the tensor: `T.ceildiv` gave it a partial last block and no guard.
- The aligned shapes pay nothing for the overrun handling. TileLang folds both the clamp and the store test away when the width divides the axis, emitting the same single 16-byte load and vector store.
- `block_m` is the config's only key, `num_stages` having named no pipelined loop. `autotune_configs` offers the one candidate the rule produces, as `conv1d.py` does for its direct path.
- Each numeric constant sits with whatever it is a property of. `_LANE_THREADS` and `_ROW_THREADS` are this kernel's launch rather than the device's, so they are private class attributes beside `_launch`, the private method that reads them. `_AMAX_FLOOR` stays at module scope, where the body can read it, naming the quantization rule it comes from. `VECTOR_ACCESS_BYTES` and `FP8_E4M3_MAX` stay in `kernels/constants.py`, being the widest access the device offers and the largest finite e4m3 value.
- `FP8QuantFwdOp` publishes what the op holds to: the scale is the floored row maximum over 448 to within one float32 ulp, and for a finite row the quantized tensor is within one `float8_e4m3fn` code of dividing by that scale. Neither output propagates a non-finite input.
- The 2026-09-08 nightly (run 34260454634) flagged two rows at or below 1.0 against `torch-compile`: 1.0000 on float16 and 0.9068 on bfloat16.
- Unchanged: the op's interface, the manifest, the workload, the reference, the benchmark path and the test cases. Test-node delta 0.

## TileFoundry Description

`Boundary` prices handing the per-row scale on through `gmem`, which is the shape of the reference's seven kernels. The two `Placed` modules are one pass over the row, at the two row widths the benchmark uses.

```python
"""FP8QuantFwd as HIR, at the workloads src/tileops/manifest/quantization.yaml benchmarks.

The step is one row of an index tensor: take the row's absolute maximum, floor it, divide
the row by it and land in fp8e4m3. The returned scale is that maximum over 448.

`Boundary` prices handing the scale on through gmem, which is the shape of the reference.
The two `Placed` modules are one pass over the row, at the two row widths the benchmark
uses. Their parameter is the op's declared tensor; the kernel tiles the flattened B*S*G
row axis that a contiguous one is a view of, which `reshard` has no form for.
"""

from tilefoundry import func, module
from tilefoundry.dsl import Mesh, ReduceKind, Tensor, Topology, tf
from tilefoundry.target import CudaTarget

H200 = CudaTarget("nvidia.h200_sxm")

FP8_MAX = 448.0  # the largest finite fp8e4m3
AMAX_FLOOR = 1e-4  # workloads/fp8_quant.py clamp(min=1e-4): a zero row keeps a finite scale


def boundary():
    """kv-index-8k-d64 f16 with the scale written out and read back."""
    B, S, G, D, DT = 1, 8192, 1, 64, "f16"

    @module(entry="fp8_quant", target=H200, topologies=(Topology("cta", 132),))
    class Boundary:
        @func
        def row_amax(x: Tensor[(B, S, G, D), DT]):
            amax = tf.reduce(tf.cast(x, "f32"), (-1,), True, ReduceKind.ABS_MAX)
            return tf.reshape(tf.maximum(amax, tf.full_like(amax, value=AMAX_FLOOR)), (B, S, G))

        @func
        def fp8_quant(x: Tensor[(B, S, G, D), DT]):
            amax = row_amax(x)  # noqa: F821
            rows = tf.cast(x, "f32")
            wide = tf.reshape(amax, (B, S, G, 1))
            quant = tf.cast(tf.clamp(rows * (FP8_MAX / wide), -FP8_MAX, FP8_MAX), "fp8e4m3")
            return amax / tf.full_like(amax, value=FP8_MAX), quant

    return Boundary


def placed(name, B, S, G, D, DT, NCTA, RPC, TPR, PER):
    """One pass, the row resident in registers.

    NCTA CTAs each own RPC rows; the TPR threads holding one row reduce it between them,
    and PER elements is one thread's access.
    """

    @module(
        entry="fp8_quant",
        target=H200,
        topologies=(Topology("cta", NCTA), Topology("thread", RPC * TPR)),
    )
    class Placed:
        @func
        def fp8_quant(x: Tensor[(B, S, G, D), DT]):
            with Mesh(("cta", "thread"), (NCTA, RPC, TPR), ("tile", "row", "t")) as m:
                held = tf.reshard(x, (B, NCTA @ m.tile, RPC @ m.row, G, TPR @ m.t, PER), "rmem")
                amax = tf.cast(tf.reduce(held, (-1, -2), True, ReduceKind.ABS_MAX), "f32")
                floored = tf.maximum(amax, tf.full_like(amax, value=AMAX_FLOOR))
                scale = floored / tf.full_like(floored, value=FP8_MAX)
                # One reciprocal per row, so the elementwise step is a multiply.
                quant = tf.cast(
                    tf.clamp(tf.cast(held, "f32") * (1.0 / scale), -FP8_MAX, FP8_MAX), "fp8e4m3"
                )
                out_scale = tf.reshard(
                    tf.reshape(scale, (B, NCTA, RPC, G)),
                    (B, NCTA @ m.tile, RPC @ m.row, G),
                    "gmem",
                )
                out_quant = tf.reshard(
                    quant, (B, NCTA @ m.tile, RPC @ m.row, G, TPR @ m.t, PER), "gmem"
                )
                return tf.reshape(out_scale, (B, S, G)), tf.reshape(out_quant, (B, S, G, D))

    Placed.__name__ = Placed.__qualname__ = name
    return Placed


Boundary = boundary()
# kv-index-8k-d64: 64 f16 is 128 bytes, so 8 threads of 16 bytes own one row.
Narrow16 = placed("Narrow16", 1, 8192, 1, 64, "f16", 512, 16, 8, 8)
# kv-index-4k-d128 f32: 128 f32 is 512 bytes, so 32 threads of 16 bytes own one row.
Wide32 = placed("Wide32", 1, 4096, 1, 128, "f32", 1024, 4, 32, 4)
```

Held to `workloads/fp8_quant.py::ref_program` through `tilefoundry check --inputs files:x.pt --expected expected.pt`:

| Selection | output[0] scale | output[1] quant |
| --- | --- | --- |
| `Narrow16` | `allclose(atol=0 rtol=1e-3)` max_violation 0 | `cosine(min=0.999)` 0.999986, `max_rel(max=0.14)` 0.125 |
| `Wide32` | `max_rel(max=1.2e-7)` 1.19189e-07 | `equal` mismatched 0 of 524288 |

The float32 workload agrees bit-for-bit on the quantized tensor and to one f32 ulp on the scale. The float16 bounds are the reference's own rounding: `ref_program` keeps the absolute maximum in float16 and divides it by 448 there, while the manifest declares an f32 scale, so the two divisors differ by up to one float16 step. `max_rel 0.125` is one fp8e4m3 code, the worst an element on a code boundary can move.

`analyze --compute-cost --memory --roofline`:

| Selection | gmem read / write, global @ per-CTA | rmem read / write | ideal-ns | bound-by |
| --- | --- | --- | ---: | --- |
| `Boundary` | `r10747904/w9109504 @ r10747904/w9109504` | `r4/w0` | 4137 | memory |
| `Narrow16` | `r1048576/w557056 @ r2048/w1088` | `r9224196/w8077312` | 335 | memory |
| `Wide32` | `r2097152/w540672 @ r2048/w528` | `r11173892/w9027584` | 550 | memory |

What each figure settles, before any kernel exists:

- `Narrow16` reads `1048576` bytes and writes `557056`, the input once and the two outputs once. There is no traffic to cut, which rules out every fusion and staging direction.
- `Boundary` reads 10.2x the input and writes 16.3x the outputs, a `@func` boundary spilling each intermediate. That prices keeping the step in one function, and it is the only module in the table whose `ideal-ns` a placement change moves.
- `@r2048/w1088` is one CTA's share, the 16 rows it owns stated exactly. The incumbent's 32-row block would read `@r4096/w2176` of the same global total, so `ideal-ns` cannot rank the two and the Performance table does.
- `ideal-ns=335` against 1984 ns measured is 5.9x. At 1.5 MB the shape is latency-bound, so the wall column is the target and the roofline is not.
- Two properties of the shipped kernel have no faithful module. `reshard` names which unit owns which contiguous slice, so it cannot state the read a block makes past the end of the axis, and `Reshape cannot express the sharded layout: new shape does not align with the input layout factorization` is what it answers to a module that merges `seq_len_kv` with `kv_group` under a shard. The modules therefore declare the op's tensor and describe the `kv_group=1` launches, which all three benchmark workloads are.
- The cost model prices a divide and a multiply alike, and counts bytes rather than transactions, so it separates neither the reciprocal from the divide nor a strided block from an adjacent-row one. The Performance tables did both.

## Performance

Operator: `FP8QuantFwdOp`

| Environment | Value |
| --- | --- |
| image | `ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-afcebed1-tilefoundry-latest` |
| digest | `sha256:ca13df9bda340edf248b8b443b88880f36e3190ab9d470f52d66ccc21c15fd59` |
| gpu | `NVIDIA H200`, device 5, no co-tenant |
| driver / cuda | `595.71.05` / `13.2` |
| torch / tilelang | `2.13.0+cu132` / `0.1.11+cu132.gitafcebed1` |
| tilefoundry | `0.1.dev146+g2bec6420e` |
| timer | CUPTI `device_busy_ms` |

Method: the manifest benchmark's own comparison, which flushes L2 before every iteration and attributes through CUPTI. Base `e0edbb12` and this branch ran alternately on the same idle card, three whole runs each, in one window; each tag's figure is its minimum over six observations, with the observed spread beneath it. `torch-compile` is bimodal on the 16-bit rows, 2.176 and 6.336 us in the same window, so its minimum is the honest bar. The wall is `out_fp8.copy_(x)`, one cast pass over the same byte count measured in the same window; it is a floor, not a comparator.

Ratio in comparator columns: implementation / candidate. &#x1F7E2; > 1 means the candidate is faster; &#x1F534; <= 1 means it is not.

| Workload | Shape | Dtype | candidate (us) | base (us)<br>/ ratio | torch-compile (us)<br>/ ratio | torch-ref (us)<br>/ ratio | wall (us)<br>/ ratio |
| --- | --- | --- | ---: | ---: | ---: | ---: | ---: |
| kv-index-8k-d64 | 1x8192x1x64 | FP16 | 1.984<br>1.984-1.984 | **2.400<br>&#x1F7E2;&nbsp;1.2097x** | **2.176<br>&#x1F7E2;&nbsp;1.0968x** | **13.664<br>&#x1F7E2;&nbsp;6.8868x** | 1.888<br>&#x1F534;&nbsp;0.9516x |
| kv-index-8k-d64 | 1x8192x1x64 | BF16 | 1.984<br>1.984-2.016 | **2.400<br>&#x1F7E2;&nbsp;1.2097x** | **2.176<br>&#x1F7E2;&nbsp;1.0968x** | **13.760<br>&#x1F7E2;&nbsp;6.9355x** | 1.888<br>&#x1F534;&nbsp;0.9516x |
| kv-index-4k-d128 | 1x4096x1x128 | FP32 | 2.528<br>2.528-2.560 | **3.360<br>&#x1F7E2;&nbsp;1.3291x** | **3.935<br>&#x1F7E2;&nbsp;1.5568x** | **13.248<br>&#x1F7E2;&nbsp;5.2405x** | 2.368<br>&#x1F534;&nbsp;0.9367x |
| geometric mean | | | 2.1509 | **2.6849<br>&#x1F7E2;&nbsp;1.2482x** | **2.6512<br>&#x1F7E2;&nbsp;1.2326x** | **13.5553<br>&#x1F7E2;&nbsp;6.3022x** | 2.0361<br>&#x1F534;&nbsp;0.9466x |

`kv_group`, measured with the two tilings compiled from one body in one window, at `index_dim=64` float16 except the last row:

| Shape | rows | one group per block | flattened row axis |
| --- | ---: | ---: | ---: |
| `[1,8192,1,64]` | 8192 | 1.984 us | 1.985 us |
| `[1,2048,4,64]` | 8192 | 2.240 us | 2.016 us |
| `[1,1024,8,64]` | 8192 | 2.176 us | 1.984 us |
| `[2,512,4,128]` | 4096 | 2.080 us | 2.017 us |

No benchmark workload has `kv_group > 1`; the manifest's three are all 1, and `tests/ops/test_fp8_quant.py` carries the one case that is 4.

## Result And Limitations

**measured SOTA at the streaming floor**

All three rows beat every comparator. The two the nightly flagged are 1.0968x over `torch-compile` and 1.2097x over the base.

**How far this can go.** `ideal-ns` is 335 for the 16-bit workloads and 550 for float32, against 1984 and 2528 ns measured. That gap is not headroom: at 1.5 and 2.6 MB the kernel is latency-bound, and one cast pass over the same bytes, with no reduction and no scale, measures 1.888 and 2.368 us on the same card in the same window. The candidate sits at 0.95, 0.95 and 0.94 of that floor, which itself moves 1.888 to 1.952 us between runs. The generated code is one 16-byte load, one 8-lane shuffle reduce with no barrier, one multiply chain and one 16-byte store per thread. The wall is `out_fp8.copy_(x)` rather than a probe shaped like the kernel because deleting the row reduction re-lays out the tile: reading the thread's own first element instead measures 4.096 us, twice the kernel. `copy_` moves 1.5 MB against the kernel's 1.605.

**Every row width.** Each `index_dim` against a cast pass over the same bytes, 524288 elements, same card and window. Ratio is wall / kernel:

| index_dim | 8 | 16 | 32 | 64 | 66 | 80 | 96 | 128 | 160 | 192 | 256 | 512 | 1024 |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| FP16 | 0.95 | 1.00 | 0.97 | 0.97 | 0.31 | 0.77 | 0.70 | 0.94 | 0.51 | 0.42 | 0.94 | 0.91 | 0.91 |
| FP32 | 0.93 | 0.94 | 0.90 | 0.92 | 0.37 | 0.78 | 0.63 | 0.94 | 0.45 | 0.42 | 0.90 | 0.88 | 0.94 |

A width whose odd part is one sits at 0.88 to 1.00. The rest take the whole-row launch:

| index_dim, FP16 unless stated | row split across threads | row in one thread |
| --- | ---: | ---: |
| 80 | 5.825 us | 2.496 us |
| 96 | 7.264 us | 2.784 us |
| 96, FP32 | 12.960 us | 3.712 us |
| 160 | 7.552 us | 3.808 us |
| 66 | 5.536 us | 6.016 us |
| 64 | 2.016 us | 2.369 us |

A width whose odd part is above five keeps a wide gap, 66 at 0.31 the worst measured and the one width the whole-row launch costs 8%. Which power-of-two thread group per row wins moves with the width, so closing those needs a per-width search. No manifest workload or test has such a width.

**Every length at full width.** At `index_dim=64` float16, all at `block_m=16`: 8192 in 2.015 us, 8190 in 2.016, 8188 in 2.016, 8184 in 2.048, 8191 in 2.048, 5000 in 1.856. Lengths of 1, 3 and 33 are correct. A caller-supplied width the rule would not pick reproduces the reference too, at 32 and 100 with `seq_len_kv=8191` and at 8192 covering the axis in one block; a non-positive width raises.

**The accuracy bound holds by construction.** The scale and the reciprocal each carry at most half a float32 ulp, so the product differs from the reference's quotient by a few ulp, far below half the eighth-relative spacing of `float8_e4m3fn` codes. An element can move to the neighbouring code and no further. Measured over 1179648 elements across the three dtypes and 17 decades of row magnitude: worst distance on the code ladder 1, worst scale deviation 1.000 float32 ulp, 622 elements differing from the reference at all. The scale is not exact because `tilelang/engine/lower.py` compiles with `--use_fast_math`, so the emitted `amax / 448.0f` is not the correctly rounded quotient.

Directions measured and not taken:

| Direction | Result |
| --- | --- |
| `block_m` x `threads` over {8,16,32,64,128} x {32,64,128,256} | Every 16-byte-per-thread pairing within 2%; 32 bytes per thread 0-5% worse, 64 and 128 bytes 5-20% worse |
| A predicated load for the overrun instead of a clamped index | 2.048 us against 2.016 at `seq_len_kv=8191`; a zero-filled tile 2.080 |
| A thread count carrying the row width's odd factor, so the share is a whole vector | 2.048 us at `index_dim=96`, and wrong: 12 threads on a row leave `T.reduce_absmax` no power-of-two group, and 276 of 512 row scales are off by up to 49% |
| The absolute maximum reduced in the storage dtype rather than f32 | 1.953 against 1.984 us, one timer step; `analyze` predicted 10% less rmem traffic and it is not on the critical path |
| Dropping the clamp, which the floored maximum and the saturating fp8 convert make redundant | Identical at every launch shape |
| The 16-bit quantize kept out of f32: two storage-dtype multiplies, then one | 1.985 and 1.983 against 2.016 us, inside one timer step. The one-multiply form overflows float16 whenever the maximum is floored, so it is unusable |
| A width rule taking every divisor of the row count rather than powers of two | 8190 at 2.784 us; the clamped overrun serves that length at 2.016 without the rule |
