### PR TITLE
[Feat][Attention] Support RoPE in FP8 Dense prefill

### DIFF
--- a/src/tileops/kernels/attention/gqa_dense.py
+++ b/src/tileops/kernels/attention/gqa_dense.py
@@ -53,9 +53,11 @@ def _gqa_dense_rope_qk_kernel(
     rotary_dim,
     rope_layout,
     dtype,
+    rope_dtype=None,
     threads=256,
     num_per_thread=4,
 ):
+    rope_dtype = dtype if rope_dtype is None else rope_dtype
     half = rotary_dim // 2
     q_rows = B * Sq * H
     k_rows = B * Skv * Hkv
@@ -72,8 +74,8 @@ def _gqa_dense_rope_qk_kernel(
     def main(
         Q: T.Tensor([q_rows * D], dtype),
         K: T.Tensor([k_rows * D], dtype),
-        RopeCos: T.Tensor([max_position, half], dtype),
-        RopeSin: T.Tensor([max_position, half], dtype),
+        RopeCos: T.Tensor([max_position, half], rope_dtype),
+        RopeSin: T.Tensor([max_position, half], rope_dtype),
         QRot: T.Tensor([q_rows * D], dtype),
         KRot: T.Tensor([k_rows * D], dtype),
     ):
@@ -136,6 +138,7 @@ class DenseQKRoPEPreprocessor:
         rotary_dim: int,
         rope_layout: str,
         dtype: str,
+        rope_dtype: Optional[str] = None,
     ) -> None:
         self.kernel = _gqa_dense_rope_qk_kernel(
             batch,
@@ -148,6 +151,7 @@ class DenseQKRoPEPreprocessor:
             rotary_dim,
             rope_layout,
             dtype,
+            rope_dtype,
         )
 
     def __call__(
@@ -176,6 +180,7 @@ def make_dense_qk_rope_preprocessor(
     rotary_dim: int,
     rope_layout: str,
     dtype: str,
+    rope_dtype: Optional[str] = None,
 ) -> Optional[DenseQKRoPEPreprocessor]:
     """Build the shared Dense Q/K RoPE stage when requested."""
     if not fuse_rope:
@@ -191,6 +196,7 @@ def make_dense_qk_rope_preprocessor(
         rotary_dim,
         rope_layout,
         dtype,
+        rope_dtype,
     )
 
 

--- a/src/tileops/kernels/attention/gqa_fwd_fp8.py
+++ b/src/tileops/kernels/attention/gqa_fwd_fp8.py
@@ -8,6 +8,7 @@ import torch
 
 from ..kernel_base import Kernel
 from .call_spec import ATTENTION_DTYPES
+from .gqa_dense import make_dense_qk_rope_preprocessor
 from .online_softmax import (
     LOG2E,
     make_online_softmax_with_score_scale,
@@ -987,8 +988,21 @@ class GQADenseFP8Kernel(Kernel):
         self.sm_scale = dim**-0.5 if sm_scale is None else sm_scale
         self.softcap = softcap
         self.fuse_rope = fuse_rope
-        del max_position, rotary_dim, rope_layout
         self._validate_spec()
+        self.rope = make_dense_qk_rope_preprocessor(
+            fuse_rope=fuse_rope,
+            batch=batch,
+            heads=heads,
+            heads_kv=heads_kv,
+            seq_len_q=seq_len_q,
+            seq_len_kv=seq_len_kv,
+            dim=dim,
+            max_position=max_position,
+            rotary_dim=rotary_dim,
+            rope_layout=rope_layout,
+            dtype="float8_e4m3fn",
+            rope_dtype=self.dtype_str,
+        )
         self.init_config(config, tune)
 
     def _validate_spec(self) -> None:
@@ -1000,8 +1014,8 @@ class GQADenseFP8Kernel(Kernel):
             raise ValueError("native-FP8 Dense GQA outputs float16 or bfloat16")
         if self.is_causal and self.seq_len_q > self.seq_len_kv:
             raise ValueError("causal FP8 Dense GQA requires seq_len_q <= seq_len_kv")
-        if self.fuse_rope:
-            raise ValueError("native-FP8 Dense GQA does not support fused RoPE")
+        if self.fuse_rope and self.seq_len_q == 1:
+            raise ValueError("FP8 Dense decode requires an in-kernel RoPE implementation")
         if self.window_size_left != -1 or self.window_size_right != -1:
             raise ValueError("native-FP8 Dense GQA does not support sliding windows")
         if not self.is_causal and self.seq_len_q != self.seq_len_kv:
@@ -1044,7 +1058,9 @@ class GQADenseFP8Kernel(Kernel):
             q.device,
         )
 
-        if rope_cos is not None or rope_sin is not None:
+        if self.rope is not None:
+            q, k = self.rope(q, k, rope_cos, rope_sin)
+        elif rope_cos is not None or rope_sin is not None:
             raise ValueError("native-FP8 Dense GQA does not accept RoPE tables")
         return _gqa_dense_fwd_fp8_wrapped_kernel(
             self.batch,

--- a/tests/ops/attention/test_gqa.py
+++ b/tests/ops/attention/test_gqa.py
@@ -196,11 +196,30 @@ def test_gqa_dense_sm90_main_kernel_matches_reference(
 
 @pytest.mark.smoke
 @pytest.mark.parametrize(
-    ("seq_len_q", "seq_len_kv", "sm_scale", "softcap"),
-    [(256, 1792, 0.125, 0.0), (255, 1793, 0.0625, 50.0)],
+    (
+        "seq_len_q",
+        "seq_len_kv",
+        "sm_scale",
+        "softcap",
+        "rope_layout",
+        "rotary_dim",
+        "out_dtype",
+    ),
+    [
+        (256, 1792, 0.125, 0.0, None, None, torch.float16),
+        (255, 1793, 0.0625, 50.0, None, None, torch.float16),
+        (256, 1792, 0.125, 0.0, "neox", 64, torch.float16),
+        (255, 1793, 0.0625, 50.0, "interleaved", 128, torch.bfloat16),
+    ],
 )
 def test_gqa_dense_fp8_causal_rectangular_matches_reference(
-    seq_len_q: int, seq_len_kv: int, sm_scale: float, softcap: float
+    seq_len_q: int,
+    seq_len_kv: int,
+    sm_scale: float,
+    softcap: float,
+    rope_layout: Optional[str],
+    rotary_dim: Optional[int],
+    out_dtype: torch.dtype,
 ) -> None:
     fp8 = getattr(torch, "float8_e4m3fn", None)
     if fp8 is None or not torch.cuda.is_available() or get_sm_version() != 90:
@@ -211,18 +230,57 @@ def test_gqa_dense_fp8_causal_rectangular_matches_reference(
     k = (torch.randn(batch, seq_len_kv, heads_kv, dim, device="cuda") * 0.2).to(fp8)
     v = (torch.randn(batch, seq_len_kv, heads_kv, dim, device="cuda") * 0.2).to(fp8)
     scale = torch.ones((batch, heads_kv), device="cuda", dtype=torch.float32)
+    rope_cos = rope_sin = None
+    if rope_layout is not None:
+        assert rotary_dim is not None
+        angles = torch.randn(seq_len_kv, rotary_dim // 2, device="cuda") * 0.1
+        rope_cos, rope_sin = angles.cos().to(out_dtype), angles.sin().to(out_dtype)
 
     op = GroupedQueryAttentionDenseFwdOp(
         is_causal=True,
-        dtype=torch.float16,
+        dtype=out_dtype,
         sm_scale=sm_scale,
         softcap=softcap,
+        pos_encoding_mode="rope" if rope_layout is not None else "none",
+        rotary_dim=rotary_dim,
+        rope_layout="neox" if rope_layout is None else rope_layout,
     )
-    output = op(q, k, v, scale, scale, scale)
+    output = op(
+        q,
+        k,
+        v,
+        scale,
+        scale,
+        scale,
+        rope_cos=rope_cos,
+        rope_sin=rope_sin,
+    )
+    q_ref = q.to(out_dtype)
+    k_ref = k.to(out_dtype)
+    if rope_layout is not None:
+        assert rope_cos is not None and rope_sin is not None and rotary_dim is not None
+        q_positions = torch.arange(seq_len_kv - seq_len_q, seq_len_kv, device="cuda")
+        k_positions = torch.arange(seq_len_kv, device="cuda")
+        q_ref = _apply_dense_rope(
+            q_ref,
+            q_positions,
+            rope_cos,
+            rope_sin,
+            rotary_dim=rotary_dim,
+            layout=rope_layout,
+        )
+        k_ref = _apply_dense_rope(
+            k_ref,
+            k_positions,
+            rope_cos,
+            rope_sin,
+            rotary_dim=rotary_dim,
+            layout=rope_layout,
+        )
     reference = _gqa_prefill_ref(
-        q.to(torch.float16),
-        k.to(torch.float16),
-        v.to(torch.float16),
+        q_ref,
+        k_ref,
+        v.to(out_dtype),
         heads=heads,
         heads_kv=heads_kv,
         is_causal=True,


### PR DESCRIPTION
## Summary

- Reuse the existing Dense Q/K RoPE preprocessor for native-FP8 prefill.
- Allow FP8 Q/K tensors to use FP16 or BF16 RoPE tables while preserving FP8 outputs for the existing WGMMA attention kernel.
- Cover NeoX/interleaved layouts, partial/full rotary dimensions, rectangular causal attention, softcap, and FP16/BF16 outputs.
- Keep FP8 decode + RoPE fail-closed; decode needs an in-kernel fused implementation.

## Validation

H200:
- targeted FP8 prefill cases: 4 passed
- Dense/FP8 smoke: 43 passed, 2 deselected
- Ruff check and format check passed

Two public-API test nodes were added: NeoX partial RoPE and interleaved full RoPE with BF16 output.

## Performance

Native CUPTI, H200, B=1, Sq=1024, Skv=8064, H=32, Hkv=8, D=128:

| Path | Device busy | Full envelope | Kernels |
| --- | ---: | ---: | ---: |
| FP8 prefill | 0.1611 ms | 0.1611 ms | 1 |
| FP8 prefill + RoPE | 0.1687 ms | 0.2287 ms | 2 |

The RoPE stage adds about 4.7% device-busy time. The eager two-kernel envelope includes about 60 us of host launch gap. This PR intentionally establishes prefill functionality first; decode will use a fused implementation.