### PR TITLE
[Refactor][Attention] Separate dense GQA decode strategy policy

### DIFF
--- a/src/tileops/kernels/attention/__init__.py
+++ b/src/tileops/kernels/attention/__init__.py
@@ -7,7 +7,7 @@ from .gqa_bwd import (
     FlashAttnBwdPreprocessKernel,
     GQABwdWgmmaPipelinedKernel,
 )
-from .gqa_decode import GQADecodeKernel
+from .gqa_decode import GQADecodeKernel, GQADecodeLongContextKernel
 from .gqa_decode_bs1 import GQADecodeBs1Kernel
 from .gqa_decode_bs1_paged import GQADecodePagedBs1Kernel
 from .gqa_decode_paged import GQADecodePagedKernel
@@ -38,6 +38,7 @@ __all__ = [
     "GQABwdWgmmaPipelinedKernel",
     "GQADecodeBs1Kernel",
     "GQADecodeKernel",
+    "GQADecodeLongContextKernel",
     "GQADecodePagedBs1Kernel",
     "GQADecodePagedKernel",
     "GQADenseWsKernel",

--- a/src/tileops/kernels/attention/gqa_decode.py
+++ b/src/tileops/kernels/attention/gqa_decode.py
@@ -693,50 +693,13 @@ class GQADecodeKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
-        high_parallelism = self._uses_high_parallelism_default()
         return {
             "block_H": 64,
-            "block_N": 64 if high_parallelism else 128,
-            "num_split": 32 if high_parallelism else 16,
+            "block_N": 128,
+            "num_split": 16,
             "num_stages": 2,
             "threads": 128,
         }
-
-    def _uses_high_parallelism_default(self) -> bool:
-        """Whether this call belongs to the measured BN64/split32 region."""
-        return self.high_parallelism_region(
-            batch=self.batch,
-            heads=self.heads,
-            heads_kv=self.groups,
-            dim=self.dim,
-            dtype=self.dtype,
-            softcap=self.softcap,
-        )
-
-    @staticmethod
-    def high_parallelism_region(
-        *,
-        batch: int,
-        heads: int,
-        heads_kv: int,
-        dim: int,
-        dtype: torch.dtype | str,
-        softcap: float,
-    ) -> bool:
-        """Whether the call matches the H200 region measured for BN64/split32."""
-        return (
-            batch == 1
-            and heads == 32
-            and heads_kv == 4
-            and dim == 128
-            and Kernel.dtype_to_str(dtype) == "float16"
-            and softcap == 0.0
-        )
-
-    @staticmethod
-    def split_capacity(seq_len_kv: int) -> int:
-        """Return the finite autotune-capacity bucket for an input KV extent."""
-        return _effective_dense_num_split(max(_SPLIT_CANDIDATES), 64, seq_len_kv)
 
     @property
     def autotune_configs(self) -> list[dict]:
@@ -899,3 +862,17 @@ class GQADecodeKernel(Kernel):
             Output_partial,
         )
         return output.unsqueeze(1)
+
+
+class GQADecodeLongContextKernel(GQADecodeKernel):
+    """Dense decode specialization with the measured long-context defaults."""
+
+    @property
+    def default_config(self) -> dict:
+        return {
+            "block_H": 64,
+            "block_N": 64,
+            "num_split": 32,
+            "num_stages": 2,
+            "threads": 128,
+        }

--- a/src/tileops/manifest/attention.yaml
+++ b/src/tileops/manifest/attention.yaml
@@ -139,6 +139,7 @@ GroupedQueryAttentionDenseFwdOp:
       gqa_dense_decode: GQADecodeKernel
       gqa_dense_decode_bs1: GQADecodeBs1Kernel
       gqa_dense_fp8: GQADenseFP8Kernel
+      gqa_dense_decode_long_context: GQADecodeLongContextKernel
       gqa_dense_sliding_window: GQADenseSlidingWindowKernel
     op: tileops/ops/attention/gqa.py
     test: tests/ops/attention/test_gqa.py

--- a/src/tileops/ops/attention/gqa.py
+++ b/src/tileops/ops/attention/gqa.py
@@ -9,6 +9,7 @@ from tileops.kernels.attention import (
     GQABwdWgmmaPipelinedKernel,
     GQADecodeBs1Kernel,
     GQADecodeKernel,
+    GQADecodeLongContextKernel,
     GQADecodePagedBs1Kernel,
     GQADecodePagedKernel,
     GQADenseFP8Kernel,
@@ -42,6 +43,12 @@ __all__ = [
 def _validate_attention_dtype(dtype: torch.dtype) -> None:
     if dtype not in (torch.float16, torch.bfloat16):
         raise ValueError(f"Expected dtype torch.float16 or torch.bfloat16, got {dtype}")
+
+
+def _dense_decode_split_capacity(seq_len_kv: int) -> int:
+    """Bucket a runtime KV extent by the largest feasible split tier."""
+    full_tiles = max(1, seq_len_kv // 64)
+    return min(32, 1 << (full_tiles.bit_length() - 1))
 
 
 def _paged_cache_dtype(cache_dtype: Optional[torch.dtype]) -> Optional[torch.dtype]:
@@ -301,6 +308,7 @@ class GroupedQueryAttentionDenseFwdOp(Op):
             "gqa_dense_decode": GQADecodeKernel,
             "gqa_dense_decode_bs1": GQADecodeBs1Kernel,
             "gqa_dense_fp8": GQADenseFP8Kernel,
+            "gqa_dense_decode_long_context": GQADecodeLongContextKernel,
             "gqa_dense_sliding_window": GQADenseSlidingWindowKernel,
         }
 
@@ -476,18 +484,16 @@ class GroupedQueryAttentionDenseFwdOp(Op):
         uses_window = self.window_size_left != -1 or self.window_size_right != -1
         rope_on = self.pos_encoding_mode == "rope"
         uses_decode = not is_fp8 and seq_len_q == 1 and not uses_window
-        uses_long_generic_decode = (
+        uses_long_context_decode = (
             uses_decode
             and not rope_on
             and seq_len_kv >= 1024
-            and GQADecodeKernel.high_parallelism_region(
-                batch=batch,
-                heads=heads,
-                heads_kv=heads_kv,
-                dim=dim,
-                dtype=q.dtype,
-                softcap=self.softcap,
-            )
+            and batch == 1
+            and heads == 32
+            and heads_kv == 4
+            and dim == 128
+            and q.dtype == torch.float16
+            and self.softcap == 0.0
         )
         uses_bs1_decode = (
             uses_decode
@@ -496,10 +502,12 @@ class GroupedQueryAttentionDenseFwdOp(Op):
             and dim == 128
             and self.softcap == 0.0
             and 1 <= heads // heads_kv <= 64
-            and not uses_long_generic_decode
+            and not uses_long_context_decode
         )
         if is_fp8:
             role = "gqa_dense_fp8"
+        elif uses_long_context_decode:
+            role = "gqa_dense_decode_long_context"
         elif uses_bs1_decode:
             role = "gqa_dense_decode_bs1"
         elif uses_decode:
@@ -596,10 +604,10 @@ class GroupedQueryAttentionDenseFwdOp(Op):
                 heads_kv,
                 dim,
             )
-            if role == "gqa_dense_decode":
+            if role in ("gqa_dense_decode", "gqa_dense_decode_long_context"):
                 # Decode may compile one of a finite set of split programs.
                 # Key the capacity tier, not the exact runtime KV length.
-                key += (GQADecodeKernel.split_capacity(seq_len_kv),)
+                key += (_dense_decode_split_capacity(seq_len_kv),)
         return self.get_or_build_kernel(role, inputs, key=key, build=build)
 
     def forward(

--- a/tests/ops/attention/test_gqa.py
+++ b/tests/ops/attention/test_gqa.py
@@ -9,6 +9,7 @@ from tests.test_base import FixtureBase, TestBase
 from tileops.kernels.attention import (
     GQADecodeBs1Kernel,
     GQADecodeKernel,
+    GQADecodeLongContextKernel,
     GQADenseFP8Kernel,
     GQADenseSlidingWindowKernel,
     GQADenseWsKernel,
@@ -281,7 +282,7 @@ def test_gqa_dense_reuses_one_kernel_across_sequence_lengths(batch: int) -> None
             (1024, 1057),
             None,
             None,
-            GQADecodeKernel,
+            GQADecodeLongContextKernel,
             id="measured-bs1-long-generic",
         ),
         pytest.param(


### PR DESCRIPTION
## Summary

- Move the measured BN64/split32 defaults into an explicit Dense long-context decode specialization.
- Keep strategy selection and split-capacity cache bucketing in the Op, removing the Op-to-concrete-Kernel policy calls.

## Benchmark

**Environment**: H200 (SM 1500 MHz), CUDA 12.9, PyTorch 2.10.0, native CUPTI, 200 samples per run

### GroupedQueryAttentionDenseFwdOp

| Shape (B, Sq, Skv, H, Hkv, D) | dtype | merged main busy (ms) | PR busy (ms) | merged main envelope (ms) | PR envelope (ms) |
| --- | --- | ---: | ---: | ---: | ---: |
| (1, 1, 1024, 32, 4, 128) | fp16 | 0.0056 | 0.0056 | 0.0086-0.0139 | 0.0103-0.0148 |
| (1, 1, 4096, 32, 4, 128) | fp16 | 0.0084 | 0.0084 | 0.0099 | 0.0097-0.0098 |

**Takeaways:** This PR claims no speedup over merged main. Both revisions execute the same two GPU kernels with the same BN64/split32 configuration and identical GPU busy time. The 1K inter-kernel gap fluctuates on both revisions; the stable 4K full envelope is unchanged.

## Regression

The existing dynamic-sequence dispatch test verifies that 1024 and 1057-token calls reuse one long-context specialization.