### PR TITLE
[Refactor][Pool] Give the avg-pool family one window type

### DIFF
--- a/src/tileops/kernels/pool/avg_pool1d.py
+++ b/src/tileops/kernels/pool/avg_pool1d.py
@@ -8,9 +8,10 @@ import torch
 from tileops.kernels.constants import STATIC_SHARED_BYTES
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.pool.common import (
+    ACCUM_DTYPE,
+    AvgPoolWindow,
     WindowSpan,
     dtype_itemsize,
-    pool_output_dim,
     window_span,
 )
 
@@ -36,32 +37,27 @@ class _WindowStaging:
     # do not fill the device.
     _MIN_LAUNCH_THREADS: ClassVar[int] = 1 << 16
 
-    def __init__(
-        self,
-        rows: int,
-        l_in: int,
-        out_l: int,
-        kernel_l: int,
-        stride_l: int,
-        pad_l: int,
-        dtype: str,
-    ) -> None:
-        self._rows = rows
-        self._l_in = l_in
-        self._out_l = out_l
-        self._kernel_l = kernel_l
-        self._stride_l = stride_l
-        self._pad_l = pad_l
+    def __init__(self, window: AvgPoolWindow, dtype: str) -> None:
+        self._window = window
         self._dtype = dtype
+        self._out_l = window.out[0]
+        self._kernel_l = window.kernel[0]
 
     def _span(self, tile_outputs: int) -> WindowSpan:
+        window = self._window
+        (l_in,), (kernel_l,), (stride_l,), (pad_l,) = (
+            window.size,
+            window.kernel,
+            window.stride,
+            window.pad,
+        )
         return window_span(
             tile_outputs,
-            tile_outputs * self._stride_l,
-            self._l_in,
-            self._kernel_l,
-            self._stride_l,
-            self._pad_l,
+            tile_outputs * stride_l,
+            l_in,
+            kernel_l,
+            stride_l,
+            pad_l,
             1,
             self._dtype,
         )
@@ -96,7 +92,7 @@ class _WindowStaging:
         """
         width = self.width()
         vectors = self._span(width).vectors
-        blocks = self._rows * ((self._out_l + width - 1) // width)
+        blocks = self._window.rows * ((self._out_l + width - 1) // width)
         return [
             {"block_ol": width, "threads": threads}
             for threads in self._THREAD_CHOICES
@@ -104,24 +100,19 @@ class _WindowStaging:
         ] or [{"block_ol": width, "threads": self._FALLBACK_THREADS}]
 
 
-@functools.lru_cache(maxsize=64)
-def _avg_pool1d_kernel(
-    n: int,
-    c_in: int,
-    l_in: int,
-    kernel_l: int,
-    stride_l: int,
-    pad_l: int,
-    ceil_mode: bool,
-    count_include_pad: bool,
-    dtype: str = "float16",
-):
-    accum_dtype = "float"
-    out_l = pool_output_dim(l_in, kernel_l, stride_l, pad_l, ceil_mode)
-    rows = n * c_in
-    window_inside = pad_l == 0 and (out_l - 1) * stride_l + kernel_l <= l_in
-    # Otherwise a window can overhang, and the divisor comes from its own extent.
-    whole_window_divides = window_inside or (count_include_pad and not ceil_mode)
+@functools.lru_cache(maxsize=32)
+def _avg_pool1d_kernel(window: AvgPoolWindow, dtype: str):
+    """One block per row tile, the stretch it pools staged in shared memory."""
+    (l_in,), (kernel_l,), (stride_l,), (pad_l,) = (
+        window.size,
+        window.kernel,
+        window.stride,
+        window.pad,
+    )
+    (out_l,) = window.out
+    rows = window.rows
+    count_include_pad = window.count_include_pad
+    whole_window_divides = window.whole_window_divides
     # The outputs whose window lies inside the row, and so divides by the kernel width.
     clean_lo = -(-pad_l // stride_l)
     clean_hi = min((l_in + pad_l - kernel_l) // stride_l, out_l - 1)
@@ -166,18 +157,18 @@ def _avg_pool1d_kernel(
         def _store(tile, j, ol, out, out_row, whole: bool):
             """Store the mean of the window `tile` holds for output ``ol``."""
             total = T.alloc_var(T.float32)
-            total = T.cast(0.0, accum_dtype)
+            total = T.cast(0.0, ACCUM_DTYPE)
             for k in T.serial(kernel_l):
-                total += T.cast(tile[base + j * stride_l + k], accum_dtype)
+                total += T.cast(tile[base + j * stride_l + k], ACCUM_DTYPE)
             if whole:
-                out[out_row, ol] = T.cast(total * T.cast(1.0 / kernel_l, accum_dtype), dtype)
+                out[out_row, ol] = T.cast(total / T.cast(kernel_l, ACCUM_DTYPE), dtype)
             else:
                 start = ol * stride_l - pad_l
                 if count_include_pad:
                     divisor = T.max(T.min(start + kernel_l, l_in + pad_l) - T.max(start, -pad_l), 1)
                 else:
                     divisor = T.max(T.min(start + kernel_l, l_in) - T.max(start, 0), 1)
-                out[out_row, ol] = T.cast(total / T.cast(divisor, accum_dtype), dtype)
+                out[out_row, ol] = T.cast(total / T.cast(divisor, ACCUM_DTYPE), dtype)
 
         @T.macro
         def _store_output(tile, j, ol, out, out_row):
@@ -250,38 +241,22 @@ class _AvgPool1dKernelBase(Kernel):
         super().__init__()
         self.n = n
         self.c_in = c_in
-        self.l_in = l_in
-        self.kernel_l = kernel_l
-        self.stride_l = stride_l
-        self.pad_l = pad_l
-        self.ceil_mode = ceil_mode
-        self.count_include_pad = count_include_pad
         self.dtype = dtype
-        self.out_l = pool_output_dim(l_in, kernel_l, stride_l, pad_l, ceil_mode)
-
-        self.kernel = _avg_pool1d_kernel(
-            n,
-            c_in,
-            l_in,
-            kernel_l,
-            stride_l,
-            pad_l,
-            ceil_mode,
-            count_include_pad,
-            self.dtype_str,
+        self.window = AvgPoolWindow(
+            rows=n * c_in,
+            size=(l_in,),
+            kernel=(kernel_l,),
+            stride=(stride_l,),
+            pad=(pad_l,),
+            ceil_mode=ceil_mode,
+            count_include_pad=count_include_pad,
+            divisor_override=None,
         )
+        self.kernel = _avg_pool1d_kernel(self.window, self.dtype_str)
         self.init_config(config, tune)
 
     def _staging(self) -> _WindowStaging:
-        return _WindowStaging(
-            self.n * self.c_in,
-            self.l_in,
-            self.out_l,
-            self.kernel_l,
-            self.stride_l,
-            self.pad_l,
-            self.dtype_str,
-        )
+        return _WindowStaging(self.window, self.dtype_str)
 
     @property
     def default_config(self) -> dict:
@@ -294,8 +269,8 @@ class _AvgPool1dKernelBase(Kernel):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         self._require_cuda(x=x)
         kernel = self.kernel(self.config["block_ol"], self.config["threads"])
-        rows = kernel(x.contiguous().view(self.n * self.c_in, self.l_in))
-        return rows.view(self.n, self.c_in, self.out_l)
+        rows = kernel(x.contiguous().view(self.window.rows, *self.window.size))
+        return rows.view(self.n, self.c_in, *self.window.out)
 
 
 class AvgPool1dSpatialKernel(_AvgPool1dKernelBase):

--- a/src/tileops/kernels/pool/avg_pool2d.py
+++ b/src/tileops/kernels/pool/avg_pool2d.py
@@ -1,308 +1,93 @@
 import functools
-import itertools
-from typing import Optional
+from typing import ClassVar, Optional
 
 import tilelang
 import tilelang.language as T
 import torch
 
 from tileops.kernels.kernel_base import Kernel
-from tileops.kernels.pool.common import pool_output_dim
+from tileops.kernels.pool.common import ACCUM_DTYPE, AvgPoolWindow
 
 __all__ = ["AvgPool2dKernel", "AvgPool2dSpatialKernel"]
 
 
-@functools.lru_cache(maxsize=64)
-def _avg_pool2d_kernel(
-    n: int,
-    c_in: int,
-    h_in: int,
-    w_in: int,
-    kernel_h: int,
-    kernel_w: int,
-    stride_h: int,
-    stride_w: int,
-    pad_h: int,
-    pad_w: int,
-    ceil_mode: bool,
-    count_include_pad: bool,
-    use_divisor_override: bool,
-    divisor_override: int,
-    dtype: str = "float16",
-):
-    accum_dtype = "float"
-    out_h = pool_output_dim(h_in, kernel_h, stride_h, pad_h, ceil_mode)
-    out_w = pool_output_dim(w_in, kernel_w, stride_w, pad_w, ceil_mode)
-    total_output = n * c_in * out_h * out_w
+@functools.lru_cache(maxsize=32)
+def _avg_pool2d_kernel(window: AvgPoolWindow, dtype: str):
+    """One output per thread, every tap read where it lies."""
+    h_in, w_in = window.size
+    kernel_h, kernel_w = window.kernel
+    stride_h, stride_w = window.stride
+    pad_h, pad_w = window.pad
+    out_h, out_w = window.out
+    (low_h, low_w), (limit_h, limit_w) = window.overlap
+    rows, total = window.rows, window.outputs
+    window_inside = window.window_inside
+    one_divisor = window.whole_window_divides or window.divisor_override is not None
+    divisor = window.divisor
 
     @tilelang.jit(out_idx=[1], compile_flags=["-O3", "-DENABLE_BF16"])
-    def _avg_pool2d_func(block_m: int, threads: int):
+    def _avg_pool2d_func(threads: int):
+        # A compile-time truth when the launch divides, and the tail test drops out.
+        block_full = total % threads == 0
+
+        @T.macro
+        def _store(total_val, oh, ow, out, row):
+            """Store one output, taking its divisor from wherever this shape has it."""
+            if one_divisor:
+                out[row, oh, ow] = T.cast(total_val / T.cast(divisor, ACCUM_DTYPE), dtype)
+            else:
+                top = oh * stride_h - pad_h
+                left = ow * stride_w - pad_w
+                # An empty window would divide by zero, so the overlap takes a floor.
+                extent = T.max(
+                    T.max(T.min(top + kernel_h, limit_h) - T.max(top, low_h), 0)
+                    * T.max(T.min(left + kernel_w, limit_w) - T.max(left, low_w), 0),
+                    1,
+                )
+                out[row, oh, ow] = T.cast(total_val / T.cast(extent, ACCUM_DTYPE), dtype)
+
         @T.prim_func
         def _avg_pool2d_main(
-            x: T.Tensor((n, c_in, h_in, w_in), dtype),  # type: ignore
-            out: T.Tensor((n, c_in, out_h, out_w), dtype),  # type: ignore
+            x: T.Tensor((rows, h_in, w_in), dtype),  # type: ignore
+            out: T.Tensor((rows, out_h, out_w), dtype),  # type: ignore
         ):
-            with T.Kernel(T.ceildiv(total_output, block_m), threads=threads) as bx:
-                for i in T.Parallel(block_m):
-                    out_idx = bx * block_m + i
-                    if out_idx < total_output:
-                        ow = out_idx % out_w
-                        spatial_idx = out_idx // out_w
-                        oh = spatial_idx % out_h
-                        channel_batch_idx = spatial_idx // out_h
-                        c_idx = channel_batch_idx % c_in
-                        batch = channel_batch_idx // c_in
-
-                        sum_val = T.alloc_var(T.float32)
-                        sum_val = T.cast(0.0, accum_dtype)
+            with T.Kernel(T.ceildiv(total, threads), threads=threads) as tile:
+                for i in T.Parallel(threads):
+                    idx = tile * threads + i
+                    if block_full or idx < total:
+                        plane_row = idx // out_w
+                        ow = idx - plane_row * out_w
+                        row = plane_row // out_h
+                        oh = plane_row - row * out_h
+                        top = oh * stride_h - pad_h
+                        left = ow * stride_w - pad_w
+                        total_val = T.alloc_var(T.float32)
+                        total_val = T.cast(0.0, ACCUM_DTYPE)
                         for kh in T.serial(kernel_h):
                             for kw in T.serial(kernel_w):
-                                ih = oh * stride_h + kh - pad_h
-                                iw = ow * stride_w + kw - pad_w
-                                if ih >= 0 and ih < h_in and iw >= 0 and iw < w_in:
-                                    sum_val += T.cast(x[batch, c_idx, ih, iw], accum_dtype)
-
-                        start_h = oh * stride_h - pad_h
-                        start_w = ow * stride_w - pad_w
-                        end_h = start_h + kernel_h
-                        end_w = start_w + kernel_w
-                        valid_h = T.max(T.min(end_h, h_in) - T.max(start_h, 0), 0)
-                        valid_w = T.max(T.min(end_w, w_in) - T.max(start_w, 0), 0)
-                        valid_count = valid_h * valid_w
-                        padded_h = T.max(T.min(end_h, h_in + pad_h) - T.max(start_h, -pad_h), 0)
-                        padded_w = T.max(T.min(end_w, w_in + pad_w) - T.max(start_w, -pad_w), 0)
-                        padded_count = padded_h * padded_w
-                        auto_divisor = T.max(
-                            T.if_then_else(count_include_pad, padded_count, valid_count),
-                            1,
-                        )
-                        divisor = T.if_then_else(
-                            use_divisor_override,
-                            divisor_override,
-                            auto_divisor,
-                        )
-                        out[batch, c_idx, oh, ow] = T.cast(
-                            sum_val / T.cast(divisor, accum_dtype),
-                            dtype,
-                        )
+                                ih = top + kh
+                                iw = left + kw
+                                # Tested where it is read, so the test predicates the
+                                # load; hoisting it per axis makes it a branch.
+                                if window_inside or (
+                                    (ih >= 0) and (ih < h_in) and (iw >= 0) and (iw < w_in)
+                                ):
+                                    total_val += T.cast(x[row, ih, iw], ACCUM_DTYPE)
+                        _store(total_val, oh, ow, out, row)
 
         return _avg_pool2d_main
 
     return _avg_pool2d_func
 
 
-@functools.lru_cache(maxsize=64)
-def _avg_pool2d_spatial_kernel(
-    n: int,
-    c_in: int,
-    h_in: int,
-    w_in: int,
-    kernel_h: int,
-    kernel_w: int,
-    stride_h: int,
-    stride_w: int,
-    pad_h: int,
-    pad_w: int,
-    dtype: str = "float16",
-):
-    accum_dtype = "float"
-    out_h = pool_output_dim(h_in, kernel_h, stride_h, pad_h, False)
-    out_w = pool_output_dim(w_in, kernel_w, stride_w, pad_w, False)
-    total_output = n * c_in * out_h * out_w
+class _AvgPool2dKernelBase(Kernel):
+    """Shape, launch planning and dispatch shared by the two avg_pool2d kernels."""
 
-    @tilelang.jit(out_idx=[1], compile_flags=["-O3", "-DENABLE_BF16"])
-    def _avg_pool2d_spatial_func(block_m: int, threads: int):
-        @T.prim_func
-        def _avg_pool2d_spatial_main(
-            x: T.Tensor((n, c_in, h_in, w_in), dtype),  # type: ignore
-            out: T.Tensor((n, c_in, out_h, out_w), dtype),  # type: ignore
-        ):
-            with T.Kernel(T.ceildiv(total_output, block_m), threads=threads) as bx:
-                for i in T.Parallel(block_m):
-                    out_idx = bx * block_m + i
-                    if out_idx < total_output:
-                        ow = out_idx % out_w
-                        spatial_idx = out_idx // out_w
-                        oh = spatial_idx % out_h
-                        channel_batch_idx = spatial_idx // out_h
-                        c_idx = channel_batch_idx % c_in
-                        batch = channel_batch_idx // c_in
-
-                        sum_val = T.alloc_var(T.float32)
-                        sum_val = T.cast(0.0, accum_dtype)
-                        for kh in T.serial(kernel_h):
-                            for kw in T.serial(kernel_w):
-                                ih = oh * stride_h + kh - pad_h
-                                iw = ow * stride_w + kw - pad_w
-                                if ih >= 0 and ih < h_in and iw >= 0 and iw < w_in:
-                                    sum_val += T.cast(x[batch, c_idx, ih, iw], accum_dtype)
-
-                        out[batch, c_idx, oh, ow] = T.cast(
-                            sum_val / T.cast(kernel_h * kernel_w, accum_dtype),
-                            dtype,
-                        )
-
-        return _avg_pool2d_spatial_main
-
-    return _avg_pool2d_spatial_func
-
-
-def _launch_avg_pool2d_spatial(
-    n: int,
-    c_in: int,
-    h_in: int,
-    w_in: int,
-    kernel_h: int,
-    kernel_w: int,
-    stride_h: int,
-    stride_w: int,
-    pad_h: int,
-    pad_w: int,
-    dtype: str,
-    block_m: int,
-    threads: int,
-    x: torch.Tensor,
-) -> torch.Tensor:
-    return _avg_pool2d_spatial_kernel(
-        n,
-        c_in,
-        h_in,
-        w_in,
-        kernel_h,
-        kernel_w,
-        stride_h,
-        stride_w,
-        pad_h,
-        pad_w,
-        dtype,
-    )(block_m, threads)(x)
-
-
-def _launch_avg_pool2d(
-    n: int,
-    c_in: int,
-    h_in: int,
-    w_in: int,
-    kernel_h: int,
-    kernel_w: int,
-    stride_h: int,
-    stride_w: int,
-    pad_h: int,
-    pad_w: int,
-    ceil_mode: bool,
-    count_include_pad: bool,
-    use_divisor_override: bool,
-    divisor_override: int,
-    dtype: str,
-    block_m: int,
-    threads: int,
-    x: torch.Tensor,
-) -> torch.Tensor:
-    return _avg_pool2d_kernel(
-        n,
-        c_in,
-        h_in,
-        w_in,
-        kernel_h,
-        kernel_w,
-        stride_h,
-        stride_w,
-        pad_h,
-        pad_w,
-        ceil_mode,
-        count_include_pad,
-        use_divisor_override,
-        divisor_override,
-        dtype,
-    )(block_m, threads)(x)
-
-
-class AvgPool2dSpatialKernel(Kernel):
-    """Fast path for common NCHW avg_pool2d workloads."""
-
-    supported_archs: list[int] = [80, 86, 89, 90]
-
-    def __init__(
-        self,
-        n: int,
-        c_in: int,
-        h_in: int,
-        w_in: int,
-        kernel_h: int,
-        kernel_w: int,
-        stride_h: int,
-        stride_w: int,
-        pad_h: int,
-        pad_w: int,
-        dtype: torch.dtype,
-        config: Optional[dict] = None,
-        tune: bool = False,
-    ) -> None:
-        super().__init__()
-        self.n = n
-        self.c_in = c_in
-        self.h_in = h_in
-        self.w_in = w_in
-        self.kernel_h = kernel_h
-        self.kernel_w = kernel_w
-        self.stride_h = stride_h
-        self.stride_w = stride_w
-        self.pad_h = pad_h
-        self.pad_w = pad_w
-        self.dtype = dtype
-        self.out_h = pool_output_dim(h_in, kernel_h, stride_h, pad_h, False)
-        self.out_w = pool_output_dim(w_in, kernel_w, stride_w, pad_w, False)
-        self.kernel = _avg_pool2d_spatial_kernel(
-            n,
-            c_in,
-            h_in,
-            w_in,
-            kernel_h,
-            kernel_w,
-            stride_h,
-            stride_w,
-            pad_h,
-            pad_w,
-            self.dtype_str,
-        )
-        self.init_config(config, tune)
-
-    @property
-    def default_config(self) -> dict:
-        return {
-            "block_m": 256,
-            "threads": 256,
-        }
-
-    @property
-    def autotune_configs(self) -> list[dict]:
-        return [
-            {"block_m": block_m, "threads": threads}
-            for block_m, threads in itertools.product([128, 256, 512], [256, 512])
-        ]
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        self._require_cuda(x=x)
-        return _launch_avg_pool2d_spatial(
-            self.n,
-            self.c_in,
-            self.h_in,
-            self.w_in,
-            self.kernel_h,
-            self.kernel_w,
-            self.stride_h,
-            self.stride_w,
-            self.pad_h,
-            self.pad_w,
-            self.dtype_str,
-            self.config["block_m"],
-            self.config["threads"],
-            x,
-        )
-
-
-class AvgPool2dKernel(Kernel):
-    supported_archs: list[int] = [80, 86, 89, 90]
+    supported_archs: ClassVar[list[int]] = [80, 86, 89, 90]
+    # One output per thread, so the block size is the whole launch space: a parallel loop
+    # wider than the block serializes it, and one narrower idles lanes.
+    _THREAD_CHOICES: ClassVar[tuple[int, ...]] = (128, 256, 512)
+    _DEFAULT_THREADS: ClassVar[int] = 256
 
     def __init__(
         self,
@@ -326,23 +111,55 @@ class AvgPool2dKernel(Kernel):
         super().__init__()
         self.n = n
         self.c_in = c_in
-        self.h_in = h_in
-        self.w_in = w_in
-        self.kernel_h = kernel_h
-        self.kernel_w = kernel_w
-        self.stride_h = stride_h
-        self.stride_w = stride_w
-        self.pad_h = pad_h
-        self.pad_w = pad_w
-        self.ceil_mode = ceil_mode
-        self.count_include_pad = count_include_pad
-        self.use_divisor_override = divisor_override is not None
-        self.divisor_override = divisor_override or 0
         self.dtype = dtype
-        self.out_h = pool_output_dim(h_in, kernel_h, stride_h, pad_h, ceil_mode)
-        self.out_w = pool_output_dim(w_in, kernel_w, stride_w, pad_w, ceil_mode)
+        self.window = AvgPoolWindow(
+            rows=n * c_in,
+            size=(h_in, w_in),
+            kernel=(kernel_h, kernel_w),
+            stride=(stride_h, stride_w),
+            pad=(pad_h, pad_w),
+            ceil_mode=ceil_mode,
+            count_include_pad=count_include_pad,
+            divisor_override=divisor_override,
+        )
+        self.kernel = _avg_pool2d_kernel(self.window, self.dtype_str)
+        self.init_config(config, tune)
 
-        self.kernel = _avg_pool2d_kernel(
+    @property
+    def default_config(self) -> dict:
+        return {"threads": self._DEFAULT_THREADS}
+
+    @property
+    def autotune_configs(self) -> list[dict]:
+        return [{"threads": threads} for threads in self._THREAD_CHOICES]
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        self._require_cuda(x=x)
+        kernel = self.kernel(self.config["threads"])
+        planes = kernel(x.contiguous().view(self.window.rows, *self.window.size))
+        return planes.view(self.n, self.c_in, *self.window.out)
+
+
+class AvgPool2dSpatialKernel(_AvgPool2dKernelBase):
+    """Fast path for common NCHW avg_pool2d workloads: floor-mode, one divisor."""
+
+    def __init__(
+        self,
+        n: int,
+        c_in: int,
+        h_in: int,
+        w_in: int,
+        kernel_h: int,
+        kernel_w: int,
+        stride_h: int,
+        stride_w: int,
+        pad_h: int,
+        pad_w: int,
+        dtype: torch.dtype,
+        config: Optional[dict] = None,
+        tune: bool = False,
+    ) -> None:
+        super().__init__(
             n,
             c_in,
             h_in,
@@ -353,47 +170,14 @@ class AvgPool2dKernel(Kernel):
             stride_w,
             pad_h,
             pad_w,
-            ceil_mode,
-            count_include_pad,
-            self.use_divisor_override,
-            self.divisor_override,
-            self.dtype_str,
+            False,
+            True,
+            None,
+            dtype,
+            config,
+            tune,
         )
-        self.init_config(config, tune)
 
-    @property
-    def default_config(self) -> dict:
-        return {
-            "block_m": 256,
-            "threads": 256,
-        }
 
-    @property
-    def autotune_configs(self) -> list[dict]:
-        return [
-            {"block_m": block_m, "threads": threads}
-            for block_m, threads in itertools.product([128, 256, 512], [128, 256, 512])
-        ]
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        self._require_cuda(x=x)
-        return _launch_avg_pool2d(
-            self.n,
-            self.c_in,
-            self.h_in,
-            self.w_in,
-            self.kernel_h,
-            self.kernel_w,
-            self.stride_h,
-            self.stride_w,
-            self.pad_h,
-            self.pad_w,
-            self.ceil_mode,
-            self.count_include_pad,
-            self.use_divisor_override,
-            self.divisor_override,
-            self.dtype_str,
-            self.config["block_m"],
-            self.config["threads"],
-            x,
-        )
+class AvgPool2dKernel(_AvgPool2dKernelBase):
+    """Average pooling over an NCHW plane, with every PyTorch flag combination."""

--- a/src/tileops/kernels/pool/avg_pool3d.py
+++ b/src/tileops/kernels/pool/avg_pool3d.py
@@ -1,5 +1,5 @@
 import functools
-from typing import ClassVar, NamedTuple, Optional, Tuple
+from typing import ClassVar, NamedTuple, Optional
 
 import tilelang
 import tilelang.language as T
@@ -7,90 +7,9 @@ import torch
 
 from tileops.kernels.constants import VECTOR_ACCESS_BYTES
 from tileops.kernels.kernel_base import Kernel
-from tileops.kernels.pool.common import dtype_itemsize, pool_output_dim
+from tileops.kernels.pool.common import ACCUM_DTYPE, AvgPoolWindow, dtype_itemsize
 
 __all__ = ["AvgPool3dKernel", "AvgPool3dSpatialKernel"]
-
-# Window sums promote to fp32 and cast back at the store: a fp16 accumulator loses the
-# low bits of a window this wide.
-_ACCUM_DTYPE = "float"
-
-
-class _Window(NamedTuple):
-    """One avg_pool3d problem, and the extents and facts that follow from it.
-
-    The builders below are cached on this, so everything they derive is derived here
-    once and cannot differ between them.
-    """
-
-    rows: int
-    size: Tuple[int, int, int]
-    kernel: Tuple[int, int, int]
-    stride: Tuple[int, int, int]
-    pad: Tuple[int, int, int]
-    ceil_mode: bool
-    count_include_pad: bool
-    divisor_override: Optional[int]
-
-    @property
-    def out(self) -> Tuple[int, int, int]:
-        return tuple(
-            pool_output_dim(size, k, s, p, self.ceil_mode)
-            for size, k, s, p in zip(self.size, self.kernel, self.stride, self.pad, strict=True)
-        )
-
-    @property
-    def outputs(self) -> int:
-        out_d, out_h, out_w = self.out
-        return self.rows * out_d * out_h * out_w
-
-    @property
-    def window_inside(self) -> bool:
-        """Whether every window lies inside the volume, so no tap carries a test.
-
-        True also settles the output extent: a window that fits is one the ceil-mode and
-        the floor-mode formula both count.
-        """
-        return all(
-            p == 0 and (o - 1) * s + k <= size
-            for size, o, k, s, p in zip(
-                self.size, self.out, self.kernel, self.stride, self.pad, strict=True
-            )
-        )
-
-    @property
-    def whole_window_divides(self) -> bool:
-        """Whether one divisor covers every output.
-
-        Without ceil mode a window reaches ``size + pad`` at the furthest, so counting
-        the padding gives every output the whole kernel. Ceil mode can overhang that, and
-        uncounted padding shortens the windows that do.
-        """
-        return self.window_inside or (self.count_include_pad and not self.ceil_mode)
-
-    @property
-    def divisor(self) -> int:
-        """The divisor every window takes where one covers them all.
-
-        An explicit divisor is used as given, negative included.
-        """
-        if self.divisor_override is not None:
-            return self.divisor_override
-        kernel_d, kernel_h, kernel_w = self.kernel
-        return kernel_d * kernel_h * kernel_w
-
-    @property
-    def overlap(self) -> Tuple[Tuple[int, int, int], Tuple[int, int, int]]:
-        """Per axis, the half-open range a window's own divisor counts.
-
-        Uncounted padding cuts the range back to the volume itself.
-        """
-        if self.count_include_pad:
-            return (
-                tuple(-p for p in self.pad),
-                tuple(size + p for size, p in zip(self.size, self.pad, strict=True)),
-            )
-        return ((0, 0, 0), self.size)
 
 
 class _WideRun(NamedTuple):
@@ -100,7 +19,7 @@ class _WideRun(NamedTuple):
     vector_elems: int
 
 
-def _wide_run(window: _Window, dtype: str) -> Optional[_WideRun]:
+def _wide_run(window: AvgPoolWindow, dtype: str) -> Optional[_WideRun]:
     """The narrowest run of outputs whose taps reach the widest access the w axis admits.
 
     ``run`` consecutive outputs cover ``run * stride_w`` consecutive inputs, and the
@@ -133,7 +52,7 @@ def _wide_run(window: _Window, dtype: str) -> Optional[_WideRun]:
 
 
 @functools.lru_cache(maxsize=32)
-def _avg_pool3d_kernel(window: _Window, dtype: str):
+def _avg_pool3d_kernel(window: AvgPoolWindow, dtype: str):
     """One output per thread, every tap read where it lies."""
     d_in, h_in, w_in = window.size
     kernel_d, kernel_h, kernel_w = window.kernel
@@ -155,7 +74,7 @@ def _avg_pool3d_kernel(window: _Window, dtype: str):
         def _store(total_val, od, oh, ow, out, row):
             """Store one output, taking its divisor from wherever this shape has it."""
             if one_divisor:
-                out[row, od, oh, ow] = T.cast(total_val / T.cast(divisor, _ACCUM_DTYPE), dtype)
+                out[row, od, oh, ow] = T.cast(total_val / T.cast(divisor, ACCUM_DTYPE), dtype)
             else:
                 front = od * stride_d - pad_d
                 top = oh * stride_h - pad_h
@@ -167,7 +86,7 @@ def _avg_pool3d_kernel(window: _Window, dtype: str):
                     * T.max(T.min(left + kernel_w, limit_w) - T.max(left, low_w), 0),
                     1,
                 )
-                out[row, od, oh, ow] = T.cast(total_val / T.cast(extent, _ACCUM_DTYPE), dtype)
+                out[row, od, oh, ow] = T.cast(total_val / T.cast(extent, ACCUM_DTYPE), dtype)
 
         @T.prim_func
         def _avg_pool3d_main(
@@ -188,7 +107,7 @@ def _avg_pool3d_kernel(window: _Window, dtype: str):
                         top = oh * stride_h - pad_h
                         left = ow * stride_w - pad_w
                         total_val = T.alloc_var(T.float32)
-                        total_val = T.cast(0.0, _ACCUM_DTYPE)
+                        total_val = T.cast(0.0, ACCUM_DTYPE)
                         for kd in T.serial(kernel_d):
                             for kh in T.serial(kernel_h):
                                 for kw in T.serial(kernel_w):
@@ -205,7 +124,7 @@ def _avg_pool3d_kernel(window: _Window, dtype: str):
                                         and (iw >= 0)
                                         and (iw < w_in)
                                     ):
-                                        total_val += T.cast(x[row, id_, ih, iw], _ACCUM_DTYPE)
+                                        total_val += T.cast(x[row, id_, ih, iw], ACCUM_DTYPE)
                         _store(total_val, od, oh, ow, out, row)
 
         return _avg_pool3d_main
@@ -214,7 +133,7 @@ def _avg_pool3d_kernel(window: _Window, dtype: str):
 
 
 @functools.lru_cache(maxsize=32)
-def _avg_pool3d_wide_kernel(window: _Window, dtype: str):
+def _avg_pool3d_wide_kernel(window: AvgPoolWindow, dtype: str):
     """A run of outputs per thread, their shared input stretch read as whole groups.
 
     Reached only where :func:`_wide_run` returns a plan, so every window lies inside the
@@ -245,7 +164,7 @@ def _avg_pool3d_wide_kernel(window: _Window, dtype: str):
         ):
             with T.Kernel(T.ceildiv(items, threads), threads=threads) as tile:
                 held = T.alloc_local((span,), dtype)
-                sums = T.alloc_local((run,), _ACCUM_DTYPE)
+                sums = T.alloc_local((run,), ACCUM_DTYPE)
                 for i in T.Parallel(threads):
                     idx = tile * threads + i
                     if block_full or idx < items:
@@ -259,7 +178,7 @@ def _avg_pool3d_wide_kernel(window: _Window, dtype: str):
                         top = oh * stride_h
                         left = jr * span
                         for j in T.serial(run):
-                            sums[j] = T.cast(0.0, _ACCUM_DTYPE)
+                            sums[j] = T.cast(0.0, ACCUM_DTYPE)
                         for kd in T.serial(kernel_d):
                             for kh in T.serial(kernel_h):
                                 # The run covers one contiguous stretch of the row, so
@@ -274,10 +193,10 @@ def _avg_pool3d_wide_kernel(window: _Window, dtype: str):
                                         ]
                                 for j in T.serial(run):
                                     for kw in T.serial(kernel_w):
-                                        sums[j] += T.cast(held[j * stride_w + kw], _ACCUM_DTYPE)
+                                        sums[j] += T.cast(held[j * stride_w + kw], ACCUM_DTYPE)
                         for j in T.serial(run):
                             out[row, od, oh, jr * run + j] = T.cast(
-                                sums[j] / T.cast(divisor, _ACCUM_DTYPE), dtype
+                                sums[j] / T.cast(divisor, ACCUM_DTYPE), dtype
                             )
 
         return _avg_pool3d_main
@@ -323,7 +242,7 @@ class _AvgPool3dKernelBase(Kernel):
         self.n = n
         self.c_in = c_in
         self.dtype = dtype
-        self.window = _Window(
+        self.window = AvgPoolWindow(
             rows=n * c_in,
             size=(d_in, h_in, w_in),
             kernel=(kernel_d, kernel_h, kernel_w),

--- a/src/tileops/kernels/pool/common.py
+++ b/src/tileops/kernels/pool/common.py
@@ -1,5 +1,6 @@
 import itertools
-from typing import Any, Callable, ClassVar, NamedTuple, Optional
+import math
+from typing import Any, Callable, ClassVar, NamedTuple, Optional, Tuple
 
 import torch
 
@@ -100,6 +101,87 @@ def pool_output_dim(
         out -= 1
 
     return max(out, 0)
+
+
+# Window sums promote to fp32 and cast back at the store: a narrow accumulator loses the
+# low bits of a window this wide.
+ACCUM_DTYPE = "float"
+
+
+class AvgPoolWindow(NamedTuple):
+    """One average-pooling problem, and the extents and facts that follow from it.
+
+    The per-axis fields carry one entry per spatial axis, so the same type serves 1d, 2d
+    and 3d. A kernel builder is cached on this, so everything it derives is derived here
+    once and cannot differ between the builders of one family.
+    """
+
+    rows: int
+    size: Tuple[int, ...]
+    kernel: Tuple[int, ...]
+    stride: Tuple[int, ...]
+    pad: Tuple[int, ...]
+    ceil_mode: bool
+    count_include_pad: bool
+    divisor_override: Optional[int]
+
+    @property
+    def out(self) -> Tuple[int, ...]:
+        return tuple(
+            pool_output_dim(size, k, s, p, self.ceil_mode)
+            for size, k, s, p in zip(self.size, self.kernel, self.stride, self.pad, strict=True)
+        )
+
+    @property
+    def outputs(self) -> int:
+        return self.rows * math.prod(self.out)
+
+    @property
+    def window_inside(self) -> bool:
+        """Whether every window lies inside the input, so no tap carries a test.
+
+        True also settles the output extent: a window that fits is one the ceil-mode and
+        the floor-mode formula both count.
+        """
+        return all(
+            p == 0 and (o - 1) * s + k <= size
+            for size, o, k, s, p in zip(
+                self.size, self.out, self.kernel, self.stride, self.pad, strict=True
+            )
+        )
+
+    @property
+    def whole_window_divides(self) -> bool:
+        """Whether one divisor covers every output.
+
+        Without ceil mode a window reaches ``size + pad`` at the furthest, so counting
+        the padding gives every output the whole kernel. Ceil mode can overhang that, and
+        uncounted padding shortens the windows that do.
+        """
+        return self.window_inside or (self.count_include_pad and not self.ceil_mode)
+
+    @property
+    def divisor(self) -> int:
+        """The divisor every window takes where one covers them all.
+
+        An explicit divisor is used as given, negative included.
+        """
+        if self.divisor_override is not None:
+            return self.divisor_override
+        return math.prod(self.kernel)
+
+    @property
+    def overlap(self) -> Tuple[Tuple[int, ...], Tuple[int, ...]]:
+        """Per axis, the half-open range a window's own divisor counts.
+
+        Uncounted padding cuts the range back to the input itself.
+        """
+        if self.count_include_pad:
+            return (
+                tuple(-p for p in self.pad),
+                tuple(size + p for size, p in zip(self.size, self.pad, strict=True)),
+            )
+        return ((0,) * len(self.pad), self.size)
 
 
 def adaptive_bin(o, size_in: int, size_out: int):

--- a/tests/ops/test_pool.py
+++ b/tests/ops/test_pool.py
@@ -25,7 +25,7 @@ from tileops.kernels.pool import (
     MaxPool3dWithIndicesKernel,
 )
 from tileops.kernels.pool.avg_pool1d import _WindowStaging
-from tileops.kernels.pool.common import pool_output_dim, window_span
+from tileops.kernels.pool.common import AvgPoolWindow, pool_output_dim, window_span
 from tileops.kernels.pool.max_pool1d import _plan as _max_pool1d_plan
 from tileops.kernels.pool.max_pool1d import _Shape as _MaxPool1dShape
 from tileops.ops import (
@@ -626,8 +626,17 @@ def test_avg_pool1d_staged_span_stays_aligned(
     Only a window too wide to stage at 128 outputs selects a width that can break this,
     which is why no benchmarked shape reaches it.
     """
-    out_l = pool_output_dim(l_in, kernel_l, stride_l, pad_l, False)
-    staging = _WindowStaging(1, l_in, out_l, kernel_l, stride_l, pad_l, dtype)
+    window = AvgPoolWindow(
+        rows=1,
+        size=(l_in,),
+        kernel=(kernel_l,),
+        stride=(stride_l,),
+        pad=(pad_l,),
+        ceil_mode=False,
+        count_include_pad=True,
+        divisor_override=None,
+    )
+    staging = _WindowStaging(window, dtype)
     for block_ol in staging.widths():
         staged = window_span(
             block_ol, block_ol * stride_l, l_in, kernel_l, stride_l, pad_l, 1, dtype
@@ -2174,8 +2183,6 @@ def test_pool_output_dim_with_dilation(
     ceil_mode: bool,
     expected: int | str,
 ) -> None:
-    from tileops.kernels.pool.common import pool_output_dim
-
     if expected == "default_matches_explicit":
         default = pool_output_dim(input_size, kernel_size, stride, padding, ceil_mode)
         explicit = pool_output_dim(


### PR DESCRIPTION
## Problems

- `avg_pool1d`, `avg_pool2d` and `avg_pool3d` each derive the same facts from a pooling shape: the output extents, whether a window can reach outside the input, whether one divisor covers every output, and the range that divisor counts.
- `avg_pool2d` derives them twice, in two builders that differ only in what they assume, and again in each of its two Kernel classes.
- The 2d divisor is two products and two `T.if_then_else` selects per output, on flags known when the kernel is built.
- The 2d spatial builder tests every tap against the input even where no window can reach outside it.
- `avg_pool1d` multiplies the whole-window store by a reciprocal, which is not bit-exact against torch.
- Each Kernel class holds the shape as a dozen attributes and passes them to its builder as a dozen positional arguments.

## Changes

- Add `AvgPoolWindow` to `pool/common.py`: one pooling problem, per-axis fields as tuples so 1d, 2d and 3d share it, deriving `out`, `outputs`, `window_inside`, `whole_window_divides`, `divisor` and `overlap` once.
- Move `ACCUM_DTYPE` there: the fp32 accumulator is a family-wide accuracy contract.
- Every builder takes `(window, dtype)`; every Kernel class holds `self.window`.
- Delete the 2d spatial builder and both `_launch_*` wrappers; the two 2d Kernel classes fold into one base with two subclasses, matching 1d and 3d.
- Resolve the 2d divisor to one compile-time branch, and drop the tap test where `window_inside` holds.
- Make the 2d config key `threads`, as in 3d: the parallel loop is the block's thread count.
- Divide in `avg_pool1d`'s whole-window store instead of multiplying by a reciprocal.