### PR TITLE
[BugFix][Attention] Align dense GQA decode split dispatch

### DIFF
--- a/src/tileops/kernels/attention/gqa_decode.py
+++ b/src/tileops/kernels/attention/gqa_decode.py
@@ -17,6 +17,20 @@ from .online_softmax import (
 
 __all__ = ["GQADecodeKernel"]
 
+
+def _effective_num_split(num_split: int, block_N: int, real_seqlen_kv: int) -> int:
+    """Split count the runtime can use for a KV extent of *real_seqlen_kv*.
+
+    The tuned or default ``num_split`` is only a ceiling: shrink it until every
+    split keeps at least one full KV tile. ``1`` means the sequence is too
+    short to split and the no-split kernel should run. Gating dispatch on the
+    tuned value itself (the old ``real_seqlen_kv < num_split * block_N`` test)
+    let a large tuned ``num_split`` push execution into the never-tuned
+    no-split kernel.
+    """
+    return max(1, min(num_split, real_seqlen_kv // block_N))
+
+
 # JIT kernel: no-split variant
 
 
@@ -262,7 +276,6 @@ def _gqa_decode_split_kernel(batch, heads, groups, dim, sm_scale, softcap, dtype
             V: T.Tensor(shape_v, dtype),
             glse: T.Tensor([batch, heads, num_split], dtype),
             Output_partial: T.Tensor(part_shape, dtype),
-            split_length: T.Tensor(num_split, "int32"),
         ):
             with T.Kernel(batch, heads // valid_block_H, num_split, threads=threads) as (
                 bx,
@@ -282,29 +295,35 @@ def _gqa_decode_split_kernel(batch, heads, groups, dim, sm_scale, softcap, dtype
                 scores_sum = T.alloc_fragment([block_H], accum_dtype)
                 logsum = T.alloc_fragment([block_H], accum_dtype)
 
-                split_length_shared = T.alloc_shared([num_split], "int32")
-                T.copy(split_length, split_length_shared, disable_tma=True)
-
                 bid = bx
                 hid = by
                 sid = bz
                 cur_kv_head = hid // (kv_group_num // valid_block_H)
+
+                # Partition whole KV tiles as evenly as possible (recipe from
+                # gqa_decode_bs1): every CTA derives its own tile range from
+                # the runtime sequence extent, so the autotuner times the same
+                # distribution forward runs and no split is left empty.
+                num_tiles = T.ceildiv(seqlen_kv, block_N)
+                base_tiles = num_tiles // num_split
+                extra_tiles = num_tiles % num_split
+                tiles_this_split = base_tiles + T.if_then_else(sid < extra_tiles, 1, 0)
+                tile_begin = sid * base_tiles + T.min(sid, extra_tiles)
+                base = tile_begin * block_N
+                this_len = T.max(T.min(seqlen_kv - base, tiles_this_split * block_N), 0)
 
                 T.copy(Q[bid, hid * valid_block_H : hid * valid_block_H + block_H, :], Q_shared)
                 T.fill(acc_o, 0)
                 T.fill(logsum, 0)
                 T.fill(scores_max, -T.infinity(accum_dtype))
 
-                loop_range = T.ceildiv(split_length_shared[sid], block_N)
+                loop_range = T.ceildiv(this_len, block_N)
 
                 for k in T.Pipelined(loop_range, num_stages=num_stages):
                     T.copy(
                         K[
                             bid,
-                            (seqlen_kv // (num_split * block_N) * block_N) * sid
-                            + k * valid_block_N : (seqlen_kv // (num_split * block_N) * block_N)
-                            * sid
-                            + (k + 1) * valid_block_N,
+                            base + k * valid_block_N : base + (k + 1) * valid_block_N,
                             cur_kv_head,
                             :,
                         ],
@@ -316,7 +335,7 @@ def _gqa_decode_split_kernel(batch, heads, groups, dim, sm_scale, softcap, dtype
                     )
                     for i, j in T.Parallel(block_H, valid_block_N):
                         acc_s[i, j] = T.if_then_else(
-                            (k * block_N + j < split_length[sid]),
+                            (base + k * block_N + j < seqlen_kv),
                             acc_s[i, j],
                             -T.infinity(accum_dtype),
                         )
@@ -330,10 +349,7 @@ def _gqa_decode_split_kernel(batch, heads, groups, dim, sm_scale, softcap, dtype
                     T.copy(
                         V[
                             bid,
-                            (seqlen_kv // (num_split * block_N) * block_N) * sid
-                            + k * valid_block_N : (seqlen_kv // (num_split * block_N) * block_N)
-                            * sid
-                            + (k + 1) * valid_block_N,
+                            base + k * valid_block_N : base + (k + 1) * valid_block_N,
                             cur_kv_head,
                             :,
                         ],
@@ -341,9 +357,15 @@ def _gqa_decode_split_kernel(batch, heads, groups, dim, sm_scale, softcap, dtype
                     )
                     T.gemm(acc_s_cast, V_shared, acc_o, policy=T.GemmWarpPolicy.FullRow)
                 for i, j in T.Parallel(block_H, dim):
-                    acc_o[i, j] /= logsum[i]
+                    # An empty split (this_len == 0) must not poison the combine
+                    # with 0/0; its glse is -inf so it weighs nothing there.
+                    acc_o[i, j] /= T.if_then_else(this_len > 0, logsum[i], 1.0)
                 for i in T.Parallel(block_H):
-                    logsum[i] = T.log2(logsum[i]) + scores_max[i] * scale
+                    logsum[i] = T.if_then_else(
+                        this_len > 0,
+                        T.log2(logsum[i]) + scores_max[i] * scale,
+                        -T.infinity(accum_dtype),
+                    )
 
                 for i in T.Parallel(block_H):
                     if i < valid_block_H:
@@ -393,10 +415,9 @@ def _gqa_decode_split_kernel(batch, heads, groups, dim, sm_scale, softcap, dtype
             V: T.Tensor(shape_v, dtype),
             glse: T.Tensor([batch, heads, num_split], dtype),
             Output_partial: T.Tensor(part_shape, dtype),
-            split_length: T.Tensor(num_split, "int32"),
             Output: T.Tensor(shape_o, dtype),
         ):
-            _gqa_decode_split(Q, K, V, glse, Output_partial, split_length)
+            _gqa_decode_split(Q, K, V, glse, Output_partial)
             combine(glse, Output_partial, Output)
 
         return gqa_decode_split
@@ -530,11 +551,10 @@ def _gqa_decode_split_op(
     V: torch.Tensor,
     glse: torch.Tensor,
     Output_partial: torch.Tensor,
-    split_length: torch.Tensor,
 ) -> torch.Tensor:
     return _gqa_decode_split_kernel(batch, heads, groups, dim, sm_scale, softcap, dtype)(
         block_H, block_N, num_split, num_stages, threads
-    )(Q, K, V, glse, Output_partial, split_length)
+    )(Q, K, V, glse, Output_partial)
 
 
 @_gqa_decode_split_op.register_fake
@@ -556,7 +576,6 @@ def _(
     V: torch.Tensor,
     glse: torch.Tensor,
     Output_partial: torch.Tensor,
-    split_length: torch.Tensor,
 ) -> torch.Tensor:
     return torch.empty_like(Q)
 
@@ -635,7 +654,8 @@ class GQADecodeKernel(Kernel):
             self.softcap,
             self.dtype_str,
         )
-        # autotune targets the split kernel
+        # autotune targets the split kernel; forward shrinks the tuned
+        # num_split to the runtime KV extent instead of gating dispatch on it
         self.kernel = self.split_jit
         self._supply_prog = self._make_supply_prog()
         self.init_config(config, tune)
@@ -652,13 +672,6 @@ class GQADecodeKernel(Kernel):
             for param in params:
                 if param.is_scalar():
                     inputs.append(seqlen_kv)
-                elif str(param.dtype) == "int32":
-                    # split_length: fill with evenly divided lengths
-                    num_split = param.shape[0]
-                    base = seqlen_kv // num_split
-                    t = torch.full((num_split,), base, dtype=torch.int32, device="cuda")
-                    t[-1] += seqlen_kv % num_split
-                    inputs.append(t)
                 else:
                     inputs.append(default_supply(param))
             return inputs
@@ -680,11 +693,13 @@ class GQADecodeKernel(Kernel):
         }
 
     def _default_num_split(self) -> int:
-        """Choose a conservative default split policy for GQA decode.
+        """Choose a conservative default split-count ceiling for GQA decode.
 
-        Single-request, high-ratio GQA decode with very few KV heads benefits
-        from more split parallelism. Keep the existing split=16 default for
-        other shapes to avoid changing batched Llama-like workloads.
+        ``forward`` shrinks this to the runtime KV extent, so it only bounds how
+        far the split kernel may parallelise. Single-request, high-ratio GQA
+        decode with very few KV heads benefits from more split parallelism.
+        Keep the existing split=16 default for other shapes to avoid changing
+        batched Llama-like workloads.
         """
         kv_group_num = self.heads // self.groups
         if self.batch == 1 and self.dim == 128 and self.groups <= 2 and kv_group_num >= 8:
@@ -697,11 +712,14 @@ class GQADecodeKernel(Kernel):
     def autotune_configs(self) -> list[dict]:
         block_N = [64, 128]
         block_H = [64]
-        num_split = [ns for ns in [2, 4, 8, 16, 32] if ns <= self.seqlen_kv] or [1]
+        num_split = [1, 2, 4, 8, 16, 32]
         num_stages = [1, 2, 3]
         threads = [128]
         _configs = list(itertools.product(block_N, block_H, num_split, num_stages, threads))
 
+        # Every split keeps at least one full KV tile, so the autotuner never
+        # times a distribution the runtime cannot run; num_split=1 lets it
+        # compare the unsplit strategy, which degenerates to no-split.
         configs = [
             {
                 "block_N": c[0],
@@ -711,6 +729,7 @@ class GQADecodeKernel(Kernel):
                 "threads": c[4],
             }
             for c in _configs
+            if c[2] <= max(1, self.seqlen_kv // c[0])
         ]
         return configs
 
@@ -735,13 +754,14 @@ class GQADecodeKernel(Kernel):
         real_seqlen_kv = k.shape[1]
         block_H = self.config["block_H"]
         block_N = self.config["block_N"]
-        num_split = self.config["num_split"]
         num_stages = self.config["num_stages"]
         threads = self.config["threads"]
+        # The tuned num_split is a ceiling: shrink it until every split keeps
+        # one full KV tile. 1 means the sequence is too short to split.
+        num_split = _effective_num_split(self.config["num_split"], block_N, real_seqlen_kv)
 
-        # Dispatch: use no-split for short sequences where splitting is not beneficial
-        threshold = num_split * block_N
-        if real_seqlen_kv < threshold:
+        # Dispatch: no-split for sequences too short to give each split a tile
+        if num_split == 1:
             if self.fuse_rope:
                 output = _gqa_decode_no_split_rope_op(
                     self.batch,
@@ -823,11 +843,7 @@ class GQADecodeKernel(Kernel):
             )
             return output.unsqueeze(1)
 
-        # Split path: compute per-split lengths
-        base_len = real_seqlen_kv // (num_split * block_N) * block_N
-        split_length = torch.full((num_split,), base_len, dtype=torch.int32, device=Q.device)
-        split_length[-1] = real_seqlen_kv - (num_split - 1) * base_len
-
+        # Split path: the kernel partitions KV tiles from the runtime extent
         glse = torch.empty((self.batch, self.heads, num_split), dtype=self.dtype, device=Q.device)
         Output_partial = torch.empty(
             (self.batch, self.heads, num_split, self.dim), dtype=self.dtype, device=Q.device
@@ -851,6 +867,5 @@ class GQADecodeKernel(Kernel):
             V,
             glse,
             Output_partial,
-            split_length,
         )
         return output.unsqueeze(1)

--- a/src/tileops/kernels/attention/gqa_decode.py
+++ b/src/tileops/kernels/attention/gqa_decode.py
@@ -18,6 +18,9 @@ from .online_softmax import (
 __all__ = ["GQADecodeKernel"]
 
 
+_SPLIT_CANDIDATES = (1, 2, 4, 8, 16, 32)
+
+
 def _effective_num_split(num_split: int, block_N: int, real_seqlen_kv: int) -> int:
     """Split count the runtime can use for a KV extent of *real_seqlen_kv*.
 
@@ -29,6 +32,12 @@ def _effective_num_split(num_split: int, block_N: int, real_seqlen_kv: int) -> i
     no-split kernel.
     """
     return max(1, min(num_split, real_seqlen_kv // block_N))
+
+
+def _effective_dense_num_split(num_split: int, block_N: int, real_seqlen_kv: int) -> int:
+    """Map Dense decode to one of its finite autotune split candidates."""
+    limit = _effective_num_split(num_split, block_N, real_seqlen_kv)
+    return max(candidate for candidate in _SPLIT_CANDIDATES if candidate <= limit)
 
 
 # JIT kernel: no-split variant
@@ -684,29 +693,50 @@ class GQADecodeKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
+        high_parallelism = self._uses_high_parallelism_default()
         return {
             "block_H": 64,
-            "block_N": 128,
-            "num_split": self._default_num_split(),
+            "block_N": 64 if high_parallelism else 128,
+            "num_split": 32 if high_parallelism else 16,
             "num_stages": 2,
             "threads": 128,
         }
 
-    def _default_num_split(self) -> int:
-        """Choose a conservative default split-count ceiling for GQA decode.
+    def _uses_high_parallelism_default(self) -> bool:
+        """Whether this call belongs to the measured BN64/split32 region."""
+        return self.high_parallelism_region(
+            batch=self.batch,
+            heads=self.heads,
+            heads_kv=self.groups,
+            dim=self.dim,
+            dtype=self.dtype,
+            softcap=self.softcap,
+        )
 
-        ``forward`` shrinks this to the runtime KV extent, so it only bounds how
-        far the split kernel may parallelise. Single-request, high-ratio GQA
-        decode with very few KV heads benefits from more split parallelism.
-        Keep the existing split=16 default for other shapes to avoid changing
-        batched Llama-like workloads.
-        """
-        kv_group_num = self.heads // self.groups
-        if self.batch == 1 and self.dim == 128 and self.groups <= 2 and kv_group_num >= 8:
-            candidate = 32
-        else:
-            candidate = 16
-        return candidate
+    @staticmethod
+    def high_parallelism_region(
+        *,
+        batch: int,
+        heads: int,
+        heads_kv: int,
+        dim: int,
+        dtype: torch.dtype | str,
+        softcap: float,
+    ) -> bool:
+        """Whether the call matches the H200 region measured for BN64/split32."""
+        return (
+            batch == 1
+            and heads == 32
+            and heads_kv == 4
+            and dim == 128
+            and Kernel.dtype_to_str(dtype) == "float16"
+            and softcap == 0.0
+        )
+
+    @staticmethod
+    def split_capacity(seq_len_kv: int) -> int:
+        """Return the finite autotune-capacity bucket for an input KV extent."""
+        return _effective_dense_num_split(max(_SPLIT_CANDIDATES), 64, seq_len_kv)
 
     @property
     def autotune_configs(self) -> list[dict]:
@@ -758,7 +788,7 @@ class GQADecodeKernel(Kernel):
         threads = self.config["threads"]
         # The tuned num_split is a ceiling: shrink it until every split keeps
         # one full KV tile. 1 means the sequence is too short to split.
-        num_split = _effective_num_split(self.config["num_split"], block_N, real_seqlen_kv)
+        num_split = _effective_dense_num_split(self.config["num_split"], block_N, real_seqlen_kv)
 
         # Dispatch: no-split for sequences too short to give each split a tile
         if num_split == 1:

--- a/src/tileops/kernels/attention/gqa_decode_paged.py
+++ b/src/tileops/kernels/attention/gqa_decode_paged.py
@@ -8,7 +8,6 @@ import torch
 
 from tileops.kernels.kernel_base import Kernel
 
-from .gqa_decode import _effective_num_split
 from .online_softmax import (
     LOG2E,
     make_apply_softcap,
@@ -568,8 +567,7 @@ class GQADecodePagedKernel(Kernel):
             self.dtype_str,
         )
 
-        # autotune targets the split kernel; forward shrinks the tuned
-        # num_split to the runtime KV extent instead of gating dispatch on it
+        # autotune targets the split kernel
         self.kernel = self.split_jit
         self._supply_prog = self._make_supply_prog()
         self.init_config(config, tune)
@@ -632,14 +630,11 @@ class GQADecodePagedKernel(Kernel):
     def autotune_configs(self) -> list[dict]:
         block_N = self._supported_block_ns
         block_H = [64]
-        num_split = [1, 2, 4, 8]
+        num_split = [2, 4, 8]
         num_stages = [1, 2, 3]
         threads = [128]
         _configs = list(itertools.product(block_N, block_H, num_split, num_stages, threads))
 
-        # Every split keeps at least one full KV tile, so the autotuner never
-        # times a distribution the runtime cannot run; num_split=1 lets it
-        # compare the unsplit strategy, which degenerates to no-split.
         configs = [
             {
                 "block_N": c[0],
@@ -649,7 +644,6 @@ class GQADecodePagedKernel(Kernel):
                 "threads": c[4],
             }
             for c in _configs
-            if c[2] <= max(1, self.seqlen_kv // c[0])
         ]
         return configs
 
@@ -663,18 +657,16 @@ class GQADecodePagedKernel(Kernel):
     ):
         block_H = self.config["block_H"]
         block_N = self.config["block_N"]
+        num_split = self.config["num_split"]
         num_stages = self.config["num_stages"]
         threads = self.config["threads"]
 
+        # Dispatch: use no-split for short sequences where splitting is not beneficial
         real_max = (
             real_seqlen_kv.max().item() if real_seqlen_kv.dim() > 0 else real_seqlen_kv.item()
         )
-        # The tuned num_split is a ceiling: shrink it until every split keeps
-        # one full KV tile of the longest sequence. 1 means no-split.
-        num_split = _effective_num_split(self.config["num_split"], block_N, real_max)
-
-        # Dispatch: no-split for sequences too short to give each split a tile
-        if num_split == 1:
+        threshold = num_split * block_N
+        if real_max < threshold:
             return _gqa_decode_paged_no_split_op(
                 self.batch,
                 self.heads,

--- a/src/tileops/kernels/attention/gqa_decode_paged.py
+++ b/src/tileops/kernels/attention/gqa_decode_paged.py
@@ -8,6 +8,7 @@ import torch
 
 from tileops.kernels.kernel_base import Kernel
 
+from .gqa_decode import _effective_num_split
 from .online_softmax import (
     LOG2E,
     make_apply_softcap,
@@ -567,7 +568,8 @@ class GQADecodePagedKernel(Kernel):
             self.dtype_str,
         )
 
-        # autotune targets the split kernel
+        # autotune targets the split kernel; forward shrinks the tuned
+        # num_split to the runtime KV extent instead of gating dispatch on it
         self.kernel = self.split_jit
         self._supply_prog = self._make_supply_prog()
         self.init_config(config, tune)
@@ -630,11 +632,14 @@ class GQADecodePagedKernel(Kernel):
     def autotune_configs(self) -> list[dict]:
         block_N = self._supported_block_ns
         block_H = [64]
-        num_split = [2, 4, 8]
+        num_split = [1, 2, 4, 8]
         num_stages = [1, 2, 3]
         threads = [128]
         _configs = list(itertools.product(block_N, block_H, num_split, num_stages, threads))
 
+        # Every split keeps at least one full KV tile, so the autotuner never
+        # times a distribution the runtime cannot run; num_split=1 lets it
+        # compare the unsplit strategy, which degenerates to no-split.
         configs = [
             {
                 "block_N": c[0],
@@ -644,6 +649,7 @@ class GQADecodePagedKernel(Kernel):
                 "threads": c[4],
             }
             for c in _configs
+            if c[2] <= max(1, self.seqlen_kv // c[0])
         ]
         return configs
 
@@ -657,16 +663,18 @@ class GQADecodePagedKernel(Kernel):
     ):
         block_H = self.config["block_H"]
         block_N = self.config["block_N"]
-        num_split = self.config["num_split"]
         num_stages = self.config["num_stages"]
         threads = self.config["threads"]
 
-        # Dispatch: use no-split for short sequences where splitting is not beneficial
         real_max = (
             real_seqlen_kv.max().item() if real_seqlen_kv.dim() > 0 else real_seqlen_kv.item()
         )
-        threshold = num_split * block_N
-        if real_max < threshold:
+        # The tuned num_split is a ceiling: shrink it until every split keeps
+        # one full KV tile of the longest sequence. 1 means no-split.
+        num_split = _effective_num_split(self.config["num_split"], block_N, real_max)
+
+        # Dispatch: no-split for sequences too short to give each split a tile
+        if num_split == 1:
             return _gqa_decode_paged_no_split_op(
                 self.batch,
                 self.heads,

--- a/src/tileops/ops/attention/gqa.py
+++ b/src/tileops/ops/attention/gqa.py
@@ -473,6 +473,19 @@ class GroupedQueryAttentionDenseFwdOp(Op):
         uses_window = self.window_size_left != -1 or self.window_size_right != -1
         rope_on = self.pos_encoding_mode == "rope"
         uses_decode = seq_len_q == 1 and not uses_window
+        uses_long_generic_decode = (
+            uses_decode
+            and not rope_on
+            and seq_len_kv >= 1024
+            and GQADecodeKernel.high_parallelism_region(
+                batch=batch,
+                heads=heads,
+                heads_kv=heads_kv,
+                dim=dim,
+                dtype=q.dtype,
+                softcap=self.softcap,
+            )
+        )
         uses_bs1_decode = (
             uses_decode
             and batch == 1
@@ -480,6 +493,7 @@ class GroupedQueryAttentionDenseFwdOp(Op):
             and dim == 128
             and self.softcap == 0.0
             and 1 <= heads // heads_kv <= 64
+            and not uses_long_generic_decode
         )
         if uses_bs1_decode:
             role = "gqa_dense_decode_bs1"
@@ -559,6 +573,10 @@ class GroupedQueryAttentionDenseFwdOp(Op):
                 heads_kv,
                 dim,
             )
+            if role == "gqa_dense_decode":
+                # Decode may compile one of a finite set of split programs.
+                # Key the capacity tier, not the exact runtime KV length.
+                key += (GQADecodeKernel.split_capacity(seq_len_kv),)
         return self.get_or_build_kernel(role, inputs, key=key, build=build)
 
     def forward(

--- a/tests/ops/attention/test_gqa.py
+++ b/tests/ops/attention/test_gqa.py
@@ -12,6 +12,11 @@ from tileops.kernels.attention import (
     GQADenseSlidingWindowKernel,
     GQADenseWsKernel,
 )
+from tileops.kernels.attention.gqa_decode import (
+    _effective_num_split,
+    _gqa_decode_no_split_op,
+    _gqa_decode_split_op,
+)
 from tileops.kernels.kernel_base import Kernel
 from tileops.ops import (
     GroupedQueryAttentionBwdOp,
@@ -322,6 +327,89 @@ def test_gqa_dense_decode_dispatch_and_dynamic_sequence_lengths(
     kernels = list(op.iter_kernels())
     assert len(kernels) == 1
     assert isinstance(kernels[0], kernel_type)
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "num_split, block_N, real_seqlen_kv, expected",
+    [
+        pytest.param(32, 64, 1024, 16, id="issue-shape-clamps-to-tiles"),
+        pytest.param(32, 64, 2048, 32, id="feasible-tuned-value-kept"),
+        pytest.param(16, 128, 1024, 8, id="block-128-clamps"),
+        pytest.param(32, 64, 100, 1, id="short-sequence-no-split"),
+        pytest.param(8, 64, 63, 1, id="sub-tile-no-split"),
+        pytest.param(4, 64, 64, 1, id="single-tile-no-split"),
+        pytest.param(4, 64, 128, 2, id="two-tiles-split-two"),
+        pytest.param(1, 64, 100000, 1, id="tuned-no-split-stays-no-split"),
+    ],
+)
+def test_gqa_decode_effective_num_split(
+    num_split: int, block_N: int, real_seqlen_kv: int, expected: int
+) -> None:
+    """The tuned num_split is a ceiling shrunk to the runtime KV extent."""
+    assert _effective_num_split(num_split, block_N, real_seqlen_kv) == expected
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("seqlen_kv", [1, 63, 128, 1024])
+def test_gqa_decode_autotune_configs_keep_full_tiles_per_split(seqlen_kv: int) -> None:
+    """Every swept config leaves each split one full KV tile; num_split=1 stays comparable."""
+    if not torch.cuda.is_available() or get_sm_version() not in (80, 89, 90):
+        pytest.skip("GQA decode requires SM80/89/90")
+    kernel = GQADecodeKernel(2, 8, 2, seqlen_kv, 128, dtype=torch.float16)
+    configs = kernel.autotune_configs
+    assert configs, "the sweep must stay non-empty for any positive sequence length"
+    for config in configs:
+        assert config["num_split"] <= max(1, seqlen_kv // config["block_N"])
+    assert any(config["num_split"] == 1 for config in configs)
+
+
+@pytest.mark.smoke
+def test_gqa_decode_tuned_split_count_tracks_runtime_sequence(monkeypatch) -> None:
+    """A tuned num_split the sequence cannot fill shrinks instead of pushing
+    dispatch into the never-tuned no-split kernel (the reported issue)."""
+    if not torch.cuda.is_available() or get_sm_version() not in (80, 89, 90):
+        pytest.skip("GQA decode requires SM80/89/90")
+    batch, heads, heads_kv, dim = 2, 32, 4, 128
+    kernel = GQADecodeKernel(
+        batch,
+        heads,
+        heads_kv,
+        1024,
+        dim,
+        dtype=torch.float16,
+        config={"block_H": 64, "block_N": 64, "num_split": 32, "num_stages": 2, "threads": 128},
+    )
+
+    calls: list[tuple[str, int]] = []
+
+    def split_spy(*args, **kwargs):
+        # num_split is the 12th positional argument of _gqa_decode_split_op
+        calls.append(("split", args[11]))
+        return _gqa_decode_split_op(*args, **kwargs)
+
+    def no_split_spy(*args, **kwargs):
+        calls.append(("no_split", 0))
+        return _gqa_decode_no_split_op(*args, **kwargs)
+
+    monkeypatch.setattr("tileops.kernels.attention.gqa_decode._gqa_decode_split_op", split_spy)
+    monkeypatch.setattr(
+        "tileops.kernels.attention.gqa_decode._gqa_decode_no_split_op", no_split_spy
+    )
+
+    # 1024 tokens fill 16 of the tuned 32 splits; 100 cannot fill two
+    for seq_len_kv, expected in ((1024, ("split", 16)), (100, ("no_split", 0))):
+        q = torch.randn(batch, 1, heads, dim, device="cuda", dtype=torch.float16)
+        k = torch.randn(batch, seq_len_kv, heads_kv, dim, device="cuda", dtype=torch.float16)
+        v = torch.randn_like(k)
+        output = kernel(q, k, v)
+        torch.testing.assert_close(
+            output,
+            _gqa_prefill_ref(q, k, v, heads=heads, heads_kv=heads_kv, is_causal=True),
+            atol=5e-3,
+            rtol=1e-5,
+        )
+        assert calls[-1] == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/ops/attention/test_gqa.py
+++ b/tests/ops/attention/test_gqa.py
@@ -13,7 +13,7 @@ from tileops.kernels.attention import (
     GQADenseWsKernel,
 )
 from tileops.kernels.attention.gqa_decode import (
-    _effective_num_split,
+    _effective_dense_num_split,
     _gqa_decode_no_split_op,
     _gqa_decode_split_op,
 )
@@ -222,21 +222,33 @@ def test_gqa_dense_reuses_one_kernel_across_sequence_lengths(batch: int) -> None
 
 
 @pytest.mark.parametrize(
-    "batch, dtype, seq_lens_kv, rope_layout, rotary_dim, kernel_type",
+    "batch, head_shape, dtype, seq_lens_kv, rope_layout, rotary_dim, kernel_type",
     [
         pytest.param(
             1,
+            (8, 2),
             torch.float16,
             (257, 1057),
             None,
             None,
             GQADecodeBs1Kernel,
-            id="bs1-fp16",
+            id="bs1-fp16-other-head-ratio",
+        ),
+        pytest.param(
+            1,
+            (32, 4),
+            torch.float16,
+            (1024, 1057),
+            None,
+            None,
+            GQADecodeKernel,
+            id="measured-bs1-long-generic",
         ),
         pytest.param(
             2,
+            (8, 2),
             torch.bfloat16,
-            (257, 2051),
+            (257, 511),
             None,
             None,
             GQADecodeKernel,
@@ -244,6 +256,7 @@ def test_gqa_dense_reuses_one_kernel_across_sequence_lengths(batch: int) -> None
         ),
         pytest.param(
             1,
+            (8, 2),
             torch.float16,
             (271,),
             "neox",
@@ -253,6 +266,7 @@ def test_gqa_dense_reuses_one_kernel_across_sequence_lengths(batch: int) -> None
         ),
         pytest.param(
             1,
+            (8, 2),
             torch.float16,
             (1057,),
             "neox",
@@ -262,6 +276,7 @@ def test_gqa_dense_reuses_one_kernel_across_sequence_lengths(batch: int) -> None
         ),
         pytest.param(
             2,
+            (8, 2),
             torch.bfloat16,
             (257,),
             "interleaved",
@@ -274,6 +289,7 @@ def test_gqa_dense_reuses_one_kernel_across_sequence_lengths(batch: int) -> None
 @pytest.mark.smoke
 def test_gqa_dense_decode_dispatch_and_dynamic_sequence_lengths(
     batch: int,
+    head_shape: tuple[int, int],
     dtype: torch.dtype,
     seq_lens_kv: tuple[int, ...],
     rope_layout: Optional[str],
@@ -282,7 +298,8 @@ def test_gqa_dense_decode_dispatch_and_dynamic_sequence_lengths(
 ) -> None:
     if not torch.cuda.is_available() or get_sm_version() != 90:
         pytest.skip("Dense decode requires SM90")
-    heads, heads_kv, dim = 8, 2, 128
+    heads, heads_kv = head_shape
+    dim = 128
     op = GroupedQueryAttentionDenseFwdOp(
         pos_encoding_mode="rope" if rope_layout is not None else "none",
         rotary_dim=rotary_dim,
@@ -334,20 +351,18 @@ def test_gqa_dense_decode_dispatch_and_dynamic_sequence_lengths(
     "num_split, block_N, real_seqlen_kv, expected",
     [
         pytest.param(32, 64, 1024, 16, id="issue-shape-clamps-to-tiles"),
-        pytest.param(32, 64, 2048, 32, id="feasible-tuned-value-kept"),
+        pytest.param(32, 64, 1000, 8, id="non-candidate-count-rounded-down"),
+        pytest.param(7, 64, 100000, 4, id="non-candidate-ceiling-rounded-down"),
         pytest.param(16, 128, 1024, 8, id="block-128-clamps"),
         pytest.param(32, 64, 100, 1, id="short-sequence-no-split"),
-        pytest.param(8, 64, 63, 1, id="sub-tile-no-split"),
-        pytest.param(4, 64, 64, 1, id="single-tile-no-split"),
-        pytest.param(4, 64, 128, 2, id="two-tiles-split-two"),
         pytest.param(1, 64, 100000, 1, id="tuned-no-split-stays-no-split"),
     ],
 )
-def test_gqa_decode_effective_num_split(
+def test_gqa_dense_decode_effective_num_split(
     num_split: int, block_N: int, real_seqlen_kv: int, expected: int
 ) -> None:
     """The tuned num_split is a ceiling shrunk to the runtime KV extent."""
-    assert _effective_num_split(num_split, block_N, real_seqlen_kv) == expected
+    assert _effective_dense_num_split(num_split, block_N, real_seqlen_kv) == expected
 
 
 @pytest.mark.smoke


### PR DESCRIPTION
## Summary

- Fix Dense GQA decode so the tuned split ceiling is reduced to a runtime-valid, finite split tier: `{1, 2, 4, 8, 16, 32}`.
- Partition whole KV tiles inside the Dense split kernel and remove its `split_length` tensor input, so autotuning and runtime use the same partitioning rule.
- Route the measured plain-FP16 Qwen3 region through the BS1 kernel below `Skv=1024` and through the updated generic split kernel from `Skv=1024` onward.
- Add the finite split-capacity tier—not exact `Skv`—to the Dense Op cache key.
- Paged decode is intentionally unchanged; it has a different layout and dispatch policy and should be evaluated separately.

## Validation

- `pytest tests/ops/attention/test_gqa.py tests/ops/attention/test_gqa_decode_paged.py -m smoke`: **49 passed, 8 deselected** on H200.
- Ruff lint/format, manifest validation, and the repository-specific Python linters pass.
- `tests/ops/attention/test_gqa.py`: **23 -> 35** collected tests (**+12**). Existing parametrized coverage was adjusted so the dispatch/cache boundary is covered without adding a separate test function.

## Native-CUPTI benchmark

Clock-locked H200, public `GroupedQueryAttentionDenseFwdOp`, `B=1, H=32, Hkv=4, D=128, fp16`:

| `Skv` | Selected path | GPU busy | Full Op envelope |
| ---: | --- | ---: | ---: |
| 256 | BS1 | 6.19 us | 6.19 us |
| 512 | BS1 | 9.28 us | 9.28 us |
| 1024 | generic BN64/split16 | 5.73 us | 8.77 us |
| 4096 | generic BN64/split32 | 8.37 us | 10.11 us |
| 16384 | generic BN64/split32 | 16.32 us | 17.79 us |
| 32768 | generic BN64/split32 | 26.64 us | 27.95 us |

The previously reported `19.6 us -> 6.6 us (2.96x)` result is a forced generic-kernel busy-time comparison, not the latency change of the B=1 public Op, which previously selected the BS1 kernel. The full CUPTI envelope above is the relevant Op latency for the two-kernel split implementation.

RoPE and other head configurations retain their previous routing until they are measured independently.
