### PR TITLE
[Perf][foundry][Gemm] Keep the streamed B tile out of L2, and cap the coop2 ring at four stages

### DIFF
--- a/src/tileops/kernels/gemm/dense.py
+++ b/src/tileops/kernels/gemm/dense.py
@@ -53,6 +53,16 @@ def _tma_misalignment(
     )
 
 
+def _b_eviction(m: int, block_m: int) -> Optional[str]:
+    """``"evict_first"`` for a ``B`` tile the grid reads at most twice, else ``None``.
+
+    Each of the ``ceil(m / block_m)`` M-tiles reads the whole of ``B``. At one or two of
+    them ``B`` is streamed and the L2 it would hold belongs to ``A``, which every N-tile
+    re-reads; above two ``B`` is itself the reused operand.
+    """
+    return "evict_first" if -(-m // block_m) <= 2 else None
+
+
 __all__ = [
     "GemmFp8BlockScaledKernel",
     "GemmFp8EpilogueKernel",
@@ -492,6 +502,7 @@ def _gemm_kernel(
         # reconcile them with the logical (M,K) x (K,N) contraction.
         a_tile = (block_k, block_m) if trans_a else (block_m, block_k)
         b_tile = (block_n, block_k) if trans_b else (block_k, block_n)
+        b_evict = _b_eviction(m, block_m)
         grid_size = -(-n // block_n) * -(-m // block_m)
         tma_epilogue = (n * 2) % 16 == 0 and grid_size > sm_count
 
@@ -574,12 +585,14 @@ def _gemm_kernel(
                                         b[n_start : n_start + block_n, k_start : k_start + block_k],
                                         b_smem[slot, :, :],
                                         barrier=ab_full[slot],
+                                        eviction_policy=b_evict,
                                     )
                                 else:
                                     T.tma_copy(
                                         b[k_start : k_start + block_k, n_start : n_start + block_n],
                                         b_smem[slot, :, :],
                                         barrier=ab_full[slot],
+                                        eviction_policy=b_evict,
                                     )
                             with trace.range("arrive", lane="barrier"):
                                 T.barrier_arrive(ab_full[slot])
@@ -687,6 +700,7 @@ def _gemm_splitk_kernel(
         k_slice = k_iters // split_k
         a_tile = (block_k, block_m) if trans_a else (block_m, block_k)
         b_tile = (block_n, block_k) if trans_b else (block_k, block_n)
+        b_evict = _b_eviction(m, block_m)
 
         @T.prim_func
         def _gemm_splitk_main(
@@ -743,12 +757,14 @@ def _gemm_splitk_kernel(
                                 b[n_start : n_start + block_n, k_start : k_start + block_k],
                                 b_smem[slot, :, :],
                                 barrier=ab_full[slot],
+                                eviction_policy=b_evict,
                             )
                         else:
                             T.tma_copy(
                                 b[k_start : k_start + block_k, n_start : n_start + block_n],
                                 b_smem[slot, :, :],
                                 barrier=ab_full[slot],
+                                eviction_policy=b_evict,
                             )
                         T.barrier_arrive(ab_full[slot])
                 else:
@@ -894,6 +910,7 @@ def _gemm_coop2_kernel(
         stage_n: int = 0,
     ) -> Callable:
         half_m = block_m // 2
+        b_evict = _b_eviction(m, block_m)
         nr = (half_m * block_n) // 128
         sn = block_n if stage_n <= 0 else stage_n
         n_chunks = block_n // sn
@@ -978,6 +995,7 @@ def _gemm_coop2_kernel(
                                     b[n_start : n_start + block_n, ks : ks + block_k],
                                     b_smem[slot, :, :],
                                     barrier=ab_full[slot],
+                                    eviction_policy=b_evict,
                                 )
                                 T.barrier_arrive(ab_full[slot])
                                 gi_prod = gi_prod + 1
@@ -1122,6 +1140,7 @@ def _gemm_coop2_splitk_kernel(
         block_n: int = 64, block_k: int = 128, num_stages: int = 4, split_k: int = 4
     ) -> Callable:
         half_m = block_m // 2
+        b_evict = _b_eviction(m, block_m)
         nr = (half_m * block_n) // 128
         k_iters_total = T.ceildiv(k, block_k)
         if k_iters_total % split_k != 0:
@@ -1185,6 +1204,7 @@ def _gemm_coop2_splitk_kernel(
                             b[n_start : n_start + block_n, ks : ks + block_k],
                             b_smem[slot, :, :],
                             barrier=ab_full[slot],
+                            eviction_policy=b_evict,
                         )
                         T.barrier_arrive(ab_full[slot])
                 elif tx < 256:
@@ -1325,6 +1345,8 @@ def _gemm_simple_kernel(
             if panel_size > 0:
                 raise ValueError("cluster_m > 1 requires panel_size == 0")
         b_tile = (block_n, block_k) if trans_b else (block_k, block_n)
+        # A cluster multicasts one B tile to all cluster_m of its M-tiles.
+        b_evict = _b_eviction(m, block_m * cluster_m)
 
         def _launch():
             if cluster_m > 1:
@@ -1348,9 +1370,9 @@ def _gemm_simple_kernel(
                 for ki in T.Pipelined(k // block_k, num_stages=num_stages):
                     T.copy(a[by * block_m, ki * block_k], a_smem)
                     if trans_b:
-                        T.copy(b[bx * block_n, ki * block_k], b_smem)
+                        T.copy(b[bx * block_n, ki * block_k], b_smem, eviction_policy=b_evict)
                     else:
-                        T.copy(b[ki * block_k, bx * block_n], b_smem)
+                        T.copy(b[ki * block_k, bx * block_n], b_smem, eviction_policy=b_evict)
                     T.gemm(a_smem, b_smem, c_local, transpose_B=trans_b)
                 T.copy(c_local, c[by * block_m, bx * block_n])
 
@@ -1400,6 +1422,7 @@ def _gemm_swap_ab_kernel(
     @tilelang.jit(out_idx=[-1], compile_flags=["-O3", "-DENABLE_BF16"])
     def _gemm_swap_ab_func(block_nn: int = 64, block_k: int = 128, num_stages: int = 4) -> Callable:
         mpad = SWAP_AB_MPAD
+        b_evict = "evict_first"  # one N range per CTA, so B is read once
 
         @T.prim_func
         def _gemm_swap_ab_main(
@@ -1415,7 +1438,7 @@ def _gemm_swap_ab_kernel(
                 ct_smem = T.alloc_shared((block_nn, mpad), dtype)
                 T.clear(ct_local)
                 for ki in T.Pipelined(T.ceildiv(k, block_k), num_stages=num_stages):
-                    T.copy(b[bx * block_nn, ki * block_k], b_smem)
+                    T.copy(b[bx * block_nn, ki * block_k], b_smem, eviction_policy=b_evict)
                     T.copy(a[0, ki * block_k], a_smem)
                     T.gemm(b_smem, a_smem, ct_local, transpose_B=True)
                 T.copy(ct_local, ct_cast)
@@ -1478,6 +1501,7 @@ def _gemm_coop2s_kernel(
                 f"m={m} % {block_m}, n={n} % {block_n}, k={k} % {block_k}"
             )
         half_m = block_m // 2
+        b_evict = _b_eviction(m, block_m)
         nr = (half_m * block_n) // 128
         k_iters = k // block_k
 
@@ -1538,6 +1562,7 @@ def _gemm_coop2s_kernel(
                             b[ks : ks + block_k, n_start : n_start + block_n],
                             b_smem[slot, :, :],
                             barrier=ab_full[slot],
+                            eviction_policy=b_evict,
                         )
                         T.barrier_arrive(ab_full[slot])
                 elif tx < 256:
@@ -1760,14 +1785,14 @@ class GemmKernel(Kernel):
         (1024, 1024, 1024, False, False, "float16"): {
             "coop2s": True,
             "block_n": 64,
-            "block_k": 128,
-            "num_stages": 4,
+            "block_k": 64,
+            "num_stages": 6,
         },
         (1024, 1024, 1024, False, False, "bfloat16"): {
             "coop2s": True,
             "block_n": 64,
-            "block_k": 128,
-            "num_stages": 4,
+            "block_k": 64,
+            "num_stages": 6,
         },
         (128, 7168, 2048, False, True, "bfloat16"): {
             "simple": True,
@@ -1787,54 +1812,6 @@ class GemmKernel(Kernel):
             "num_stages": 4,
             "threads": 128,
             "panel_size": 8,
-        },
-        (4096, 2112, 7168, False, True, "bfloat16"): {
-            "coop2": True,
-            "block_n": 192,
-            "block_k": 64,
-            "num_stages": 5,
-            "group_size_m": 16,
-            "stage_n": 96,
-        },
-        (4096, 4096, 7168, False, True, "float16"): {
-            "coop2": True,
-            "block_n": 256,
-            "block_k": 64,
-            "num_stages": 3,
-            "group_size_m": 16,
-            "stage_n": 0,
-        },
-        (4096, 4096, 7168, False, True, "bfloat16"): {
-            "coop2": True,
-            "block_n": 256,
-            "block_k": 64,
-            "num_stages": 3,
-            "group_size_m": 16,
-            "stage_n": 0,
-        },
-        (4096, 7168, 2048, False, True, "bfloat16"): {
-            "coop2": True,
-            "block_n": 256,
-            "block_k": 64,
-            "num_stages": 4,
-            "group_size_m": 16,
-            "stage_n": 128,
-        },
-        (4096, 7168, 16384, False, True, "bfloat16"): {
-            "coop2": True,
-            "block_n": 256,
-            "block_k": 64,
-            "num_stages": 3,
-            "group_size_m": 16,
-            "stage_n": 0,
-        },
-        (4096, 24576, 1536, False, True, "bfloat16"): {
-            "coop2": True,
-            "block_n": 256,
-            "block_k": 64,
-            "num_stages": 3,
-            "group_size_m": 16,
-            "stage_n": 0,
         },
     }
 
@@ -2009,6 +1986,7 @@ def _gemm_small_batch_kernel(m: int, n: int, k: int, dtype: str = "float16") -> 
     ) -> Callable:
         tile_k = 128 // (str2dtype[dtype].itemsize * 8)
         block_k = reduce_threads * tile_k
+        b_evict = "evict_first"  # one N range per CTA, so B is read once
 
         @T.prim_func
         def _gemm_small_batch_main(
@@ -2025,7 +2003,12 @@ def _gemm_small_batch_kernel(m: int, n: int, k: int, dtype: str = "float16") -> 
                 a_local = T.alloc_local((m, tile_k), dtype)
 
                 for bk in T.Pipelined(T.ceildiv(k, block_k), num_stages=num_stages):
-                    T.copy(b[bn * block_n, bk * block_k], b_shared, disable_tma=True)
+                    T.copy(
+                        b[bn * block_n, bk * block_k],
+                        b_shared,
+                        disable_tma=True,
+                        eviction_policy=b_evict,
+                    )
                     for mi in T.serial(m):
                         for _k in T.vectorized(tile_k):
                             a_local[mi, _k] = a[mi, bk * block_k + tk * tile_k + _k]

--- a/src/tileops/kernels/gemm/heuristics.py
+++ b/src/tileops/kernels/gemm/heuristics.py
@@ -57,7 +57,7 @@ TINY_M_BLOCK_N = 128
 _SWAP_AB_BLOCK_NN = 64
 SWAP_AB_MPAD = 8
 
-_NS_CAP = {"basic": 4, "splitk": 4, "coop2": 6, "coop2_splitk": 4}
+_NS_CAP = {"basic": 4, "splitk": 4, "coop2": 4, "coop2_splitk": 4}
 
 
 @dataclass(frozen=True)
@@ -161,8 +161,8 @@ def _ns_basic(bm: int, bn: int, bk: int) -> int:
 
 
 def _coop2_ns_sn(bn: int, bk: int):
-    """Deepest ring the SMEM budget allows; shrink the epilogue staging
-    chunk (stage_n) when that buys another pipeline stage."""
+    """Deepest ring under ``_NS_CAP`` the SMEM budget allows; shrink the epilogue
+    staging chunk (stage_n) when that buys another pipeline stage."""
     ring = (128 + bn) * bk * 2
     best = None
     for sn in (bn, bn // 2, bn // 4):

--- a/tests/ops/test_gemm.py
+++ b/tests/ops/test_gemm.py
@@ -3,7 +3,7 @@ import torch
 
 from tests.test_base import FixtureBase, TestBase
 from tileops.kernels.gemm import GemmKernel, SmallBatchGemmKernel
-from tileops.kernels.gemm.dense import GemmFp8BlockScaledKernel
+from tileops.kernels.gemm.dense import GemmFp8BlockScaledKernel, _b_eviction
 from tileops.kernels.gemm.heuristics import best_config
 from tileops.ops import GemmFp8FwdOp, GemmFwdOp, GemmW4A16FwdOp
 from workloads.gemm import GemmFp8Workload, GemmW4A16Workload, GemmWorkload, quantize_weight_int4
@@ -793,6 +793,44 @@ def test_gemm_refuses_non_matrix_operands_before_building_anything() -> None:
         op(a, a)
     assert (op.m, op.n, op.k) == (None, None, None)
     assert not op.built_kernels("gemm_kernel")
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("num_stages, stage_n", [(3, 0), (4, 128)])
+def test_coop2_epilogue_chunking_matches_reference(num_stages: int, stage_n: int) -> None:
+    """Shape coverage: the coop2 epilogue staged in one SMEM chunk and in two.
+
+    ``stage_n`` cuts a ``block_n``-wide output tile into ``block_n / stage_n`` chunks.
+    """
+    m, n, k = 1536, 3072, 256
+    test = GemmTest(m, n, k, torch.bfloat16, False, True)
+    a, b = test.gen_inputs()
+    kernel = GemmKernel(
+        m,
+        n,
+        k,
+        torch.bfloat16,
+        trans_a=False,
+        trans_b=True,
+        config={
+            "coop2": True,
+            "block_n": 256,
+            "block_k": 64,
+            "num_stages": num_stages,
+            "group_size_m": 16,
+            "stage_n": stage_n,
+        },
+    )
+    torch.testing.assert_close(kernel.forward(a, b), torch.matmul(a, b.T), atol=1.6e-2, rtol=1.6e-2)
+
+
+@pytest.mark.smoke
+def test_b_tile_eviction_hint_follows_the_m_tile_count() -> None:
+    """Dispatch branch: the streaming-B hint is on at one or two M-tiles, off above."""
+    assert _b_eviction(64, 64) == "evict_first"
+    assert _b_eviction(128, 64) == "evict_first"
+    assert _b_eviction(129, 64) is None
+    assert _b_eviction(4096, 128) is None
 
 
 @pytest.mark.smoke


### PR DESCRIPTION
## Summary

- The `B` tile is loaded `evict_first` where the launch grid reads it at most twice; `_b_eviction(m, block_m)` is that rule and every builder that streams `B` passes it.
- A cluster multicasts one `B` tile to all its M-tiles, so `cluster_m` divides the count.
- `_NS_CAP["coop2"]` drops from 6 to 4: at `block_n=192` a fifth stage costs 5%.
- Six `_TUNED_CONFIGS` pins are deleted; `best_config` reproduces or beats each.
- The two `1024x1024x1024` NN pins move to `block_k=64`, `num_stages=6`.
- Unchanged: every kernel's structure, the op, the manifest, the workloads.
- Test-node delta: +3 (60 to 63) — the eviction boundary, and the coop2 epilogue staged in one SMEM chunk and in two, which no fixture case reached.

## TileFoundry Description

`*_unsplit` is one contraction with no mesh: the reference the kernel is checked against, and the roofline every measured number here is read against. `*_tiled` is the placement the shipped kernel implements -- one CTA per output tile, both operands staged in `smem` one k-block at a time, the accumulator in `rmem`.

```python
"""GemmFwdOp as HIR, at the src/tileops/manifest/gemm.yaml workloads that lose to cuBLAS."""

from tilefoundry import func, module
from tilefoundry.dsl import ConstTensor, Mesh, Tensor, Topology, tf, tile
from tilefoundry.target import CudaTarget

H200 = CudaTarget("nvidia.h200_sxm")
CTA1 = Topology("cta", 1)

BM, BK = 128, 64  # the shipped kernel's output-tile rows and k-block


def unsplit(m: int, n: int, k: int, dt: str):
    """``d = a @ bᵀ`` as one call: every operand read once, the result written once."""

    @module(entry="gemm", target=H200, topologies=(CTA1,))
    class Unsplit:
        @func
        def gemm(a: Tensor[(m, k), dt], b: ConstTensor[(n, k), dt]):
            return tf.matmul(a, b, b_layout="NK")

    return Unsplit


def tiled(m: int, n: int, k: int, dt: str, bn: int):
    """One CTA per ``(BM, bn)`` output tile, k-block by k-block through ``smem``."""
    mt, nt = -(-m // BM), -(-n // bn)

    @module(entry="gemm", target=H200, topologies=(Topology("cta", mt * nt),))
    class Tiled:
        @func
        def gemm(a: Tensor[(m, k), dt], b: ConstTensor[(n, k), dt]):
            with Mesh(("cta",), layout=(mt, nt), names=("m", "n")) as cta:
                acc = tf.zeros(Tensor[(m @ cta.m, n @ cta.n), "f32", "rmem"])
                for t in tile(k, BK):
                    sa = tf.reshard(a[:, t], (m @ cta.m, BK), "smem")
                    sb = tf.reshard(b[:, t], (n @ cta.n, BK), "smem")
                    step = tf.matmul(sa, sb, b_layout="NK")
                    held = tf.reshard(step, (m @ cta.m, n @ cta.n), "rmem")
                    acc = acc + tf.cast(held, dtype="f32")
                return tf.reshard(tf.cast(acc, dtype=dt), (m, n), "gmem")

    return Tiled


# label -> (m, n, k, dtype, the shipped kernel's block_n at that workload)
WORKLOADS = {
    "prefill_gate_up": (4096, 2112, 7168, "bf16", 192),
    "prefill_down": (4096, 7168, 2048, "bf16", 256),
    "prefill_attn_proj": (4096, 4096, 7168, "bf16", 256),
    "k_dominant": (4096, 7168, 16384, "bf16", 256),
    "wide_n": (4096, 24576, 1536, "bf16", 256),
    "decode_down": (128, 7168, 2048, "bf16", 128),
    "decode_gate_up": (128, 2112, 7168, "bf16", 64),
    "mid_m64_down": (64, 7168, 2048, "bf16", 64),
}

for _label, (_m, _n, _k, _dt, _bn) in WORKLOADS.items():
    _u = unsplit(_m, _n, _k, _dt)
    _u.__name__ = _u.__qualname__ = f"{_label}_unsplit"
    globals()[_u.__name__] = _u
    _t = tiled(_m, _n, _k, _dt, _bn)
    _t.__name__ = _t.__qualname__ = f"{_label}_tiled"
    globals()[_t.__name__] = _t
```

`check` against `torch.matmul` at the op's own BF16 tolerance (`rtol = atol = 1.6e-2`, `benchmarks/baselines._TOLERANCES`), on `64x7168x2048`:

```text
gemm_fwd.py:mid_m64_down_unsplit
  reference: expected.pt
  output   bf16[64,7168]   ref_norm 30733.7
    allclose(atol=0.016 rtol=0.016)    max_violation 0            PASS
```

`analyze --compute-cost --memory --roofline`:

| workload | gmem read / write (B) | ideal-ns unsplit | ideal-ns tiled | per-CTA read / write (B) | bound-by |
| --- | ---: | ---: | ---: | ---: | --- |
| `prefill_gate_up` | 88997888 / 17301504 | 125334 | 154264 | 4587520 / 49152 | compute |
| `prefill_down` | 46137344 / 58720256 | 121536 | 149611 | 1572864 / 65536 | compute |
| `prefill_attn_proj` | 117440512 / 33554432 | 243071 | 299179 | 5505024 / 65536 | compute |
| `k_dominant` | 369098752 / 58720256 | 972282 | 1196676 | 12582912 / 65536 | compute |
| `wide_n` | 88080384 / 201326592 | 312520 | 384738 | 1179648 / 65536 | compute |
| `decode_down` | 29884416 / 1835008 | 6609 | 6609 | 1048576 / 32768 | memory |
| `decode_gate_up` | 32112640 / 540672 | 6803 | 6803 | 2752512 / 16384 | memory |
| `mid_m64_down` | 29622272 / 917504 | 6363 | 6363 | 524288 / 8192 | memory |

Three things this HIR does and does not say:

- Unique gmem traffic is the same under both placements: the access relation counts each coordinate once, so the tiling's operand re-reads are priced as the per-CTA projection, not as extra DRAM traffic.
- `*_tiled`'s `ideal-ns` is 23% above `*_unsplit`'s on every compute-bound row. HIR has no accumulating matmul, so a k-blocked placement prices the accumulation as separate f32 work that a WGMMA does inside the tensor core, and rounding each partial product to BF16 also puts it 0.3 absolute off `torch.matmul`. The unsplit row is the bound; the tiled row is a traffic ledger, not a reference.
- Ring depth (`num_stages`) and epilogue chunk width (`stage_n`), the two knobs this PR changes, are schedule choices inside one placement. HIR states neither, so every number below is measured, not analyzed.

## Performance

Operator: `GemmFwdOp`

| Environment | Value |
| --- | --- |
| image | `ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-afcebed1-tilefoundry-latest` |
| digest | `sha256:ca13df9bda340edf248b8b443b88880f36e3190ab9d470f52d66ccc21c15fd59` |
| gpu | `NVIDIA H200` |
| driver | `595.71.05` |
| cuda | `13.2` |
| torch | `2.13.0+cu132` |
| tilelang | `0.1.11+cu132.gitafcebed1` |
| tilefoundry | `0.1.dev146+g2bec6420e` |
| timer | `CUPTI device_busy_ms` |

Method: `benchmarks/ops/bench_gemm.py`, whose `bench_kernel` clears L2 before every iteration. Four runs on one idle H200, alternating incumbent and branch; every figure below is the per-row median of two runs of each. Alternation is not decoration: on a single pass the second arm reads 1-8% slow on the longest rows.

Ratio in every comparator column is comparator / candidate on `device_busy_ms`. &#x1F7E2; > 1 means the candidate is faster; &#x1F534; <= 1 means it is not.

| Workload | m x n x k | Dtype | candidate (ms) | incumbent<br>/ ratio | torch-cublas<br>/ ratio | cublaslt-best<br>/ ratio | deepgemm<br>/ ratio | flaggems<br>/ ratio |
| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| square-1k-nn | 1024x1024x1024 | FP16 | 0.006200 | **0.006300<br>&#x1F7E2;&nbsp;1.016129x** | 0.006200<br>&#x1F534;&nbsp;1.000000x | 0.006100<br>&#x1F534;&nbsp;0.983871x | - | **0.009950<br>&#x1F7E2;&nbsp;1.604839x** |
| square-1k-nn | 1024x1024x1024 | BF16 | 0.006200 | **0.006300<br>&#x1F7E2;&nbsp;1.016129x** | 0.006100<br>&#x1F534;&nbsp;0.983871x | 0.006000<br>&#x1F534;&nbsp;0.967742x | - | **0.009850<br>&#x1F7E2;&nbsp;1.588710x** |
| ds-v3-decode-gate-up | 128x2112x7168 | BF16 | 0.014500 | **0.016000<br>&#x1F7E2;&nbsp;1.103448x** | **0.016300<br>&#x1F7E2;&nbsp;1.124138x** | **0.016300<br>&#x1F7E2;&nbsp;1.124138x** | **0.018800<br>&#x1F7E2;&nbsp;1.296552x** | - |
| ds-v3-decode-down | 128x7168x2048 | BF16 | 0.012500 | **0.013650<br>&#x1F7E2;&nbsp;1.092000x** | **0.012650<br>&#x1F7E2;&nbsp;1.012000x** | **0.012600<br>&#x1F7E2;&nbsp;1.008000x** | **0.013100<br>&#x1F7E2;&nbsp;1.048000x** | - |
| ds-v3-prefill-gate-up | 4096x2112x7168 | BF16 | 0.178700 | **0.186700<br>&#x1F7E2;&nbsp;1.044768x** | 0.157800<br>&#x1F534;&nbsp;0.883044x | 0.157500<br>&#x1F534;&nbsp;0.881365x | 0.162400<br>&#x1F534;&nbsp;0.908786x | - |
| ds-v3-prefill-down | 4096x7168x2048 | BF16 | 0.160350 | 0.160300<br>&#x1F534;&nbsp;0.999688x | 0.157800<br>&#x1F534;&nbsp;0.984097x | 0.150300<br>&#x1F534;&nbsp;0.937325x | 0.157000<br>&#x1F534;&nbsp;0.979108x | - |
| ds-v3-prefill-attn-proj | 4096x4096x7168 | FP16 | 0.316150 | **0.324150<br>&#x1F7E2;&nbsp;1.025304x** | 0.310000<br>&#x1F534;&nbsp;0.980547x | 0.310950<br>&#x1F534;&nbsp;0.983552x | - | - |
| ds-v3-prefill-attn-proj | 4096x4096x7168 | BF16 | 0.300500 | **0.309950<br>&#x1F7E2;&nbsp;1.031448x** | 0.297700<br>&#x1F534;&nbsp;0.990682x | **0.300600<br>&#x1F7E2;&nbsp;1.000333x** | **0.309750<br>&#x1F7E2;&nbsp;1.030782x** | - |
| k-dominant-7168x16384 | 4096x7168x16384 | BF16 | 1.219800 | 1.205950<br>&#x1F534;&nbsp;0.988646x | **1.242450<br>&#x1F7E2;&nbsp;1.018569x** | **1.300100<br>&#x1F7E2;&nbsp;1.065830x** | **1.304000<br>&#x1F7E2;&nbsp;1.069028x** | - |
| wide-n-24576 | 4096x24576x1536 | BF16 | 0.420200 | **0.424200<br>&#x1F7E2;&nbsp;1.009519x** | 0.416000<br>&#x1F534;&nbsp;0.990005x | 0.379600<br>&#x1F534;&nbsp;0.903379x | 0.415650<br>&#x1F534;&nbsp;0.989172x | - |
| mid-m16-attn | 16x4096x7168 | BF16 | 0.020250 | **0.022900<br>&#x1F7E2;&nbsp;1.130864x** | **0.023500<br>&#x1F7E2;&nbsp;1.160494x** | **0.023200<br>&#x1F7E2;&nbsp;1.145679x** | **0.032550<br>&#x1F7E2;&nbsp;1.607407x** | - |
| mid-m32-attn | 32x4096x7168 | BF16 | 0.020500 | **0.023300<br>&#x1F7E2;&nbsp;1.136585x** | **0.023450<br>&#x1F7E2;&nbsp;1.143902x** | **0.023500<br>&#x1F7E2;&nbsp;1.146341x** | **0.027950<br>&#x1F7E2;&nbsp;1.363415x** | - |
| mid-m64-down | 64x7168x2048 | BF16 | 0.011400 | **0.012650<br>&#x1F7E2;&nbsp;1.109649x** | **0.012800<br>&#x1F7E2;&nbsp;1.122807x** | **0.012300<br>&#x1F7E2;&nbsp;1.078947x** | **0.012850<br>&#x1F7E2;&nbsp;1.127193x** | - |
| mid-m96-gate-up | 96x2112x7168 | BF16 | 0.014600 | **0.015500<br>&#x1F7E2;&nbsp;1.061644x** | **0.015900<br>&#x1F7E2;&nbsp;1.089041x** | **0.015900<br>&#x1F7E2;&nbsp;1.089041x** | **0.021200<br>&#x1F7E2;&nbsp;1.452055x** | - |
| ds-v3-decode-gate-up-b1 | 1x2112x7168 | BF16 | 0.011400 | 0.011350<br>&#x1F534;&nbsp;0.995614x | **0.014800<br>&#x1F7E2;&nbsp;1.298246x** | **0.014100<br>&#x1F7E2;&nbsp;1.236842x** | **0.030950<br>&#x1F7E2;&nbsp;2.714912x** | - |
| ds-v3-decode-gate-up-b2 | 2x2112x7168 | BF16 | 0.014450 | 0.014450<br>&#x1F534;&nbsp;1.000000x | **0.014800<br>&#x1F7E2;&nbsp;1.024221x** | 0.014100<br>&#x1F534;&nbsp;0.975779x | **0.030550<br>&#x1F7E2;&nbsp;2.114187x** | - |

## Result And Limitations

**improvement without SOTA**

Nine of sixteen workloads improve, by 1.6% to 13.7%, and the rest are flat. Three rows cross the baseline tag: `ds-v3-decode-down` 0.927x to 1.012x, `mid-m64-down` 0.992x to 1.123x, `ds-v3-decode-gate-up-b2` 1.013x to 1.024x.

Six rows still sit under `torch-cublas`, and they are not one story:

- `ds-v3-prefill-gate-up` 0.883x is the one real gap. Its `n = 2112` admits no tile that both keeps operand traffic down and fills the grid: `block_n=192` leaves 352 tiles over 132 SMs, 2.67 waves, so 88.9% wave efficiency; `block_n=176` divides 2112 exactly but measures 339 us against 177 us, the swizzle collapses; `block_n=64` fills the grid exactly (1056 tiles, 8 waves) and measures 269.5 us, at 1.8x the operand traffic. 41 `coop2` configurations were swept.
- `square-1k-nn` 0.984x BF16, `ds-v3-prefill-down` 0.984x, `ds-v3-prefill-attn-proj` 0.981x FP16 and 0.991x BF16, `wide-n-24576` 0.990x are each within 2%. Interleaved five-repeat measurements of these shapes spread 0.4-15.7% run to run (`ds-v3-prefill-attn-proj` FP16 is the 15.7%), so a 1-2% ordering against cuBLAS is not something this instrument resolves.

What the mainloop waits on, measured with the WGMMAs removed from the `coop2` body and nothing else changed:

| workload | tile loads alone | compute floor at 989 TFLOP/s | wave eff | full kernel |
| --- | ---: | ---: | ---: | ---: |
| `ds-v3-prefill-gate-up` | 132.4 us @ 12.19 TB/s | 125.3 us | 0.889 | 178.7 us |
| `ds-v3-prefill-attn-proj` BF16 | 231.0 us @ 12.20 TB/s | 243.1 us | 0.970 | 300.5 us |
| `ds-v3-prefill-down` | 94.2 us @ 14.97 TB/s | 121.5 us | 0.970 | 160.4 us |
| `wide-n-24576` | 269.8 us @ 13.43 TB/s | 312.5 us | 0.977 | 420.2 us |

Loads and math are within 10% of each other on three of the four, so the kernel sits 1.20-1.28x above `max(loads, math)` where cuBLAS sits at 1.10-1.24x. That gap is the mainloop's, not the tiling's, and none of the attempts below closed it.

For the memory-bound rows 4.8 TB/s is not the floor to read against: a cold 29.4 MB read of `B` at the kernel's own tile shape measures 11.5 us (2.55 TB/s) and a 58.7 MB read 20.3 us (2.89 TB/s). `ds-v3-decode-down` now runs 12.50 us against that 11.5 us floor plus 2.3 MB of `A` and `C`.

Five structural attempts were measured and rejected; none is in the diff:

| attempt | shape | incumbent | attempt | verdict |
| --- | --- | ---: | ---: | --- |
| TMA multicast of `B` over a 2-CTA cluster | 4096x2112x7168 | 178.8 us | 181.0 us | no gain |
| the same over a 4-CTA cluster | 4096x2112x7168 | 178.8 us | 230.7 us | worse |
| two WGMMA groups in flight (`wait_wgmma(2)`) | 4096x2112x7168 | 177.0 us | 228.7 us | worse |
| accumulator stored straight to gmem, no SMEM staging | 4096x4096x7168 BF16 | 340.8 us | 385.9 us | worse |
| output tile cut along N, each consumer reading all of `A` | 4096x4096x7168 BF16 | 298.2 us | 458.4 us | worse |

The multicast result says the L2-to-SM fabric is not what the mainloop waits on: it halves the `B` fetch and changes nothing. The N-cut result is TileLang's WGMMA wanting a 64-row accumulator per warpgroup; a 128-row one falls off the fast path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
