### PR TITLE
[Perf][foundry][Pool] Read an overlapping max-pool window off shared memory, and reduce a one-output row across lanes

### DIFF
--- a/src/tileops/kernels/pool/avg_pool1d.py
+++ b/src/tileops/kernels/pool/avg_pool1d.py
@@ -1,53 +1,20 @@
 import functools
-from typing import ClassVar, NamedTuple, Optional, Tuple
+from typing import ClassVar, Optional, Tuple
 
 import tilelang
 import tilelang.language as T
 import torch
 
-from tileops.kernels.constants import STATIC_SHARED_BYTES, VECTOR_ACCESS_BYTES
+from tileops.kernels.constants import STATIC_SHARED_BYTES
 from tileops.kernels.kernel_base import Kernel
-from tileops.kernels.pool.common import dtype_itemsize, pool_output_dim
+from tileops.kernels.pool.common import (
+    WindowSpan,
+    dtype_itemsize,
+    pool_output_dim,
+    window_span,
+)
 
 __all__ = ["AvgPool1dKernel", "AvgPool1dSpatialKernel"]
-
-
-class _Span(NamedTuple):
-    """The stretch of a row one block stages, in the row's own coordinates."""
-
-    # Elements one full-width access covers.
-    vector_elems: int
-    # Elements staged in front of the block's leftmost window.
-    head: int
-    # Elements the block stages.
-    span: int
-
-    @property
-    def vectors(self) -> int:
-        """Full-width loads the staging pass issues."""
-        return self.span // self.vector_elems
-
-
-def _round_up(value: int, step: int) -> int:
-    return ((value + step - 1) // step) * step
-
-
-def _span(
-    tile_outputs: int, l_in: int, kernel_l: int, stride_l: int, pad_l: int, dtype: str
-) -> _Span:
-    """The stretch of a row a block stages to cover ``tile_outputs`` outputs.
-
-    A group of ``vector_elems`` is loaded or zeroed as one, so it has to sit wholly
-    inside the row or wholly outside it. The width is narrowed until the block step, the
-    head and the row end all divide it.
-    """
-    vector_elems = VECTOR_ACCESS_BYTES // dtype_itemsize(dtype)
-    step = tile_outputs * stride_l
-    while vector_elems > 1 and (l_in % vector_elems or step % vector_elems):
-        vector_elems //= 2
-    head = _round_up(pad_l, vector_elems)
-    reach = head + (tile_outputs - 1) * stride_l + kernel_l
-    return _Span(vector_elems, head, _round_up(reach, vector_elems))
 
 
 class _WindowStaging:
@@ -87,9 +54,16 @@ class _WindowStaging:
         self._pad_l = pad_l
         self._dtype = dtype
 
-    def _span(self, tile_outputs: int) -> _Span:
-        return _span(
-            tile_outputs, self._l_in, self._kernel_l, self._stride_l, self._pad_l, self._dtype
+    def _span(self, tile_outputs: int) -> WindowSpan:
+        return window_span(
+            tile_outputs,
+            tile_outputs * self._stride_l,
+            self._l_in,
+            self._kernel_l,
+            self._stride_l,
+            self._pad_l,
+            1,
+            self._dtype,
         )
 
     def widths(self) -> list[int]:
@@ -156,7 +130,9 @@ def _avg_pool1d_kernel(
     def _avg_pool1d_func(block_ol: int, threads: int):
         # A warp taking one output each reads one short stretch of the row `kernel_l`
         # times over. A block stages that stretch with full-width loads instead.
-        vector_elems, head, span = _span(block_ol, l_in, kernel_l, stride_l, pad_l, dtype)
+        vector_elems, head, span = window_span(
+            block_ol, block_ol * stride_l, l_in, kernel_l, stride_l, pad_l, 1, dtype
+        )
         vectors = span // vector_elems
         # The tile holds zeros outside the row, so a tap needs no test and this offset.
         base = head - pad_l

--- a/src/tileops/kernels/pool/common.py
+++ b/src/tileops/kernels/pool/common.py
@@ -1,9 +1,9 @@
 import itertools
-from typing import Any, Callable, ClassVar, Optional
+from typing import Any, Callable, ClassVar, NamedTuple, Optional
 
 import torch
 
-from tileops.kernels.constants import STATIC_SHARED_BYTES
+from tileops.kernels.constants import STATIC_SHARED_BYTES, VECTOR_ACCESS_BYTES
 from tileops.kernels.kernel_base import Kernel
 
 
@@ -23,6 +23,65 @@ def fits_static_shared(elements: int, dtype: str) -> bool:
         True when the tile fits :data:`STATIC_SHARED_BYTES`.
     """
     return elements * dtype_itemsize(dtype) <= STATIC_SHARED_BYTES
+
+
+class WindowSpan(NamedTuple):
+    """The stretch of a row one block stages, in the row's own coordinates."""
+
+    # Elements one full-width access covers.
+    vector_elems: int
+    # Elements staged in front of the block's leftmost window.
+    head: int
+    # Elements the block stages.
+    span: int
+
+    @property
+    def vectors(self) -> int:
+        """Full-width loads the staging pass issues over one row."""
+        return self.span // self.vector_elems
+
+
+def round_up(value: int, step: int) -> int:
+    return ((value + step - 1) // step) * step
+
+
+def window_span(
+    tile_outputs: int,
+    step: int,
+    l_in: int,
+    kernel_l: int,
+    stride_l: int,
+    pad_l: int,
+    dilation_l: int,
+    dtype: str,
+) -> WindowSpan:
+    """The stretch of a row a block stages to cover ``tile_outputs`` outputs.
+
+    A group of ``vector_elems`` is loaded as one, so it has to sit wholly inside the row
+    or wholly outside it. The width is narrowed until the head, the row end and *step*
+    all divide it.
+
+    Args:
+        tile_outputs: Outputs one block covers.
+        step: Elements between the origins of two consecutive blocks of one row, or 0
+            when one block covers the whole row and every origin is the same.
+        l_in: Elements one row holds.
+        kernel_l: Elements one window reaches over, before dilation.
+        stride_l: Elements between two consecutive windows.
+        pad_l: Elements the leftmost window reaches in front of the row.
+        dilation_l: Elements between two taps of one window.
+        dtype: TileLang name of the element type.
+
+    Returns:
+        The access width, the elements staged in front of the first window, and the
+        elements staged in all.
+    """
+    vector_elems = VECTOR_ACCESS_BYTES // dtype_itemsize(dtype)
+    while vector_elems > 1 and (l_in % vector_elems or step % vector_elems):
+        vector_elems //= 2
+    head = round_up(pad_l, vector_elems)
+    reach = head + (tile_outputs - 1) * stride_l + dilation_l * (kernel_l - 1) + 1
+    return WindowSpan(vector_elems, head, round_up(reach, vector_elems))
 
 
 def pool_output_dim(

--- a/src/tileops/kernels/pool/common.py
+++ b/src/tileops/kernels/pool/common.py
@@ -37,7 +37,6 @@ class WindowSpan(NamedTuple):
 
     @property
     def vectors(self) -> int:
-        """Full-width loads the staging pass issues over one row."""
         return self.span // self.vector_elems
 
 
@@ -57,9 +56,8 @@ def window_span(
 ) -> WindowSpan:
     """The stretch of a row a block stages to cover ``tile_outputs`` outputs.
 
-    A group of ``vector_elems`` is loaded as one, so it has to sit wholly inside the row
-    or wholly outside it. The width is narrowed until the head, the row end and *step*
-    all divide it.
+    A group of ``vector_elems`` is loaded as one, so the width is narrowed until the
+    head, the row end and *step* all divide it and no group straddles the row's edge.
 
     Args:
         tile_outputs: Outputs one block covers.

--- a/src/tileops/kernels/pool/max_pool1d.py
+++ b/src/tileops/kernels/pool/max_pool1d.py
@@ -1,60 +1,690 @@
 import functools
-import itertools
-from typing import Any, Callable, ClassVar, Optional, Tuple
+from typing import Any, Callable, ClassVar, NamedTuple, Optional, Tuple
 
 import tilelang
 import tilelang.language as T
 import torch
 
+from tileops.kernels.constants import STATIC_SHARED_BYTES, VECTOR_ACCESS_BYTES
 from tileops.kernels.kernel_base import Kernel
-from tileops.kernels.pool.common import fits_static_shared, pool_output_dim
+from tileops.kernels.pool.common import dtype_itemsize, pool_output_dim, window_span
 
 __all__ = ["MaxPool1dKernel", "MaxPool1dWithIndicesKernel"]
 
+_NEG_INF = float("-inf")
+_NAN = float("nan")
+_JIT_FLAGS = ["-O3", "-DENABLE_BF16"]
 
-def _window_geometry(
+# Taps one fragment of the row-reduce body may hold. Above this the fragment costs more
+# registers than the occupancy it buys back.
+_MAX_FRAGMENT_TAPS = 8192
+
+# Elements between two staged rows, past the span itself. Off a whole number of banks,
+# so two lanes reducing the same output of neighbouring rows do not serialize. Measured
+# on an H200; re-measure elsewhere.
+_STAGE_ROW_PAD = 8
+
+
+class _Plan(NamedTuple):
+    """Which body reads a shape, and the extents that body needs."""
+
+    body: str
+    # Outputs along the pooled axis.
+    out_l: int
+    # Whether every tap of every window lies inside the row.
+    always_in_bounds: bool
+    # Elements the staged tile holds in front of the row, and in all. Both zero unless
+    # the body is "staged".
+    head: int
+    span: int
+    # Full-width accesses one window takes. Zero unless the body is "rowreduce".
+    window_vectors: int
+
+
+def _plan(
     l_in: int,
     kernel_w: int,
     stride_w: int,
     pad_w: int,
     dilation_w: int,
     ceil_mode: bool,
-) -> Tuple[int, bool]:
-    """Outputs along the pooled axis, and whether every window stays in its row.
+    dtype: str,
+    with_indices: bool,
+) -> _Plan:
+    """The body that reads this shape, chosen from the window geometry alone.
 
-    The second decides whether a tap carries a bounds test, and both 1d max-pool
-    kernels read it, so the test for it has one home.
+    ``rowreduce`` takes a shape whose row yields one output. The window is then the
+    row's own reduction, and taking the taps of several rows off one fragment is what
+    keeps a block wide enough to fill the device -- one output per lane leaves a launch
+    of one thread per row. It emits no position, so it is not offered with indices.
+
+    ``staged`` takes a shape whose windows overlap, so a tap feeds more than one output.
+    The row reaches shared memory once and every tap comes off it. A block takes as many
+    rows as its lanes have outputs to reduce, so a narrow output row does not leave them
+    idle.
+
+    ``windowed`` takes the rest, where each element feeds one window and staging the row
+    would add a copy of it for nothing.
+
+    Args:
+        l_in: Elements one row holds.
+        kernel_w: Taps one window has.
+        stride_w: Elements between two consecutive windows.
+        pad_w: Elements the leftmost window reaches in front of the row.
+        dilation_w: Elements between two taps of one window.
+        ceil_mode: Whether the output extent rounds up.
+        dtype: TileLang name of the element type.
+        with_indices: Whether the kernel also emits each maximum's position.
+
+    Returns:
+        The plan the builder for the chosen body reads.
     """
     out_l = pool_output_dim(l_in, kernel_w, stride_w, pad_w, ceil_mode, dilation_w)
-    last_tap = (out_l - 1) * stride_w + dilation_w * (kernel_w - 1)
-    return out_l, pad_w == 0 and last_tap < l_in
+    reach = dilation_w * (kernel_w - 1) + 1
+    always_in_bounds = pad_w == 0 and (out_l - 1) * stride_w + reach <= l_in
+    itemsize = dtype_itemsize(dtype)
+    window_bytes = kernel_w * itemsize
+
+    if (
+        not with_indices
+        and out_l == 1
+        and always_in_bounds
+        and pad_w == 0
+        and dilation_w == 1
+        and window_bytes % VECTOR_ACCESS_BYTES == 0
+        # A fragment whose trailing extent is not a power of two has no layout.
+        and kernel_w & (kernel_w - 1) == 0
+        and kernel_w <= _MAX_FRAGMENT_TAPS
+    ):
+        return _Plan(
+            "rowreduce", out_l, always_in_bounds, 0, 0, window_bytes // VECTOR_ACCESS_BYTES
+        )
+
+    if reach > stride_w:
+        # The whole row at once, so every block's origin is the row's own start and the
+        # block step puts no constraint on the access width.
+        _, head, span = window_span(out_l, 0, l_in, kernel_w, stride_w, pad_w, dilation_w, dtype)
+        if span * itemsize <= STATIC_SHARED_BYTES:
+            return _Plan("staged", out_l, always_in_bounds, head, span, 0)
+
+    return _Plan("windowed", out_l, always_in_bounds, 0, 0, 0)
 
 
-def _stage_rows(
-    block_m: int, out_l: int, c_in: int, l_in: int, dtype: str
-) -> Optional[Tuple[int, int]]:
-    """Rows of one image a block stages, and the width of one staged row, or None.
+def _stage_rows(rows: int, out_l: int, span: int, itemsize: int, threads: int) -> Tuple[int, int]:
+    """Rows one staged tile holds, and the elements between two of them.
 
-    None means the block reads global instead, which every shape does unless its
-    outputs form whole rows of one image and those rows fit in shared memory. The
-    width exceeds `l_in` by the pad that keeps two staged rows off one bank.
+    One row per lane's worth of outputs: below that a block would leave lanes with
+    nothing to reduce, and above it the extra rows only cost residency. A tile holding
+    more than one row pads the stride between them off a whole number of banks, so two
+    lanes reducing the same output of neighbouring rows do not serialize.
+
+    ``rows`` dividing the count is what leaves the last block whole, and the shared
+    budget is the second bound.
     """
-    # A warp's width. At or below it a warp spans more than one (batch, channel)
-    # row, so neighbouring threads read global memory `l_in` elements apart.
-    max_out_l = 32
-    # Off a whole number of banks. Measured on an H200; re-measure elsewhere.
-    row_pad = 8
+    wanted = max(threads // out_l, 1)
+    count = 1
+    while count * 2 <= wanted and rows % (count * 2) == 0:
+        count *= 2
+    while count > 1:
+        stride = span + _STAGE_ROW_PAD
+        if count * stride * itemsize <= STATIC_SHARED_BYTES:
+            return count, stride
+        count //= 2
+    return 1, span
 
-    if out_l > max_out_l or block_m % out_l:
-        return None
-    rows = block_m // out_l
-    # Dividing c_in leaves no ragged last block, so the staged body needs no test.
-    if rows > c_in or c_in % rows:
-        return None
-    row_width = l_in + row_pad
-    if not fits_static_shared(rows * row_width, dtype):
-        return None
-    return rows, row_width
+
+def _block_rows(rows: int, kernel_w: int, window_vectors: int, threads: int) -> int:
+    """Rows the row-reduce body takes per block.
+
+    One lane per full-width access of a window keeps the load coalesced across the
+    block: a warp then covers whole windows rather than one element of each. The
+    fragment holds every tap of every row the block takes, so its budget is the second
+    bound, and ``rows`` dividing the count is what leaves the last block whole.
+    """
+    wanted = min(
+        max(threads // window_vectors, 1),
+        max(_MAX_FRAGMENT_TAPS // kernel_w, 1),
+    )
+    count = 1
+    while count * 2 <= wanted and rows % (count * 2) == 0:
+        count *= 2
+    return count
+
+
+class _Launch:
+    """The launch shapes worth offering for one plan.
+
+    These figures describe this kernel's access patterns, not the device, and are held
+    here so that a later kernel does not read them as general truths.
+    """
+
+    # Outputs one block covers where the body reads `block_ol`, and the block sizes
+    # each body is timed at. A body whose rate falls off either side of one thread
+    # count is given that count and not a space: the rows this kernel is measured on
+    # run in single-digit microseconds, where a candidate's own measurement is too
+    # coarse to rank the rest.
+    _BLOCK_OUTPUTS: ClassVar[int] = 256
+    _FALLBACK_THREADS: ClassVar[int] = 128
+    _CANDIDATES: ClassVar[dict] = {
+        # A wider block covers more of the flattened output, which is what keeps the
+        # ragged block at the end of a row from being most of a launch.
+        "windowed": ((256, 128), (512, 256), (1024, 256)),
+        # The staging copy is the whole cost, and it is issued fastest by a block that
+        # does not outnumber the row's full-width accesses.
+        "staged": ((256, 128),),
+        # One lane per full-width access of a window, so the block follows the window.
+        "rowreduce": ((256, 256), (256, 512)),
+    }
+    # Threads a launch needs before a candidate is offered; under this the blocks do not
+    # fill the device.
+    _MIN_LAUNCH_THREADS: ClassVar[int] = 1 << 16
+
+    def __init__(self, rows: int, kernel_w: int, itemsize: int, plan: _Plan) -> None:
+        self._rows = rows
+        self._kernel_w = kernel_w
+        self._itemsize = itemsize
+        self._plan = plan
+
+    def default(self) -> dict:
+        return {"block_ol": self._BLOCK_OUTPUTS, "threads": self._FALLBACK_THREADS}
+
+    def tuned(self) -> list[dict]:
+        candidates = [
+            {"block_ol": block_ol, "threads": threads}
+            for block_ol, threads in self._CANDIDATES[self._plan.body]
+        ]
+        return [
+            candidate
+            for candidate in candidates
+            if self._blocks(candidate) * candidate["threads"] >= self._MIN_LAUNCH_THREADS
+        ] or [self.default()]
+
+    def _blocks(self, candidate: dict) -> int:
+        if self._plan.body == "windowed":
+            total = self._rows * self._plan.out_l
+            return (total + candidate["block_ol"] - 1) // candidate["block_ol"]
+        if self._plan.body == "staged":
+            stage_rows, _ = _stage_rows(
+                self._rows,
+                self._plan.out_l,
+                self._plan.span,
+                self._itemsize,
+                candidate["threads"],
+            )
+            return self._rows // stage_rows
+        return self._rows // _block_rows(
+            self._rows, self._kernel_w, self._plan.window_vectors, candidate["threads"]
+        )
+
+
+def _windowed_scan(
+    l_in: int,
+    kernel_w: int,
+    stride_w: int,
+    pad_w: int,
+    dilation_w: int,
+    dtype: str,
+    accum_dtype: str,
+    always_in_bounds: bool,
+):
+    """The windowed body's scan over one output, reading each tap where it lies.
+
+    ``T.max`` drops NaN, so the two ways to propagate it as PyTorch does are a second
+    accumulator saying one was seen, and a select per tap that lets NaN into the value
+    and keeps it there -- a later value fails ``val > NaN``. Which is cheaper follows
+    the bounds test: where every tap is in range the flag costs one boolean or per tap
+    against the select's whole compare, and where a tap is tested anyway the select
+    rides in the test's shadow and the flag's extra register does not.
+    """
+
+    @T.macro
+    def _store(x, out, row, ol, idx):
+        max_val = T.alloc_var(T.float32)
+        max_val = T.cast(_NEG_INF, accum_dtype)
+        if always_in_bounds:
+            has_nan = T.alloc_var(T.bool)
+            has_nan = False
+            for kw in T.serial(kernel_w):
+                val = T.cast(x[row, ol * stride_w - pad_w + kw * dilation_w], accum_dtype)
+                has_nan = has_nan | T.isnan(val)
+                max_val = T.max(max_val, val)
+            out[idx] = T.cast(T.if_then_else(has_nan, T.cast(_NAN, accum_dtype), max_val), dtype)
+        else:
+            for kw in T.serial(kernel_w):
+                iw = ol * stride_w - pad_w + kw * dilation_w
+                if (iw >= 0) and (iw < l_in):
+                    val = T.cast(x[row, iw], accum_dtype)
+                    max_val = T.if_then_else(T.isnan(val) or (val > max_val), val, max_val)
+            out[idx] = T.cast(max_val, dtype)
+
+    return _store
+
+
+def _windowed_indices_scan(
+    l_in: int,
+    kernel_w: int,
+    stride_w: int,
+    pad_w: int,
+    dilation_w: int,
+    dtype: str,
+    accum_dtype: str,
+    always_in_bounds: bool,
+):
+    """The windowed body's scan over one output, with the tap that won it."""
+
+    @T.macro
+    def _store(x, out, indices, row, ol, idx):
+        max_val = T.alloc_var(T.float32)
+        max_idx = T.alloc_var(T.int32)
+        # -1 until a NaN is seen, so it is also the flag saying one was.
+        nan_idx = T.alloc_var(T.int32)
+        max_val = T.cast(_NEG_INF, accum_dtype)
+        nan_idx = -1
+        if always_in_bounds:
+            # An expression, not a variable: a variable is opaque to the range analysis,
+            # and each tap would then load under a bounds check this window's extent
+            # rules out.
+            iw0 = ol * stride_w - pad_w
+            max_idx = iw0
+        else:
+            # A variable, because each tap is bounds-tested anyway and this then stays
+            # out of all of them.
+            iw0 = T.alloc_var(T.int32)
+            iw0 = ol * stride_w - pad_w
+            # The first tap the row holds, on the dilation grid. Only padding starts a
+            # window before position 0, and that tap is the position PyTorch reports
+            # when every tap the row holds is -inf.
+            max_idx = iw0 + dilation_w * T.ceildiv(T.max(-iw0, 0), dilation_w)
+        for kw in T.serial(kernel_w):
+            iw = iw0 + kw * dilation_w
+            if always_in_bounds or ((iw >= 0) and (iw < l_in)):
+                val = T.cast(x[row, iw], accum_dtype)
+                # `max_val` is never NaN and NaN fails `>`, so the compare rejects NaN
+                # without a separate test. Strict `>` also keeps the seed against a tap
+                # equal to it, and the first maximum against a later equal one, which is
+                # what PyTorch reports.
+                take = val > max_val
+                max_val = T.if_then_else(take, val, max_val)
+                max_idx = T.if_then_else(take, iw, max_idx)
+                nan_idx = T.if_then_else(T.isnan(val), iw, nan_idx)
+
+        # PyTorch reports the last NaN a window visited.
+        out[idx] = T.cast(T.if_then_else(nan_idx >= 0, T.cast(_NAN, accum_dtype), max_val), dtype)
+        indices[idx] = T.cast(T.if_then_else(nan_idx >= 0, nan_idx, max_idx), "int64")
+
+    return _store
+
+
+def _windowed_builder(
+    rows: int,
+    l_in: int,
+    kernel_w: int,
+    stride_w: int,
+    pad_w: int,
+    dilation_w: int,
+    dtype: str,
+    accum_dtype: str,
+    out_l: int,
+    always_in_bounds: bool,
+):
+    """One output per lane, each tap read where it lies."""
+    total_output = rows * out_l
+
+    @tilelang.jit(out_idx=[1], compile_flags=_JIT_FLAGS)
+    def _build(block_ol: int, threads: int):
+        # Every lane of every block owns an output, so none of them carries a test.
+        tail_free = total_output % block_ol == 0
+        store = _windowed_scan(
+            l_in,
+            kernel_w,
+            stride_w,
+            pad_w,
+            dilation_w,
+            dtype,
+            accum_dtype,
+            always_in_bounds,
+        )
+
+        @T.prim_func
+        def _main(
+            x: T.Tensor((rows, l_in), dtype),  # type: ignore
+            out: T.Tensor((total_output,), dtype),  # type: ignore
+        ):
+            with T.Kernel(T.ceildiv(total_output, block_ol), threads=threads) as bx:
+                for i in T.Parallel(block_ol):
+                    idx = bx * block_ol + i
+                    if tail_free:
+                        store(x, out, idx // out_l, idx % out_l, idx)
+                    else:
+                        if idx < total_output:
+                            store(x, out, idx // out_l, idx % out_l, idx)
+
+        return _main
+
+    return _build
+
+
+def _windowed_indices_builder(
+    rows: int,
+    l_in: int,
+    kernel_w: int,
+    stride_w: int,
+    pad_w: int,
+    dilation_w: int,
+    dtype: str,
+    accum_dtype: str,
+    out_l: int,
+    always_in_bounds: bool,
+):
+    """The windowed body, also emitting each maximum's position."""
+    total_output = rows * out_l
+
+    @tilelang.jit(out_idx=[1, 2], compile_flags=_JIT_FLAGS)
+    def _build(block_ol: int, threads: int):
+        tail_free = total_output % block_ol == 0
+        store = _windowed_indices_scan(
+            l_in,
+            kernel_w,
+            stride_w,
+            pad_w,
+            dilation_w,
+            dtype,
+            accum_dtype,
+            always_in_bounds,
+        )
+
+        @T.prim_func
+        def _main(
+            x: T.Tensor((rows, l_in), dtype),  # type: ignore
+            out: T.Tensor((total_output,), dtype),  # type: ignore
+            indices: T.Tensor((total_output,), "int64"),  # type: ignore
+        ):
+            with T.Kernel(T.ceildiv(total_output, block_ol), threads=threads) as bx:
+                for i in T.Parallel(block_ol):
+                    idx = bx * block_ol + i
+                    if tail_free:
+                        store(x, out, indices, idx // out_l, idx % out_l, idx)
+                    else:
+                        if idx < total_output:
+                            store(x, out, indices, idx // out_l, idx % out_l, idx)
+
+        return _main
+
+    return _build
+
+
+def _stage_macro(l_in: int, head: int, staged: int, tail: int, stage_rows: int, dtype: str):
+    """The staging pass: the block's rows, with -inf outside each of them.
+
+    The head and the staged extent both divide the access width, so the copy is
+    full-width and the two fills touch only elements outside a row. A tap reading one of
+    those elements reads -inf, which is the value PyTorch pads a max-pool window with
+    and which no tap can win against.
+    """
+
+    @T.macro
+    def _stage(tile, x, row0):
+        if head:
+            for r, i in T.Parallel(stage_rows, head):
+                tile[r, i] = T.cast(_NEG_INF, dtype)
+        if tail:
+            for r, i in T.Parallel(stage_rows, tail):
+                tile[r, head + staged + i] = T.cast(_NEG_INF, dtype)
+        T.copy(x[row0 : row0 + stage_rows, 0:staged], tile[:, head : head + staged])
+
+    return _stage
+
+
+def _staged_scan(
+    kernel_w: int, stride_w: int, dilation_w: int, base: int, dtype: str, accum_dtype: str
+):
+    """The staged body's scan over one output, every tap read off the tile.
+
+    Resident taps make the scan arithmetic-bound, which wants the opposite trade to the
+    windowed body: no tap carries a bounds test, so NaN rides in a second accumulator
+    rather than costing a select per tap.
+    """
+
+    @T.macro
+    def _store(tile, out, r, row, ol):
+        max_val = T.alloc_var(T.float32)
+        has_nan = T.alloc_var(T.bool)
+        max_val = T.cast(_NEG_INF, accum_dtype)
+        has_nan = False
+        for kw in T.serial(kernel_w):
+            val = T.cast(tile[r, base + ol * stride_w + kw * dilation_w], accum_dtype)
+            has_nan = has_nan | T.isnan(val)
+            max_val = T.max(max_val, val)
+
+        out[row, ol] = T.cast(T.if_then_else(has_nan, T.cast(_NAN, accum_dtype), max_val), dtype)
+
+    return _store
+
+
+def _staged_indices_scan(
+    kernel_w: int,
+    stride_w: int,
+    pad_w: int,
+    dilation_w: int,
+    base: int,
+    dtype: str,
+    accum_dtype: str,
+):
+    """The staged body's scan over one output, with the tap that won it."""
+
+    @T.macro
+    def _store(tile, out, indices, r, row, ol):
+        max_val = T.alloc_var(T.float32)
+        max_idx = T.alloc_var(T.int32)
+        nan_idx = T.alloc_var(T.int32)
+        max_val = T.cast(_NEG_INF, accum_dtype)
+        nan_idx = -1
+        iw0 = ol * stride_w - pad_w
+        # The first tap the row holds, which is the position PyTorch reports when every
+        # tap the row holds is -inf.
+        max_idx = iw0 + dilation_w * T.ceildiv(T.max(-iw0, 0), dilation_w)
+        for kw in T.serial(kernel_w):
+            val = T.cast(tile[r, base + ol * stride_w + kw * dilation_w], accum_dtype)
+            # A padded tap is -inf in the tile, so it never wins and needs no test.
+            take = val > max_val
+            max_val = T.if_then_else(take, val, max_val)
+            max_idx = T.if_then_else(take, iw0 + kw * dilation_w, max_idx)
+            nan_idx = T.if_then_else(T.isnan(val), iw0 + kw * dilation_w, nan_idx)
+
+        out[row, ol] = T.cast(
+            T.if_then_else(nan_idx >= 0, T.cast(_NAN, accum_dtype), max_val), dtype
+        )
+        indices[row, ol] = T.cast(T.if_then_else(nan_idx >= 0, nan_idx, max_idx), "int64")
+
+    return _store
+
+
+def _staged_extents(l_in: int, head: int, span: int) -> Tuple[int, int]:
+    """Elements of a row the tile holds, and elements of -inf past them.
+
+    The span covers the last window's last tap and then the rest of that access width,
+    which is short of the row's end wherever the windows overlap without dividing it.
+    """
+    staged = min(l_in, span - head)
+    return staged, span - head - staged
+
+
+def _staged_builder(
+    rows: int,
+    l_in: int,
+    kernel_w: int,
+    stride_w: int,
+    pad_w: int,
+    dilation_w: int,
+    dtype: str,
+    accum_dtype: str,
+    out_l: int,
+    head: int,
+    span: int,
+    itemsize: int,
+):
+    """A block's rows staged in shared memory once, every tap read off them."""
+    # The tile carries the padding as -inf, so a tap needs no test and this offset.
+    base = head - pad_w
+    staged, tail = _staged_extents(l_in, head, span)
+
+    @tilelang.jit(out_idx=[1], compile_flags=_JIT_FLAGS)
+    def _build(block_ol: int, threads: int):
+        stage_rows, row_stride = _stage_rows(rows, out_l, span, itemsize, threads)
+        stage = _stage_macro(l_in, head, staged, tail, stage_rows, dtype)
+        store = _staged_scan(kernel_w, stride_w, dilation_w, base, dtype, accum_dtype)
+
+        @T.prim_func
+        def _main(
+            x: T.Tensor((rows, l_in), dtype),  # type: ignore
+            out: T.Tensor((rows, out_l), dtype),  # type: ignore
+        ):
+            with T.Kernel(rows // stage_rows, threads=threads) as bx:
+                tile = T.alloc_shared((stage_rows, row_stride), dtype)
+                row0 = bx * stage_rows
+                stage(tile, x, row0)
+                for r, ol in T.Parallel(stage_rows, out_l):
+                    store(tile, out, r, row0 + r, ol)
+
+        return _main
+
+    return _build
+
+
+def _staged_indices_builder(
+    rows: int,
+    l_in: int,
+    kernel_w: int,
+    stride_w: int,
+    pad_w: int,
+    dilation_w: int,
+    dtype: str,
+    accum_dtype: str,
+    out_l: int,
+    head: int,
+    span: int,
+    itemsize: int,
+):
+    """The staged body, also emitting each maximum's position."""
+    base = head - pad_w
+    staged, tail = _staged_extents(l_in, head, span)
+
+    @tilelang.jit(out_idx=[1, 2], compile_flags=_JIT_FLAGS)
+    def _build(block_ol: int, threads: int):
+        stage_rows, row_stride = _stage_rows(rows, out_l, span, itemsize, threads)
+        stage = _stage_macro(l_in, head, staged, tail, stage_rows, dtype)
+        store = _staged_indices_scan(
+            kernel_w, stride_w, pad_w, dilation_w, base, dtype, accum_dtype
+        )
+
+        @T.prim_func
+        def _main(
+            x: T.Tensor((rows, l_in), dtype),  # type: ignore
+            out: T.Tensor((rows, out_l), dtype),  # type: ignore
+            indices: T.Tensor((rows, out_l), "int64"),  # type: ignore
+        ):
+            with T.Kernel(rows // stage_rows, threads=threads) as bx:
+                tile = T.alloc_shared((stage_rows, row_stride), dtype)
+                row0 = bx * stage_rows
+                stage(tile, x, row0)
+                for r, ol in T.Parallel(stage_rows, out_l):
+                    store(tile, out, indices, r, row0 + r, ol)
+
+        return _main
+
+    return _build
+
+
+def _rowreduce_builder(
+    rows: int,
+    l_in: int,
+    kernel_w: int,
+    dtype: str,
+    accum_dtype: str,
+    window_vectors: int,
+):
+    """One output per row, taken off a fragment holding the taps of several rows."""
+
+    @tilelang.jit(out_idx=[1], compile_flags=_JIT_FLAGS)
+    def _build(block_ol: int, threads: int):
+        block_rows = _block_rows(rows, kernel_w, window_vectors, threads)
+
+        @T.prim_func
+        def _main(
+            x: T.Tensor((rows, l_in), dtype),  # type: ignore
+            out: T.Tensor((rows, 1), dtype),  # type: ignore
+        ):
+            with T.Kernel(rows // block_rows, threads=threads) as bx:
+                taps = T.alloc_fragment((block_rows, kernel_w), accum_dtype)
+                nans = T.alloc_fragment((block_rows, kernel_w), accum_dtype)
+                best = T.alloc_fragment((block_rows,), accum_dtype)
+                seen = T.alloc_fragment((block_rows,), accum_dtype)
+                for r, kw in T.Parallel(block_rows, kernel_w):
+                    taps[r, kw] = T.cast(x[bx * block_rows + r, kw], accum_dtype)
+                # `T.reduce_max` drops NaN, so which taps were NaN is reduced alongside
+                # the value and the two answers meet at the store.
+                for r, kw in T.Parallel(block_rows, kernel_w):
+                    nans[r, kw] = T.if_then_else(T.isnan(taps[r, kw]), 1.0, 0.0)
+                T.reduce_max(taps, best, dim=1, clear=True)
+                T.reduce_max(nans, seen, dim=1, clear=True)
+                for r in T.Parallel(block_rows):
+                    out[bx * block_rows + r, 0] = T.cast(
+                        T.if_then_else(seen[r] > 0.0, T.cast(_NAN, accum_dtype), best[r]),
+                        dtype,
+                    )
+
+        return _main
+
+    return _build
+
+
+def _build_kernel(
+    n: int,
+    c_in: int,
+    l_in: int,
+    kernel_w: int,
+    stride_w: int,
+    pad_w: int,
+    dilation_w: int,
+    ceil_mode: bool,
+    dtype: str,
+    with_indices: bool,
+):
+    """The jit builder for the body this shape's plan selects."""
+    accum_dtype = "float"
+    rows = n * c_in
+    plan = _plan(l_in, kernel_w, stride_w, pad_w, dilation_w, ceil_mode, dtype, with_indices)
+    if plan.body == "rowreduce":
+        return _rowreduce_builder(rows, l_in, kernel_w, dtype, accum_dtype, plan.window_vectors)
+    if plan.body == "staged":
+        build = _staged_indices_builder if with_indices else _staged_builder
+        return build(
+            rows,
+            l_in,
+            kernel_w,
+            stride_w,
+            pad_w,
+            dilation_w,
+            dtype,
+            accum_dtype,
+            plan.out_l,
+            plan.head,
+            plan.span,
+            dtype_itemsize(dtype),
+        )
+    build = _windowed_indices_builder if with_indices else _windowed_builder
+    return build(
+        rows,
+        l_in,
+        kernel_w,
+        stride_w,
+        pad_w,
+        dilation_w,
+        dtype,
+        accum_dtype,
+        plan.out_l,
+        plan.always_in_bounds,
+    )
 
 
 @functools.lru_cache(maxsize=32)
@@ -69,93 +699,26 @@ def _max_pool1d_kernel(
     ceil_mode: bool,
     dtype: str = "float16",
 ):
-    accum_dtype = "float"
-    out_l, always_in_bounds = _window_geometry(
-        l_in, kernel_w, stride_w, pad_w, dilation_w, ceil_mode
+    return _build_kernel(
+        n, c_in, l_in, kernel_w, stride_w, pad_w, dilation_w, ceil_mode, dtype, False
     )
-    total_output = n * c_in * out_l
 
-    @tilelang.jit(out_idx=[1], compile_flags=["-O3", "-DENABLE_BF16"])
-    def _max_pool1d_func(block_m: int, threads: int):
-        staged = _stage_rows(block_m, out_l, c_in, l_in, dtype)
 
-        @T.macro
-        def _reduce_window_global(src, src_c, src_row, ow, out, out_c, out_row):
-            """Store the max over one window, for taps that come from global.
-
-            ``src`` is indexed with a leading axis so the staged tile and ``x`` are
-            read the same way.
-
-            NaN enters ``max_val`` and never leaves: a later value fails
-            ``val > NaN``, which is how PyTorch propagates it. Spending a select per
-            tap to save the accumulator's register is the trade a scan that waits on
-            memory wants.
-            """
-            max_val = T.alloc_var(T.float32)
-            max_val = T.cast(float("-inf"), accum_dtype)
-            for kw in T.serial(kernel_w):
-                iw = ow * stride_w - pad_w + kw * dilation_w
-                if always_in_bounds or (iw >= 0 and iw < l_in):
-                    val = T.cast(src[src_c, src_row, iw], accum_dtype)
-                    max_val = T.if_then_else(T.isnan(val) or (val > max_val), val, max_val)
-
-            out[out_c, out_row, ow] = T.cast(max_val, dtype)
-
-        @T.macro
-        def _reduce_window_shared(src, src_c, src_row, ow, out, out_c, out_row):
-            """Store the max over one window, for taps that come from shared.
-
-            ``src`` is indexed with a leading axis so the staged tile and ``x`` are
-            read the same way.
-
-            Resident taps make the scan arithmetic-bound, which wants the opposite
-            trade: ``T.max`` drops NaN, so NaN rides in an accumulator instead of
-            costing a select per tap.
-            """
-            max_val = T.alloc_var(T.float32)
-            has_nan = T.alloc_var(T.bool)
-            max_val = T.cast(float("-inf"), accum_dtype)
-            has_nan = False
-            for kw in T.serial(kernel_w):
-                iw = ow * stride_w - pad_w + kw * dilation_w
-                if always_in_bounds or (iw >= 0 and iw < l_in):
-                    val = T.cast(src[src_c, src_row, iw], accum_dtype)
-                    has_nan = has_nan | T.isnan(val)
-                    max_val = T.max(max_val, val)
-
-            out[out_c, out_row, ow] = T.cast(
-                T.if_then_else(has_nan, T.cast(float("nan"), accum_dtype), max_val), dtype
-            )
-
-        @T.prim_func
-        def _max_pool1d_main(
-            x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
-            out: T.Tensor((n, c_in, out_l), dtype),  # type: ignore
-        ):
-            with T.Kernel(T.ceildiv(total_output, block_m), threads=threads) as bx:
-                if staged is None:
-                    for i in T.Parallel(block_m):
-                        out_idx = bx * block_m + i
-                        if out_idx < total_output:
-                            ow = out_idx % out_l
-                            channel_batch_idx = out_idx // out_l
-                            c_idx = channel_batch_idx % c_in
-                            batch = channel_batch_idx // c_in
-                            _reduce_window_global(x, batch, c_idx, ow, out, batch, c_idx)
-                else:
-                    stage_rows, row_width = staged
-                    tile = T.alloc_shared((1, stage_rows, row_width), dtype)
-                    batch = bx * stage_rows // c_in
-                    c_base = bx * stage_rows % c_in
-                    T.copy(x[batch, c_base : c_base + stage_rows, 0:l_in], tile[0, :, 0:l_in])
-                    for i in T.Parallel(block_m):
-                        ow = i % out_l
-                        row = i // out_l
-                        _reduce_window_shared(tile, 0, row, ow, out, batch, c_base + row)
-
-        return _max_pool1d_main
-
-    return _max_pool1d_func
+@functools.lru_cache(maxsize=32)
+def _max_pool1d_with_indices_kernel(
+    n: int,
+    c_in: int,
+    l_in: int,
+    kernel_w: int,
+    stride_w: int,
+    pad_w: int,
+    dilation_w: int,
+    ceil_mode: bool,
+    dtype: str = "float16",
+):
+    return _build_kernel(
+        n, c_in, l_in, kernel_w, stride_w, pad_w, dilation_w, ceil_mode, dtype, True
+    )
 
 
 def _launch_max_pool1d(
@@ -168,33 +731,50 @@ def _launch_max_pool1d(
     dilation_w: int,
     ceil_mode: bool,
     dtype: str,
-    block_m: int,
+    block_ol: int,
     threads: int,
     x: torch.Tensor,
 ) -> torch.Tensor:
-    return _max_pool1d_kernel(
-        n,
-        c_in,
-        l_in,
-        kernel_w,
-        stride_w,
-        pad_w,
-        dilation_w,
-        ceil_mode,
-        dtype,
-    )(block_m, threads)(x)
+    out_l = pool_output_dim(l_in, kernel_w, stride_w, pad_w, ceil_mode, dilation_w)
+    kernel = _max_pool1d_kernel(
+        n, c_in, l_in, kernel_w, stride_w, pad_w, dilation_w, ceil_mode, dtype
+    )(block_ol, threads)
+    return kernel(x.contiguous().view(n * c_in, l_in)).view(n, c_in, out_l)
+
+
+def _launch_max_pool1d_with_indices(
+    n: int,
+    c_in: int,
+    l_in: int,
+    kernel_w: int,
+    stride_w: int,
+    pad_w: int,
+    dilation_w: int,
+    ceil_mode: bool,
+    dtype: str,
+    block_ol: int,
+    threads: int,
+    x: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    out_l = pool_output_dim(l_in, kernel_w, stride_w, pad_w, ceil_mode, dilation_w)
+    kernel = _max_pool1d_with_indices_kernel(
+        n, c_in, l_in, kernel_w, stride_w, pad_w, dilation_w, ceil_mode, dtype
+    )(block_ol, threads)
+    out, indices = kernel(x.contiguous().view(n * c_in, l_in))
+    return out.view(n, c_in, out_l), indices.view(n, c_in, out_l)
 
 
 class _MaxPool1dKernelBase(Kernel):
-    """Shared construction and dispatch for the 1d max-pool kernels.
+    """Shape, launch planning and dispatch shared by the two 1d max-pool kernels.
 
-    Concrete kernels supply ``_build`` and ``_dispatch``; everything else —
-    parameter capture, output extents, config and launch — is identical
-    between the value-only and with-indices variants.
+    Concrete kernels supply ``_build``, ``_dispatch`` and ``_with_indices``; everything
+    else -- parameter capture, output extents, config and launch -- is identical between
+    the value-only and with-indices variants.
     """
 
     _build: ClassVar[Callable[..., Any]]
     _dispatch: ClassVar[Callable[..., Any]]
+    _with_indices: ClassVar[bool]
 
     supported_archs: ClassVar[list[int]] = [80, 86, 89, 90]
 
@@ -240,21 +820,26 @@ class _MaxPool1dKernelBase(Kernel):
         )
         self.init_config(config, tune)
 
+    def _launch(self) -> _Launch:
+        plan = _plan(
+            self.l_in,
+            self.kernel_w,
+            self.stride_w,
+            self.pad_w,
+            self.dilation_w,
+            self.ceil_mode,
+            self.dtype_str,
+            type(self)._with_indices,
+        )
+        return _Launch(self.n * self.c_in, self.kernel_w, dtype_itemsize(self.dtype_str), plan)
+
     @property
     def default_config(self) -> dict:
-        return {
-            "block_m": 256,
-            "threads": 256,
-        }
+        return self._launch().default()
 
     @property
     def autotune_configs(self) -> list[dict]:
-        # `block_m` counts outputs, and a row of a real workload runs into the
-        # thousands of them, so the widest block here is four per thread at 256.
-        return [
-            {"block_m": block_m, "threads": threads}
-            for block_m, threads in itertools.product([128, 256, 512, 1024], [128, 256, 512])
-        ]
+        return self._launch().tuned()
 
     def forward(self, x: torch.Tensor) -> Any:
         self._require_cuda(x=x)
@@ -268,7 +853,7 @@ class _MaxPool1dKernelBase(Kernel):
             self.dilation_w,
             self.ceil_mode,
             self.dtype_str,
-            self.config["block_m"],
+            self.config["block_ol"],
             self.config["threads"],
             x,
         )
@@ -279,132 +864,7 @@ class MaxPool1dKernel(_MaxPool1dKernelBase):
 
     _build = staticmethod(_max_pool1d_kernel)
     _dispatch = staticmethod(_launch_max_pool1d)
-
-
-@functools.lru_cache(maxsize=32)
-def _max_pool1d_with_indices_kernel(
-    n: int,
-    c_in: int,
-    l_in: int,
-    kernel_w: int,
-    stride_w: int,
-    pad_w: int,
-    dilation_w: int,
-    ceil_mode: bool,
-    dtype: str = "float16",
-):
-    accum_dtype = "float"
-    out_l, always_in_bounds = _window_geometry(
-        l_in, kernel_w, stride_w, pad_w, dilation_w, ceil_mode
-    )
-    total_output = n * c_in * out_l
-
-    @tilelang.jit(out_idx=[1, 2], compile_flags=["-O3", "-DENABLE_BF16"])
-    def _max_pool1d_with_indices_func(block_m: int, threads: int):
-        staged = _stage_rows(block_m, out_l, c_in, l_in, dtype)
-
-        @T.macro
-        def _reduce_window(src, src_c, src_row, ow, out, indices, out_c, out_row):
-            """Store the max and its index over one window of ``src[src_c, src_row]``."""
-            max_val = T.alloc_var(T.float32)
-            max_idx = T.alloc_var(T.int32)
-            # -1 until a NaN is seen, so it is also the flag saying one was.
-            nan_idx = T.alloc_var(T.int32)
-            max_val = T.cast(float("-inf"), accum_dtype)
-            nan_idx = -1
-            if always_in_bounds:
-                # An expression, not a variable: a variable is opaque to the range
-                # analysis, and each tap would load under a bounds check this
-                # window's extent rules out.
-                iw0 = ow * stride_w - pad_w
-                max_idx = iw0
-            else:
-                # A variable, because each tap is bounds-tested anyway and this
-                # then stays out of all of them.
-                iw0 = T.alloc_var(T.int32)
-                iw0 = ow * stride_w - pad_w
-                # The first tap the row holds, on the dilation grid. Only padding
-                # starts a window before position 0, and that tap is the position
-                # PyTorch reports when every tap the row holds is -inf.
-                max_idx = iw0 + dilation_w * T.ceildiv(T.max(-iw0, 0), dilation_w)
-            for kw in T.serial(kernel_w):
-                iw = iw0 + kw * dilation_w
-                if always_in_bounds or (iw >= 0 and iw < l_in):
-                    val = T.cast(src[src_c, src_row, iw], accum_dtype)
-                    # `max_val` is never NaN and NaN fails `>`, so the compare
-                    # rejects NaN without a separate test. Strict `>` also keeps
-                    # the seed against a tap equal to it, and the first maximum
-                    # against a later equal one, which is what PyTorch reports.
-                    take = val > max_val
-                    max_val = T.if_then_else(take, val, max_val)
-                    max_idx = T.if_then_else(take, iw, max_idx)
-                    nan_idx = T.if_then_else(T.isnan(val), iw, nan_idx)
-
-            # PyTorch reports the last NaN a window visited.
-            out[out_c, out_row, ow] = T.cast(
-                T.if_then_else(nan_idx >= 0, T.cast(float("nan"), accum_dtype), max_val), dtype
-            )
-            indices[out_c, out_row, ow] = T.cast(
-                T.if_then_else(nan_idx >= 0, nan_idx, max_idx), "int64"
-            )
-
-        @T.prim_func
-        def _max_pool1d_with_indices_main(
-            x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
-            out: T.Tensor((n, c_in, out_l), dtype),  # type: ignore
-            indices: T.Tensor((n, c_in, out_l), "int64"),  # type: ignore
-        ):
-            with T.Kernel(T.ceildiv(total_output, block_m), threads=threads) as bx:
-                if staged is None:
-                    for i in T.Parallel(block_m):
-                        out_idx = bx * block_m + i
-                        if out_idx < total_output:
-                            ow = out_idx % out_l
-                            channel_batch_idx = out_idx // out_l
-                            c_idx = channel_batch_idx % c_in
-                            batch = channel_batch_idx // c_in
-                            _reduce_window(x, batch, c_idx, ow, out, indices, batch, c_idx)
-                else:
-                    stage_rows, row_width = staged
-                    tile = T.alloc_shared((1, stage_rows, row_width), dtype)
-                    batch = bx * stage_rows // c_in
-                    c_base = bx * stage_rows % c_in
-                    T.copy(x[batch, c_base : c_base + stage_rows, 0:l_in], tile[0, :, 0:l_in])
-                    for i in T.Parallel(block_m):
-                        ow = i % out_l
-                        row = i // out_l
-                        _reduce_window(tile, 0, row, ow, out, indices, batch, c_base + row)
-
-        return _max_pool1d_with_indices_main
-
-    return _max_pool1d_with_indices_func
-
-
-def _launch_max_pool1d_with_indices(
-    n: int,
-    c_in: int,
-    l_in: int,
-    kernel_w: int,
-    stride_w: int,
-    pad_w: int,
-    dilation_w: int,
-    ceil_mode: bool,
-    dtype: str,
-    block_m: int,
-    threads: int,
-    x: torch.Tensor,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    return _max_pool1d_with_indices_kernel(
-        n,
-        c_in,
-        l_in,
-        kernel_w,
-        stride_w,
-        pad_w,
-        dilation_w,
-        ceil_mode,
-        dtype,
-    )(block_m, threads)(x)
+    _with_indices = False
 
 
 class MaxPool1dWithIndicesKernel(_MaxPool1dKernelBase):
@@ -412,3 +872,4 @@ class MaxPool1dWithIndicesKernel(_MaxPool1dKernelBase):
 
     _build = staticmethod(_max_pool1d_with_indices_kernel)
     _dispatch = staticmethod(_launch_max_pool1d_with_indices)
+    _with_indices = True

--- a/src/tileops/kernels/pool/max_pool1d.py
+++ b/src/tileops/kernels/pool/max_pool1d.py
@@ -13,77 +13,56 @@ __all__ = ["MaxPool1dKernel", "MaxPool1dWithIndicesKernel"]
 
 _NEG_INF = float("-inf")
 _NAN = float("nan")
+_ACCUM_DTYPE = "float"
 _JIT_FLAGS = ["-O3", "-DENABLE_BF16"]
 
-# Taps one fragment of the row-reduce body may hold. Above this the fragment costs more
-# registers than the occupancy it buys back.
+# Taps one row-reduce block may hold. It bounds the two f32 fragments together: 8192
+# taps is 64 KB over a 256-thread block, or 64 registers a thread.
 _MAX_FRAGMENT_TAPS = 8192
 
-# Elements between two staged rows, past the span itself. Off a whole number of banks,
-# so two lanes reducing the same output of neighbouring rows do not serialize. Measured
-# on an H200; re-measure elsewhere.
-_STAGE_ROW_PAD = 8
+
+class _Shape(NamedTuple):
+    """The geometry one kernel is built for, over rows flattened from ``(N, C)``."""
+
+    rows: int
+    l_in: int
+    kernel_w: int
+    stride_w: int
+    pad_w: int
+    dilation_w: int
+    dtype: str
+
+    @property
+    def itemsize(self) -> int:
+        return dtype_itemsize(self.dtype)
 
 
 class _Plan(NamedTuple):
     """Which body reads a shape, and the extents that body needs."""
 
     body: str
-    # Outputs along the pooled axis.
     out_l: int
     # Whether every tap of every window lies inside the row.
     always_in_bounds: bool
-    # Elements the staged tile holds in front of the row, and in all. Both zero unless
-    # the body is "staged".
+    # The staged tile, in front of the row and in all. Zero outside the staged body.
     head: int
     span: int
-    # Full-width accesses one window takes. Zero unless the body is "rowreduce".
+    # Full-width accesses one window takes. Zero outside the row-reduce body.
     window_vectors: int
 
 
-def _plan(
-    l_in: int,
-    kernel_w: int,
-    stride_w: int,
-    pad_w: int,
-    dilation_w: int,
-    ceil_mode: bool,
-    dtype: str,
-    with_indices: bool,
-) -> _Plan:
+def _plan(shape: _Shape, ceil_mode: bool, with_indices: bool) -> _Plan:
     """The body that reads this shape, chosen from the window geometry alone.
 
-    ``rowreduce`` takes a shape whose row yields one output. The window is then the
-    row's own reduction, and taking the taps of several rows off one fragment is what
-    keeps a block wide enough to fill the device -- one output per lane leaves a launch
-    of one thread per row. It emits no position, so it is not offered with indices.
-
-    ``staged`` takes a shape whose windows overlap, so a tap feeds more than one output.
-    The row reaches shared memory once and every tap comes off it. A block takes as many
-    rows as its lanes have outputs to reduce, so a narrow output row does not leave them
-    idle.
-
-    ``windowed`` takes the rest, where each element feeds one window and staging the row
-    would add a copy of it for nothing.
-
-    Args:
-        l_in: Elements one row holds.
-        kernel_w: Taps one window has.
-        stride_w: Elements between two consecutive windows.
-        pad_w: Elements the leftmost window reaches in front of the row.
-        dilation_w: Elements between two taps of one window.
-        ceil_mode: Whether the output extent rounds up.
-        dtype: TileLang name of the element type.
-        with_indices: Whether the kernel also emits each maximum's position.
-
-    Returns:
-        The plan the builder for the chosen body reads.
+    ``rowreduce`` takes a row yielding one output, and emits no position, so it is not
+    offered with indices. ``staged`` takes overlapping windows, whose taps it reads off
+    shared memory. ``windowed`` takes the rest and reads each tap where it lies.
     """
+    rows, l_in, kernel_w, stride_w, pad_w, dilation_w, dtype = shape
     out_l = pool_output_dim(l_in, kernel_w, stride_w, pad_w, ceil_mode, dilation_w)
     reach = dilation_w * (kernel_w - 1) + 1
     always_in_bounds = pad_w == 0 and (out_l - 1) * stride_w + reach <= l_in
-    itemsize = dtype_itemsize(dtype)
-    window_bytes = kernel_w * itemsize
+    window_bytes = kernel_w * shape.itemsize
 
     if (
         not with_indices
@@ -101,10 +80,10 @@ def _plan(
         )
 
     if reach > stride_w:
-        # The whole row at once, so every block's origin is the row's own start and the
-        # block step puts no constraint on the access width.
+        # Step 0: overlapping windows are staged a whole row at a time, so there is no
+        # second block of a row whose origin the access width would have to divide.
         _, head, span = window_span(out_l, 0, l_in, kernel_w, stride_w, pad_w, dilation_w, dtype)
-        if span * itemsize <= STATIC_SHARED_BYTES:
+        if span * shape.itemsize <= STATIC_SHARED_BYTES:
             return _Plan("staged", out_l, always_in_bounds, head, span, 0)
 
     return _Plan("windowed", out_l, always_in_bounds, 0, 0, 0)
@@ -113,22 +92,19 @@ def _plan(
 def _stage_rows(rows: int, out_l: int, span: int, itemsize: int, threads: int) -> Tuple[int, int]:
     """Rows one staged tile holds, and the elements between two of them.
 
-    One row per lane's worth of outputs: below that a block would leave lanes with
-    nothing to reduce, and above it the extra rows only cost residency. A tile holding
-    more than one row pads the stride between them off a whole number of banks, so two
-    lanes reducing the same output of neighbouring rows do not serialize.
-
-    ``rows`` dividing the count is what leaves the last block whole, and the shared
-    budget is the second bound.
+    The count divides ``rows``, so no block is left ragged, and fits the shared budget.
+    A tile of more than one row pads the stride between them by one full-width access,
+    which moves two lanes reducing the same output off one bank and keeps the staging
+    copy aligned.
     """
+    pad = VECTOR_ACCESS_BYTES // itemsize
     wanted = max(threads // out_l, 1)
     count = 1
     while count * 2 <= wanted and rows % (count * 2) == 0:
         count *= 2
     while count > 1:
-        stride = span + _STAGE_ROW_PAD
-        if count * stride * itemsize <= STATIC_SHARED_BYTES:
-            return count, stride
+        if count * (span + pad) * itemsize <= STATIC_SHARED_BYTES:
+            return count, span + pad
         count //= 2
     return 1, span
 
@@ -136,10 +112,8 @@ def _stage_rows(rows: int, out_l: int, span: int, itemsize: int, threads: int) -
 def _block_rows(rows: int, kernel_w: int, window_vectors: int, threads: int) -> int:
     """Rows the row-reduce body takes per block.
 
-    One lane per full-width access of a window keeps the load coalesced across the
-    block: a warp then covers whole windows rather than one element of each. The
-    fragment holds every tap of every row the block takes, so its budget is the second
-    bound, and ``rows`` dividing the count is what leaves the last block whole.
+    One lane per full-width access of a window. The count divides ``rows`` and its
+    fragments fit :data:`_MAX_FRAGMENT_TAPS`.
     """
     wanted = min(
         max(threads // window_vectors, 1),
@@ -151,72 +125,6 @@ def _block_rows(rows: int, kernel_w: int, window_vectors: int, threads: int) -> 
     return count
 
 
-class _Launch:
-    """The launch shapes worth offering for one plan.
-
-    These figures describe this kernel's access patterns, not the device, and are held
-    here so that a later kernel does not read them as general truths.
-    """
-
-    # Outputs one block covers where the body reads `block_ol`, and the block sizes
-    # each body is timed at. A body whose rate falls off either side of one thread
-    # count is given that count and not a space: the rows this kernel is measured on
-    # run in single-digit microseconds, where a candidate's own measurement is too
-    # coarse to rank the rest.
-    _BLOCK_OUTPUTS: ClassVar[int] = 256
-    _FALLBACK_THREADS: ClassVar[int] = 128
-    _CANDIDATES: ClassVar[dict] = {
-        # A wider block covers more of the flattened output, which is what keeps the
-        # ragged block at the end of a row from being most of a launch.
-        "windowed": ((256, 128), (512, 256), (1024, 256)),
-        # The staging copy is the whole cost, and it is issued fastest by a block that
-        # does not outnumber the row's full-width accesses.
-        "staged": ((256, 128),),
-        # One lane per full-width access of a window, so the block follows the window.
-        "rowreduce": ((256, 256), (256, 512)),
-    }
-    # Threads a launch needs before a candidate is offered; under this the blocks do not
-    # fill the device.
-    _MIN_LAUNCH_THREADS: ClassVar[int] = 1 << 16
-
-    def __init__(self, rows: int, kernel_w: int, itemsize: int, plan: _Plan) -> None:
-        self._rows = rows
-        self._kernel_w = kernel_w
-        self._itemsize = itemsize
-        self._plan = plan
-
-    def default(self) -> dict:
-        return {"block_ol": self._BLOCK_OUTPUTS, "threads": self._FALLBACK_THREADS}
-
-    def tuned(self) -> list[dict]:
-        candidates = [
-            {"block_ol": block_ol, "threads": threads}
-            for block_ol, threads in self._CANDIDATES[self._plan.body]
-        ]
-        return [
-            candidate
-            for candidate in candidates
-            if self._blocks(candidate) * candidate["threads"] >= self._MIN_LAUNCH_THREADS
-        ] or [self.default()]
-
-    def _blocks(self, candidate: dict) -> int:
-        if self._plan.body == "windowed":
-            total = self._rows * self._plan.out_l
-            return (total + candidate["block_ol"] - 1) // candidate["block_ol"]
-        if self._plan.body == "staged":
-            stage_rows, _ = _stage_rows(
-                self._rows,
-                self._plan.out_l,
-                self._plan.span,
-                self._itemsize,
-                candidate["threads"],
-            )
-            return self._rows // stage_rows
-        return self._rows // _block_rows(
-            self._rows, self._kernel_w, self._plan.window_vectors, candidate["threads"]
-        )
-
-
 def _windowed_scan(
     l_in: int,
     kernel_w: int,
@@ -224,36 +132,32 @@ def _windowed_scan(
     pad_w: int,
     dilation_w: int,
     dtype: str,
-    accum_dtype: str,
     always_in_bounds: bool,
 ):
     """The windowed body's scan over one output, reading each tap where it lies.
 
-    ``T.max`` drops NaN, so the two ways to propagate it as PyTorch does are a second
-    accumulator saying one was seen, and a select per tap that lets NaN into the value
-    and keeps it there -- a later value fails ``val > NaN``. Which is cheaper follows
-    the bounds test: where every tap is in range the flag costs one boolean or per tap
-    against the select's whole compare, and where a tap is tested anyway the select
-    rides in the test's shadow and the flag's extra register does not.
+    ``T.max`` drops NaN, so PyTorch's propagation is spelled two ways: a flag where no
+    tap is bounds-tested, a select per tap where one is. Both are kept because which is
+    cheaper follows the bounds test.
     """
 
     @T.macro
     def _store(x, out, row, ol, idx):
         max_val = T.alloc_var(T.float32)
-        max_val = T.cast(_NEG_INF, accum_dtype)
+        max_val = T.cast(_NEG_INF, _ACCUM_DTYPE)
         if always_in_bounds:
             has_nan = T.alloc_var(T.bool)
             has_nan = False
             for kw in T.serial(kernel_w):
-                val = T.cast(x[row, ol * stride_w - pad_w + kw * dilation_w], accum_dtype)
+                val = T.cast(x[row, ol * stride_w - pad_w + kw * dilation_w], _ACCUM_DTYPE)
                 has_nan = has_nan | T.isnan(val)
                 max_val = T.max(max_val, val)
-            out[idx] = T.cast(T.if_then_else(has_nan, T.cast(_NAN, accum_dtype), max_val), dtype)
+            out[idx] = T.cast(T.if_then_else(has_nan, T.cast(_NAN, _ACCUM_DTYPE), max_val), dtype)
         else:
             for kw in T.serial(kernel_w):
                 iw = ol * stride_w - pad_w + kw * dilation_w
                 if (iw >= 0) and (iw < l_in):
-                    val = T.cast(x[row, iw], accum_dtype)
+                    val = T.cast(x[row, iw], _ACCUM_DTYPE)
                     max_val = T.if_then_else(T.isnan(val) or (val > max_val), val, max_val)
             out[idx] = T.cast(max_val, dtype)
 
@@ -267,7 +171,6 @@ def _windowed_indices_scan(
     pad_w: int,
     dilation_w: int,
     dtype: str,
-    accum_dtype: str,
     always_in_bounds: bool,
 ):
     """The windowed body's scan over one output, with the tap that won it."""
@@ -278,72 +181,47 @@ def _windowed_indices_scan(
         max_idx = T.alloc_var(T.int32)
         # -1 until a NaN is seen, so it is also the flag saying one was.
         nan_idx = T.alloc_var(T.int32)
-        max_val = T.cast(_NEG_INF, accum_dtype)
+        max_val = T.cast(_NEG_INF, _ACCUM_DTYPE)
         nan_idx = -1
         if always_in_bounds:
-            # An expression, not a variable: a variable is opaque to the range analysis,
-            # and each tap would then load under a bounds check this window's extent
-            # rules out.
+            # Why an expression and not a variable: a variable is opaque to the range
+            # analysis, and every tap would load under a bounds check it rules out.
             iw0 = ol * stride_w - pad_w
             max_idx = iw0
         else:
-            # A variable, because each tap is bounds-tested anyway and this then stays
-            # out of all of them.
             iw0 = T.alloc_var(T.int32)
             iw0 = ol * stride_w - pad_w
-            # The first tap the row holds, on the dilation grid. Only padding starts a
-            # window before position 0, and that tap is the position PyTorch reports
-            # when every tap the row holds is -inf.
+            # The first tap the row holds, which is what PyTorch reports for a window
+            # whose every in-row tap is -inf.
             max_idx = iw0 + dilation_w * T.ceildiv(T.max(-iw0, 0), dilation_w)
         for kw in T.serial(kernel_w):
             iw = iw0 + kw * dilation_w
             if always_in_bounds or ((iw >= 0) and (iw < l_in)):
-                val = T.cast(x[row, iw], accum_dtype)
-                # `max_val` is never NaN and NaN fails `>`, so the compare rejects NaN
-                # without a separate test. Strict `>` also keeps the seed against a tap
-                # equal to it, and the first maximum against a later equal one, which is
-                # what PyTorch reports.
+                val = T.cast(x[row, iw], _ACCUM_DTYPE)
+                # Strict `>` reports the first of equal maxima, as PyTorch does, and
+                # rejects NaN without a separate test.
                 take = val > max_val
                 max_val = T.if_then_else(take, val, max_val)
                 max_idx = T.if_then_else(take, iw, max_idx)
                 nan_idx = T.if_then_else(T.isnan(val), iw, nan_idx)
 
         # PyTorch reports the last NaN a window visited.
-        out[idx] = T.cast(T.if_then_else(nan_idx >= 0, T.cast(_NAN, accum_dtype), max_val), dtype)
+        out[idx] = T.cast(T.if_then_else(nan_idx >= 0, T.cast(_NAN, _ACCUM_DTYPE), max_val), dtype)
         indices[idx] = T.cast(T.if_then_else(nan_idx >= 0, nan_idx, max_idx), "int64")
 
     return _store
 
 
-def _windowed_builder(
-    rows: int,
-    l_in: int,
-    kernel_w: int,
-    stride_w: int,
-    pad_w: int,
-    dilation_w: int,
-    dtype: str,
-    accum_dtype: str,
-    out_l: int,
-    always_in_bounds: bool,
-):
+def _windowed_builder(shape: _Shape, plan: _Plan):
     """One output per lane, each tap read where it lies."""
+    rows, l_in, kernel_w, stride_w, pad_w, dilation_w, dtype = shape
+    out_l, in_bounds = plan.out_l, plan.always_in_bounds
     total_output = rows * out_l
 
     @tilelang.jit(out_idx=[1], compile_flags=_JIT_FLAGS)
     def _build(block_ol: int, threads: int):
-        # Every lane of every block owns an output, so none of them carries a test.
         tail_free = total_output % block_ol == 0
-        store = _windowed_scan(
-            l_in,
-            kernel_w,
-            stride_w,
-            pad_w,
-            dilation_w,
-            dtype,
-            accum_dtype,
-            always_in_bounds,
-        )
+        scan = _windowed_scan(l_in, kernel_w, stride_w, pad_w, dilation_w, dtype, in_bounds)
 
         @T.prim_func
         def _main(
@@ -354,44 +232,26 @@ def _windowed_builder(
                 for i in T.Parallel(block_ol):
                     idx = bx * block_ol + i
                     if tail_free:
-                        store(x, out, idx // out_l, idx % out_l, idx)
+                        scan(x, out, idx // out_l, idx % out_l, idx)
                     else:
                         if idx < total_output:
-                            store(x, out, idx // out_l, idx % out_l, idx)
+                            scan(x, out, idx // out_l, idx % out_l, idx)
 
         return _main
 
     return _build
 
 
-def _windowed_indices_builder(
-    rows: int,
-    l_in: int,
-    kernel_w: int,
-    stride_w: int,
-    pad_w: int,
-    dilation_w: int,
-    dtype: str,
-    accum_dtype: str,
-    out_l: int,
-    always_in_bounds: bool,
-):
+def _windowed_indices_builder(shape: _Shape, plan: _Plan):
     """The windowed body, also emitting each maximum's position."""
+    rows, l_in, kernel_w, stride_w, pad_w, dilation_w, dtype = shape
+    out_l, in_bounds = plan.out_l, plan.always_in_bounds
     total_output = rows * out_l
 
     @tilelang.jit(out_idx=[1, 2], compile_flags=_JIT_FLAGS)
     def _build(block_ol: int, threads: int):
         tail_free = total_output % block_ol == 0
-        store = _windowed_indices_scan(
-            l_in,
-            kernel_w,
-            stride_w,
-            pad_w,
-            dilation_w,
-            dtype,
-            accum_dtype,
-            always_in_bounds,
-        )
+        scan = _windowed_indices_scan(l_in, kernel_w, stride_w, pad_w, dilation_w, dtype, in_bounds)
 
         @T.prim_func
         def _main(
@@ -403,23 +263,31 @@ def _windowed_indices_builder(
                 for i in T.Parallel(block_ol):
                     idx = bx * block_ol + i
                     if tail_free:
-                        store(x, out, indices, idx // out_l, idx % out_l, idx)
+                        scan(x, out, indices, idx // out_l, idx % out_l, idx)
                     else:
                         if idx < total_output:
-                            store(x, out, indices, idx // out_l, idx % out_l, idx)
+                            scan(x, out, indices, idx // out_l, idx % out_l, idx)
 
         return _main
 
     return _build
 
 
-def _stage_macro(l_in: int, head: int, staged: int, tail: int, stage_rows: int, dtype: str):
+def _staged_extents(l_in: int, head: int, span: int) -> Tuple[int, int]:
+    """Elements of a row the tile holds, and elements of -inf past them.
+
+    The span reaches no further than the last window's access width, which is short of
+    the row's end wherever the windows overlap without dividing it.
+    """
+    staged = min(l_in, span - head)
+    return staged, span - head - staged
+
+
+def _stage_macro(head: int, staged: int, tail: int, stage_rows: int, dtype: str):
     """The staging pass: the block's rows, with -inf outside each of them.
 
-    The head and the staged extent both divide the access width, so the copy is
-    full-width and the two fills touch only elements outside a row. A tap reading one of
-    those elements reads -inf, which is the value PyTorch pads a max-pool window with
-    and which no tap can win against.
+    -inf is what PyTorch pads a max-pool window with, so a tap outside the row needs no
+    test.
     """
 
     @T.macro
@@ -435,40 +303,27 @@ def _stage_macro(l_in: int, head: int, staged: int, tail: int, stage_rows: int, 
     return _stage
 
 
-def _staged_scan(
-    kernel_w: int, stride_w: int, dilation_w: int, base: int, dtype: str, accum_dtype: str
-):
-    """The staged body's scan over one output, every tap read off the tile.
-
-    Resident taps make the scan arithmetic-bound, which wants the opposite trade to the
-    windowed body: no tap carries a bounds test, so NaN rides in a second accumulator
-    rather than costing a select per tap.
-    """
+def _staged_scan(kernel_w: int, stride_w: int, dilation_w: int, base: int, dtype: str):
+    """The staged body's scan over one output, every tap read off the tile."""
 
     @T.macro
     def _store(tile, out, r, row, ol):
         max_val = T.alloc_var(T.float32)
         has_nan = T.alloc_var(T.bool)
-        max_val = T.cast(_NEG_INF, accum_dtype)
+        max_val = T.cast(_NEG_INF, _ACCUM_DTYPE)
         has_nan = False
         for kw in T.serial(kernel_w):
-            val = T.cast(tile[r, base + ol * stride_w + kw * dilation_w], accum_dtype)
+            val = T.cast(tile[r, base + ol * stride_w + kw * dilation_w], _ACCUM_DTYPE)
             has_nan = has_nan | T.isnan(val)
             max_val = T.max(max_val, val)
 
-        out[row, ol] = T.cast(T.if_then_else(has_nan, T.cast(_NAN, accum_dtype), max_val), dtype)
+        out[row, ol] = T.cast(T.if_then_else(has_nan, T.cast(_NAN, _ACCUM_DTYPE), max_val), dtype)
 
     return _store
 
 
 def _staged_indices_scan(
-    kernel_w: int,
-    stride_w: int,
-    pad_w: int,
-    dilation_w: int,
-    base: int,
-    dtype: str,
-    accum_dtype: str,
+    kernel_w: int, stride_w: int, pad_w: int, dilation_w: int, base: int, dtype: str
 ):
     """The staged body's scan over one output, with the tap that won it."""
 
@@ -477,62 +332,41 @@ def _staged_indices_scan(
         max_val = T.alloc_var(T.float32)
         max_idx = T.alloc_var(T.int32)
         nan_idx = T.alloc_var(T.int32)
-        max_val = T.cast(_NEG_INF, accum_dtype)
+        max_val = T.cast(_NEG_INF, _ACCUM_DTYPE)
         nan_idx = -1
         iw0 = ol * stride_w - pad_w
-        # The first tap the row holds, which is the position PyTorch reports when every
-        # tap the row holds is -inf.
+        # The first tap the row holds, which is what PyTorch reports for a window whose
+        # every in-row tap is -inf.
         max_idx = iw0 + dilation_w * T.ceildiv(T.max(-iw0, 0), dilation_w)
         for kw in T.serial(kernel_w):
-            val = T.cast(tile[r, base + ol * stride_w + kw * dilation_w], accum_dtype)
-            # A padded tap is -inf in the tile, so it never wins and needs no test.
+            val = T.cast(tile[r, base + ol * stride_w + kw * dilation_w], _ACCUM_DTYPE)
             take = val > max_val
             max_val = T.if_then_else(take, val, max_val)
             max_idx = T.if_then_else(take, iw0 + kw * dilation_w, max_idx)
             nan_idx = T.if_then_else(T.isnan(val), iw0 + kw * dilation_w, nan_idx)
 
         out[row, ol] = T.cast(
-            T.if_then_else(nan_idx >= 0, T.cast(_NAN, accum_dtype), max_val), dtype
+            T.if_then_else(nan_idx >= 0, T.cast(_NAN, _ACCUM_DTYPE), max_val), dtype
         )
         indices[row, ol] = T.cast(T.if_then_else(nan_idx >= 0, nan_idx, max_idx), "int64")
 
     return _store
 
 
-def _staged_extents(l_in: int, head: int, span: int) -> Tuple[int, int]:
-    """Elements of a row the tile holds, and elements of -inf past them.
-
-    The span covers the last window's last tap and then the rest of that access width,
-    which is short of the row's end wherever the windows overlap without dividing it.
-    """
-    staged = min(l_in, span - head)
-    return staged, span - head - staged
-
-
-def _staged_builder(
-    rows: int,
-    l_in: int,
-    kernel_w: int,
-    stride_w: int,
-    pad_w: int,
-    dilation_w: int,
-    dtype: str,
-    accum_dtype: str,
-    out_l: int,
-    head: int,
-    span: int,
-    itemsize: int,
-):
+def _staged_builder(shape: _Shape, plan: _Plan):
     """A block's rows staged in shared memory once, every tap read off them."""
-    # The tile carries the padding as -inf, so a tap needs no test and this offset.
+    rows, l_in, kernel_w, stride_w, pad_w, dilation_w, dtype = shape
+    itemsize = shape.itemsize
+    out_l, head, span = plan.out_l, plan.head, plan.span
+    # Tap ``kw`` of output ``ol`` sits at ``base + ol * stride + kw * dilation``.
     base = head - pad_w
     staged, tail = _staged_extents(l_in, head, span)
 
     @tilelang.jit(out_idx=[1], compile_flags=_JIT_FLAGS)
     def _build(block_ol: int, threads: int):
         stage_rows, row_stride = _stage_rows(rows, out_l, span, itemsize, threads)
-        stage = _stage_macro(l_in, head, staged, tail, stage_rows, dtype)
-        store = _staged_scan(kernel_w, stride_w, dilation_w, base, dtype, accum_dtype)
+        stage = _stage_macro(head, staged, tail, stage_rows, dtype)
+        scan = _staged_scan(kernel_w, stride_w, dilation_w, base, dtype)
 
         @T.prim_func
         def _main(
@@ -544,38 +378,26 @@ def _staged_builder(
                 row0 = bx * stage_rows
                 stage(tile, x, row0)
                 for r, ol in T.Parallel(stage_rows, out_l):
-                    store(tile, out, r, row0 + r, ol)
+                    scan(tile, out, r, row0 + r, ol)
 
         return _main
 
     return _build
 
 
-def _staged_indices_builder(
-    rows: int,
-    l_in: int,
-    kernel_w: int,
-    stride_w: int,
-    pad_w: int,
-    dilation_w: int,
-    dtype: str,
-    accum_dtype: str,
-    out_l: int,
-    head: int,
-    span: int,
-    itemsize: int,
-):
+def _staged_indices_builder(shape: _Shape, plan: _Plan):
     """The staged body, also emitting each maximum's position."""
+    rows, l_in, kernel_w, stride_w, pad_w, dilation_w, dtype = shape
+    itemsize = shape.itemsize
+    out_l, head, span = plan.out_l, plan.head, plan.span
     base = head - pad_w
     staged, tail = _staged_extents(l_in, head, span)
 
     @tilelang.jit(out_idx=[1, 2], compile_flags=_JIT_FLAGS)
     def _build(block_ol: int, threads: int):
         stage_rows, row_stride = _stage_rows(rows, out_l, span, itemsize, threads)
-        stage = _stage_macro(l_in, head, staged, tail, stage_rows, dtype)
-        store = _staged_indices_scan(
-            kernel_w, stride_w, pad_w, dilation_w, base, dtype, accum_dtype
-        )
+        stage = _stage_macro(head, staged, tail, stage_rows, dtype)
+        scan = _staged_indices_scan(kernel_w, stride_w, pad_w, dilation_w, base, dtype)
 
         @T.prim_func
         def _main(
@@ -588,22 +410,17 @@ def _staged_indices_builder(
                 row0 = bx * stage_rows
                 stage(tile, x, row0)
                 for r, ol in T.Parallel(stage_rows, out_l):
-                    store(tile, out, indices, r, row0 + r, ol)
+                    scan(tile, out, indices, r, row0 + r, ol)
 
         return _main
 
     return _build
 
 
-def _rowreduce_builder(
-    rows: int,
-    l_in: int,
-    kernel_w: int,
-    dtype: str,
-    accum_dtype: str,
-    window_vectors: int,
-):
-    """One output per row, taken off a fragment holding the taps of several rows."""
+def _rowreduce_builder(shape: _Shape, plan: _Plan):
+    """One output per row, taken off fragments holding the taps of several rows."""
+    rows, l_in, kernel_w, dtype = shape.rows, shape.l_in, shape.kernel_w, shape.dtype
+    window_vectors = plan.window_vectors
 
     @tilelang.jit(out_idx=[1], compile_flags=_JIT_FLAGS)
     def _build(block_ol: int, threads: int):
@@ -615,27 +432,35 @@ def _rowreduce_builder(
             out: T.Tensor((rows, 1), dtype),  # type: ignore
         ):
             with T.Kernel(rows // block_rows, threads=threads) as bx:
-                taps = T.alloc_fragment((block_rows, kernel_w), accum_dtype)
-                nans = T.alloc_fragment((block_rows, kernel_w), accum_dtype)
-                best = T.alloc_fragment((block_rows,), accum_dtype)
-                seen = T.alloc_fragment((block_rows,), accum_dtype)
+                taps = T.alloc_fragment((block_rows, kernel_w), _ACCUM_DTYPE)
+                nans = T.alloc_fragment((block_rows, kernel_w), _ACCUM_DTYPE)
+                best = T.alloc_fragment((block_rows,), _ACCUM_DTYPE)
+                seen = T.alloc_fragment((block_rows,), _ACCUM_DTYPE)
                 for r, kw in T.Parallel(block_rows, kernel_w):
-                    taps[r, kw] = T.cast(x[bx * block_rows + r, kw], accum_dtype)
-                # `T.reduce_max` drops NaN, so which taps were NaN is reduced alongside
-                # the value and the two answers meet at the store.
+                    taps[r, kw] = T.cast(x[bx * block_rows + r, kw], _ACCUM_DTYPE)
+                # `T.reduce_max` drops NaN, so which taps were NaN is reduced too.
                 for r, kw in T.Parallel(block_rows, kernel_w):
                     nans[r, kw] = T.if_then_else(T.isnan(taps[r, kw]), 1.0, 0.0)
                 T.reduce_max(taps, best, dim=1, clear=True)
                 T.reduce_max(nans, seen, dim=1, clear=True)
                 for r in T.Parallel(block_rows):
                     out[bx * block_rows + r, 0] = T.cast(
-                        T.if_then_else(seen[r] > 0.0, T.cast(_NAN, accum_dtype), best[r]),
+                        T.if_then_else(seen[r] > 0.0, T.cast(_NAN, _ACCUM_DTYPE), best[r]),
                         dtype,
                     )
 
         return _main
 
     return _build
+
+
+_BUILDERS = {
+    ("rowreduce", False): _rowreduce_builder,
+    ("staged", False): _staged_builder,
+    ("staged", True): _staged_indices_builder,
+    ("windowed", False): _windowed_builder,
+    ("windowed", True): _windowed_indices_builder,
+}
 
 
 def _build_kernel(
@@ -651,40 +476,9 @@ def _build_kernel(
     with_indices: bool,
 ):
     """The jit builder for the body this shape's plan selects."""
-    accum_dtype = "float"
-    rows = n * c_in
-    plan = _plan(l_in, kernel_w, stride_w, pad_w, dilation_w, ceil_mode, dtype, with_indices)
-    if plan.body == "rowreduce":
-        return _rowreduce_builder(rows, l_in, kernel_w, dtype, accum_dtype, plan.window_vectors)
-    if plan.body == "staged":
-        build = _staged_indices_builder if with_indices else _staged_builder
-        return build(
-            rows,
-            l_in,
-            kernel_w,
-            stride_w,
-            pad_w,
-            dilation_w,
-            dtype,
-            accum_dtype,
-            plan.out_l,
-            plan.head,
-            plan.span,
-            dtype_itemsize(dtype),
-        )
-    build = _windowed_indices_builder if with_indices else _windowed_builder
-    return build(
-        rows,
-        l_in,
-        kernel_w,
-        stride_w,
-        pad_w,
-        dilation_w,
-        dtype,
-        accum_dtype,
-        plan.out_l,
-        plan.always_in_bounds,
-    )
+    shape = _Shape(n * c_in, l_in, kernel_w, stride_w, pad_w, dilation_w, dtype)
+    plan = _plan(shape, ceil_mode, with_indices)
+    return _BUILDERS[plan.body, with_indices](shape, plan)
 
 
 @functools.lru_cache(maxsize=32)
@@ -721,62 +515,32 @@ def _max_pool1d_with_indices_kernel(
     )
 
 
-def _launch_max_pool1d(
-    n: int,
-    c_in: int,
-    l_in: int,
-    kernel_w: int,
-    stride_w: int,
-    pad_w: int,
-    dilation_w: int,
-    ceil_mode: bool,
-    dtype: str,
-    block_ol: int,
-    threads: int,
-    x: torch.Tensor,
-) -> torch.Tensor:
-    out_l = pool_output_dim(l_in, kernel_w, stride_w, pad_w, ceil_mode, dilation_w)
-    kernel = _max_pool1d_kernel(
-        n, c_in, l_in, kernel_w, stride_w, pad_w, dilation_w, ceil_mode, dtype
-    )(block_ol, threads)
-    return kernel(x.contiguous().view(n * c_in, l_in)).view(n, c_in, out_l)
-
-
-def _launch_max_pool1d_with_indices(
-    n: int,
-    c_in: int,
-    l_in: int,
-    kernel_w: int,
-    stride_w: int,
-    pad_w: int,
-    dilation_w: int,
-    ceil_mode: bool,
-    dtype: str,
-    block_ol: int,
-    threads: int,
-    x: torch.Tensor,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    out_l = pool_output_dim(l_in, kernel_w, stride_w, pad_w, ceil_mode, dilation_w)
-    kernel = _max_pool1d_with_indices_kernel(
-        n, c_in, l_in, kernel_w, stride_w, pad_w, dilation_w, ceil_mode, dtype
-    )(block_ol, threads)
-    out, indices = kernel(x.contiguous().view(n * c_in, l_in))
-    return out.view(n, c_in, out_l), indices.view(n, c_in, out_l)
-
-
 class _MaxPool1dKernelBase(Kernel):
     """Shape, launch planning and dispatch shared by the two 1d max-pool kernels.
 
-    Concrete kernels supply ``_build``, ``_dispatch`` and ``_with_indices``; everything
+    Concrete kernels supply ``_build``, ``_shaped`` and ``_with_indices``; everything
     else -- parameter capture, output extents, config and launch -- is identical between
     the value-only and with-indices variants.
     """
 
     _build: ClassVar[Callable[..., Any]]
-    _dispatch: ClassVar[Callable[..., Any]]
+    _shaped: ClassVar[Callable[..., Any]]
     _with_indices: ClassVar[bool]
 
     supported_archs: ClassVar[list[int]] = [80, 86, 89, 90]
+
+    _BLOCK_OUTPUTS: ClassVar[int] = 256
+    _FALLBACK_THREADS: ClassVar[int] = 128
+    # ``(block_ol, threads)`` per body, measured on an H200. A body is given one thread
+    # count where its rate falls off either side of it.
+    _CANDIDATES: ClassVar[dict] = {
+        "windowed": ((256, 128), (512, 256), (1024, 256)),
+        "staged": ((256, 128),),
+        "rowreduce": ((256, 256), (256, 512)),
+    }
+    # Threads a launch needs before a candidate is offered: below one resident block per
+    # SM on a device of a few hundred SMs, a wider block is the better trade.
+    _MIN_LAUNCH_THREADS: ClassVar[int] = 1 << 16
 
     def __init__(
         self,
@@ -820,56 +584,80 @@ class _MaxPool1dKernelBase(Kernel):
         )
         self.init_config(config, tune)
 
-    def _launch(self) -> _Launch:
-        plan = _plan(
+    @property
+    def _shape(self) -> _Shape:
+        return _Shape(
+            self.n * self.c_in,
             self.l_in,
             self.kernel_w,
             self.stride_w,
             self.pad_w,
             self.dilation_w,
-            self.ceil_mode,
             self.dtype_str,
-            type(self)._with_indices,
         )
-        return _Launch(self.n * self.c_in, self.kernel_w, dtype_itemsize(self.dtype_str), plan)
+
+    @property
+    def _plan(self) -> _Plan:
+        return _plan(self._shape, self.ceil_mode, type(self)._with_indices)
+
+    def _blocks(self, candidate: dict) -> int:
+        """Blocks the launch takes at *candidate*, which decides whether to offer it."""
+        shape, plan = self._shape, self._plan
+        if plan.body == "windowed":
+            total = shape.rows * plan.out_l
+            return (total + candidate["block_ol"] - 1) // candidate["block_ol"]
+        if plan.body == "staged":
+            stage_rows, _ = _stage_rows(
+                shape.rows, plan.out_l, plan.span, shape.itemsize, candidate["threads"]
+            )
+            return shape.rows // stage_rows
+        return shape.rows // _block_rows(
+            shape.rows, shape.kernel_w, plan.window_vectors, candidate["threads"]
+        )
 
     @property
     def default_config(self) -> dict:
-        return self._launch().default()
+        return {"block_ol": self._BLOCK_OUTPUTS, "threads": self._FALLBACK_THREADS}
 
     @property
     def autotune_configs(self) -> list[dict]:
-        return self._launch().tuned()
+        candidates = [
+            {"block_ol": block_ol, "threads": threads}
+            for block_ol, threads in self._CANDIDATES[self._plan.body]
+        ]
+        return [
+            candidate
+            for candidate in candidates
+            if self._blocks(candidate) * candidate["threads"] >= self._MIN_LAUNCH_THREADS
+        ] or [self.default_config]
 
     def forward(self, x: torch.Tensor) -> Any:
         self._require_cuda(x=x)
-        return type(self)._dispatch(
-            self.n,
-            self.c_in,
-            self.l_in,
-            self.kernel_w,
-            self.stride_w,
-            self.pad_w,
-            self.dilation_w,
-            self.ceil_mode,
-            self.dtype_str,
-            self.config["block_ol"],
-            self.config["threads"],
-            x,
-        )
+        kernel = self.kernel(self.config["block_ol"], self.config["threads"])
+        rows = kernel(x.contiguous().view(self.n * self.c_in, self.l_in))
+        return type(self)._shaped(rows, (self.n, self.c_in, self.out_l))
 
 
 class MaxPool1dKernel(_MaxPool1dKernelBase):
     """Max pooling forward kernel (return_indices=False)."""
 
     _build = staticmethod(_max_pool1d_kernel)
-    _dispatch = staticmethod(_launch_max_pool1d)
     _with_indices = False
+
+    @staticmethod
+    def _shaped(result: torch.Tensor, shape: Tuple[int, int, int]) -> torch.Tensor:
+        return result.view(shape)
 
 
 class MaxPool1dWithIndicesKernel(_MaxPool1dKernelBase):
     """Max pooling forward-with-indices kernel."""
 
     _build = staticmethod(_max_pool1d_with_indices_kernel)
-    _dispatch = staticmethod(_launch_max_pool1d_with_indices)
     _with_indices = True
+
+    @staticmethod
+    def _shaped(
+        result: Tuple[torch.Tensor, torch.Tensor], shape: Tuple[int, int, int]
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        values, indices = result
+        return values.view(shape), indices.view(shape)

--- a/tests/ops/test_pool.py
+++ b/tests/ops/test_pool.py
@@ -24,8 +24,9 @@ from tileops.kernels.pool import (
     MaxPool3dKernel,
     MaxPool3dWithIndicesKernel,
 )
-from tileops.kernels.pool.avg_pool1d import _span, _WindowStaging
-from tileops.kernels.pool.common import pool_output_dim
+from tileops.kernels.pool.avg_pool1d import _WindowStaging
+from tileops.kernels.pool.common import pool_output_dim, window_span
+from tileops.kernels.pool.max_pool1d import _plan as _max_pool1d_plan
 from tileops.ops import (
     AdaptiveAvgPool2dFwdOp,
     AdaptiveMaxPool2dFwdOp,
@@ -593,13 +594,31 @@ def test_avg_pool1d_staged_span_stays_aligned(
     out_l = pool_output_dim(l_in, kernel_l, stride_l, pad_l, False)
     staging = _WindowStaging(1, l_in, out_l, kernel_l, stride_l, pad_l, dtype)
     for block_ol in staging.widths():
-        staged = _span(block_ol, l_in, kernel_l, stride_l, pad_l, dtype)
+        staged = window_span(
+            block_ol, block_ol * stride_l, l_in, kernel_l, stride_l, pad_l, 1, dtype
+        )
         assert (block_ol * stride_l) % staged.vector_elems == 0
         assert l_in % staged.vector_elems == 0
         assert staged.head % staged.vector_elems == 0
         assert staged.span % staged.vector_elems == 0
         assert staged.head >= pad_l
         assert staged.span >= staged.head + (block_ol - 1) * stride_l + kernel_l
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("l_in, kernel_l", [(15, 16), (31, 32), (100, 128), (1000, 1024)])
+def test_max_pool1d_row_reduce_takes_no_tap_past_the_row(l_in: int, kernel_l: int) -> None:
+    """A window wider than the row does not reach the row-reduce body.
+
+    That body reads taps 0 to ``kernel_size - 1`` of the row with no bounds test, which
+    only holds where the window fits. Ceil mode admits a window wider than the row --
+    PyTorch pads the missing taps with ``-inf`` and still emits one output -- and the
+    taps past the row's end would then read the row after it.
+    """
+    plan = _max_pool1d_plan(l_in, kernel_l, kernel_l, 0, 1, True, "float16", False)
+    assert plan.out_l == 1
+    assert not plan.always_in_bounds
+    assert plan.body != "rowreduce"
 
 
 @pytest.mark.smoke
@@ -1052,7 +1071,7 @@ _MAX_POOL1D_PARAMS = [
         marks=pytest.mark.full,
         id="full-ceil-k5-s3-p2-bf16",
     ),
-    # Short output: sends max_pool1d down the shared-memory staged read.
+    # Non-overlapping windows over a short output row: the windowed read.
     pytest.param(
         2,
         32,
@@ -1066,7 +1085,23 @@ _MAX_POOL1D_PARAMS = [
         False,
         True,
         marks=pytest.mark.full,
-        id="full-staged-short-output-fp16",
+        id="full-windowed-short-output-fp16",
+    ),
+    # One output a row, at a window width the row-reduce fragment takes.
+    pytest.param(
+        2,
+        8,
+        32,
+        (32,),
+        (32,),
+        (0,),
+        (1,),
+        False,
+        torch.float16,
+        False,
+        True,
+        marks=pytest.mark.full,
+        id="full-rowreduce-one-output-fp16",
     ),
 ]
 

--- a/tests/ops/test_pool.py
+++ b/tests/ops/test_pool.py
@@ -27,6 +27,7 @@ from tileops.kernels.pool import (
 from tileops.kernels.pool.avg_pool1d import _WindowStaging
 from tileops.kernels.pool.common import pool_output_dim, window_span
 from tileops.kernels.pool.max_pool1d import _plan as _max_pool1d_plan
+from tileops.kernels.pool.max_pool1d import _Shape as _MaxPool1dShape
 from tileops.ops import (
     AdaptiveAvgPool2dFwdOp,
     AdaptiveMaxPool2dFwdOp,
@@ -615,7 +616,8 @@ def test_max_pool1d_row_reduce_takes_no_tap_past_the_row(l_in: int, kernel_l: in
     PyTorch pads the missing taps with ``-inf`` and still emits one output -- and the
     taps past the row's end would then read the row after it.
     """
-    plan = _max_pool1d_plan(l_in, kernel_l, kernel_l, 0, 1, True, "float16", False)
+    shape = _MaxPool1dShape(8, l_in, kernel_l, kernel_l, 0, 1, "float16")
+    plan = _max_pool1d_plan(shape, True, False)
     assert plan.out_l == 1
     assert not plan.always_in_bounds
     assert plan.body != "rowreduce"


### PR DESCRIPTION
## Summary

- `MaxPool1dFwd` read every tap from global memory whatever the shape. Two of its three benchmarked workloads want something else, and which one follows from the window geometry, so `_plan()` picks one of three bodies at build time.
- `staged`: the window's reach exceeds its stride, so a tap feeds more than one output. The block's rows reach `smem` once through `T.copy` and every tap is read off the tile. The dilated workload's global read falls from 20951040 B to 8409088 B.
- `rowreduce`: the row yields one output, so the window is the row's own reduction. The taps of several rows go into a fragment and `T.reduce_max` reduces along the window, putting one lane on each 16-byte group of a row instead of one lane on the row.
- `windowed`: the rest, where each element feeds one window. It now stores through the flattened output index the lane already holds, and drops the tail test where the block width divides the output.
- The staged tile carries `-inf` over the padding and the ceil-mode overshoot, so no tap in that body is bounds-tested.
- Both NaN forms are kept, a flag where no tap is tested and a select per tap where one is: they measured 37% apart in opposite directions.
- Bug fix: the row-reduce gate did not require the window to fit the row, and ceil mode admits a wider one whose taps read the row after it. At `(1, 4, 15)`, `kernel_size=16`, `stride=16`, `ceil_mode=True`, every element `-1.0` except `x[0,1,0]=100.0`, that returned `[0.0, 100.0, 0.0, 0.0]` against PyTorch's `[-1.0, 100.0, -1.0, -1.0]`.
- The span geometry moves to `pool/common.py` as `window_span`, which `avg_pool1d` calls with dilation 1. Its access width, head and span are unchanged for every shape it takes.
- Config key `block_m` -> `block_ol`: it counts outputs. Each body carries the block sizes it was timed at.
- Second commit, no emitted program changed but the float32 staged pad: the launch policy moves onto `_MaxPool1dKernelBase`, the builder signatures go from eleven and twelve scalars to a `_Shape` and a `_Plan`, the staged row pad is derived as one full-width access, and comment lines fall from 184 to 122.
- Unchanged: the op, kernel dispatch, output semantics, the manifest, the workloads, the reference and the benchmark path.
- Test-node delta: +5 (272 to 277).

## TileFoundry Description

`SincnetWindowed`, `EcgWindowed` and `TextcnnDirect` are the placement this PR replaces: every tap read where it lies, for all three workloads. `SincnetStaged`, `EcgStaged` and `TextcnnRowReduce` are the placements it implements. The `*Reference` modules are unplaced and take the raw row, so `check` holds the `-inf` padding convention itself against `torch.nn.functional.max_pool1d`.

A placed module declares the row already padded with `-inf` on both ends, which is what the kernel's tile carries outside the row.

```python
"""MaxPool1dFwd as HIR, at the three workloads src/tileops/manifest/pool.yaml benchmarks.

A placed module declares the row already padded with `-inf` on both ends, so a tap is a
strided view of it and the window arithmetic is the whole content of the program. The
padding is what the kernel's tile carries outside the row: 5 of 2053 elements at the one
padded workload, which leaves the traffic these modules are read for unchanged.

`Reference` is unplaced and takes the raw row, so `check` holds the padding convention
itself against `torch.nn.functional.max_pool1d`.
"""

import math

from tilefoundry import func, module
from tilefoundry.dsl import Mesh, ReduceKind, Tensor, Topology, tf
from tilefoundry.target import CudaTarget

H200 = CudaTarget("nvidia.h200_sxm")
NEG_INF = -math.inf


def sincnet_reference():
    """[32,80,4096] k3 s3 p0 d1 f16, unplaced: the taps of one output as a reduction axis."""
    ROWS, L_IN, KW, SW, DW = 2560, 4096, 3, 3, 1
    OUT_L, DT = 1365, "f16"
    SPAN = (OUT_L - 1) * SW + 1

    @module(entry="max_pool1d", target=H200, topologies=(Topology("cta", 1),))
    class SincnetReference:
        @func
        def max_pool1d(x: Tensor[(ROWS, L_IN), DT]):
            vals = tf.cast(x, "f32")
            taps = tf.stack(
                [vals[:, kw * DW : kw * DW + SPAN : SW] for kw in range(KW)], axis=-1
            )
            best = tf.reduce(taps, axes=(-1,), keepdim=False, kind=ReduceKind.MAX)
            return tf.cast(best, DT)

    return SincnetReference


def sincnet_windowed():
    """The placement in main: one thread owns a window, its taps read where they lie."""
    ROWS, L_IN, KW, SW, DW = 2560, 4096, 3, 3, 1
    OUT_L, DT = 1365, "f16"
    SPAN = (OUT_L - 1) * SW + 1
    NT = 195  # threads per CTA; OUT_L // NT = 7 outputs each

    @module(
        entry="max_pool1d",
        target=H200,
        topologies=(Topology("cta", ROWS), Topology("thread", NT)),
    )
    class SincnetWindowed:
        @func
        def max_pool1d(x: Tensor[(ROWS, L_IN), DT]):
            with Mesh(("cta",), layout=(ROWS,), names=("row",)) as cta:
                with Mesh(("thread",), layout=(NT,), names=("t",)) as m:
                    taps = tf.stack(
                        [
                            tf.reshard(
                                x[:, kw * DW : kw * DW + SPAN : SW],
                                (ROWS @ cta.row, OUT_L @ m.t),
                                "rmem",
                            )
                            for kw in range(KW)
                        ],
                        axis=-1,
                    )
                    best = tf.reduce(
                        tf.cast(taps, "f32"), axes=(-1,), keepdim=False, kind=ReduceKind.MAX
                    )
                    return tf.reshard(tf.cast(best, DT), (ROWS, OUT_L), "gmem")

    return SincnetWindowed


def sincnet_staged():
    """The same step with the row staged in smem once and every tap read from it."""
    ROWS, L_IN, KW, SW, DW = 2560, 4096, 3, 3, 1
    OUT_L, DT = 1365, "f16"
    SPAN = (OUT_L - 1) * SW + 1
    NT = 195  # threads per CTA; OUT_L // NT = 7 outputs each

    @module(
        entry="max_pool1d",
        target=H200,
        topologies=(Topology("cta", ROWS), Topology("thread", NT)),
    )
    class SincnetStaged:
        @func
        def max_pool1d(x: Tensor[(ROWS, L_IN), DT]):
            with Mesh(("cta",), layout=(ROWS,), names=("row",)) as cta:
                with Mesh(("thread",), layout=(NT,), names=("t",)) as m:
                    held = tf.reshard(x, (ROWS @ cta.row, L_IN), "smem")
                    taps = tf.stack(
                        [
                            tf.reshard(
                                held[:, kw * DW : kw * DW + SPAN : SW],
                                (ROWS @ cta.row, OUT_L @ m.t),
                                "rmem",
                            )
                            for kw in range(KW)
                        ],
                        axis=-1,
                    )
                    best = tf.reduce(
                        tf.cast(taps, "f32"), axes=(-1,), keepdim=False, kind=ReduceKind.MAX
                    )
                    return tf.reshard(tf.cast(best, DT), (ROWS, OUT_L), "gmem")

    return SincnetStaged


def ecg_reference():
    """[16,128,2048] k5 s2 p2 d2 ceil bf16, unplaced: padding and overshoot as `-inf`."""
    ROWS, L_IN, KW, SW, PW, DW = 2048, 2048, 5, 2, 2, 2
    OUT_L, DT = 1023, "bf16"
    # The prefix is the padding; the suffix is the ceil-mode overshoot, where the last
    # window reaches past the row. PyTorch drops both from the max, which `-inf` does.
    OVERSHOOT = (OUT_L - 1) * SW + DW * (KW - 1) + 1 - (L_IN + PW)
    SPAN = (OUT_L - 1) * SW + 1

    @module(entry="max_pool1d", target=H200, topologies=(Topology("cta", 1),))
    class EcgReference:
        @func
        def max_pool1d(x: Tensor[(ROWS, L_IN), DT]):
            vals = tf.cast(x, "f32")
            padded = tf.concat(
                [
                    tf.full_like(vals[:, 0:PW], NEG_INF),
                    vals,
                    tf.full_like(vals[:, 0:OVERSHOOT], NEG_INF),
                ],
                axis=-1,
            )
            taps = tf.stack(
                [padded[:, kw * DW : kw * DW + SPAN : SW] for kw in range(KW)], axis=-1
            )
            best = tf.reduce(taps, axes=(-1,), keepdim=False, kind=ReduceKind.MAX)
            return tf.cast(best, DT)

    return EcgReference


def ecg_windowed():
    """The placement in main at the padded dilated workload: five views, each read whole."""
    ROWS, KW, SW, DW = 2048, 5, 2, 2
    OUT_L, L_PAD, DT = 1023, 2053, "bf16"
    SPAN = (OUT_L - 1) * SW + 1
    NT = 341  # threads per CTA; OUT_L // NT = 3 outputs each

    @module(
        entry="max_pool1d",
        target=H200,
        topologies=(Topology("cta", ROWS), Topology("thread", NT)),
    )
    class EcgWindowed:
        @func
        def max_pool1d(xpad: Tensor[(ROWS, L_PAD), DT]):
            with Mesh(("cta",), layout=(ROWS,), names=("row",)) as cta:
                with Mesh(("thread",), layout=(NT,), names=("t",)) as m:
                    taps = tf.stack(
                        [
                            tf.reshard(
                                xpad[:, kw * DW : kw * DW + SPAN : SW],
                                (ROWS @ cta.row, OUT_L @ m.t),
                                "rmem",
                            )
                            for kw in range(KW)
                        ],
                        axis=-1,
                    )
                    best = tf.reduce(
                        tf.cast(taps, "f32"), axes=(-1,), keepdim=False, kind=ReduceKind.MAX
                    )
                    return tf.reshard(tf.cast(best, DT), (ROWS, OUT_L), "gmem")

    return EcgWindowed


def ecg_staged():
    """Dilation 2 at stride 2 makes the five views overlap 4.5x; smem carries the re-read."""
    ROWS, KW, SW, DW = 2048, 5, 2, 2
    OUT_L, L_PAD, DT = 1023, 2053, "bf16"
    SPAN = (OUT_L - 1) * SW + 1
    NT = 341  # threads per CTA; OUT_L // NT = 3 outputs each

    @module(
        entry="max_pool1d",
        target=H200,
        topologies=(Topology("cta", ROWS), Topology("thread", NT)),
    )
    class EcgStaged:
        @func
        def max_pool1d(xpad: Tensor[(ROWS, L_PAD), DT]):
            with Mesh(("cta",), layout=(ROWS,), names=("row",)) as cta:
                with Mesh(("thread",), layout=(NT,), names=("t",)) as m:
                    held = tf.reshard(xpad, (ROWS @ cta.row, L_PAD), "smem")
                    taps = tf.stack(
                        [
                            tf.reshard(
                                held[:, kw * DW : kw * DW + SPAN : SW],
                                (ROWS @ cta.row, OUT_L @ m.t),
                                "rmem",
                            )
                            for kw in range(KW)
                        ],
                        axis=-1,
                    )
                    best = tf.reduce(
                        tf.cast(taps, "f32"), axes=(-1,), keepdim=False, kind=ReduceKind.MAX
                    )
                    return tf.reshard(tf.cast(best, DT), (ROWS, OUT_L), "gmem")

    return EcgStaged


def textcnn_reference():
    """[64,256,128] k128 s1 p0 f16, unplaced: the window is the whole row."""
    ROWS, L_IN, DT = 16384, 128, "f16"

    @module(entry="max_pool1d", target=H200, topologies=(Topology("cta", 1),))
    class TextcnnReference:
        @func
        def max_pool1d(x: Tensor[(ROWS, L_IN), DT]):
            best = tf.reduce(tf.cast(x, "f32"), axes=(-1,), keepdim=True, kind=ReduceKind.MAX)
            return tf.cast(best, DT)

    return TextcnnReference


def textcnn_direct():
    """The placement in main: one thread reads one whole row out of gmem."""
    ROWS, L_IN, DT = 16384, 128, "f16"
    NT = 128
    CTAS = ROWS // NT

    @module(
        entry="max_pool1d",
        target=H200,
        topologies=(Topology("cta", CTAS), Topology("thread", NT)),
    )
    class TextcnnDirect:
        @func
        def max_pool1d(x: Tensor[(ROWS, L_IN), DT]):
            rows = tf.reshape(x, new_shape=(CTAS, NT, L_IN))
            with Mesh(("cta",), layout=(CTAS,), names=("blk",)) as cta:
                with Mesh(("thread",), layout=(NT,), names=("t",)) as m:
                    held = tf.reshard(rows, (CTAS @ cta.blk, NT @ m.t, L_IN), "rmem")
                    best = tf.reduce(
                        tf.cast(held, "f32"), axes=(-1,), keepdim=True, kind=ReduceKind.MAX
                    )
                    out = tf.reshard(tf.cast(best, DT), (CTAS, NT, 1), "gmem")
                    return tf.reshape(out, new_shape=(ROWS, 1))

    return TextcnnDirect


def textcnn_rowreduce():
    """The window sharded across the lanes that cover it, so the reduce is a cross-lane one.

    One output a row and one lane a row is a launch of one thread per row, which is 16384
    of them: too few to fill the device whatever each one does. Sharding the window over
    the lanes that cover it puts `LANES` threads on every row instead, and the reduction
    over the sharded axis is what combines them.
    """
    ROWS, L_IN, DT = 16384, 128, "f16"
    # One lane per 16-byte group of the window: 128 f16 taps is 16 of them.
    LANES = 16
    ROWS_PER_CTA = 32
    NT = ROWS_PER_CTA * LANES
    CTAS = ROWS // ROWS_PER_CTA

    @module(
        entry="max_pool1d",
        target=H200,
        topologies=(Topology("cta", CTAS), Topology("thread", NT)),
    )
    class TextcnnRowReduce:
        @func
        def max_pool1d(x: Tensor[(ROWS, L_IN), DT]):
            rows = tf.reshape(x, new_shape=(CTAS, ROWS_PER_CTA, L_IN))
            with Mesh(("cta",), layout=(CTAS,), names=("blk",)) as cta:
                with Mesh(("thread",), layout=(ROWS_PER_CTA, LANES), names=("r", "t")) as m:
                    held = tf.reshard(
                        rows,
                        (CTAS @ cta.blk, ROWS_PER_CTA @ m.r, L_IN @ m.t),
                        "rmem",
                    )
                    best = tf.reduce(
                        tf.cast(held, "f32"), axes=(-1,), keepdim=True, kind=ReduceKind.MAX
                    )
                    out = tf.reshard(tf.cast(best, DT), (CTAS, ROWS_PER_CTA, 1), "gmem")
                    return tf.reshape(out, new_shape=(ROWS, 1))

    return TextcnnRowReduce


SincnetReference = sincnet_reference()
SincnetWindowed = sincnet_windowed()
SincnetStaged = sincnet_staged()
EcgReference = ecg_reference()
EcgWindowed = ecg_windowed()
EcgStaged = ecg_staged()
TextcnnReference = textcnn_reference()
TextcnnDirect = textcnn_direct()
TextcnnRowReduce = textcnn_rowreduce()
```

All nine modules pass `check` against `torch.nn.functional.max_pool1d` at `atol = rtol = 1e-3` for FP16 and `8e-3` for BF16.

`analyze --compute-cost --memory --roofline` reports every module memory-bound:

| module | gmem read / write (B) | per-CTA gmem read (B) | ideal-ns |
| --- | ---: | ---: | ---: |
| `SincnetWindowed` | 20966400 / 6988800 | 8190 | 5824 |
| `SincnetStaged` | 20971520 / 6988800 | 8192 | 5826 |
| `EcgWindowed` | 20951040 / 4190208 | 10230 | 5238 |
| `EcgStaged` | 8409088 / 4190208 | 4106 | 2625 |
| `TextcnnDirect` | 4194304 / 32768 | 32768 | 881 |
| `TextcnnRowReduce` | 4194304 / 32768 | 8192 | 881 |

The three rows read differently, and the analysis says so before any kernel exists.

`EcgStaged` reads 2.49x less than `EcgWindowed` and its `ideal-ns` halves: dilation 2 at stride 2 makes the five views overlap 4.5x, and `smem` carries that re-read at 20951040 / 8409088. That is the change worth making, and it is the one this PR makes.

`SincnetStaged` differs from `SincnetWindowed` by 5120 B of 21 MB, which is the row's last five elements that no tap reads. Stride 3 at kernel 3 makes the three views partition the row, so nothing is read twice and a staging copy would be pure addition. The windowed placement is kept, and measurement agreed: the staged form ran 11.616 us against the windowed form's 10.752 us, and its `smem` round trip of 42 MB costs more than the strided read's sector waste saves.

`TextcnnRowReduce` moves no less global traffic than `TextcnnDirect` -- the window is the whole row, so every element is read once whatever the residency -- but its per-CTA read falls 4x. That is the decision: the reduction is sharded over the lanes covering the window, so the launch is not one thread per row.

## Performance

Operator: `MaxPool1dFwdOp` and `MaxPool1dIndicesFwdOp`, at the three workloads `src/tileops/manifest/pool.yaml` benchmarks.

| | |
| --- | --- |
| image | `ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-afcebed1-tilefoundry-latest` |
| digest | `sha256:ca13df9bda340edf248b8b443b88880f36e3190ab9d470f52d66ccc21c15fd59` |
| gpu | NVIDIA H200 |
| driver | 595.71.05 |
| cuda | 13.2 |
| torch | 2.13.0+cu132 |
| tilelang | 0.1.11+cu132.gitafcebed1 |
| tilefoundry | 0.1.dev146+g2bec6420e |
| triton | 3.7.1 |
| timer | `device_busy_ms`, CUPTI, through `benchmarks/ops/bench_pool.py` |

Method: four runs of the whole comparison in a fresh container on GPU 4 of this host, candidate and comparators timed inside each run. The candidate figure is its median; the bar is the comparator's minimum, because `torch-compile` returns two distinct times on three of these rows (4.832 and 6.657 us, 3.456 and 3.872 us, 15.328 and 16.768 us). The candidate's own spread is 0.6% to 3.0%.

Ratios are comparator / candidate: &#x1F7E2; above 1, &#x1F534; at or below. The last column is against `torch-ref`, the tag the nightly holds these rows to.

| op | workload | shape | dtype | tileops (us) | torch-compile (us) | torch-ref (us) | vs best | vs baseline |
| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: |
| `MaxPool1dFwd` | sincnet-speaker-local | `[32, 80, 4096] k3 s3` | fp16 | 10.816 | 10.528 | 38.752 | &#x1F534; 0.973 | 3.58x |
| `MaxPool1dFwd` | textcnn-global | `[64, 256, 128] k128 s1` | fp16 | 3.216 | 3.456 | 20.768 | &#x1F7E2; 1.075 | 6.46x |
| `MaxPool1dFwd` | ecg-cnn-dilated | `[16, 128, 2048] k5 s2 p2 d2 ceil` | bf16 | 5.360 | 6.848 | 27.200 | &#x1F7E2; 1.278 | 5.07x |
| `MaxPool1dIndicesFwd` | sincnet-speaker-local | `[32, 80, 4096] k3 s3` | fp16 | 15.776 | 15.328 | 38.720 | &#x1F534; 0.972 | 2.45x |
| `MaxPool1dIndicesFwd` | textcnn-global | `[64, 256, 128] k128 s1` | fp16 | 4.144 | 4.768 | 20.768 | &#x1F7E2; 1.151 | 5.01x |
| `MaxPool1dIndicesFwd` | ecg-cnn-dilated | `[16, 128, 2048] k5 s2 p2 d2 ceil` | bf16 | 9.840 | 10.752 | 27.168 | &#x1F7E2; 1.093 | 2.76x |
| **geomean** | | | | | | | **1.085** | |

`avg_pool1d` shares `window_span` after this change and is measured in the same runs, unregressed:

| workload | tileops (us) | torch-compile (us) | ratio |
| --- | ---: | ---: | ---: |
| audio-downsample | 3.504 | 3.680 | &#x1F7E2; 1.050 |
| long-temporal | 13.576 | 16.096 | &#x1F7E2; 1.186 |
| ceil | 2.080 | 2.048 | &#x1F534; 0.985 |

## Result And Limitations

**Measured SOTA on four of the six rows. The two `sincnet` rows are 2.7% short of `torch-compile` and sit at their access pattern's own floor.**

- `ecg-cnn-dilated` 6.720 -> 5.360 us, which is 0.90 of a `torch.neg` pass over the same bytes at 4.800 us. Its indices row 11.680 -> 9.840 us.
- `textcnn-global` 3.648 -> 3.216 us against a wall of 2.656 us, or 0.82 of it. Its indices row 4.256 -> 4.144 us.
- `sincnet-speaker-local` 10.880 -> 10.816 us against `torch-compile`'s 10.528 us. The bound it is held to is not the 8.832 us wall but what this access pattern reaches: reading one tap per output instead of three, at the same stride and fetching the same lines, costs 10.432 us. `torch-compile` emits the same program and adds `eviction_policy='evict_last'` to each load, which TileLang exposes on `T.copy` and TMA but not on an indexed load.
- Eight mechanisms were measured on that row and none was faster. The one with the most left in it, giving a lane a run of eight outputs so its taps arrive as three full-width vectors, TileLang refuses to build: a fragment whose trailing extent is `8 * stride` has no layout.

Limitations:

- `rowreduce` emits no position, so it is not offered with indices; `MaxPool1dIndicesFwd`'s `textcnn` row takes the staged body and gains 2% where the value-only row gains 12%.
- `staged` needs the padded row to fit the 48 KB a block gets. A wider row takes the windowed body, which is the shape `avg_pool1d`'s `long-temporal` workload has.
- The `-inf` fills and the staged row pad are measured on an H200 and not re-derived elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
