### PR TITLE
[Perf][foundry][GEMM] Warp-specialize the FP8 GEMM and stage its block128 scales in shared memory

### DIFF
--- a/benchmarks/ops/bench_gemm.py
+++ b/benchmarks/ops/bench_gemm.py
@@ -1,4 +1,5 @@
 import contextlib
+import functools
 from typing import Any, Callable, Optional
 
 import pytest
@@ -507,13 +508,25 @@ def test_gemm_fp8_bench(
     else:
         try:
             import flashinfer  # noqa: F401
-        except ImportError as exc:
-            print(f"  [skip] flashinfer-fp8-blockscale-sm90: {exc}")
-        else:
-            functors["flashinfer-fp8-blockscale-sm90"] = (
-                lambda *args: _flashinfer_fp8_blockscale_ref(workload, *args),
-                inputs,
+
+            blockscale_fn = functools.partial(_flashinfer_fp8_blockscale_ref, workload)
+            assert_matches_reference(
+                blockscale_fn,
+                workload.torch_scaled_matmul,
+                *inputs,
+                **reference_tolerance(out_dtype),
             )
+        except (ImportError, ValueError) as exc:
+            print(f"  [skip] flashinfer-fp8-blockscale-sm90: {str(exc).splitlines()[0]}")
+        except AssertionError as exc:
+            # Preferred, not selected: a tag whose kernel disagrees with the reference
+            # is dropped rather than taking the op's own numbers down with it.
+            print(
+                "  [skip] flashinfer-fp8-blockscale-sm90: disagrees with the reference "
+                f"({str(exc).splitlines()[0]})"
+            )
+        else:
+            functors["flashinfer-fp8-blockscale-sm90"] = (blockscale_fn, inputs)
 
     bm.compare(functors, *inputs)
 

--- a/benchmarks/ops/bench_gemm.py
+++ b/benchmarks/ops/bench_gemm.py
@@ -519,8 +519,7 @@ def test_gemm_fp8_bench(
         except (ImportError, ValueError) as exc:
             print(f"  [skip] flashinfer-fp8-blockscale-sm90: {str(exc).splitlines()[0]}")
         except AssertionError as exc:
-            # Preferred, not selected: a tag whose kernel disagrees with the reference
-            # is dropped rather than taking the op's own numbers down with it.
+            # Preferred, not selected: drop the tag rather than fail the row.
             print(
                 "  [skip] flashinfer-fp8-blockscale-sm90: disagrees with the reference "
                 f"({str(exc).splitlines()[0]})"

--- a/src/tileops/kernels/gemm/dense.py
+++ b/src/tileops/kernels/gemm/dense.py
@@ -21,6 +21,12 @@ from .heuristics import (
 _CONSUMER_BAR_WG0 = 8
 _CONSUMER_BAR_WG1 = 9
 
+# The warp-specialized FP8 tile: two 64-row consumers, and one 128-element scale block per
+# K-step. Neither is a tunable — the consumer split fixes the first, the scale grid the second.
+_FP8_WS_BLOCK_M = 128
+_FP8_WS_HALF_M = _FP8_WS_BLOCK_M // 2
+_FP8_WS_BLOCK_K = 128
+
 
 def _tma_misalignment(
     m: int, n: int, k: int, dtype: torch.dtype, trans_a: bool, trans_b: bool
@@ -76,11 +82,8 @@ __all__ = [
 def _fp8_ws_refusal(m: int, n: int, k: int, dtype: torch.dtype) -> Optional[str]:
     """Why the warp-specialized FP8 kernel cannot serve this call, or ``None``.
 
-    Its operands move through TMA, so the contraction dim carries the alignment
-    the descriptor needs, and its ring epilogue releases a slot the mainloop
-    named, so there has to be at least one K-tile. The pipelined fallback loads
-    through predicated element copies and clears its accumulator up front, so it
-    carries neither requirement.
+    It loads through TMA and its epilogue releases a ring slot the mainloop
+    named. The pipelined fallback carries neither requirement.
     """
     if dtype != torch.float8_e4m3fn:
         return f"the warp-specialized FP8 kernel is e4m3-only, got {dtype}"
@@ -92,9 +95,8 @@ def _fp8_ws_refusal(m: int, n: int, k: int, dtype: torch.dtype) -> Optional[str]
 class _GemmFp8Kernel(Kernel):
     """Shared body of the two FP8 GEMM kernels; ``BLOCK_SCALED`` picks the scale grid.
 
-    Both take the warp-specialized SM90 path (:func:`_gemm_fp8_ws_kernel`) and
-    fall back to the pipelined :func:`_gemm_fp8_kernel` on a shape TMA cannot
-    address.
+    Takes :func:`_gemm_fp8_ws_kernel`, or :func:`_gemm_fp8_kernel` on a call
+    :func:`_fp8_ws_refusal` rejects.
     """
 
     # Whether this kernel reads block128 scale grids rather than per-tensor scalars.
@@ -109,14 +111,15 @@ class _GemmFp8Kernel(Kernel):
         out_dtype: torch.dtype,
         config: Optional[dict] = None,
         tune: bool = False,
+        device_index: Optional[int] = None,
     ) -> None:
-        super().__init__()
+        super().__init__(device_index=device_index)
         self.m = m
         self.n = n
         self.k = k
         self.dtype = dtype
         self.out_dtype = out_dtype
-        self.sm_count = get_sm_count()
+        self.sm_count = get_sm_count(self.device_index)
         self.ws_refusal = _fp8_ws_refusal(m, n, k, dtype)
         self.kernel = self._builder()
         self.init_config(config, tune)
@@ -185,11 +188,10 @@ class _GemmFp8Kernel(Kernel):
         }
 
     def _bias_operand(self, bias: Optional[torch.Tensor], like: torch.Tensor) -> torch.Tensor:
-        """The bias the compiled kernel is called with, a one-element stand-in when absent.
+        """The bias operand, a one-element stand-in when the call has none.
 
-        The warp-specialized kernel keeps one parameter list for both cases and
-        compiles the bias read away, but the call still needs a tensor to bind;
-        the no-bias build declares that parameter as one element.
+        The no-bias build declares the parameter as one element and compiles
+        every read of it away, but the call still needs a tensor to bind.
         """
         if bias is not None:
             return bias
@@ -269,8 +271,8 @@ def _fp8_ws_splitk_pair(
 ) -> tuple[Callable, Callable]:
     """The compiled (mainloop, reduce) pair for one split-K configuration.
 
-    Why: the two launches sit back to back, so resolving both in one cached call
-    keeps the host out of the window between them.
+    Why one call: the two launches sit back to back, so the host must not be
+    resolving the second one in the window between them.
     """
     mainloop = _gemm_fp8_ws_splitk_kernel(
         m, n, k, dtype, out_dtype, block_scaled, has_bias, split_k=split_k
@@ -499,6 +501,187 @@ def _gemm_fp8_kernel(
     return _gemm_fp8_func
 
 
+@T.macro
+def _fp8_ws_tile_id(flat_id, mt, nt, *, group_size_m: int, num_pid_m: int, num_pid_n: int):
+    """Write the grouped-rasterization (m, n) tile coordinates of a flat tile id."""
+    gin = T.int32(group_size_m * num_pid_n)
+    gid = flat_id // gin
+    first_m = gid * T.int32(group_size_m)
+    gsize = T.min(T.int32(group_size_m), T.int32(num_pid_m) - first_m)
+    mt[0] = first_m + (flat_id % gin) % gsize
+    nt[0] = (flat_id % gin) // gsize
+
+
+@T.macro
+def _fp8_ws_stage(
+    a,
+    b,
+    scale_a,
+    scale_b,
+    a_top,
+    a_bot,
+    b_smem,
+    sa_stage,
+    sb_stage,
+    ab_full,
+    slot,
+    kb,
+    m_start,
+    n_start,
+    *,
+    m: int,
+    n: int,
+    block_n: int,
+    block_scaled: bool,
+):
+    """One K-step of the producer: the step's three TMA boxes and its two scale vectors."""
+    half_m = _FP8_WS_HALF_M
+    block_m = _FP8_WS_BLOCK_M
+    ks = kb * _FP8_WS_BLOCK_K
+    T.tma_copy(
+        a[m_start : m_start + half_m, ks : ks + _FP8_WS_BLOCK_K],
+        a_top[slot, :, :],
+        barrier=ab_full[slot],
+    )
+    T.tma_copy(
+        a[m_start + half_m : m_start + block_m, ks : ks + _FP8_WS_BLOCK_K],
+        a_bot[slot, :, :],
+        barrier=ab_full[slot],
+    )
+    T.tma_copy(
+        b[n_start : n_start + block_n, ks : ks + _FP8_WS_BLOCK_K],
+        b_smem[slot, :, :],
+        barrier=ab_full[slot],
+    )
+    if block_scaled:
+        for i in T.Parallel(block_m):
+            sa_stage[slot, i] = scale_a[T.min(m_start + i, m - 1), kb]
+        for j in T.Parallel(block_n):
+            sb_stage[slot, j] = scale_b[T.min(n_start + j, n - 1), kb]
+        T.fence_proxy_async()
+    T.barrier_arrive(ab_full[slot])
+
+
+@T.macro
+def _fp8_ws_scaled_step(
+    a_smem,
+    b_smem,
+    sa_stage,
+    sb_stage,
+    ab_full,
+    ab_empty,
+    acc,
+    part,
+    sa_f,
+    sb_f,
+    slot,
+    phase,
+    *,
+    row_base: int,
+    block_n: int,
+):
+    """One K-step of a block128 consumer: WGMMA into a fresh accumulator, then promote it.
+
+    The scale vectors come from the step's ring slot, and both are copied into
+    fragments so the promotion is register-local. ``row_base`` is this
+    consumer's offset into the staged ``A`` row scales.
+    """
+    T.barrier_wait(ab_full[slot], phase)
+    T.wgmma_gemm(
+        a_smem[slot, :, :],
+        b_smem[slot, :, :],
+        part,
+        transpose_B=True,
+        policy=T.GemmWarpPolicy.FullRow,
+        clear_accum=True,
+    )
+    T.copy(sa_stage[slot, row_base : row_base + _FP8_WS_HALF_M], sa_f)
+    T.copy(sb_stage[slot, :], sb_f)
+    T.wait_wgmma(0)
+    for i, j in T.Parallel(_FP8_WS_HALF_M, block_n):
+        acc[i, j] += part[i, j] * sa_f[i] * sb_f[j]
+    T.barrier_arrive(ab_empty[slot])
+
+
+@T.macro
+def _fp8_ws_plain_step(a_smem, b_smem, ab_full, ab_empty, acc, prev, slot, phase, ki):
+    """One K-step of a per-tensor consumer: WGMMA accumulates, the previous slot is released.
+
+    The release trails by one step because the WGMMA of step ``ki`` still reads
+    slot ``ki``; ``prev`` carries the slot the next release belongs to.
+    """
+    T.barrier_wait(ab_full[slot], phase)
+    T.wgmma_gemm(
+        a_smem[slot, :, :],
+        b_smem[slot, :, :],
+        acc,
+        transpose_B=True,
+        policy=T.GemmWarpPolicy.FullRow,
+        clear_accum=(ki == 0),
+    )
+    if ki > 0:
+        T.wait_wgmma(1)
+        T.barrier_arrive(ab_empty[prev[0]])
+    prev[0] = slot
+
+
+@T.macro
+def _fp8_ws_plain_drain(ab_empty, acc, prev, scale_a, scale_b, *, num_regs: int, block_n: int):
+    """Close a per-tensor consumer's mainloop and apply the two scalars."""
+    T.wait_wgmma(0)
+    T.barrier_arrive(ab_empty[prev[0]])
+    T.warpgroup_fence_operand(acc, num_regs=num_regs)
+    for i, j in T.Parallel(_FP8_WS_HALF_M, block_n):
+        acc[i, j] *= scale_a[0, 0] * scale_b[0, 0]
+
+
+@T.macro
+def _fp8_ws_epilogue(
+    c,
+    bias,
+    acc,
+    out,
+    c_smem,
+    m_start,
+    n_start,
+    rows,
+    cols,
+    *,
+    bar: int,
+    block_n: int,
+    n: int,
+    out_dtype: str,
+    has_bias: bool,
+    stage_store: bool,
+):
+    """Cast one consumer's tile and store it: one TMA box when full, elements otherwise.
+
+    ``stage_store`` is False where no row tile can be full, which is every ``m``
+    inside one consumer's half; the staging tile is then dead and not allocated.
+    """
+    half_m = _FP8_WS_HALF_M
+    if has_bias:
+        for i, j in T.Parallel(half_m, block_n):
+            out[i, j] = T.cast(acc[i, j], out_dtype) + bias[T.min(n_start + j, n - 1)]
+    else:
+        T.copy(acc, out)
+    if not stage_store:
+        if rows > T.int32(0):
+            for i, j in T.Parallel(half_m, block_n):
+                if i < rows and j < cols:
+                    c[m_start + i, n_start + j] = out[i, j]
+    elif rows == T.int32(half_m) and cols == T.int32(block_n):
+        T.sync_threads(barrier_id=bar, arrive_count=128)
+        T.copy(out, c_smem)
+        T.fence_proxy_async()
+        T.sync_threads(barrier_id=bar, arrive_count=128)
+        T.copy(c_smem, c[m_start, n_start])
+    elif rows > T.int32(0):
+        for i, j in T.Parallel(half_m, block_n):
+            if i < rows and j < cols:
+                c[m_start + i, n_start + j] = out[i, j]
+
+
 @functools.lru_cache(maxsize=32)
 def _gemm_fp8_ws_kernel(
     m: int,
@@ -513,22 +696,26 @@ def _gemm_fp8_ws_kernel(
 ) -> Callable:
     """Warp-specialized FP8 NT GEMM for Hopper: 1 producer + 2 consumer warpgroups.
 
-    Same split-A / shared-B layout as :func:`_gemm_coop2_kernel` — a producer
+    Same split-A / shared-B layout as :func:`_gemm_coop2_kernel`: a producer
     warpgroup issues the TMA loads, two consumer warpgroups each own 64 of the
-    tile's 128 rows and run their own WGMMA over a shared ``B`` ring. The
-    persistent grid sweeps a Triton-style grouped tile order so concurrently
-    resident CTAs share a ``B`` column stripe in L2.
+    tile's 128 rows and run their own WGMMA over a shared ``B`` ring, and the
+    persistent grid sweeps a grouped tile order for L2 reuse.
 
-    Block128 scaling is the one place this differs from the bf16 family. The
-    producer stages a K-step's ``A`` row scales and ``B`` column scales into that
-    step's ring slot, and the consumer folds a fresh WGMMA accumulator in as
-    ``acc += partial * scale_a[row] * scale_b[col]``. Why the staging: each
-    thread needs ``block_n / 4`` distinct column scales, and reading those from
-    global inside the mainloop is that many uncoalesced sectors per K-step —
-    2.4x the whole kernel on ``4096x7168x2048``.
+    Under block128 scaling the producer also stages the K-step's ``A`` row
+    scales and ``B`` column scales into that step's ring slot, and the consumer
+    folds a fresh WGMMA accumulator in as
+    ``acc += partial * scale_a[row] * scale_b[col]``. Why the staging: a thread
+    holds ``block_n / 4`` distinct output columns, so reading their scales from
+    global inside the mainloop is that many uncoalesced sectors per K-step, and
+    measured 2.4x the whole kernel on ``4096x7168x2048``.
 
     Per-tensor scaling has no such step: WGMMA accumulates across the whole K
     axis and the two scalars land in the epilogue.
+
+    ``M``, ``N`` and ``K`` tails need no predicate on the load side: a TMA box
+    that runs past the tensor is zero-filled, so a K tail contributes a zero
+    term under any scale, and the epilogue predicates the store. Measured on
+    ``65x129x144`` in both scale modes.
 
     Args:
         m: Rows of ``A`` / ``C``.
@@ -546,8 +733,8 @@ def _gemm_fp8_ws_kernel(
         group_size_m)`` returns the compiled ``prim_func``.
     """
     accum_dtype = "float"
-    block_m = 128
-    block_k = 128
+    block_m = _FP8_WS_BLOCK_M
+    block_k = _FP8_WS_BLOCK_K
     scale_k = (k + 127) // 128
 
     @tilelang.jit(
@@ -572,15 +759,8 @@ def _gemm_fp8_ws_kernel(
         scale_b_shape = (n, scale_k) if block_scaled else (1, 1)
         bias_shape = (n,) if has_bias else (1,)
         stage_rows = num_stages if block_scaled else 1
-
-        @T.macro
-        def decode(flat_id, mt, nt):
-            gin = T.int32(group_size_m * num_pid_n)
-            gid = flat_id // gin
-            first_m = gid * T.int32(group_size_m)
-            gsize = T.min(T.int32(group_size_m), T.int32(num_pid_m) - first_m)
-            mt[0] = first_m + (flat_id % gin) % gsize
-            nt[0] = (flat_id % gin) // gsize
+        stage_store = m > half_m
+        store_rows = half_m if stage_store else 1
 
         @T.prim_func
         def _gemm_fp8_ws_main(
@@ -595,8 +775,8 @@ def _gemm_fp8_ws_kernel(
                 a_top = T.alloc_shared((num_stages, half_m, block_k), dtype)
                 a_bot = T.alloc_shared((num_stages, half_m, block_k), dtype)
                 b_smem = T.alloc_shared((num_stages, block_n, block_k), dtype)
-                c_smem_0 = T.alloc_shared((half_m, block_n), out_dtype)
-                c_smem_1 = T.alloc_shared((half_m, block_n), out_dtype)
+                c_smem_0 = T.alloc_shared((store_rows, block_n), out_dtype)
+                c_smem_1 = T.alloc_shared((store_rows, block_n), out_dtype)
                 sa_stage = T.alloc_shared((stage_rows, block_m), accum_dtype)
                 sb_stage = T.alloc_shared((stage_rows, block_n), accum_dtype)
                 acc_0 = T.alloc_fragment((half_m, block_n), accum_dtype)
@@ -610,15 +790,15 @@ def _gemm_fp8_ws_kernel(
                 sb_0 = T.alloc_fragment((block_n,), accum_dtype)
                 sb_1 = T.alloc_fragment((block_n,), accum_dtype)
 
-                T.annotate_layout(
-                    {
-                        a_top: tilelang.layout.make_swizzled_layout(a_top),
-                        a_bot: tilelang.layout.make_swizzled_layout(a_bot),
-                        b_smem: tilelang.layout.make_swizzled_layout(b_smem),
-                        c_smem_0: tilelang.layout.make_swizzled_layout(c_smem_0),
-                        c_smem_1: tilelang.layout.make_swizzled_layout(c_smem_1),
-                    }
-                )
+                layouts = {
+                    a_top: tilelang.layout.make_swizzled_layout(a_top),
+                    a_bot: tilelang.layout.make_swizzled_layout(a_bot),
+                    b_smem: tilelang.layout.make_swizzled_layout(b_smem),
+                }
+                if stage_store:
+                    layouts[c_smem_0] = tilelang.layout.make_swizzled_layout(c_smem_0)
+                    layouts[c_smem_1] = tilelang.layout.make_swizzled_layout(c_smem_1)
+                T.annotate_layout(layouts)
 
                 ab_full = T.alloc_barrier([128] * num_stages)
                 ab_empty = T.alloc_barrier([256] * num_stages)
@@ -638,35 +818,39 @@ def _gemm_fp8_ws_kernel(
                     for w in T.serial(max_waves):
                         flat_id = T.int32(grid) * w + pid
                         if flat_id < total_tiles:
-                            decode(flat_id, mt, nt)
+                            _fp8_ws_tile_id(
+                                flat_id,
+                                mt,
+                                nt,
+                                group_size_m=group_size_m,
+                                num_pid_m=num_pid_m,
+                                num_pid_n=num_pid_n,
+                            )
                             m_start = mt[0] * block_m
                             n_start = nt[0] * block_n
                             for ki in T.Pipelined(k_iters, num_stages=0):
                                 slot = gi_prod % num_stages
-                                ks = ki * block_k
                                 T.barrier_wait(ab_empty[slot], ((gi_prod // num_stages) & 1) ^ 1)
-                                T.tma_copy(
-                                    a[m_start : m_start + half_m, ks : ks + block_k],
-                                    a_top[slot, :, :],
-                                    barrier=ab_full[slot],
+                                _fp8_ws_stage(
+                                    a,
+                                    b,
+                                    scale_a,
+                                    scale_b,
+                                    a_top,
+                                    a_bot,
+                                    b_smem,
+                                    sa_stage,
+                                    sb_stage,
+                                    ab_full,
+                                    slot,
+                                    ki,
+                                    m_start,
+                                    n_start,
+                                    m=m,
+                                    n=n,
+                                    block_n=block_n,
+                                    block_scaled=block_scaled,
                                 )
-                                T.tma_copy(
-                                    a[m_start + half_m : m_start + block_m, ks : ks + block_k],
-                                    a_bot[slot, :, :],
-                                    barrier=ab_full[slot],
-                                )
-                                T.tma_copy(
-                                    b[n_start : n_start + block_n, ks : ks + block_k],
-                                    b_smem[slot, :, :],
-                                    barrier=ab_full[slot],
-                                )
-                                if block_scaled:
-                                    for i in T.Parallel(block_m):
-                                        sa_stage[slot, i] = scale_a[T.min(m_start + i, m - 1), ki]
-                                    for j in T.Parallel(block_n):
-                                        sb_stage[slot, j] = scale_b[T.min(n_start + j, n - 1), ki]
-                                    T.fence_proxy_async()
-                                T.barrier_arrive(ab_full[slot])
                                 gi_prod = gi_prod + 1
 
                 elif tx < 256:
@@ -674,7 +858,14 @@ def _gemm_fp8_ws_kernel(
                     for w in T.serial(max_waves):
                         flat_id = T.int32(grid) * w + pid
                         if flat_id < total_tiles:
-                            decode(flat_id, mt, nt)
+                            _fp8_ws_tile_id(
+                                flat_id,
+                                mt,
+                                nt,
+                                group_size_m=group_size_m,
+                                num_pid_m=num_pid_m,
+                                num_pid_n=num_pid_n,
+                            )
                             m_start = mt[0] * block_m
                             n_start = nt[0] * block_n
                             arows = T.min(T.int32(half_m), T.int32(m) - m_start)
@@ -683,133 +874,144 @@ def _gemm_fp8_ws_kernel(
                                 T.clear(acc_0)
                                 for _ki in T.Pipelined(k_iters, num_stages=0):
                                     slot = gi_cons_0 % num_stages
-                                    T.barrier_wait(ab_full[slot], (gi_cons_0 // num_stages) & 1)
-                                    T.wgmma_gemm(
-                                        a_top[slot, :, :],
-                                        b_smem[slot, :, :],
+                                    _fp8_ws_scaled_step(
+                                        a_top,
+                                        b_smem,
+                                        sa_stage,
+                                        sb_stage,
+                                        ab_full,
+                                        ab_empty,
+                                        acc_0,
                                         part_0,
-                                        transpose_B=True,
-                                        policy=T.GemmWarpPolicy.FullRow,
-                                        clear_accum=True,
+                                        sa_0,
+                                        sb_0,
+                                        slot,
+                                        (gi_cons_0 // num_stages) & 1,
+                                        row_base=0,
+                                        block_n=block_n,
                                     )
-                                    T.copy(sa_stage[slot, 0:half_m], sa_0)
-                                    T.copy(sb_stage[slot, :], sb_0)
-                                    T.wait_wgmma(0)
-                                    for i, j in T.Parallel(half_m, block_n):
-                                        acc_0[i, j] += part_0[i, j] * sa_0[i] * sb_0[j]
-                                    T.barrier_arrive(ab_empty[slot])
                                     gi_cons_0 = gi_cons_0 + 1
                             else:
                                 for ki in T.Pipelined(k_iters, num_stages=0):
                                     slot = gi_cons_0 % num_stages
-                                    T.barrier_wait(ab_full[slot], (gi_cons_0 // num_stages) & 1)
-                                    T.wgmma_gemm(
-                                        a_top[slot, :, :],
-                                        b_smem[slot, :, :],
+                                    _fp8_ws_plain_step(
+                                        a_top,
+                                        b_smem,
+                                        ab_full,
+                                        ab_empty,
                                         acc_0,
-                                        transpose_B=True,
-                                        policy=T.GemmWarpPolicy.FullRow,
-                                        clear_accum=(ki == 0),
+                                        ps0,
+                                        slot,
+                                        (gi_cons_0 // num_stages) & 1,
+                                        ki,
                                     )
-                                    if ki > 0:
-                                        T.wait_wgmma(1)
-                                        T.barrier_arrive(ab_empty[ps0[0]])
-                                    ps0[0] = slot
                                     gi_cons_0 = gi_cons_0 + 1
-                                T.wait_wgmma(0)
-                                T.barrier_arrive(ab_empty[ps0[0]])
-                                T.warpgroup_fence_operand(acc_0, num_regs=nr)
-                                for i, j in T.Parallel(half_m, block_n):
-                                    acc_0[i, j] *= scale_a[0, 0] * scale_b[0, 0]
-                            if has_bias:
-                                for i, j in T.Parallel(half_m, block_n):
-                                    out_0[i, j] = (
-                                        T.cast(acc_0[i, j], out_dtype)
-                                        + bias[T.min(n_start + j, n - 1)]
-                                    )
-                            else:
-                                T.copy(acc_0, out_0)
-                            if arows == T.int32(half_m) and acols == T.int32(block_n):
-                                T.sync_threads(barrier_id=_CONSUMER_BAR_WG0, arrive_count=128)
-                                T.copy(out_0, c_smem_0)
-                                T.fence_proxy_async()
-                                T.sync_threads(barrier_id=_CONSUMER_BAR_WG0, arrive_count=128)
-                                T.copy(c_smem_0, c[m_start, n_start])
-                            else:
-                                for i, j in T.Parallel(half_m, block_n):
-                                    if i < arows and j < acols:
-                                        c[m_start + i, n_start + j] = out_0[i, j]
+                                _fp8_ws_plain_drain(
+                                    ab_empty,
+                                    acc_0,
+                                    ps0,
+                                    scale_a,
+                                    scale_b,
+                                    num_regs=nr,
+                                    block_n=block_n,
+                                )
+                            _fp8_ws_epilogue(
+                                c,
+                                bias,
+                                acc_0,
+                                out_0,
+                                c_smem_0,
+                                m_start,
+                                n_start,
+                                arows,
+                                acols,
+                                bar=_CONSUMER_BAR_WG0,
+                                block_n=block_n,
+                                n=n,
+                                out_dtype=out_dtype,
+                                has_bias=has_bias,
+                                stage_store=stage_store,
+                            )
 
                 else:
                     T.inc_max_nreg(232)
                     for w in T.serial(max_waves):
                         flat_id = T.int32(grid) * w + pid
                         if flat_id < total_tiles:
-                            decode(flat_id, mt, nt)
+                            _fp8_ws_tile_id(
+                                flat_id,
+                                mt,
+                                nt,
+                                group_size_m=group_size_m,
+                                num_pid_m=num_pid_m,
+                                num_pid_n=num_pid_n,
+                            )
                             m_start = mt[0] * block_m + half_m
                             n_start = nt[0] * block_n
-                            arows = T.max(T.int32(0), T.min(T.int32(half_m), T.int32(m) - m_start))
-                            acols = T.min(T.int32(block_n), T.int32(n) - n_start)
+                            brows = T.max(T.int32(0), T.min(T.int32(half_m), T.int32(m) - m_start))
+                            bcols = T.min(T.int32(block_n), T.int32(n) - n_start)
                             if block_scaled:
                                 T.clear(acc_1)
                                 for _ki in T.Pipelined(k_iters, num_stages=0):
                                     slot = gi_cons_1 % num_stages
-                                    T.barrier_wait(ab_full[slot], (gi_cons_1 // num_stages) & 1)
-                                    T.wgmma_gemm(
-                                        a_bot[slot, :, :],
-                                        b_smem[slot, :, :],
+                                    _fp8_ws_scaled_step(
+                                        a_bot,
+                                        b_smem,
+                                        sa_stage,
+                                        sb_stage,
+                                        ab_full,
+                                        ab_empty,
+                                        acc_1,
                                         part_1,
-                                        transpose_B=True,
-                                        policy=T.GemmWarpPolicy.FullRow,
-                                        clear_accum=True,
+                                        sa_1,
+                                        sb_1,
+                                        slot,
+                                        (gi_cons_1 // num_stages) & 1,
+                                        row_base=half_m,
+                                        block_n=block_n,
                                     )
-                                    T.copy(sa_stage[slot, half_m:block_m], sa_1)
-                                    T.copy(sb_stage[slot, :], sb_1)
-                                    T.wait_wgmma(0)
-                                    for i, j in T.Parallel(half_m, block_n):
-                                        acc_1[i, j] += part_1[i, j] * sa_1[i] * sb_1[j]
-                                    T.barrier_arrive(ab_empty[slot])
                                     gi_cons_1 = gi_cons_1 + 1
                             else:
                                 for ki in T.Pipelined(k_iters, num_stages=0):
                                     slot = gi_cons_1 % num_stages
-                                    T.barrier_wait(ab_full[slot], (gi_cons_1 // num_stages) & 1)
-                                    T.wgmma_gemm(
-                                        a_bot[slot, :, :],
-                                        b_smem[slot, :, :],
+                                    _fp8_ws_plain_step(
+                                        a_bot,
+                                        b_smem,
+                                        ab_full,
+                                        ab_empty,
                                         acc_1,
-                                        transpose_B=True,
-                                        policy=T.GemmWarpPolicy.FullRow,
-                                        clear_accum=(ki == 0),
+                                        ps1,
+                                        slot,
+                                        (gi_cons_1 // num_stages) & 1,
+                                        ki,
                                     )
-                                    if ki > 0:
-                                        T.wait_wgmma(1)
-                                        T.barrier_arrive(ab_empty[ps1[0]])
-                                    ps1[0] = slot
                                     gi_cons_1 = gi_cons_1 + 1
-                                T.wait_wgmma(0)
-                                T.barrier_arrive(ab_empty[ps1[0]])
-                                T.warpgroup_fence_operand(acc_1, num_regs=nr)
-                                for i, j in T.Parallel(half_m, block_n):
-                                    acc_1[i, j] *= scale_a[0, 0] * scale_b[0, 0]
-                            if has_bias:
-                                for i, j in T.Parallel(half_m, block_n):
-                                    out_1[i, j] = (
-                                        T.cast(acc_1[i, j], out_dtype)
-                                        + bias[T.min(n_start + j, n - 1)]
-                                    )
-                            else:
-                                T.copy(acc_1, out_1)
-                            if arows == T.int32(half_m) and acols == T.int32(block_n):
-                                T.sync_threads(barrier_id=_CONSUMER_BAR_WG1, arrive_count=128)
-                                T.copy(out_1, c_smem_1)
-                                T.fence_proxy_async()
-                                T.sync_threads(barrier_id=_CONSUMER_BAR_WG1, arrive_count=128)
-                                T.copy(c_smem_1, c[m_start, n_start])
-                            elif arows > T.int32(0):
-                                for i, j in T.Parallel(half_m, block_n):
-                                    if i < arows and j < acols:
-                                        c[m_start + i, n_start + j] = out_1[i, j]
+                                _fp8_ws_plain_drain(
+                                    ab_empty,
+                                    acc_1,
+                                    ps1,
+                                    scale_a,
+                                    scale_b,
+                                    num_regs=nr,
+                                    block_n=block_n,
+                                )
+                            _fp8_ws_epilogue(
+                                c,
+                                bias,
+                                acc_1,
+                                out_1,
+                                c_smem_1,
+                                m_start,
+                                n_start,
+                                brows,
+                                bcols,
+                                bar=_CONSUMER_BAR_WG1,
+                                block_n=block_n,
+                                n=n,
+                                out_dtype=out_dtype,
+                                has_bias=has_bias,
+                                stage_store=stage_store,
+                            )
 
         return _gemm_fp8_ws_main
 
@@ -831,11 +1033,15 @@ def _gemm_fp8_ws_splitk_kernel(
     """Split-K variant of the warp-specialized FP8 mainloop (NT).
 
     Slicing K across ``grid.y`` multiplies the grid by ``split_k`` without
-    changing the bytes any CTA reads, which is what the decode shapes need: one
+    changing the bytes any CTA reads, which is what a decode shape needs: one
     ``block_m`` row tile and few column tiles leave most of the device idle and
     each resident CTA at its own SM's read bandwidth. Each slice writes an fp32
     partial tile into ``slices[split_k, m, n]``; :func:`_splitk_reduce_kernel`
     sums them and casts. Slice 0 carries the bias, so the sum adds it once.
+
+    The mainloop bodies are the same macros :func:`_gemm_fp8_ws_kernel` uses;
+    what differs is the shell — a two-dimensional grid instead of a persistent
+    sweep, and an fp32 workspace instead of the cast-and-store epilogue.
 
     Args:
         m: Rows of ``A`` / ``C``.
@@ -853,8 +1059,8 @@ def _gemm_fp8_ws_splitk_kernel(
         workspace.
     """
     accum_dtype = "float"
-    block_m = 128
-    block_k = 128
+    block_m = _FP8_WS_BLOCK_M
+    block_k = _FP8_WS_BLOCK_K
     scale_k = (k + 127) // 128
     k_iters_total = -(-k // block_k)
     if k_iters_total % split_k:
@@ -882,15 +1088,6 @@ def _gemm_fp8_ws_splitk_kernel(
         scale_b_shape = (n, scale_k) if block_scaled else (1, 1)
         stage_rows = num_stages if block_scaled else 1
         bias_shape = (n,) if has_bias else (1,)
-
-        @T.macro
-        def decode(flat_id, mt, nt):
-            gin = T.int32(group_size_m * num_pid_n)
-            gid = flat_id // gin
-            first_m = gid * T.int32(group_size_m)
-            gsize = T.min(T.int32(group_size_m), T.int32(num_pid_m) - first_m)
-            mt[0] = first_m + (flat_id % gin) % gsize
-            nt[0] = (flat_id % gin) // gsize
 
         @T.prim_func
         def _gemm_fp8_ws_splitk_main(
@@ -932,7 +1129,14 @@ def _gemm_fp8_ws_splitk_kernel(
                 mt = T.alloc_local((1,), "int32")
                 nt = T.alloc_local((1,), "int32")
 
-                decode(pid, mt, nt)
+                _fp8_ws_tile_id(
+                    pid,
+                    mt,
+                    nt,
+                    group_size_m=group_size_m,
+                    num_pid_m=num_pid_m,
+                    num_pid_n=num_pid_n,
+                )
                 m_start = mt[0] * block_m
                 n_start = nt[0] * block_n
                 tx = T.get_thread_binding()
@@ -941,31 +1145,27 @@ def _gemm_fp8_ws_splitk_kernel(
                     T.dec_max_nreg(24)
                     for ki in T.Pipelined(k_iters, num_stages=0):
                         slot = ki % num_stages
-                        kb = bz * k_iters + ki
-                        ks = kb * block_k
                         T.barrier_wait(ab_empty[slot], ((ki // num_stages) & 1) ^ 1)
-                        T.tma_copy(
-                            a[m_start : m_start + half_m, ks : ks + block_k],
-                            a_top[slot, :, :],
-                            barrier=ab_full[slot],
+                        _fp8_ws_stage(
+                            a,
+                            b,
+                            scale_a,
+                            scale_b,
+                            a_top,
+                            a_bot,
+                            b_smem,
+                            sa_stage,
+                            sb_stage,
+                            ab_full,
+                            slot,
+                            bz * k_iters + ki,
+                            m_start,
+                            n_start,
+                            m=m,
+                            n=n,
+                            block_n=block_n,
+                            block_scaled=block_scaled,
                         )
-                        T.tma_copy(
-                            a[m_start + half_m : m_start + block_m, ks : ks + block_k],
-                            a_bot[slot, :, :],
-                            barrier=ab_full[slot],
-                        )
-                        T.tma_copy(
-                            b[n_start : n_start + block_n, ks : ks + block_k],
-                            b_smem[slot, :, :],
-                            barrier=ab_full[slot],
-                        )
-                        if block_scaled:
-                            for i in T.Parallel(block_m):
-                                sa_stage[slot, i] = scale_a[T.min(m_start + i, m - 1), kb]
-                            for j in T.Parallel(block_n):
-                                sb_stage[slot, j] = scale_b[T.min(n_start + j, n - 1), kb]
-                            T.fence_proxy_async()
-                        T.barrier_arrive(ab_full[slot])
 
                 elif tx < 256:
                     T.inc_max_nreg(232)
@@ -974,43 +1174,44 @@ def _gemm_fp8_ws_splitk_kernel(
                     if block_scaled:
                         T.clear(acc_0)
                         for ki in T.Pipelined(k_iters, num_stages=0):
-                            slot = ki % num_stages
-                            T.barrier_wait(ab_full[slot], (ki // num_stages) & 1)
-                            T.wgmma_gemm(
-                                a_top[slot, :, :],
-                                b_smem[slot, :, :],
+                            _fp8_ws_scaled_step(
+                                a_top,
+                                b_smem,
+                                sa_stage,
+                                sb_stage,
+                                ab_full,
+                                ab_empty,
+                                acc_0,
                                 part_0,
-                                transpose_B=True,
-                                policy=T.GemmWarpPolicy.FullRow,
-                                clear_accum=True,
+                                sa_0,
+                                sb_0,
+                                ki % num_stages,
+                                (ki // num_stages) & 1,
+                                row_base=0,
+                                block_n=block_n,
                             )
-                            T.copy(sa_stage[slot, 0:half_m], sa_0)
-                            T.copy(sb_stage[slot, :], sb_0)
-                            T.wait_wgmma(0)
-                            for i, j in T.Parallel(half_m, block_n):
-                                acc_0[i, j] += part_0[i, j] * sa_0[i] * sb_0[j]
-                            T.barrier_arrive(ab_empty[slot])
                     else:
                         for ki in T.Pipelined(k_iters, num_stages=0):
-                            slot = ki % num_stages
-                            T.barrier_wait(ab_full[slot], (ki // num_stages) & 1)
-                            T.wgmma_gemm(
-                                a_top[slot, :, :],
-                                b_smem[slot, :, :],
+                            _fp8_ws_plain_step(
+                                a_top,
+                                b_smem,
+                                ab_full,
+                                ab_empty,
                                 acc_0,
-                                transpose_B=True,
-                                policy=T.GemmWarpPolicy.FullRow,
-                                clear_accum=(ki == 0),
+                                ps0,
+                                ki % num_stages,
+                                (ki // num_stages) & 1,
+                                ki,
                             )
-                            if ki > 0:
-                                T.wait_wgmma(1)
-                                T.barrier_arrive(ab_empty[ps0[0]])
-                            ps0[0] = slot
-                        T.wait_wgmma(0)
-                        T.barrier_arrive(ab_empty[ps0[0]])
-                        T.warpgroup_fence_operand(acc_0, num_regs=nr)
-                        for i, j in T.Parallel(half_m, block_n):
-                            acc_0[i, j] *= scale_a[0, 0] * scale_b[0, 0]
+                        _fp8_ws_plain_drain(
+                            ab_empty,
+                            acc_0,
+                            ps0,
+                            scale_a,
+                            scale_b,
+                            num_regs=nr,
+                            block_n=block_n,
+                        )
                     if has_bias and bz == 0:
                         for i, j in T.Parallel(half_m, block_n):
                             acc_0[i, j] += T.cast(bias[T.min(n_start + j, n - 1)], accum_dtype)
@@ -1025,43 +1226,44 @@ def _gemm_fp8_ws_splitk_kernel(
                     if block_scaled:
                         T.clear(acc_1)
                         for ki in T.Pipelined(k_iters, num_stages=0):
-                            slot = ki % num_stages
-                            T.barrier_wait(ab_full[slot], (ki // num_stages) & 1)
-                            T.wgmma_gemm(
-                                a_bot[slot, :, :],
-                                b_smem[slot, :, :],
+                            _fp8_ws_scaled_step(
+                                a_bot,
+                                b_smem,
+                                sa_stage,
+                                sb_stage,
+                                ab_full,
+                                ab_empty,
+                                acc_1,
                                 part_1,
-                                transpose_B=True,
-                                policy=T.GemmWarpPolicy.FullRow,
-                                clear_accum=True,
+                                sa_1,
+                                sb_1,
+                                ki % num_stages,
+                                (ki // num_stages) & 1,
+                                row_base=half_m,
+                                block_n=block_n,
                             )
-                            T.copy(sa_stage[slot, half_m:block_m], sa_1)
-                            T.copy(sb_stage[slot, :], sb_1)
-                            T.wait_wgmma(0)
-                            for i, j in T.Parallel(half_m, block_n):
-                                acc_1[i, j] += part_1[i, j] * sa_1[i] * sb_1[j]
-                            T.barrier_arrive(ab_empty[slot])
                     else:
                         for ki in T.Pipelined(k_iters, num_stages=0):
-                            slot = ki % num_stages
-                            T.barrier_wait(ab_full[slot], (ki // num_stages) & 1)
-                            T.wgmma_gemm(
-                                a_bot[slot, :, :],
-                                b_smem[slot, :, :],
+                            _fp8_ws_plain_step(
+                                a_bot,
+                                b_smem,
+                                ab_full,
+                                ab_empty,
                                 acc_1,
-                                transpose_B=True,
-                                policy=T.GemmWarpPolicy.FullRow,
-                                clear_accum=(ki == 0),
+                                ps1,
+                                ki % num_stages,
+                                (ki // num_stages) & 1,
+                                ki,
                             )
-                            if ki > 0:
-                                T.wait_wgmma(1)
-                                T.barrier_arrive(ab_empty[ps1[0]])
-                            ps1[0] = slot
-                        T.wait_wgmma(0)
-                        T.barrier_arrive(ab_empty[ps1[0]])
-                        T.warpgroup_fence_operand(acc_1, num_regs=nr)
-                        for i, j in T.Parallel(half_m, block_n):
-                            acc_1[i, j] *= scale_a[0, 0] * scale_b[0, 0]
+                        _fp8_ws_plain_drain(
+                            ab_empty,
+                            acc_1,
+                            ps1,
+                            scale_a,
+                            scale_b,
+                            num_regs=nr,
+                            block_n=block_n,
+                        )
                     if has_bias and bz == 0:
                         for i, j in T.Parallel(half_m, block_n):
                             acc_1[i, j] += T.cast(bias[T.min(n_start + j, n - 1)], accum_dtype)

--- a/src/tileops/kernels/gemm/dense.py
+++ b/src/tileops/kernels/gemm/dense.py
@@ -21,8 +21,7 @@ from .heuristics import (
 _CONSUMER_BAR_WG0 = 8
 _CONSUMER_BAR_WG1 = 9
 
-# The warp-specialized FP8 tile: two 64-row consumers, and one 128-element scale block per
-# K-step. Neither is a tunable — the consumer split fixes the first, the scale grid the second.
+# Fixed by the two-consumer split and by the block128 scale grid; not tunable.
 _FP8_WS_BLOCK_M = 128
 _FP8_WS_HALF_M = _FP8_WS_BLOCK_M // 2
 _FP8_WS_BLOCK_K = 128
@@ -82,8 +81,8 @@ __all__ = [
 def _fp8_ws_refusal(m: int, n: int, k: int, dtype: torch.dtype) -> Optional[str]:
     """Why the warp-specialized FP8 kernel cannot serve this call, or ``None``.
 
-    It loads through TMA and its epilogue releases a ring slot the mainloop
-    named. The pipelined fallback carries neither requirement.
+    It loads through TMA, and its epilogue releases a ring slot the mainloop
+    named, so it needs at least one K-tile. The fallback carries neither.
     """
     if dtype != torch.float8_e4m3fn:
         return f"the warp-specialized FP8 kernel is e4m3-only, got {dtype}"
@@ -188,11 +187,7 @@ class _GemmFp8Kernel(Kernel):
         }
 
     def _bias_operand(self, bias: Optional[torch.Tensor], like: torch.Tensor) -> torch.Tensor:
-        """The bias operand, a one-element stand-in when the call has none.
-
-        The no-bias build declares the parameter as one element and compiles
-        every read of it away, but the call still needs a tensor to bind.
-        """
+        """The bias operand, or a one-element stand-in the no-bias build never reads."""
         if bias is not None:
             return bias
         if self._unused_bias is None or self._unused_bias.device != like.device:
@@ -271,8 +266,8 @@ def _fp8_ws_splitk_pair(
 ) -> tuple[Callable, Callable]:
     """The compiled (mainloop, reduce) pair for one split-K configuration.
 
-    Why one call: the two launches sit back to back, so the host must not be
-    resolving the second one in the window between them.
+    Resolved together so the host is not building the second launch while the
+    first is already draining.
     """
     mainloop = _gemm_fp8_ws_splitk_kernel(
         m, n, k, dtype, out_dtype, block_scaled, has_bias, split_k=split_k
@@ -582,9 +577,9 @@ def _fp8_ws_scaled_step(
 ):
     """One K-step of a block128 consumer: WGMMA into a fresh accumulator, then promote it.
 
-    The scale vectors come from the step's ring slot, and both are copied into
-    fragments so the promotion is register-local. ``row_base`` is this
-    consumer's offset into the staged ``A`` row scales.
+    Both scale vectors are copied out of the step's ring slot into fragments,
+    which keeps the promotion register-local. ``row_base`` is this consumer's
+    offset into the staged ``A`` row scales.
     """
     T.barrier_wait(ab_full[slot], phase)
     T.wgmma_gemm(
@@ -607,8 +602,8 @@ def _fp8_ws_scaled_step(
 def _fp8_ws_plain_step(a_smem, b_smem, ab_full, ab_empty, acc, prev, slot, phase, ki):
     """One K-step of a per-tensor consumer: WGMMA accumulates, the previous slot is released.
 
-    The release trails by one step because the WGMMA of step ``ki`` still reads
-    slot ``ki``; ``prev`` carries the slot the next release belongs to.
+    The release trails by one step because step ``ki``'s WGMMA still reads slot
+    ``ki``; ``prev`` carries the slot the next release belongs to.
     """
     T.barrier_wait(ab_full[slot], phase)
     T.wgmma_gemm(
@@ -656,8 +651,8 @@ def _fp8_ws_epilogue(
 ):
     """Cast one consumer's tile and store it: one TMA box when full, elements otherwise.
 
-    ``stage_store`` is False where no row tile can be full, which is every ``m``
-    inside one consumer's half; the staging tile is then dead and not allocated.
+    ``stage_store`` is False where no row tile can be full — every ``m`` inside
+    one consumer's half — and the staging tile is then not allocated.
     """
     half_m = _FP8_WS_HALF_M
     if has_bias:
@@ -704,18 +699,17 @@ def _gemm_fp8_ws_kernel(
     Under block128 scaling the producer also stages the K-step's ``A`` row
     scales and ``B`` column scales into that step's ring slot, and the consumer
     folds a fresh WGMMA accumulator in as
-    ``acc += partial * scale_a[row] * scale_b[col]``. Why the staging: a thread
-    holds ``block_n / 4`` distinct output columns, so reading their scales from
-    global inside the mainloop is that many uncoalesced sectors per K-step, and
-    measured 2.4x the whole kernel on ``4096x7168x2048``.
+    ``acc += partial * scale_a[row] * scale_b[col]``. The staging is what makes
+    that affordable: a thread holds ``block_n / 4`` distinct output columns, and
+    reading their scales from global inside the mainloop is that many
+    uncoalesced sectors per K-step.
 
     Per-tensor scaling has no such step: WGMMA accumulates across the whole K
     axis and the two scalars land in the epilogue.
 
     ``M``, ``N`` and ``K`` tails need no predicate on the load side: a TMA box
-    that runs past the tensor is zero-filled, so a K tail contributes a zero
-    term under any scale, and the epilogue predicates the store. Measured on
-    ``65x129x144`` in both scale modes.
+    past the end of the tensor is zero-filled, so a K tail contributes a zero
+    term under any scale, and the epilogue predicates the store.
 
     Args:
         m: Rows of ``A`` / ``C``.
@@ -1039,9 +1033,9 @@ def _gemm_fp8_ws_splitk_kernel(
     partial tile into ``slices[split_k, m, n]``; :func:`_splitk_reduce_kernel`
     sums them and casts. Slice 0 carries the bias, so the sum adds it once.
 
-    The mainloop bodies are the same macros :func:`_gemm_fp8_ws_kernel` uses;
-    what differs is the shell — a two-dimensional grid instead of a persistent
-    sweep, and an fp32 workspace instead of the cast-and-store epilogue.
+    The mainloop bodies are the macros :func:`_gemm_fp8_ws_kernel` uses; the
+    shell differs — a two-dimensional grid instead of a persistent sweep, and
+    an fp32 workspace instead of the cast-and-store epilogue.
 
     Args:
         m: Rows of ``A`` / ``C``.

--- a/src/tileops/kernels/gemm/dense.py
+++ b/src/tileops/kernels/gemm/dense.py
@@ -12,6 +12,7 @@ from tileops.utils import get_sm_count, str2dtype
 from .heuristics import (
     SWAP_AB_MPAD,
     best_config,
+    fp8_ws_config,
     gemv_config,
     small_batch_config,
     swap_ab_grid_underfills,
@@ -72,8 +73,32 @@ __all__ = [
 ]
 
 
-class GemmFp8EpilogueKernel(Kernel):
-    """Simple TileLang FP8 GEMM for per-tensor scales."""
+def _fp8_ws_refusal(m: int, n: int, k: int, dtype: torch.dtype) -> Optional[str]:
+    """Why the warp-specialized FP8 kernel cannot serve this call, or ``None``.
+
+    Its operands move through TMA, so the contraction dim carries the alignment
+    the descriptor needs, and its ring epilogue releases a slot the mainloop
+    named, so there has to be at least one K-tile. The pipelined fallback loads
+    through predicated element copies and clears its accumulator up front, so it
+    carries neither requirement.
+    """
+    if dtype != torch.float8_e4m3fn:
+        return f"the warp-specialized FP8 kernel is e4m3-only, got {dtype}"
+    if k == 0:
+        return "the warp-specialized mainloop has no K-tile to run at k=0"
+    return _tma_misalignment(m, n, k, dtype, trans_a=False, trans_b=True)
+
+
+class _GemmFp8Kernel(Kernel):
+    """Shared body of the two FP8 GEMM kernels; ``BLOCK_SCALED`` picks the scale grid.
+
+    Both take the warp-specialized SM90 path (:func:`_gemm_fp8_ws_kernel`) and
+    fall back to the pipelined :func:`_gemm_fp8_kernel` on a shape TMA cannot
+    address.
+    """
+
+    # Whether this kernel reads block128 scale grids rather than per-tensor scalars.
+    BLOCK_SCALED = False
 
     def __init__(
         self,
@@ -91,10 +116,57 @@ class GemmFp8EpilogueKernel(Kernel):
         self.k = k
         self.dtype = dtype
         self.out_dtype = out_dtype
-        self.kernel = _gemm_fp8_kernel(
-            m, n, k, self.dtype_str, self.out_dtype_str, block_scaled=False
-        )
+        self.sm_count = get_sm_count()
+        self.ws_refusal = _fp8_ws_refusal(m, n, k, dtype)
+        self.kernel = self._builder()
         self.init_config(config, tune)
+        self._unused_bias: Optional[torch.Tensor] = None
+
+    def _builder(self) -> Callable:
+        if self.ws_refusal is None:
+            return _gemm_fp8_ws_kernel(
+                self.m,
+                self.n,
+                self.k,
+                self.dtype_str,
+                self.out_dtype_str,
+                self.BLOCK_SCALED,
+                has_bias=False,
+                sm_count=self.sm_count,
+            )
+        return _gemm_fp8_kernel(
+            self.m, self.n, self.k, self.dtype_str, self.out_dtype_str, self.BLOCK_SCALED
+        )
+
+    def _run_split_k(
+        self,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        scale_a: torch.Tensor,
+        scale_b: torch.Tensor,
+        bias: Optional[torch.Tensor],
+        split_k: int,
+        tile_config: dict,
+    ) -> torch.Tensor:
+        """Run the sliced mainloop and reduce its fp32 workspace into the output."""
+        mainloop, reduce = _fp8_ws_splitk_pair(
+            self.m,
+            self.n,
+            self.k,
+            self.dtype_str,
+            self.out_dtype_str,
+            self.BLOCK_SCALED,
+            bias is not None,
+            split_k,
+            tile_config["block_n"],
+            tile_config["num_stages"],
+            tile_config["group_size_m"],
+        )
+        slices = torch.empty((split_k, self.m, self.n), dtype=torch.float32, device=a.device)
+        c = torch.empty((self.m, self.n), dtype=self.out_dtype, device=a.device)
+        mainloop(a, b, scale_a, scale_b, self._bias_operand(bias, a), slices)
+        reduce(slices, c)
+        return c
 
     @property
     def out_dtype_str(self) -> str:
@@ -102,6 +174,8 @@ class GemmFp8EpilogueKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
+        if self.ws_refusal is None:
+            return fp8_ws_config(self.m, self.n, self.k, self.sm_count, self.BLOCK_SCALED)
         return {
             "block_m": 128,
             "block_n": 128,
@@ -110,78 +184,18 @@ class GemmFp8EpilogueKernel(Kernel):
             "threads": 256,
         }
 
-    def forward(
-        self,
-        a: torch.Tensor,
-        b: torch.Tensor,
-        scale_a: torch.Tensor,
-        scale_b: torch.Tensor,
-        bias: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
-        if self.dtype != torch.float8_e4m3fn:
-            raise NotImplementedError(
-                f"GemmFp8EpilogueKernel only supports torch.float8_e4m3fn, got {self.dtype}"
-            )
-        compiled = _gemm_fp8_kernel(
-            self.m,
-            self.n,
-            self.k,
-            self.dtype_str,
-            self.out_dtype_str,
-            block_scaled=False,
-            has_bias=bias is not None,
-        )(**self.config)
+    def _bias_operand(self, bias: Optional[torch.Tensor], like: torch.Tensor) -> torch.Tensor:
+        """The bias the compiled kernel is called with, a one-element stand-in when absent.
+
+        The warp-specialized kernel keeps one parameter list for both cases and
+        compiles the bias read away, but the call still needs a tensor to bind;
+        the no-bias build declares that parameter as one element.
+        """
         if bias is not None:
-            return compiled(a, b, scale_a, scale_b, bias)
-        return compiled(a, b, scale_a, scale_b)
-
-
-class GemmFp8BlockScaledKernel(Kernel):
-    """Simple TileLang FP8 GEMM for K-block scales."""
-
-    def __init__(
-        self,
-        m: int,
-        n: int,
-        k: int,
-        dtype: torch.dtype,
-        out_dtype: torch.dtype,
-        config: Optional[dict] = None,
-        tune: bool = False,
-    ) -> None:
-        super().__init__()
-        self.m = m
-        self.n = n
-        self.k = k
-        self.dtype = dtype
-        self.out_dtype = out_dtype
-        self.kernel = _gemm_fp8_kernel(
-            m, n, k, self.dtype_str, self.out_dtype_str, block_scaled=True
-        )
-        self.init_config(config, tune)
-
-    @property
-    def out_dtype_str(self) -> str:
-        return self.dtype_to_str(self.out_dtype)
-
-    @property
-    def default_config(self) -> dict:
-        # Block scaling keeps both the unscaled WGMMA fragment and the scaled
-        # accumulator live. Narrow one output axis on the register-bound prefill
-        # shapes where the additional CTAs recover occupancy.
-        if (self.m, self.n, self.k) == (4096, 2112, 7168):
-            block_m, block_n = 128, 64
-        elif (self.m, self.n, self.k) == (4096, 4096, 7168):
-            block_m, block_n = 64, 128
-        else:
-            block_m, block_n = 128, 128
-        return {
-            "block_m": block_m,
-            "block_n": block_n,
-            "block_k": 128,
-            "num_stages": 3,
-            "threads": 256,
-        }
+            return bias
+        if self._unused_bias is None or self._unused_bias.device != like.device:
+            self._unused_bias = torch.zeros(1, dtype=self.out_dtype, device=like.device)
+        return self._unused_bias
 
     def forward(
         self,
@@ -193,20 +207,75 @@ class GemmFp8BlockScaledKernel(Kernel):
     ) -> torch.Tensor:
         if self.dtype != torch.float8_e4m3fn:
             raise NotImplementedError(
-                f"GemmFp8BlockScaledKernel only supports torch.float8_e4m3fn, got {self.dtype}"
+                f"{type(self).__name__} only supports torch.float8_e4m3fn, got {self.dtype}"
             )
+        if self.ws_refusal is None:
+            tile_config = {key: value for key, value in self.config.items() if key != "split_k"}
+            split_k = self.config.get("split_k", 1)
+            if split_k > 1:
+                return self._run_split_k(a, b, scale_a, scale_b, bias, split_k, tile_config)
+            builder = self.kernel
+            if bias is not None:
+                builder = _gemm_fp8_ws_kernel(
+                    self.m,
+                    self.n,
+                    self.k,
+                    self.dtype_str,
+                    self.out_dtype_str,
+                    self.BLOCK_SCALED,
+                    has_bias=True,
+                    sm_count=self.sm_count,
+                )
+            return builder(**tile_config)(a, b, scale_a, scale_b, self._bias_operand(bias, a))
         compiled = _gemm_fp8_kernel(
             self.m,
             self.n,
             self.k,
             self.dtype_str,
             self.out_dtype_str,
-            block_scaled=True,
+            self.BLOCK_SCALED,
             has_bias=bias is not None,
         )(**self.config)
         if bias is not None:
             return compiled(a, b, scale_a, scale_b, bias)
         return compiled(a, b, scale_a, scale_b)
+
+
+class GemmFp8EpilogueKernel(_GemmFp8Kernel):
+    """FP8 NT GEMM for per-tensor scales; the two scalars land in the epilogue."""
+
+    BLOCK_SCALED = False
+
+
+class GemmFp8BlockScaledKernel(_GemmFp8Kernel):
+    """FP8 NT GEMM for block128 scale grids; each K-step's partial is scaled and folded in."""
+
+    BLOCK_SCALED = True
+
+
+@functools.lru_cache(maxsize=32)
+def _fp8_ws_splitk_pair(
+    m: int,
+    n: int,
+    k: int,
+    dtype: str,
+    out_dtype: str,
+    block_scaled: bool,
+    has_bias: bool,
+    split_k: int,
+    block_n: int,
+    num_stages: int,
+    group_size_m: int,
+) -> tuple[Callable, Callable]:
+    """The compiled (mainloop, reduce) pair for one split-K configuration.
+
+    Why: the two launches sit back to back, so resolving both in one cached call
+    keeps the host out of the window between them.
+    """
+    mainloop = _gemm_fp8_ws_splitk_kernel(
+        m, n, k, dtype, out_dtype, block_scaled, has_bias, split_k=split_k
+    )(block_n, num_stages, group_size_m)
+    return mainloop, _splitk_reduce_kernel(split_k, m, n, out_dtype)()
 
 
 @functools.lru_cache(maxsize=32)
@@ -428,6 +497,581 @@ def _gemm_fp8_kernel(
         return _gemm_fp8_bias_main if has_bias else _gemm_fp8_main
 
     return _gemm_fp8_func
+
+
+@functools.lru_cache(maxsize=32)
+def _gemm_fp8_ws_kernel(
+    m: int,
+    n: int,
+    k: int,
+    dtype: str,
+    out_dtype: str,
+    block_scaled: bool,
+    has_bias: bool,
+    *,
+    sm_count: int,
+) -> Callable:
+    """Warp-specialized FP8 NT GEMM for Hopper: 1 producer + 2 consumer warpgroups.
+
+    Same split-A / shared-B layout as :func:`_gemm_coop2_kernel` — a producer
+    warpgroup issues the TMA loads, two consumer warpgroups each own 64 of the
+    tile's 128 rows and run their own WGMMA over a shared ``B`` ring. The
+    persistent grid sweeps a Triton-style grouped tile order so concurrently
+    resident CTAs share a ``B`` column stripe in L2.
+
+    Block128 scaling is the one place this differs from the bf16 family. The
+    producer stages a K-step's ``A`` row scales and ``B`` column scales into that
+    step's ring slot, and the consumer folds a fresh WGMMA accumulator in as
+    ``acc += partial * scale_a[row] * scale_b[col]``. Why the staging: each
+    thread needs ``block_n / 4`` distinct column scales, and reading those from
+    global inside the mainloop is that many uncoalesced sectors per K-step —
+    2.4x the whole kernel on ``4096x7168x2048``.
+
+    Per-tensor scaling has no such step: WGMMA accumulates across the whole K
+    axis and the two scalars land in the epilogue.
+
+    Args:
+        m: Rows of ``A`` / ``C``.
+        n: Columns of ``op(B)`` / ``C``.
+        k: Contraction dim.
+        dtype: FP8 operand dtype string.
+        out_dtype: Output dtype string.
+        block_scaled: True for block128 scale grids, False for per-tensor scalars.
+        has_bias: Whether the compiled function takes a ``[n]`` bias operand.
+        sm_count: Persistent grid width — the device SM count. Part of the cache
+            key so a kernel built for one GPU is never reused on another.
+
+    Returns:
+        A ``@tilelang.jit`` factory; calling it with ``(block_n, num_stages,
+        group_size_m)`` returns the compiled ``prim_func``.
+    """
+    accum_dtype = "float"
+    block_m = 128
+    block_k = 128
+    scale_k = (k + 127) // 128
+
+    @tilelang.jit(
+        out_idx=[-1],
+        pass_configs={"tl.disable_warp_specialized": True},
+        compile_flags=["-O3", "-DENABLE_BF16", "-DENABLE_FP8"],
+    )
+    def _gemm_fp8_ws_func(
+        block_n: int = 128,
+        num_stages: int = 4,
+        group_size_m: int = 8,
+    ) -> Callable:
+        half_m = block_m // 2
+        nr = (half_m * block_n) // 128
+        num_pid_m = -(-m // block_m)
+        num_pid_n = -(-n // block_n)
+        total_tiles = num_pid_m * num_pid_n
+        grid = min(sm_count, total_tiles)
+        max_waves = -(-total_tiles // grid) + 1
+        k_iters = -(-k // block_k)
+        scale_a_shape = (m, scale_k) if block_scaled else (1, 1)
+        scale_b_shape = (n, scale_k) if block_scaled else (1, 1)
+        bias_shape = (n,) if has_bias else (1,)
+        stage_rows = num_stages if block_scaled else 1
+
+        @T.macro
+        def decode(flat_id, mt, nt):
+            gin = T.int32(group_size_m * num_pid_n)
+            gid = flat_id // gin
+            first_m = gid * T.int32(group_size_m)
+            gsize = T.min(T.int32(group_size_m), T.int32(num_pid_m) - first_m)
+            mt[0] = first_m + (flat_id % gin) % gsize
+            nt[0] = (flat_id % gin) // gsize
+
+        @T.prim_func
+        def _gemm_fp8_ws_main(
+            a: T.Tensor((m, k), dtype),  # type: ignore
+            b: T.Tensor((n, k), dtype),  # type: ignore
+            scale_a: T.Tensor(scale_a_shape, "float32"),  # type: ignore
+            scale_b: T.Tensor(scale_b_shape, "float32"),  # type: ignore
+            bias: T.Tensor(bias_shape, out_dtype),  # type: ignore
+            c: T.Tensor((m, n), out_dtype),  # type: ignore
+        ) -> None:
+            with T.Kernel(grid, threads=384) as (pid,):
+                a_top = T.alloc_shared((num_stages, half_m, block_k), dtype)
+                a_bot = T.alloc_shared((num_stages, half_m, block_k), dtype)
+                b_smem = T.alloc_shared((num_stages, block_n, block_k), dtype)
+                c_smem_0 = T.alloc_shared((half_m, block_n), out_dtype)
+                c_smem_1 = T.alloc_shared((half_m, block_n), out_dtype)
+                sa_stage = T.alloc_shared((stage_rows, block_m), accum_dtype)
+                sb_stage = T.alloc_shared((stage_rows, block_n), accum_dtype)
+                acc_0 = T.alloc_fragment((half_m, block_n), accum_dtype)
+                acc_1 = T.alloc_fragment((half_m, block_n), accum_dtype)
+                part_0 = T.alloc_fragment((half_m, block_n), accum_dtype)
+                part_1 = T.alloc_fragment((half_m, block_n), accum_dtype)
+                out_0 = T.alloc_fragment((half_m, block_n), out_dtype)
+                out_1 = T.alloc_fragment((half_m, block_n), out_dtype)
+                sa_0 = T.alloc_fragment((half_m,), accum_dtype)
+                sa_1 = T.alloc_fragment((half_m,), accum_dtype)
+                sb_0 = T.alloc_fragment((block_n,), accum_dtype)
+                sb_1 = T.alloc_fragment((block_n,), accum_dtype)
+
+                T.annotate_layout(
+                    {
+                        a_top: tilelang.layout.make_swizzled_layout(a_top),
+                        a_bot: tilelang.layout.make_swizzled_layout(a_bot),
+                        b_smem: tilelang.layout.make_swizzled_layout(b_smem),
+                        c_smem_0: tilelang.layout.make_swizzled_layout(c_smem_0),
+                        c_smem_1: tilelang.layout.make_swizzled_layout(c_smem_1),
+                    }
+                )
+
+                ab_full = T.alloc_barrier([128] * num_stages)
+                ab_empty = T.alloc_barrier([256] * num_stages)
+
+                gi_prod = T.alloc_var("int32", init=0)
+                gi_cons_0 = T.alloc_var("int32", init=0)
+                gi_cons_1 = T.alloc_var("int32", init=0)
+                ps0 = T.alloc_local((1,), "int32")
+                ps1 = T.alloc_local((1,), "int32")
+                mt = T.alloc_local((1,), "int32")
+                nt = T.alloc_local((1,), "int32")
+
+                tx = T.get_thread_binding()
+
+                if tx < 128:
+                    T.dec_max_nreg(24)
+                    for w in T.serial(max_waves):
+                        flat_id = T.int32(grid) * w + pid
+                        if flat_id < total_tiles:
+                            decode(flat_id, mt, nt)
+                            m_start = mt[0] * block_m
+                            n_start = nt[0] * block_n
+                            for ki in T.Pipelined(k_iters, num_stages=0):
+                                slot = gi_prod % num_stages
+                                ks = ki * block_k
+                                T.barrier_wait(ab_empty[slot], ((gi_prod // num_stages) & 1) ^ 1)
+                                T.tma_copy(
+                                    a[m_start : m_start + half_m, ks : ks + block_k],
+                                    a_top[slot, :, :],
+                                    barrier=ab_full[slot],
+                                )
+                                T.tma_copy(
+                                    a[m_start + half_m : m_start + block_m, ks : ks + block_k],
+                                    a_bot[slot, :, :],
+                                    barrier=ab_full[slot],
+                                )
+                                T.tma_copy(
+                                    b[n_start : n_start + block_n, ks : ks + block_k],
+                                    b_smem[slot, :, :],
+                                    barrier=ab_full[slot],
+                                )
+                                if block_scaled:
+                                    for i in T.Parallel(block_m):
+                                        sa_stage[slot, i] = scale_a[T.min(m_start + i, m - 1), ki]
+                                    for j in T.Parallel(block_n):
+                                        sb_stage[slot, j] = scale_b[T.min(n_start + j, n - 1), ki]
+                                    T.fence_proxy_async()
+                                T.barrier_arrive(ab_full[slot])
+                                gi_prod = gi_prod + 1
+
+                elif tx < 256:
+                    T.inc_max_nreg(232)
+                    for w in T.serial(max_waves):
+                        flat_id = T.int32(grid) * w + pid
+                        if flat_id < total_tiles:
+                            decode(flat_id, mt, nt)
+                            m_start = mt[0] * block_m
+                            n_start = nt[0] * block_n
+                            arows = T.min(T.int32(half_m), T.int32(m) - m_start)
+                            acols = T.min(T.int32(block_n), T.int32(n) - n_start)
+                            if block_scaled:
+                                T.clear(acc_0)
+                                for _ki in T.Pipelined(k_iters, num_stages=0):
+                                    slot = gi_cons_0 % num_stages
+                                    T.barrier_wait(ab_full[slot], (gi_cons_0 // num_stages) & 1)
+                                    T.wgmma_gemm(
+                                        a_top[slot, :, :],
+                                        b_smem[slot, :, :],
+                                        part_0,
+                                        transpose_B=True,
+                                        policy=T.GemmWarpPolicy.FullRow,
+                                        clear_accum=True,
+                                    )
+                                    T.copy(sa_stage[slot, 0:half_m], sa_0)
+                                    T.copy(sb_stage[slot, :], sb_0)
+                                    T.wait_wgmma(0)
+                                    for i, j in T.Parallel(half_m, block_n):
+                                        acc_0[i, j] += part_0[i, j] * sa_0[i] * sb_0[j]
+                                    T.barrier_arrive(ab_empty[slot])
+                                    gi_cons_0 = gi_cons_0 + 1
+                            else:
+                                for ki in T.Pipelined(k_iters, num_stages=0):
+                                    slot = gi_cons_0 % num_stages
+                                    T.barrier_wait(ab_full[slot], (gi_cons_0 // num_stages) & 1)
+                                    T.wgmma_gemm(
+                                        a_top[slot, :, :],
+                                        b_smem[slot, :, :],
+                                        acc_0,
+                                        transpose_B=True,
+                                        policy=T.GemmWarpPolicy.FullRow,
+                                        clear_accum=(ki == 0),
+                                    )
+                                    if ki > 0:
+                                        T.wait_wgmma(1)
+                                        T.barrier_arrive(ab_empty[ps0[0]])
+                                    ps0[0] = slot
+                                    gi_cons_0 = gi_cons_0 + 1
+                                T.wait_wgmma(0)
+                                T.barrier_arrive(ab_empty[ps0[0]])
+                                T.warpgroup_fence_operand(acc_0, num_regs=nr)
+                                for i, j in T.Parallel(half_m, block_n):
+                                    acc_0[i, j] *= scale_a[0, 0] * scale_b[0, 0]
+                            if has_bias:
+                                for i, j in T.Parallel(half_m, block_n):
+                                    out_0[i, j] = (
+                                        T.cast(acc_0[i, j], out_dtype)
+                                        + bias[T.min(n_start + j, n - 1)]
+                                    )
+                            else:
+                                T.copy(acc_0, out_0)
+                            if arows == T.int32(half_m) and acols == T.int32(block_n):
+                                T.sync_threads(barrier_id=_CONSUMER_BAR_WG0, arrive_count=128)
+                                T.copy(out_0, c_smem_0)
+                                T.fence_proxy_async()
+                                T.sync_threads(barrier_id=_CONSUMER_BAR_WG0, arrive_count=128)
+                                T.copy(c_smem_0, c[m_start, n_start])
+                            else:
+                                for i, j in T.Parallel(half_m, block_n):
+                                    if i < arows and j < acols:
+                                        c[m_start + i, n_start + j] = out_0[i, j]
+
+                else:
+                    T.inc_max_nreg(232)
+                    for w in T.serial(max_waves):
+                        flat_id = T.int32(grid) * w + pid
+                        if flat_id < total_tiles:
+                            decode(flat_id, mt, nt)
+                            m_start = mt[0] * block_m + half_m
+                            n_start = nt[0] * block_n
+                            arows = T.max(T.int32(0), T.min(T.int32(half_m), T.int32(m) - m_start))
+                            acols = T.min(T.int32(block_n), T.int32(n) - n_start)
+                            if block_scaled:
+                                T.clear(acc_1)
+                                for _ki in T.Pipelined(k_iters, num_stages=0):
+                                    slot = gi_cons_1 % num_stages
+                                    T.barrier_wait(ab_full[slot], (gi_cons_1 // num_stages) & 1)
+                                    T.wgmma_gemm(
+                                        a_bot[slot, :, :],
+                                        b_smem[slot, :, :],
+                                        part_1,
+                                        transpose_B=True,
+                                        policy=T.GemmWarpPolicy.FullRow,
+                                        clear_accum=True,
+                                    )
+                                    T.copy(sa_stage[slot, half_m:block_m], sa_1)
+                                    T.copy(sb_stage[slot, :], sb_1)
+                                    T.wait_wgmma(0)
+                                    for i, j in T.Parallel(half_m, block_n):
+                                        acc_1[i, j] += part_1[i, j] * sa_1[i] * sb_1[j]
+                                    T.barrier_arrive(ab_empty[slot])
+                                    gi_cons_1 = gi_cons_1 + 1
+                            else:
+                                for ki in T.Pipelined(k_iters, num_stages=0):
+                                    slot = gi_cons_1 % num_stages
+                                    T.barrier_wait(ab_full[slot], (gi_cons_1 // num_stages) & 1)
+                                    T.wgmma_gemm(
+                                        a_bot[slot, :, :],
+                                        b_smem[slot, :, :],
+                                        acc_1,
+                                        transpose_B=True,
+                                        policy=T.GemmWarpPolicy.FullRow,
+                                        clear_accum=(ki == 0),
+                                    )
+                                    if ki > 0:
+                                        T.wait_wgmma(1)
+                                        T.barrier_arrive(ab_empty[ps1[0]])
+                                    ps1[0] = slot
+                                    gi_cons_1 = gi_cons_1 + 1
+                                T.wait_wgmma(0)
+                                T.barrier_arrive(ab_empty[ps1[0]])
+                                T.warpgroup_fence_operand(acc_1, num_regs=nr)
+                                for i, j in T.Parallel(half_m, block_n):
+                                    acc_1[i, j] *= scale_a[0, 0] * scale_b[0, 0]
+                            if has_bias:
+                                for i, j in T.Parallel(half_m, block_n):
+                                    out_1[i, j] = (
+                                        T.cast(acc_1[i, j], out_dtype)
+                                        + bias[T.min(n_start + j, n - 1)]
+                                    )
+                            else:
+                                T.copy(acc_1, out_1)
+                            if arows == T.int32(half_m) and acols == T.int32(block_n):
+                                T.sync_threads(barrier_id=_CONSUMER_BAR_WG1, arrive_count=128)
+                                T.copy(out_1, c_smem_1)
+                                T.fence_proxy_async()
+                                T.sync_threads(barrier_id=_CONSUMER_BAR_WG1, arrive_count=128)
+                                T.copy(c_smem_1, c[m_start, n_start])
+                            elif arows > T.int32(0):
+                                for i, j in T.Parallel(half_m, block_n):
+                                    if i < arows and j < acols:
+                                        c[m_start + i, n_start + j] = out_1[i, j]
+
+        return _gemm_fp8_ws_main
+
+    return _gemm_fp8_ws_func
+
+
+@functools.lru_cache(maxsize=32)
+def _gemm_fp8_ws_splitk_kernel(
+    m: int,
+    n: int,
+    k: int,
+    dtype: str,
+    out_dtype: str,
+    block_scaled: bool,
+    has_bias: bool,
+    *,
+    split_k: int,
+) -> Callable:
+    """Split-K variant of the warp-specialized FP8 mainloop (NT).
+
+    Slicing K across ``grid.y`` multiplies the grid by ``split_k`` without
+    changing the bytes any CTA reads, which is what the decode shapes need: one
+    ``block_m`` row tile and few column tiles leave most of the device idle and
+    each resident CTA at its own SM's read bandwidth. Each slice writes an fp32
+    partial tile into ``slices[split_k, m, n]``; :func:`_splitk_reduce_kernel`
+    sums them and casts. Slice 0 carries the bias, so the sum adds it once.
+
+    Args:
+        m: Rows of ``A`` / ``C``.
+        n: Columns of ``op(B)`` / ``C``.
+        k: Contraction dim.
+        dtype: FP8 operand dtype string.
+        out_dtype: Output dtype string, which the bias operand also carries.
+        block_scaled: True for block128 scale grids, False for per-tensor scalars.
+        has_bias: Whether the compiled function takes a ``[n]`` bias operand.
+        split_k: Number of K slices; must divide the block128 K-tile count evenly.
+
+    Returns:
+        A ``@tilelang.jit`` factory; calling it with ``(block_n, num_stages,
+        group_size_m)`` returns the compiled ``prim_func`` producing the fp32
+        workspace.
+    """
+    accum_dtype = "float"
+    block_m = 128
+    block_k = 128
+    scale_k = (k + 127) // 128
+    k_iters_total = -(-k // block_k)
+    if k_iters_total % split_k:
+        raise ValueError(
+            f"split_k={split_k} must divide the K-tile count evenly "
+            f"(k={k}, block_k={block_k} -> {k_iters_total} tiles)"
+        )
+
+    @tilelang.jit(
+        pass_configs={"tl.disable_warp_specialized": True},
+        compile_flags=["-O3", "-DENABLE_BF16", "-DENABLE_FP8"],
+    )
+    def _gemm_fp8_ws_splitk_func(
+        block_n: int = 64,
+        num_stages: int = 5,
+        group_size_m: int = 8,
+    ) -> Callable:
+        half_m = block_m // 2
+        nr = (half_m * block_n) // 128
+        num_pid_m = -(-m // block_m)
+        num_pid_n = -(-n // block_n)
+        total_tiles = num_pid_m * num_pid_n
+        k_iters = k_iters_total // split_k
+        scale_a_shape = (m, scale_k) if block_scaled else (1, 1)
+        scale_b_shape = (n, scale_k) if block_scaled else (1, 1)
+        stage_rows = num_stages if block_scaled else 1
+        bias_shape = (n,) if has_bias else (1,)
+
+        @T.macro
+        def decode(flat_id, mt, nt):
+            gin = T.int32(group_size_m * num_pid_n)
+            gid = flat_id // gin
+            first_m = gid * T.int32(group_size_m)
+            gsize = T.min(T.int32(group_size_m), T.int32(num_pid_m) - first_m)
+            mt[0] = first_m + (flat_id % gin) % gsize
+            nt[0] = (flat_id % gin) // gsize
+
+        @T.prim_func
+        def _gemm_fp8_ws_splitk_main(
+            a: T.Tensor((m, k), dtype),  # type: ignore
+            b: T.Tensor((n, k), dtype),  # type: ignore
+            scale_a: T.Tensor(scale_a_shape, "float32"),  # type: ignore
+            scale_b: T.Tensor(scale_b_shape, "float32"),  # type: ignore
+            bias: T.Tensor(bias_shape, out_dtype),  # type: ignore
+            slices: T.Tensor((split_k, m, n), accum_dtype),  # type: ignore
+        ) -> None:
+            with T.Kernel(total_tiles, split_k, threads=384) as (pid, bz):
+                a_top = T.alloc_shared((num_stages, half_m, block_k), dtype)
+                a_bot = T.alloc_shared((num_stages, half_m, block_k), dtype)
+                b_smem = T.alloc_shared((num_stages, block_n, block_k), dtype)
+                sa_stage = T.alloc_shared((stage_rows, block_m), accum_dtype)
+                sb_stage = T.alloc_shared((stage_rows, block_n), accum_dtype)
+                acc_0 = T.alloc_fragment((half_m, block_n), accum_dtype)
+                acc_1 = T.alloc_fragment((half_m, block_n), accum_dtype)
+                part_0 = T.alloc_fragment((half_m, block_n), accum_dtype)
+                part_1 = T.alloc_fragment((half_m, block_n), accum_dtype)
+                sa_0 = T.alloc_fragment((half_m,), accum_dtype)
+                sa_1 = T.alloc_fragment((half_m,), accum_dtype)
+                sb_0 = T.alloc_fragment((block_n,), accum_dtype)
+                sb_1 = T.alloc_fragment((block_n,), accum_dtype)
+
+                T.annotate_layout(
+                    {
+                        a_top: tilelang.layout.make_swizzled_layout(a_top),
+                        a_bot: tilelang.layout.make_swizzled_layout(a_bot),
+                        b_smem: tilelang.layout.make_swizzled_layout(b_smem),
+                    }
+                )
+
+                ab_full = T.alloc_barrier([128] * num_stages)
+                ab_empty = T.alloc_barrier([256] * num_stages)
+
+                ps0 = T.alloc_local((1,), "int32")
+                ps1 = T.alloc_local((1,), "int32")
+                mt = T.alloc_local((1,), "int32")
+                nt = T.alloc_local((1,), "int32")
+
+                decode(pid, mt, nt)
+                m_start = mt[0] * block_m
+                n_start = nt[0] * block_n
+                tx = T.get_thread_binding()
+
+                if tx < 128:
+                    T.dec_max_nreg(24)
+                    for ki in T.Pipelined(k_iters, num_stages=0):
+                        slot = ki % num_stages
+                        kb = bz * k_iters + ki
+                        ks = kb * block_k
+                        T.barrier_wait(ab_empty[slot], ((ki // num_stages) & 1) ^ 1)
+                        T.tma_copy(
+                            a[m_start : m_start + half_m, ks : ks + block_k],
+                            a_top[slot, :, :],
+                            barrier=ab_full[slot],
+                        )
+                        T.tma_copy(
+                            a[m_start + half_m : m_start + block_m, ks : ks + block_k],
+                            a_bot[slot, :, :],
+                            barrier=ab_full[slot],
+                        )
+                        T.tma_copy(
+                            b[n_start : n_start + block_n, ks : ks + block_k],
+                            b_smem[slot, :, :],
+                            barrier=ab_full[slot],
+                        )
+                        if block_scaled:
+                            for i in T.Parallel(block_m):
+                                sa_stage[slot, i] = scale_a[T.min(m_start + i, m - 1), kb]
+                            for j in T.Parallel(block_n):
+                                sb_stage[slot, j] = scale_b[T.min(n_start + j, n - 1), kb]
+                            T.fence_proxy_async()
+                        T.barrier_arrive(ab_full[slot])
+
+                elif tx < 256:
+                    T.inc_max_nreg(232)
+                    arows = T.min(T.int32(half_m), T.int32(m) - m_start)
+                    acols = T.min(T.int32(block_n), T.int32(n) - n_start)
+                    if block_scaled:
+                        T.clear(acc_0)
+                        for ki in T.Pipelined(k_iters, num_stages=0):
+                            slot = ki % num_stages
+                            T.barrier_wait(ab_full[slot], (ki // num_stages) & 1)
+                            T.wgmma_gemm(
+                                a_top[slot, :, :],
+                                b_smem[slot, :, :],
+                                part_0,
+                                transpose_B=True,
+                                policy=T.GemmWarpPolicy.FullRow,
+                                clear_accum=True,
+                            )
+                            T.copy(sa_stage[slot, 0:half_m], sa_0)
+                            T.copy(sb_stage[slot, :], sb_0)
+                            T.wait_wgmma(0)
+                            for i, j in T.Parallel(half_m, block_n):
+                                acc_0[i, j] += part_0[i, j] * sa_0[i] * sb_0[j]
+                            T.barrier_arrive(ab_empty[slot])
+                    else:
+                        for ki in T.Pipelined(k_iters, num_stages=0):
+                            slot = ki % num_stages
+                            T.barrier_wait(ab_full[slot], (ki // num_stages) & 1)
+                            T.wgmma_gemm(
+                                a_top[slot, :, :],
+                                b_smem[slot, :, :],
+                                acc_0,
+                                transpose_B=True,
+                                policy=T.GemmWarpPolicy.FullRow,
+                                clear_accum=(ki == 0),
+                            )
+                            if ki > 0:
+                                T.wait_wgmma(1)
+                                T.barrier_arrive(ab_empty[ps0[0]])
+                            ps0[0] = slot
+                        T.wait_wgmma(0)
+                        T.barrier_arrive(ab_empty[ps0[0]])
+                        T.warpgroup_fence_operand(acc_0, num_regs=nr)
+                        for i, j in T.Parallel(half_m, block_n):
+                            acc_0[i, j] *= scale_a[0, 0] * scale_b[0, 0]
+                    if has_bias and bz == 0:
+                        for i, j in T.Parallel(half_m, block_n):
+                            acc_0[i, j] += T.cast(bias[T.min(n_start + j, n - 1)], accum_dtype)
+                    for i, j in T.Parallel(half_m, block_n):
+                        if i < arows and j < acols:
+                            slices[bz, m_start + i, n_start + j] = acc_0[i, j]
+
+                else:
+                    T.inc_max_nreg(232)
+                    brows = T.max(T.int32(0), T.min(T.int32(half_m), T.int32(m) - m_start - half_m))
+                    bcols = T.min(T.int32(block_n), T.int32(n) - n_start)
+                    if block_scaled:
+                        T.clear(acc_1)
+                        for ki in T.Pipelined(k_iters, num_stages=0):
+                            slot = ki % num_stages
+                            T.barrier_wait(ab_full[slot], (ki // num_stages) & 1)
+                            T.wgmma_gemm(
+                                a_bot[slot, :, :],
+                                b_smem[slot, :, :],
+                                part_1,
+                                transpose_B=True,
+                                policy=T.GemmWarpPolicy.FullRow,
+                                clear_accum=True,
+                            )
+                            T.copy(sa_stage[slot, half_m:block_m], sa_1)
+                            T.copy(sb_stage[slot, :], sb_1)
+                            T.wait_wgmma(0)
+                            for i, j in T.Parallel(half_m, block_n):
+                                acc_1[i, j] += part_1[i, j] * sa_1[i] * sb_1[j]
+                            T.barrier_arrive(ab_empty[slot])
+                    else:
+                        for ki in T.Pipelined(k_iters, num_stages=0):
+                            slot = ki % num_stages
+                            T.barrier_wait(ab_full[slot], (ki // num_stages) & 1)
+                            T.wgmma_gemm(
+                                a_bot[slot, :, :],
+                                b_smem[slot, :, :],
+                                acc_1,
+                                transpose_B=True,
+                                policy=T.GemmWarpPolicy.FullRow,
+                                clear_accum=(ki == 0),
+                            )
+                            if ki > 0:
+                                T.wait_wgmma(1)
+                                T.barrier_arrive(ab_empty[ps1[0]])
+                            ps1[0] = slot
+                        T.wait_wgmma(0)
+                        T.barrier_arrive(ab_empty[ps1[0]])
+                        T.warpgroup_fence_operand(acc_1, num_regs=nr)
+                        for i, j in T.Parallel(half_m, block_n):
+                            acc_1[i, j] *= scale_a[0, 0] * scale_b[0, 0]
+                    if has_bias and bz == 0:
+                        for i, j in T.Parallel(half_m, block_n):
+                            acc_1[i, j] += T.cast(bias[T.min(n_start + j, n - 1)], accum_dtype)
+                    for i, j in T.Parallel(half_m, block_n):
+                        if i < brows and j < bcols:
+                            slices[bz, m_start + half_m + i, n_start + j] = acc_1[i, j]
+
+        return _gemm_fp8_ws_splitk_main
+
+    return _gemm_fp8_ws_splitk_func
 
 
 @functools.lru_cache(maxsize=32)

--- a/src/tileops/kernels/gemm/heuristics.py
+++ b/src/tileops/kernels/gemm/heuristics.py
@@ -55,7 +55,7 @@ _MAX_ACCUM_REGS = 200
 
 TINY_M_BLOCK_N = 128
 
-# Shortest K slice the FP8 split-K path pays for; below it the reduce pass wins back nothing.
+# Shortest K slice the FP8 split-K path pays for.
 _FP8_MIN_SLICE_K_TILES = 12
 
 _SWAP_AB_BLOCK_NN = 64
@@ -433,9 +433,8 @@ def _fp8_ws_stages(m: int, block_n: int, block_scaled: bool) -> int:
     """Deepest ring the SMEM budget allows for one warp-specialized FP8 tile.
 
     A stage holds two 64-row ``A`` halves, one ``block_n`` ``B`` tile, and the
-    block128 scale vectors when they are staged. The epilogue's two staging
-    tiles are live alongside the ring, except at an ``m`` inside one consumer's
-    half, where no row tile can be full and the kernel does not allocate them.
+    block128 scale vectors when staged. The epilogue's two staging tiles are
+    live alongside the ring, and exist only for ``m`` over one consumer's half.
     """
     per_stage = (2 * 64 + block_n) * 128 + (block_scaled * (128 + block_n) * 4)
     epilogue = 2 * 64 * block_n * 2 if m > 64 else 0
@@ -445,24 +444,19 @@ def _fp8_ws_stages(m: int, block_n: int, block_scaled: bool) -> int:
 def fp8_ws_config(m: int, n: int, k: int, sm_count: int, block_scaled: bool) -> dict:
     """Tile, ring depth and K split for the warp-specialized FP8 GEMM.
 
-    ``block_m`` is fixed at 128 by the two-consumer split, so the only tile
-    freedom is ``block_n``. 256 is not a candidate: its accumulator and scaled
-    partial together need 256 registers per thread, which spills.
+    ``block_m`` is fixed at 128 by the two-consumer split, so the tile freedom
+    is ``block_n``, over ``{64, 128}``. 256 spills: its accumulator and scaled
+    partial together want 256 registers per thread.
 
-    - ``m <= 8``: a 128-row ``A`` tile is almost entirely padding, so the cost
-      that matters is the number of times the ``B`` panel is re-read. Take the
-      wider tile even though it halves the CTA count.
-    - otherwise, a ``block_n = 128`` grid that does not fill one wave leaves
-      SMs idle for the whole launch; the narrow tile doubles the grid and the
-      re-read of ``A`` it costs stays in L2.
-    - per-tensor ring depth: the deepest the budget allows, because nothing sits
-      between two K-steps and the mainloop only ever waits on the ring.
-    - block128 ring depth: a K-step ends in a promotion the next WGMMA cannot
-      start under, so a deeper ring only spends SMEM. Three exceptions: an ``m``
-      inside one consumer's half, where the shape is a weight stream and the
-      ring is all that covers the read latency; a K axis short enough that the
-      fill is a visible fraction of it; and one long enough that a shallower
-      ring frees the L2 sooner.
+    - ``block_n``: 128, except where that grid does not fill one wave, which
+      leaves SMs idle for the whole launch. The narrow tile doubles the grid,
+      and the re-read of ``A`` it costs stays in L2. At ``m <= 8`` the ``A``
+      tile is mostly padding and the ``B`` re-read decides instead, so the wide
+      tile wins even under a short grid.
+    - ring depth: the deepest the budget allows, except in block128, where a
+      K-step ends in a promotion the next WGMMA cannot start under. There the
+      ring covers nothing beyond the fill, and 4 stages is enough — 3 over a
+      long K axis, 5 over a short one or a weight stream.
     - split-K: only where the sliced grid still fits one wave and every slice
       keeps enough K-tiles to amortize the fill and the fp32 workspace.
     """

--- a/src/tileops/kernels/gemm/heuristics.py
+++ b/src/tileops/kernels/gemm/heuristics.py
@@ -44,6 +44,7 @@ from typing import Optional
 __all__ = [
     "SWAP_AB_MPAD",
     "best_config",
+    "fp8_ws_config",
     "gemv_config",
     "small_batch_config",
     "swap_ab_grid_underfills",
@@ -53,6 +54,9 @@ _SMEM_BUDGET = 227 * 1024
 _MAX_ACCUM_REGS = 200
 
 TINY_M_BLOCK_N = 128
+
+# Shortest K slice the FP8 split-K path pays for; below it the reduce pass wins back nothing.
+_FP8_MIN_SLICE_K_TILES = 12
 
 _SWAP_AB_BLOCK_NN = 64
 SWAP_AB_MPAD = 8
@@ -423,3 +427,71 @@ def small_batch_config(n: int, k: int, sm_count: int) -> dict:
     if n >= 28 * sm_count and k_iters >= 12:
         cfg["num_stages"] = 2
     return cfg
+
+
+def _fp8_ws_stages(block_n: int, block_scaled: bool) -> int:
+    """Deepest ring the SMEM budget allows for one warp-specialized FP8 tile.
+
+    Per stage the ring holds two 64-row ``A`` halves and one ``block_n`` ``B``
+    tile of FP8, plus the block128 scale vectors when they are staged. The
+    epilogue's two ``out_dtype`` staging tiles are live at the same time.
+    """
+    per_stage = (2 * 64 + block_n) * 128 + (block_scaled * (128 + block_n) * 4)
+    epilogue = 2 * 64 * block_n * 2
+    return (_SMEM_BUDGET - epilogue) // per_stage
+
+
+def fp8_ws_config(m: int, n: int, k: int, sm_count: int, block_scaled: bool) -> dict:
+    """Tile, ring depth and K split for the warp-specialized FP8 GEMM.
+
+    ``block_m`` is fixed at 128 by the two-consumer split, so the only tile
+    freedom is ``block_n``. 256 is not a candidate: its accumulator and scaled
+    partial together need 256 registers per thread, which spills.
+
+    - ``m <= 8``: a 128-row ``A`` tile is almost entirely padding, so the cost
+      that matters is the number of times the ``B`` panel is re-read. Take the
+      wider tile even though it halves the CTA count.
+    - otherwise, a ``block_n = 128`` grid that does not fill one wave leaves
+      SMs idle for the whole launch; the narrow tile doubles the grid and the
+      re-read of ``A`` it costs stays in L2.
+    - per-tensor ring depth: the deepest the budget allows. WGMMA accumulates
+      across the whole K axis with nothing between two K-steps, so the mainloop
+      only ever waits on the ring.
+    - block128 ring depth: a K-step ends in a promotion the next WGMMA cannot
+      start under, so the mainloop is not load-bound and a deeper ring only
+      spends SMEM. The exceptions are a K axis short enough that the fill is a
+      visible fraction of it, and one long enough that a shallower ring frees
+      the L2 sooner.
+    - split-K: a grid that leaves three quarters of the device idle runs each
+      resident CTA at its own SM's read bandwidth, so slicing K multiplies the
+      grid without changing the bytes any CTA reads. It is taken only where the
+      sliced grid still fits one wave and every slice stays long enough to
+      amortize the pipeline fill and the fp32 workspace round trip.
+    """
+    block_n = 128 if m <= 8 or -(-m // 128) * -(-n // 128) >= sm_count else 64
+    k_iters = -(-k // 128)
+    deepest = _fp8_ws_stages(block_n, block_scaled)
+    if not block_scaled:
+        num_stages = deepest
+    elif block_n == 64 or m <= 8 or k_iters <= 12:
+        num_stages = min(5, deepest)
+    elif k_iters >= 128:
+        num_stages = 3
+    else:
+        num_stages = 4
+    tiles = -(-m // 128) * -(-n // block_n)
+    split_k = 1
+    for candidate in (4, 2):
+        if (
+            tiles * candidate <= sm_count
+            and k_iters % candidate == 0
+            and k_iters // candidate >= _FP8_MIN_SLICE_K_TILES
+        ):
+            split_k = candidate
+            break
+    return {
+        "block_n": block_n,
+        "num_stages": num_stages,
+        "group_size_m": 8,
+        "split_k": split_k,
+    }

--- a/src/tileops/kernels/gemm/heuristics.py
+++ b/src/tileops/kernels/gemm/heuristics.py
@@ -429,15 +429,16 @@ def small_batch_config(n: int, k: int, sm_count: int) -> dict:
     return cfg
 
 
-def _fp8_ws_stages(block_n: int, block_scaled: bool) -> int:
+def _fp8_ws_stages(m: int, block_n: int, block_scaled: bool) -> int:
     """Deepest ring the SMEM budget allows for one warp-specialized FP8 tile.
 
-    Per stage the ring holds two 64-row ``A`` halves and one ``block_n`` ``B``
-    tile of FP8, plus the block128 scale vectors when they are staged. The
-    epilogue's two ``out_dtype`` staging tiles are live at the same time.
+    A stage holds two 64-row ``A`` halves, one ``block_n`` ``B`` tile, and the
+    block128 scale vectors when they are staged. The epilogue's two staging
+    tiles are live alongside the ring, except at an ``m`` inside one consumer's
+    half, where no row tile can be full and the kernel does not allocate them.
     """
     per_stage = (2 * 64 + block_n) * 128 + (block_scaled * (128 + block_n) * 4)
-    epilogue = 2 * 64 * block_n * 2
+    epilogue = 2 * 64 * block_n * 2 if m > 64 else 0
     return (_SMEM_BUDGET - epilogue) // per_stage
 
 
@@ -454,26 +455,23 @@ def fp8_ws_config(m: int, n: int, k: int, sm_count: int, block_scaled: bool) -> 
     - otherwise, a ``block_n = 128`` grid that does not fill one wave leaves
       SMs idle for the whole launch; the narrow tile doubles the grid and the
       re-read of ``A`` it costs stays in L2.
-    - per-tensor ring depth: the deepest the budget allows. WGMMA accumulates
-      across the whole K axis with nothing between two K-steps, so the mainloop
-      only ever waits on the ring.
+    - per-tensor ring depth: the deepest the budget allows, because nothing sits
+      between two K-steps and the mainloop only ever waits on the ring.
     - block128 ring depth: a K-step ends in a promotion the next WGMMA cannot
-      start under, so the mainloop is not load-bound and a deeper ring only
-      spends SMEM. The exceptions are a K axis short enough that the fill is a
-      visible fraction of it, and one long enough that a shallower ring frees
-      the L2 sooner.
-    - split-K: a grid that leaves three quarters of the device idle runs each
-      resident CTA at its own SM's read bandwidth, so slicing K multiplies the
-      grid without changing the bytes any CTA reads. It is taken only where the
-      sliced grid still fits one wave and every slice stays long enough to
-      amortize the pipeline fill and the fp32 workspace round trip.
+      start under, so a deeper ring only spends SMEM. Three exceptions: an ``m``
+      inside one consumer's half, where the shape is a weight stream and the
+      ring is all that covers the read latency; a K axis short enough that the
+      fill is a visible fraction of it; and one long enough that a shallower
+      ring frees the L2 sooner.
+    - split-K: only where the sliced grid still fits one wave and every slice
+      keeps enough K-tiles to amortize the fill and the fp32 workspace.
     """
     block_n = 128 if m <= 8 or -(-m // 128) * -(-n // 128) >= sm_count else 64
     k_iters = -(-k // 128)
-    deepest = _fp8_ws_stages(block_n, block_scaled)
-    if not block_scaled:
+    deepest = _fp8_ws_stages(m, block_n, block_scaled)
+    if not block_scaled or m <= 8:
         num_stages = deepest
-    elif block_n == 64 or m <= 8 or k_iters <= 12:
+    elif block_n == 64 or k_iters <= 12:
         num_stages = min(5, deepest)
     elif k_iters >= 128:
         num_stages = 3

--- a/src/tileops/ops/gemm/gemm.py
+++ b/src/tileops/ops/gemm/gemm.py
@@ -348,13 +348,14 @@ class GemmFp8FwdOp(Op):
         dtype: torch.dtype,
         scale_a_shape: Tuple[int, ...],
         scale_b_shape: Tuple[int, ...],
+        device_index: Optional[int],
     ) -> Kernel:
         return self.get_or_build_kernel(
             kernel_name,
             inputs,
-            key=(m, n, k, dtype, scale_a_shape, scale_b_shape, self.out_dtype),
+            key=(m, n, k, dtype, scale_a_shape, scale_b_shape, self.out_dtype, device_index),
             build=lambda: self.kernel_map[kernel_name](
-                m, n, k, dtype, self.out_dtype, tune=self.tune
+                m, n, k, dtype, self.out_dtype, tune=self.tune, device_index=device_index
             ),
         )
 
@@ -393,6 +394,7 @@ class GemmFp8FwdOp(Op):
             ```
         """
         sig = (
+            a.device,
             a.shape,
             b.shape,
             scale_a.shape,
@@ -422,6 +424,7 @@ class GemmFp8FwdOp(Op):
                 a.dtype,
                 tuple(scale_a.shape),
                 tuple(scale_b.shape),
+                a.device.index,
             )
             self.kernel = kernel
             self._active = kernel

--- a/tests/ops/test_gemm.py
+++ b/tests/ops/test_gemm.py
@@ -552,7 +552,7 @@ def test_gemm_fp8_block128_single_k_block_uses_block_kernel() -> None:
         ),
         pytest.param(
             (8, 7168, 2048),
-            (128, 5),
+            (128, 6),
             marks=pytest.mark.full,
             id="tiny-m-widens-the-tile",
         ),

--- a/tests/ops/test_gemm.py
+++ b/tests/ops/test_gemm.py
@@ -396,6 +396,28 @@ class GemmFp8Fixture(FixtureBase):
                     marks=pytest.mark.full,
                     id="full-fp8-e4m3-per-tensor-gemv",
                 ),
+                pytest.param(
+                    128,
+                    256,
+                    6144,
+                    torch.float8_e4m3fn,
+                    "block128",
+                    torch.bfloat16,
+                    False,
+                    marks=pytest.mark.full,
+                    id="full-fp8-e4m3-block128-split-k",
+                ),
+                pytest.param(
+                    128,
+                    256,
+                    6144,
+                    torch.float8_e4m3fn,
+                    "per_tensor",
+                    torch.bfloat16,
+                    True,
+                    marks=pytest.mark.full,
+                    id="full-fp8-e4m3-per-tensor-split-k-bias",
+                ),
             ],
         ),
     ]
@@ -514,30 +536,36 @@ def test_gemm_fp8_block128_single_k_block_uses_block_kernel() -> None:
 
 
 @pytest.mark.parametrize(
-    ("shape", "expected_tile"),
+    ("shape", "expected"),
     [
         pytest.param(
             (4096, 2112, 7168),
-            (128, 64),
+            (128, 4),
             marks=pytest.mark.smoke,
             id="prefill-gate-up",
         ),
         pytest.param(
-            (4096, 4096, 7168),
-            (64, 128),
+            (128, 7168, 2048),
+            (64, 5),
             marks=pytest.mark.full,
-            id="prefill-attn-proj",
+            id="decode-grid-underfills",
         ),
         pytest.param(
-            (4096, 7168, 2048),
-            (128, 128),
+            (8, 7168, 2048),
+            (128, 5),
             marks=pytest.mark.full,
-            id="prefill-down-default",
+            id="tiny-m-widens-the-tile",
+        ),
+        pytest.param(
+            (4096, 7168, 16384),
+            (128, 3),
+            marks=pytest.mark.full,
+            id="long-k-shallow-ring",
         ),
     ],
 )
 def test_gemm_fp8_block128_default_config(
-    shape: tuple[int, int, int], expected_tile: tuple[int, int]
+    shape: tuple[int, int, int], expected: tuple[int, int]
 ) -> None:
     kernel = GemmFp8BlockScaledKernel(
         *shape,
@@ -545,7 +573,7 @@ def test_gemm_fp8_block128_default_config(
         out_dtype=torch.bfloat16,
     )
 
-    assert (kernel.config["block_m"], kernel.config["block_n"]) == expected_tile
+    assert (kernel.config["block_n"], kernel.config["num_stages"]) == expected
 
 
 @pytest.mark.smoke


### PR DESCRIPTION
## Summary

- Replace both FP8 GEMM kernels with the SM90 warp-specialized layout the bf16 family already uses: one producer warpgroup issuing TMA loads into a ring, two consumer warpgroups each owning 64 rows of a 128-row tile, a persistent grid in grouped tile order, and a TMA store epilogue. The old kernels loaded every tile with predicated element copies on one 256-thread consumer.
- Stage each block128 K-step's row and column scale vectors into that step's ring slot from the producer, so the consumer reads them from shared memory instead of issuing `block_n / 4` uncoalesced global sectors per thread per K-step.
- Add a split-K variant for the decode shapes, whose `(M, N)` grid covers a quarter of the device and leaves every resident CTA at its own SM's read bandwidth. Slice 0 carries the bias, so the reduce adds it once.
- Select `block_n`, ring depth and K split analytically in `fp8_ws_config`; the previous two hard-coded prefill tile exceptions are gone. Where no row tile can be full the epilogue's staging tile is not allocated, which buys two more ring stages.
- The device joins the op's active signature and the kernel cache key, because the FP8 kernels now read its SM count for their grid width.
- Drop the `flashinfer-fp8-blockscale-sm90` benchmark comparator: it was the only comparator on this op that no reference checked, and it disagrees with the reference on every block128 row. Details under Result And Limitations.
- Public `GemmFp8FwdOp`, kernel class names, scale-grid dispatch, output semantics and manifest are unchanged.
- Test-node delta: +3 (63 to 66) in `tests/ops/test_gemm.py` — two split-K correctness cases (block128, and per-tensor with bias) and one more config-rule case.

## TileFoundry Description

The authored placement is one output tile per CTA walking the whole K axis, with each K-block's FP8 operands staged in smem, its partial and the two scale vectors in rmem, and the fp32 accumulator resident across the loop. `M`, `N`, `K` and the tile are module constants; the numbers below are that program re-emitted per workload.

```python
#!/usr/bin/env python3
"""GemmFp8FwdOp block128 placement: one output tile per CTA, K streamed by block."""

from tilefoundry import func, module
from tilefoundry.dsl import Mesh, Tensor, tf
from tilefoundry.dsl.tf import *  # noqa: F401, F403 - bare tile() in the mainloop
from tilefoundry.ir.types.shard import Topology
from tilefoundry.target import CudaTarget

M, N, K = 4096, 7168, 2048
BLOCK = 128  # manifest: scale_mode block128, one scale per 128 contraction elements
KB = K // BLOCK
BM, BN = 128, 128
MT, NT = M // BM, N // BN

_H200 = CudaTarget("nvidia.h200_sxm")


@module(
    entry="gemm_fp8",
    target=_H200,
    topologies=(Topology("cta", MT * NT), Topology("thread", 384)),
)
class Tiled:
    """One CTA owns one BM x BN output tile and walks the whole K axis."""

    @func
    def gemm_fp8(
        a: Tensor[(M, KB, BLOCK), "fp8e4m3"],
        b: Tensor[(N, KB, BLOCK), "fp8e4m3"],
        scale_a: Tensor[(M, KB, 1), "f32"],
        scale_b: Tensor[(N, KB, 1), "f32"],
    ) -> Tensor[(1, M, N), "bf16"]:
        with Mesh(("cta",), layout=(MT, NT), names=("m_cta", "n_cta")) as cta:
            acc = tf.zeros(Tensor[(1, M @ cta.m_cta, N @ cta.n_cta), "f32", "rmem"])
            for kb in tile(KB, 1):  # noqa: F821
                a_smem = tf.reshard(a[:, kb, :], (M @ cta.m_cta, 1, BLOCK), "smem")
                b_smem = tf.reshard(b[:, kb, :], (N @ cta.n_cta, 1, BLOCK), "smem")
                a_tile = tf.transpose(a_smem, perm=(1, 0, 2))
                b_tile = tf.transpose(b_smem, perm=(1, 0, 2))
                product = tf.cast(
                    tf.matmul(
                        tf.cast(a_tile, dtype="bf16"),
                        tf.cast(b_tile, dtype="bf16"),
                        b_layout="NK",
                    ),
                    dtype="f32",
                )
                partial = tf.reshard(product, (1, M @ cta.m_cta, N @ cta.n_cta), "rmem")
                sa_smem = tf.reshard(scale_a[:, kb, :], (M @ cta.m_cta, 1, 1), "smem")
                sb_smem = tf.reshard(scale_b[:, kb, :], (N @ cta.n_cta, 1, 1), "smem")
                sa = tf.transpose(
                    tf.reshard(sa_smem, (M @ cta.m_cta, 1, 1), "rmem"), perm=(1, 0, 2)
                )
                sb = tf.transpose(
                    tf.reshard(sb_smem, (N @ cta.n_cta, 1, 1), "rmem"), perm=(1, 2, 0)
                )
                acc = acc + partial * sa * sb
            out = tf.cast(acc, dtype="bf16")
            return tf.reshard(out, (1, M @ cta.m_cta, N @ cta.n_cta), "gmem")
```

`tf.matmul` takes the result dtype from its operands, so the K-block product cannot be both an FP8 contraction and an f32 accumulation. Two forms of the same program answer the two questions:

- `Tiled` above casts the operands to bf16, so the report prices the contraction on the tensor cores. The target states FP8 at exactly twice the bf16 rate (1979 vs 989.5 TFLOP/s), so the FP8 ideal is the reported `ideal-ns` halved.
- `TiledExact` is the same program with the K-block product in f32. It is the reference `check` holds the shipped kernel to; the bf16 form is not, because rounding each K-block partial to bf16 moves a cancelling output element by 0.57 where the kernel's own error is 0.003.

```text
tilefoundry check twin_exact.py:Fast --inputs random --out output --fn allclose --atol 5e-2 --rtol 2e-2
  reference: evaluator on TiledExact.gemm_fp8      (128 x 256 x 6144, block128)
  output   bf16[1,128,256]   ref_norm 14291.7
    allclose(atol=0.05 rtol=0.02)      max_violation 0            PASS
    nan_inf                            nan 0 inf 0                PASS
```

`tilefoundry analyze <module> --compute-cost --memory --roofline`, one run per workload:

| Workload | Tile | `ideal-ns` (bf16 rate) | FP8 ideal (us) | gmem traffic (MB) | at 4.8 TB/s (us) | SOL (us) |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| ds-v3-prefill-down-block128 | 128x128 | 150561 | 75.3 | 82.5 | 17.2 | 75.3 |
| ds-v3-prefill-attn-proj-block128 | 128x128 | 301078 | 150.5 | 94.1 | 19.6 | 150.5 |
| k-dominant-7168x16384-block128 | 128x128 | 1204272 | 602.1 | 249.0 | 51.9 | 602.1 |
| wide-n-24576-block128 | 128x128 | 387180 | 193.6 | 246.7 | 51.4 | 193.6 |
| ds-v3-decode-gate-up-block128 | 128x64 | 4867 | 2.4 | 17.1 | 3.6 | 3.6 |
| ds-v3-decode-down-block128 | 128x64 | 4721 | 2.4 | 17.2 | 3.6 | 3.6 |

What the analysis decided, before any kernel existed:

- The report says `bound-by=compute` on every row, but that is the bf16 rate. At the FP8 rate the two decode rows flip: 2.4 us of arithmetic against 3.6 us of traffic. They are weight streams, and the lever on them is how much of the device is reading, not how fast it multiplies.
- The per-CTA projection is `(block_m + block_n) * K` bytes, so the traffic a tiling costs is `A * ceil(N/block_n) + B * ceil(M/block_m)`. That is what makes `block_n = 64` right where the wide tile's grid underfills and wrong everywhere else: the extra re-read of `A` it costs stays in L2, and the idle SMs it buys back do not.
- `peak-footprint=smem:98304` for the 128x128 tile at four stages is what fixed the ring-depth ceiling; `_fp8_ws_stages` computes the same budget in the heuristic.
- Splitting K in the authored program adds an fp32 workspace round trip to `traffic` (`+8.6 MB` on the decode gate-up shape) while the per-CTA read stays put. That is the trade the split-K rule prices: it is taken only where the sliced grid still fits one wave.

Two things the HIR could not be asked. `tf.matmul` has no accumulate dtype, hence the two forms above. And a ragged `N` tile has no sharded form — `4096 x 2112 x 7168` refuses at `block_n = 128` because 2112 is not a multiple of it — so that workload is analyzed at `block_n = 64` and the shipped kernel's ragged last column tile is priced by the benchmark, not by `analyze`.

## Performance

Operator: `GemmFp8FwdOp`

| Environment | Value |
| --- | --- |
| image | `ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-afcebed1-tilefoundry-latest` |
| digest | `sha256:ca13df9bda340edf248b8b443b88880f36e3190ab9d470f52d66ccc21c15fd59` |
| gpu | `NVIDIA H200`, device 4, SM clock 1980 MHz, memory clock 3201 MHz |
| driver | `595.71.05` |
| cuda | `13.2` |
| torch | `2.13.0+cu132` |
| tilelang | `0.1.11+cu132.gitafcebed1` |
| tilefoundry | `0.1.dev146+g2bec6420e` |
| DeepGEMM | `2.1.1` |
| FlashInfer | `0.6.16.post3` (blockscale entry point dropped, see below) |
| timer | `CUPTI device_busy_ms` |

Method: `benchmarks/ops/bench_gemm.py -k test_gemm_fp8_bench`, which is `ManifestBenchmark.compare` with forward/reverse interleaving. Incumbent and candidate were measured on the same device in the same session. The incumbent column is the FP8 path at e0edbb12 measured the same way, not the nightly snapshot, whose SM clock was 1500 MHz; #2110 landed in between and touched only the bf16 kernels, so the incumbent FP8 numbers still stand.

Ratio in comparator columns: implementation / candidate. &#x1F7E2; > 1 means the candidate is faster; &#x1F534; <= 1 means it is not.

| Workload | M | N | K | Mode | TileOPs candidate (ms) | TileOPs incumbent (ms)<br>/ candidate | torch-scaled-mm (ms)<br>/ candidate | DeepGEMM (ms)<br>/ candidate |
| --- | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: |
| ds-v3-decode-gate-up-per-tensor | 128 | 2112 | 7168 | per_tensor | 0.0132 | **0.0963<br>&#x1F7E2;&nbsp;7.295x** | **0.1988<br>&#x1F7E2;&nbsp;15.061x** | N/A |
| ds-v3-decode-down-per-tensor | 128 | 7168 | 2048 | per_tensor | 0.0079 | **0.0231<br>&#x1F7E2;&nbsp;2.924x** | **0.2012<br>&#x1F7E2;&nbsp;25.468x** | **0.0089<br>&#x1F7E2;&nbsp;1.127x** |
| ds-v3-prefill-gate-up-per-tensor | 4096 | 2112 | 7168 | per_tensor | 0.1103 | **0.4377<br>&#x1F7E2;&nbsp;3.968x** | **2.6308<br>&#x1F7E2;&nbsp;23.851x** | N/A |
| ds-v3-prefill-down-per-tensor | 4096 | 7168 | 2048 | per_tensor | 0.0900 | **0.1802<br>&#x1F7E2;&nbsp;2.002x** | **2.5682<br>&#x1F7E2;&nbsp;28.536x** | **0.0916<br>&#x1F7E2;&nbsp;1.018x** |
| ds-v3-decode-gate-up-block128 | 128 | 2112 | 7168 | block128 | 0.0154 | **0.1205<br>&#x1F7E2;&nbsp;7.825x** | **0.2382<br>&#x1F7E2;&nbsp;15.468x** | N/A |
| ds-v3-decode-down-block128 | 128 | 7168 | 2048 | block128 | 0.0111 | **0.0328<br>&#x1F7E2;&nbsp;2.955x** | **0.2384<br>&#x1F7E2;&nbsp;21.477x** | N/A |
| ds-v3-prefill-gate-up-block128 | 4096 | 2112 | 7168 | block128 | 0.1726 | **0.3277<br>&#x1F7E2;&nbsp;1.899x** | **2.7428<br>&#x1F7E2;&nbsp;15.891x** | N/A |
| ds-v3-prefill-down-block128 | 4096 | 7168 | 2048 | block128 | 0.1481 | **0.3762<br>&#x1F7E2;&nbsp;2.540x** | **2.6298<br>&#x1F7E2;&nbsp;17.757x** | N/A |
| ds-v3-prefill-attn-proj-block128 | 4096 | 4096 | 7168 | block128 | 0.2692 | **0.6601<br>&#x1F7E2;&nbsp;2.452x** | **5.2052<br>&#x1F7E2;&nbsp;19.336x** | N/A |
| k-dominant-7168x16384-block128 | 4096 | 7168 | 16384 | block128 | 1.3776 | **3.1255<br>&#x1F7E2;&nbsp;2.269x** | **20.7095<br>&#x1F7E2;&nbsp;15.033x** | N/A |
| wide-n-24576-block128 | 4096 | 24576 | 1536 | block128 | 0.3781 | **0.9082<br>&#x1F7E2;&nbsp;2.402x** | **6.6006<br>&#x1F7E2;&nbsp;17.457x** | N/A |
| small-batch-down-m8-per-tensor | 8 | 7168 | 2048 | per_tensor | 0.0080 | **0.0234<br>&#x1F7E2;&nbsp;2.925x** | **0.1459<br>&#x1F7E2;&nbsp;18.238x** | **0.0078<br>&#x1F534;&nbsp;0.975x** |
| gemv-down-m1-per-tensor | 1 | 7168 | 2048 | per_tensor | 0.0093 | **0.0230<br>&#x1F7E2;&nbsp;2.473x** | **0.1151<br>&#x1F7E2;&nbsp;12.376x** | **0.0099<br>&#x1F7E2;&nbsp;1.065x** |
| gemv-down-m1-block128 | 1 | 7168 | 2048 | block128 | 0.0108 | **0.0369<br>&#x1F7E2;&nbsp;3.417x** | **0.1515<br>&#x1F7E2;&nbsp;14.028x** | N/A |
| ds-v3-decode-gate-up-per-tensor-bias | 128 | 2112 | 7168 | per_tensor | 0.0137 | **0.0970<br>&#x1F7E2;&nbsp;7.080x** | **0.2044<br>&#x1F7E2;&nbsp;14.920x** | N/A |
| geometric mean |  |  |  |  | 0.0453 | **0.1465<br>&#x1F7E2;&nbsp;3.234x** | | |

## Result And Limitations

**improvement without SOTA**

- Every workload improves, by 1.90x to 7.82x, and the fifteen-row geometric mean by 3.23x.
- Fourteen of fifteen rows beat the strongest comparator that both runs and agrees with the reference. The exception is `small-batch-down-m8-per-tensor` at 0.975x against DeepGEMM.
- The `flashinfer-fp8-blockscale-sm90` comparator is dropped. It was the only comparator on this op with no `assert_matches_reference`, and `fp8_blockscale_gemm_sm90` disagrees with the reference on every block128 row: 36% to 91% of elements outside 5% relative, deterministic across runs, for both weight-scale granularities its own docstring states (`(N, K//128)` and `(N//128, K//128)`) and with its own `per_token_cast_to_fp8` / `per_block_cast_to_fp8` producing the inputs. Both granularities also time the same (8.38 vs 8.48 us on `128x7168x2048`), so it is not a cheaper kernel being credited — it is the same kernel returning wrong numbers. Against it the eight block128 rows read 0.61x to 0.88x, which is what the previous revision of this PR reported; those figures are withdrawn.
- The block128 mode costs 1.5x the per-tensor mode on the same kernel, and that is measured, not a tuning miss. Folding a K-step's partial in is two FP32 operations per accumulator element against `2 * block_k` FP8 tensor-core operations, which prices at 52% of the WGMMA time, and none of it overlaps: on `4096 x 4096 x 7168` the same kernel runs 180 us per-tensor and 273 us block128, and the isolated costs are +16 us for the extra accumulate, +26 us for the row scale (FP32 peak for one operation per element on that shape is 31 us) and +44 us for the column scale. Five structures were measured against it — software-pipelined partials with `wait_wgmma(1)`, the same with explicit accumulator fences, a one-consumer 64-row tile aimed at two CTAs per SM, a lowered `setmaxnreg` request for the same purpose, and register-hoisted scale vectors. ptxas names why the first two fail: `wgmma.mma_async instructions are serialized due to non wgmma instructions reading accumulator registers of a wgmma between start and end of the pipeline stage`. Two CTAs per SM is out of reach because ptxas's static register count (168 for `block_n = 128`) times 384 threads already fills the file, and `setmaxnreg` only redistributes inside that. Wider tiles spill: `block_n = 192` needs 192 accumulator registers plus 192 for the partial and measured 1.8x slower. Only the last of the five shipped, and it is worth 3%.
- The split-K path serves only shapes whose sliced grid still fits one wave and whose slices keep at least 12 K-tiles. On this manifest that is the decode gate-up shape alone, where it is worth 1.8x on the block128 row.
- The two FP8 warp-specialized builders share their mainloop through module-level `@T.macro`s. The refactor costs +183 lines against writing each body out four times; the generated CUDA is byte-identical across all eight (scale mode x bias) builds except for one always-true row guard the shared epilogue adds to the top consumer.
- FlashInfer's per-tensor FP8 entry does not run here: its low-latency GEMM requires sm100+. DeepGEMM requires `n` and `k` divisible by 128, so it does not run on the `n = 2112` rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
