### PR TITLE
[Perf][TopK] Remove redundant radix work

### DIFF
--- a/src/tileops/kernels/topk_selector.py
+++ b/src/tileops/kernels/topk_selector.py
@@ -1,5 +1,4 @@
 import functools
-import itertools
 from typing import Optional
 
 import tilelang
@@ -36,9 +35,11 @@ def _topk_selector_kernel(batch, seq_len, seq_len_kv, kv_group, topk, in_dtype, 
             tilelang.PassConfigKey.TL_DISABLE_THREAD_STORAGE_SYNC: True,
         },
     )
-    def topk_selector_fwd_func(RADIX=1 << 8, BLOCK_SIZE=1024, SMEM_INPUT_SIZE=4096, block_m=32):
+    def topk_selector_fwd_func(BLOCK_SIZE=1024):
         batch = T.dynamic("batch")
         seq_len_kv = T.dynamic("seq_len_kv")
+        RADIX = 1 << 8
+        SMEM_INPUT_SIZE = 4096
 
         @T.prim_func
         def _topk_selector_kernel_main(
@@ -68,6 +69,7 @@ def _topk_selector_kernel(batch, seq_len, seq_len_kv, kv_group, topk, in_dtype, 
                 l_end_idx = T.alloc_var(T.int32)
                 l_out_pos = T.alloc_var(T.int32)
                 l_pos = T.alloc_var(T.int32)
+                l_score = T.alloc_var(T.float32)
 
                 l_new_topk = topk
                 l_start_idx = starts[bx, seq_row]
@@ -75,9 +77,12 @@ def _topk_selector_kernel(batch, seq_len, seq_len_kv, kv_group, topk, in_dtype, 
 
                 # stage 1: use 8bit to do quick topk
 
-                for j in T.serial(RADIX + 1):
-                    s_histogram[j] = 0
-                s_num_input[0] = 0
+                for j in T.serial(T.ceildiv(RADIX + 1, BLOCK_SIZE)):
+                    histogram_idx = j * BLOCK_SIZE + tx
+                    if histogram_idx < RADIX + 1:
+                        s_histogram[histogram_idx] = 0
+                if tx == 0:
+                    s_num_input[0] = 0
 
                 T.sync_threads()
 
@@ -88,7 +93,8 @@ def _topk_selector_kernel(batch, seq_len, seq_len_kv, kv_group, topk, in_dtype, 
                         and input_idx >= l_start_idx
                         and input_idx < seq_len_kv
                     ):
-                        inval_int16 = convert_to_uint16(index_score[bx, seq_row, input_idx, g])
+                        l_score = index_score[bx, seq_row, input_idx, g]
+                        inval_int16 = convert_to_uint16(l_score)
                         T.atomic_add(s_histogram[inval_int16], 1)
                 T.sync_threads()
 
@@ -122,7 +128,8 @@ def _topk_selector_kernel(batch, seq_len, seq_len_kv, kv_group, topk, in_dtype, 
                         and input_idx >= l_start_idx
                         and input_idx < seq_len_kv
                     ):
-                        bin_id = convert_to_uint16(index_score[bx, seq_row, input_idx, g])
+                        l_score = index_score[bx, seq_row, input_idx, g]
+                        bin_id = convert_to_uint16(l_score)
                         l_bin_id32 = T.Cast(T.int32, bin_id)
                         if l_bin_id32 > l_threshold_bin_id:
                             l_pos = T.atomic_add(s_histogram[l_bin_id32 + 1], 1, return_prev=True)
@@ -143,8 +150,10 @@ def _topk_selector_kernel(batch, seq_len, seq_len_kv, kv_group, topk, in_dtype, 
                     l_start_pos = topk - l_new_topk
 
                     T.sync_threads()
-                    for j in T.serial(RADIX + 1):
-                        s_histogram[j] = 0
+                    for j in T.serial(T.ceildiv(RADIX + 1, BLOCK_SIZE)):
+                        histogram_idx = j * BLOCK_SIZE + tx
+                        if histogram_idx < RADIX + 1:
+                            s_histogram[histogram_idx] = 0
                     if tx == 0:
                         s_num_input[r_idx ^ 1] = 0
                     T.sync_threads()
@@ -152,22 +161,15 @@ def _topk_selector_kernel(batch, seq_len, seq_len_kv, kv_group, topk, in_dtype, 
                     l_num_input = T.min(s_num_input[r_idx], SMEM_INPUT_SIZE)
                     for s in T.serial(T.ceildiv(l_num_input, BLOCK_SIZE)):
                         if s * BLOCK_SIZE + tx < l_num_input:
+                            l_score = index_score[
+                                bx,
+                                seq_row,
+                                s_input_idx[r_idx, s * BLOCK_SIZE + tx],
+                                g,
+                            ]
                             l_bin_id32 = T.Cast(
                                 T.int32,
-                                (
-                                    (
-                                        convert_to_uint32(
-                                            index_score[
-                                                bx,
-                                                seq_row,
-                                                s_input_idx[r_idx, s * BLOCK_SIZE + tx],
-                                                g,
-                                            ]
-                                        )
-                                        >> (24 - round * 8)
-                                    )
-                                    & 0xFF
-                                ),
+                                ((convert_to_uint32(l_score) >> (24 - round * 8)) & 0xFF),
                             )
                             T.atomic_add(s_histogram[l_bin_id32], 1)
                     T.sync_threads()
@@ -194,22 +196,15 @@ def _topk_selector_kernel(batch, seq_len, seq_len_kv, kv_group, topk, in_dtype, 
 
                     for s in T.serial(T.ceildiv(l_num_input, BLOCK_SIZE)):
                         if s * BLOCK_SIZE + tx < l_num_input:
+                            l_score = index_score[
+                                bx,
+                                seq_row,
+                                s_input_idx[r_idx, s * BLOCK_SIZE + tx],
+                                g,
+                            ]
                             l_bin_id32 = T.Cast(
                                 T.int32,
-                                (
-                                    (
-                                        convert_to_uint32(
-                                            index_score[
-                                                bx,
-                                                seq_row,
-                                                s_input_idx[r_idx, s * BLOCK_SIZE + tx],
-                                                g,
-                                            ]
-                                        )
-                                        >> (24 - round * 8)
-                                    )
-                                    & 0xFF
-                                ),
+                                ((convert_to_uint32(l_score) >> (24 - round * 8)) & 0xFF),
                             )
                             if l_bin_id32 > l_threshold_bin_id:
                                 l_pos = (
@@ -254,16 +249,13 @@ def _topk_selector_wrapped_kernel(
     topk: int,
     in_dtype: str,
     out_dtype: str,
-    RADIX: int,
     BLOCK_SIZE: int,
-    SMEM_INPUT_SIZE: int,
-    block_m: int,
     index_score: torch.Tensor,
     starts: torch.Tensor,
     ends: torch.Tensor,
 ) -> torch.Tensor:
     return _topk_selector_kernel(batch, seq_len, seq_len_kv, kv_group, topk, in_dtype, out_dtype)(
-        RADIX, BLOCK_SIZE, SMEM_INPUT_SIZE, block_m
+        BLOCK_SIZE
     )(index_score, starts, ends)
 
 
@@ -283,8 +275,7 @@ class TopkSelectorKernel(Kernel):
         topk: Number of indices selected per row.
         dtype: Torch dtype of the input scores.
         out_dtype: Torch dtype of the emitted indices.
-        config: Optional dict with "RADIX", "BLOCK_SIZE", "SMEM_INPUT_SIZE"
-            and "block_m".
+        config: Optional dict with "BLOCK_SIZE".
         tune: Whether to autotune.
     """
 
@@ -377,31 +368,11 @@ class TopkSelectorKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
-        return {
-            "RADIX": 1 << 8,
-            "BLOCK_SIZE": 1024,
-            "SMEM_INPUT_SIZE": 4096,
-            "block_m": 32,
-        }
+        return {"BLOCK_SIZE": 1024}
 
     @property
     def autotune_configs(self) -> list[dict]:
-        """
-        Generates a list of autotuning configurations for the kernel.
-
-        Returns:
-            list[dict]: A list of dictionaries containing 'block_i' and 'threads' combinations.
-        """
-        RADIX = [1 << 8]
-        BLOCK_SIZE = [1024]
-        SMEM_INPUT_SIZE = [4096]
-        block_m = [32]
-        _configs = list(itertools.product(RADIX, BLOCK_SIZE, SMEM_INPUT_SIZE, block_m))
-
-        return [
-            {"RADIX": c[0], "BLOCK_SIZE": c[1], "SMEM_INPUT_SIZE": c[2], "block_m": c[3]}
-            for c in _configs
-        ]
+        return [{"BLOCK_SIZE": block_size} for block_size in (256, 512, 1024)]
 
     def forward(
         self, index_score: torch.Tensor, starts: torch.Tensor, ends: torch.Tensor
@@ -414,10 +385,7 @@ class TopkSelectorKernel(Kernel):
             self.topk,
             self.dtype_str,
             self.out_dtype_str,
-            self.config["RADIX"],
             self.config["BLOCK_SIZE"],
-            self.config["SMEM_INPUT_SIZE"],
-            self.config["block_m"],
             index_score,
             starts,
             ends,

--- a/tests/ops/test_topk_selector.py
+++ b/tests/ops/test_topk_selector.py
@@ -49,17 +49,6 @@ class TopkSelectorFixture(FixtureBase):
     ]
 
 
-def _set_compare(output: torch.Tensor, output_ref: torch.Tensor) -> None:
-    """Compare using set intersection (topk indices may be in different order)."""
-    ref_np = output_ref.cpu().to(torch.int32).numpy()
-    trt_np = output.cpu().to(torch.int32).numpy()
-
-    set_ref = set(ref_np.flatten().tolist())
-    set_trt = set(trt_np.flatten().tolist())
-    intersection = set_ref & set_trt
-    assert len(intersection) / len(set_ref) == 1.0, "output indices do not match reference indices"
-
-
 @TopkSelectorFixture
 def test_topk_selector_op(
     batch: int,
@@ -75,4 +64,14 @@ def test_topk_selector_op(
     out_dtype = str2dtype[out_dtype_str]
     test = TopkSelectorTest(batch, seq_len, seq_len_kv, kv_group, topk, in_dtype, out_dtype)
     op = TopkSelectorFwdOp(topk=topk, tune=tune)
-    test.check(op, *test.gen_inputs(), compare=_set_compare)
+    inputs = test.gen_inputs()
+
+    def compare(output: torch.Tensor, output_ref: torch.Tensor) -> None:
+        def selected(indices: torch.Tensor) -> torch.Tensor:
+            gather_index = indices.permute(0, 1, 3, 2).long()
+            values = torch.gather(inputs[0], 2, gather_index).permute(0, 1, 3, 2)
+            return torch.sort(values, dim=-1).values
+
+        torch.testing.assert_close(selected(output), selected(output_ref))
+
+    test.check(op, *inputs, compare=compare)


### PR DESCRIPTION
## Summary

- clear radix histograms cooperatively instead of having every thread clear every bin
- keep each loaded score in a local fp32 value so generated CUDA does not repeat global reads
- remove the unused `block_m` parameter and keep algorithm invariants out of the public kernel config
- replace the flattened global-index test with per-row selected-score validation