### PR TITLE
[Feat][Kernels] Support pre-Hopper archs in GEMM, sparse MLA and FP8 BMM

### DIFF
--- a/src/tileops/kernels/__init__.py
+++ b/src/tileops/kernels/__init__.py
@@ -19,6 +19,7 @@ from .attention import (
     NSACmpFwdVarlenKernel,
     NSAFwdVarlenKernel,
     NSATopkVarlenKernel,
+    SparseMlaBasicKernel,
     SparseMlaKernel,
 )
 from .convolution import (
@@ -40,6 +41,7 @@ from .fp8_quant import FP8QuantKernel
 from .gemm import (
     BmmFp8Kernel,
     BmmKernel,
+    GemmBasicKernel,
     GemmFp8BlockScaledKernel,
     GemmFp8EpilogueKernel,
     GemmKernel,
@@ -163,6 +165,7 @@ __all__ = [
     "GatedDeltaNetFwdKernel",
     "GatedDeltaNetFwdProductionKernel",
     "GatedDeltaNetPrefillFwdKernel",
+    "GemmBasicKernel",
     "GemmFp8BlockScaledKernel",
     "GemmFp8EpilogueKernel",
     "GemmKernel",
@@ -199,6 +202,7 @@ __all__ = [
     "RopeNonNeoxKernel",
     "RopeYarnKernel",
     "SmallBatchGemmKernel",
+    "SparseMlaBasicKernel",
     "SparseMlaKernel",
     "TopkSelectorKernel",
     "UnaryKernel",

--- a/src/tileops/kernels/attention/__init__.py
+++ b/src/tileops/kernels/attention/__init__.py
@@ -1,4 +1,4 @@
-from .deepseek_dsa_decode import SparseMlaKernel
+from .deepseek_dsa_decode import SparseMlaBasicKernel, SparseMlaKernel
 from .deepseek_mla_decode import MLADecodeWsKernel
 from .deepseek_nsa_cmp_fwd import NSACmpFwdVarlenKernel
 from .deepseek_nsa_fwd import NSAFwdVarlenKernel
@@ -61,5 +61,6 @@ __all__ = [
     "NSACmpFwdVarlenKernel",
     "NSAFwdVarlenKernel",
     "NSATopkVarlenKernel",
+    "SparseMlaBasicKernel",
     "SparseMlaKernel",
 ]

--- a/src/tileops/kernels/attention/deepseek_dsa_decode.py
+++ b/src/tileops/kernels/attention/deepseek_dsa_decode.py
@@ -1,6 +1,6 @@
 import functools
 import itertools
-from typing import Optional
+from typing import Callable, Optional
 
 import tilelang
 import tilelang.language as T
@@ -8,10 +8,11 @@ import torch
 from tilelang.autotuner import autotune
 
 from tileops.kernels.kernel_base import Kernel
+from tileops.utils import get_sm_version
 
 from .online_softmax import LOG2E
 
-__all__ = ["SparseMlaKernel"]
+__all__ = ["SparseMlaBasicKernel", "SparseMlaKernel"]
 
 
 @functools.lru_cache(maxsize=32)
@@ -474,6 +475,472 @@ def _sparse_mla_wrapped_kernel(
 @_sparse_mla_wrapped_kernel.register_fake
 def _(batch: int, seq_len: int, heads: int, dim: int, *inputs) -> None:
     return torch.empty([batch, seq_len, heads, dim], device=inputs[0].device, dtype=inputs[0].dtype)
+
+
+@functools.lru_cache(maxsize=32)
+def _sparse_mla_basic_kernel(
+    batch: int,
+    seq_len: int,
+    seq_len_kv: int,
+    heads: int,
+    dim: int,
+    tail_dim: int,
+    topk: int,
+    kv_stride: int,
+    q_start_index_s: int,
+    kv_group: int = 1,
+    sm_scale: float = None,
+    is_causal: bool = True,
+    cp0: bool = True,
+    dtype: torch.dtype = "float16",
+) -> None:
+    """
+    Architecture-agnostic sparse MLA forward (plain T.gemm + T.Pipelined).
+
+    Re-implements ``_sparse_mla_kernel`` without WGMMA or warp specialization
+    so it compiles on pre-SM90 targets (sm80 / sm86 / sm89). The math (online
+    softmax over gathered top-k KV rows) is identical to the WGMMA version;
+    only the execution strategy changes:
+
+    - One homogeneous thread group instead of producer + 2 consumer warpgroups.
+    - ``T.Pipelined`` software pipelining instead of hand-rolled double
+      buffering with mbarriers.
+    - Per-row KV gather via ``T.copy`` with runtime row indices.
+    """
+    if dim != tilelang.math.next_power_of_2(dim):
+        raise ValueError(f"haven't check padding correctness yet, dim={dim}")
+    if tail_dim != tilelang.math.next_power_of_2(tail_dim):
+        raise ValueError(f"haven't check padding correctness yet, dim={tail_dim}")
+    if not is_causal:
+        raise ValueError("non-causal is not supported")
+    sm_scale = ((1.0 / (dim + tail_dim)) ** 0.5 if sm_scale is None else sm_scale) * LOG2E
+
+    head_kv = heads // kv_group
+    ori_heads = heads
+    indices_dtype = "int32"
+    accum_dtype = "float"
+
+    @tilelang.jit(
+        out_idx=[-1],
+        compile_flags=[
+            "--use_fast_math",
+            "-O3",
+            "-Wno-deprecated-declarations",
+            "-U__CUDA_NO_HALF_OPERATORS__",
+            "-U__CUDA_NO_HALF_CONVERSIONS__",
+            "-U__CUDA_NO_HALF2_OPERATORS__",
+            "-U__CUDA_NO_BFLOAT16_CONVERSIONS__",
+            "--expt-relaxed-constexpr",
+            "--expt-extended-lambda",
+            "--ptxas-options=-v,--register-usage-level=10",
+            "-DNDEBUG",
+        ],
+    )
+    def _sparse_mla_basic_fwd_func(block_i: int, threads: int, num_stages: int = 2) -> None:
+        if topk % block_i != 0:
+            raise ValueError("otherwise will load some index=0 thus causing wrong kv to be loaded")
+        i_block = block_i
+        n_i = tilelang.cdiv(topk, block_i)
+
+        d = dim
+        d_tail = tail_dim
+        stride_kv = kv_stride
+
+        if head_kv > 64:
+            if head_kv % 64 != 0:
+                raise ValueError("head_kv should be a multiple of 64")
+            replicate_h = head_kv // 64
+        else:
+            replicate_h = 1
+
+        padded_h = max(tilelang.math.next_power_of_2(head_kv), 16)
+        if padded_h != head_kv and kv_group != 1:
+            raise ValueError(
+                "here we solve the heads padding automatically, "
+                "other wise you should handle q copy and output copy "
+                "with your mask (when kv_group == 1, use g_i * padded_h:(g_i+1) * "
+                "padded_h would be handled automatically)"
+            )
+
+        h_per_block = padded_h if replicate_h == 1 else 64
+
+        q_shape = (batch, seq_len, ori_heads, dim + tail_dim)
+        kv_shape = (batch, seq_len_kv, kv_group, dim + tail_dim)
+        o_shape = (batch, seq_len, ori_heads, dim)
+        indices_shape = (batch, seq_len, kv_group, topk)
+
+        @T.prim_func
+        def _sparse_mla_basic_fwd_main(
+            q: T.Tensor(q_shape, dtype),  # type: ignore
+            kv: T.Tensor(kv_shape, dtype),  # type: ignore
+            indices: T.Tensor(indices_shape, indices_dtype),  # type: ignore
+            output: T.Tensor(o_shape, dtype),  # type: ignore
+        ) -> None:
+            with T.Kernel(
+                (seq_len - stride_kv + 1 if cp0 else seq_len) * replicate_h,
+                batch,
+                kv_group,
+                threads=threads,
+            ) as (bx, by, bz):
+                # Q/KV are split at [.., :d] / [.., d:] so the PV gemm can
+                # consume kv_shared directly: V is the first `dim` columns of
+                # the fused KV cache (v = kv[..., :dim]).
+                q_shared = T.alloc_shared([h_per_block, d], dtype)
+                q_tail_shared = T.alloc_shared([h_per_block, d_tail], dtype)
+                kv_shared = T.alloc_shared([i_block, d], dtype)
+                kv_tail_shared = T.alloc_shared([i_block, d_tail], dtype)
+                s_shared = T.alloc_shared([h_per_block, i_block], dtype)
+                # Q is dead once the last QK^T gemm has been issued, so the
+                # output staging reuses its shared buffer.
+                o_shared = q_shared
+
+                acc_s = T.alloc_fragment([h_per_block, i_block], accum_dtype)
+                acc_o = T.alloc_fragment([h_per_block, d], accum_dtype)
+                sumexp = T.alloc_fragment([h_per_block], accum_dtype)
+                sumexp_i = T.alloc_fragment([h_per_block], accum_dtype)
+                alpha_local = T.alloc_fragment([h_per_block], accum_dtype)
+                m_i = T.alloc_fragment([h_per_block], accum_dtype)
+                m_i_prev = T.alloc_fragment([h_per_block], accum_dtype)
+
+                b_i, g_i = by, bz
+                s_i = (
+                    (bx + (stride_kv - 1 if cp0 else 0))
+                    if replicate_h == 1
+                    else (bx // replicate_h + (stride_kv - 1 if cp0 else 0))
+                )
+                q_i = q_start_index_s + s_i
+                max_kv_i = (q_i + 1 - stride_kv) // stride_kv
+
+                h0 = g_i * padded_h + (0 if replicate_h == 1 else (bx % replicate_h) * 64)
+                h1 = h0 + h_per_block
+
+                T.copy(q[b_i, s_i, h0:h1, :d], q_shared)
+                T.copy(q[b_i, s_i, h0:h1, d:], q_tail_shared)
+                T.fill(sumexp, 0)
+                T.fill(m_i, -(2**30))  # avoid -inf - inf to cause nan
+                T.fill(acc_o, 0)
+
+                for i_i in T.Pipelined(n_i, num_stages=num_stages):
+                    # Gather the top-k KV rows selected by indices. Rows whose
+                    # index exceeds max_kv_i are left untouched (stale data);
+                    # the -inf mask below makes their softmax weight zero, so
+                    # stale values never reach the output — the same contract
+                    # as the WGMMA producer warpgroup.
+                    for r in T.serial(i_block):
+                        kv_idx = indices[b_i, s_i, g_i, i_i * i_block + r]
+                        if kv_idx <= max_kv_i:
+                            T.copy(kv[b_i, kv_idx, g_i, :d], kv_shared[r, :])
+                            T.copy(kv[b_i, kv_idx, g_i, d:], kv_tail_shared[r, :])
+
+                    # acc_s starts at 0 for valid rows / -inf for invalid
+                    # ones; the gemms below accumulate onto it.
+                    for h_i, bi_i in T.Parallel(h_per_block, i_block):
+                        acc_s[h_i, bi_i] = T.if_then_else(
+                            indices[b_i, s_i, g_i, i_i * i_block + bi_i] <= max_kv_i,
+                            0,
+                            -T.infinity(acc_s.dtype),
+                        )
+                    T.gemm(
+                        q_shared,
+                        kv_shared,
+                        acc_s,
+                        transpose_B=True,
+                        policy=T.GemmWarpPolicy.FullCol,
+                    )
+                    T.gemm(
+                        q_tail_shared,
+                        kv_tail_shared,
+                        acc_s,
+                        transpose_B=True,
+                        policy=T.GemmWarpPolicy.FullCol,
+                    )
+
+                    # Online softmax — same math as the WGMMA version.
+                    T.copy(m_i, m_i_prev)
+                    T.reduce_max(acc_s, m_i, dim=1, clear=False)
+                    for h_i in T.Parallel(h_per_block):
+                        alpha_local[h_i] = T.exp2((m_i_prev[h_i] - m_i[h_i]) * sm_scale)
+                    for h_i, bi_i in T.Parallel(h_per_block, i_block):
+                        acc_s[h_i, bi_i] = T.exp2(acc_s[h_i, bi_i] * sm_scale - m_i[h_i] * sm_scale)
+                    T.reduce_sum(acc_s, sumexp_i, dim=1)
+                    for h_i in T.Parallel(h_per_block):
+                        sumexp[h_i] = sumexp[h_i] * alpha_local[h_i] + sumexp_i[h_i]
+                    for h_i, d_i in T.Parallel(h_per_block, d):
+                        acc_o[h_i, d_i] *= alpha_local[h_i]
+
+                    # O += P @ V (V is kv[..., :dim]).
+                    T.copy(acc_s, s_shared)
+                    T.gemm(s_shared, kv_shared, acc_o, policy=T.GemmWarpPolicy.FullCol)
+
+                # Rescale
+                for h_i, d_i in T.Parallel(h_per_block, d):
+                    acc_o[h_i, d_i] /= sumexp[h_i]
+                T.copy(acc_o, o_shared)
+                T.copy(o_shared, output[b_i, s_i, h0:h1, :d])
+
+        return _sparse_mla_basic_fwd_main
+
+    return _sparse_mla_basic_fwd_func
+
+
+@torch.library.custom_op("tileops::sparse_mla_basic_fwd_wrapped_kernel", mutates_args=())
+def _sparse_mla_basic_wrapped_kernel(
+    batch: int,
+    seq_len: int,
+    seq_len_kv: int,
+    heads: int,
+    dim: int,
+    tail_dim: int,
+    topk: int,
+    kv_stride: int,
+    q_start_index_s: int,
+    kv_group: int,
+    sm_scale: Optional[float],
+    is_causal: bool,
+    cp0: bool,
+    dtype: str,
+    block_i: int,
+    threads: int,
+    num_stages: int,
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+) -> torch.Tensor:
+    """Wrapper for the architecture-agnostic sparse MLA kernel execution."""
+    return _sparse_mla_basic_kernel(
+        batch,
+        seq_len,
+        seq_len_kv,
+        heads,
+        dim,
+        tail_dim,
+        topk,
+        kv_stride,
+        q_start_index_s,
+        kv_group,
+        sm_scale,
+        is_causal,
+        cp0,
+        dtype,
+    )(block_i, threads, num_stages)(q, kv, indices)
+
+
+@_sparse_mla_basic_wrapped_kernel.register_fake
+def _(batch: int, seq_len: int, heads: int, dim: int, *inputs) -> None:
+    return torch.empty([batch, seq_len, heads, dim], device=inputs[0].device, dtype=inputs[0].dtype)
+
+
+class SparseMlaBasicKernel(Kernel):
+    """
+    Architecture-agnostic sparse MLA kernel (sm80+).
+
+    ``SparseMlaKernel`` requires Hopper WGMMA plus manual warp specialization;
+    this variant re-implements the same computation with plain ``T.gemm`` and
+    ``T.Pipelined`` software pipelining so it runs on any tensor-core target
+    (sm80, sm86, sm89). Constructor / forward signatures are identical to
+    ``SparseMlaKernel`` so the op layer can swap between the two.
+
+    Args:
+        batch (int): The batch size for the operation.
+        seq_len (int): The sequence length for the query input.
+        seq_len_kv (int): The sequence length for the key and value inputs.
+        heads (int): The number of attention heads.
+        dim (int): The dimension of the attention vectors.
+        tail_dim (int): The tail dimension of the attention vectors.
+        dtype (dtype): The data type of the tensor (e.g., float16).
+        topk (int): The top-k value for sparse attention.
+        kv_stride (int): The stride of the key-value tensor.
+        kv_group (int): The number of key-value groups.
+        sm_scale (Optional[float]): The scaling factor for the softmax operation.
+        is_causal (bool): Whether the attention mechanism is causal.
+        q_start_index_s (int): The starting index of the query tensor.
+        cp0 (bool): A configuration parameter that indicates whether
+                        the current computation unit is responsible for
+                        the first chunk of data (i.e., whether `cp_rank == 0`).
+    """
+
+    supported_archs: list[int] = [80, 86, 89, 90]
+
+    def __init__(
+        self,
+        batch: int,
+        seq_len: int,
+        seq_len_kv: int,
+        heads: int,
+        dim: int,
+        tail_dim: int,
+        dtype: torch.dtype,
+        topk: int,
+        kv_stride: int,
+        q_start_index_s: int,
+        kv_group: int = 1,
+        sm_scale: float = None,
+        is_causal: bool = True,
+        cp0: bool = True,
+        config: Optional[dict] = None,
+        tune: bool = False,
+    ) -> None:
+        super().__init__()
+        self.batch = batch
+        self.seq_len = seq_len
+        self.seq_len_kv = seq_len_kv
+        self.heads = heads
+        self.dim = dim
+        self.tail_dim = tail_dim
+        self.dtype = dtype
+        self.topk = topk
+        self.kv_stride = kv_stride
+        self.kv_group = kv_group
+        self.sm_scale = sm_scale
+        self.is_causal = is_causal
+        self.q_start_index_s = q_start_index_s
+        self.cp0 = cp0
+
+        self.kernel = _sparse_mla_basic_kernel(
+            self.batch,
+            self.seq_len,
+            self.seq_len_kv,
+            self.heads,
+            self.dim,
+            self.tail_dim,
+            self.topk,
+            self.kv_stride,
+            self.q_start_index_s,
+            self.kv_group,
+            self.sm_scale,
+            self.is_causal,
+            self.cp0,
+            self.dtype_str,
+        )
+
+        self.init_config(config, tune)
+
+    @property
+    def default_config(self) -> dict:
+        # 128 threads (4 warps) matches the row-parallel online-softmax
+        # layout and MLADecodeKernel's sm89 best config. The WGMMA version
+        # instead spreads acc_o across two 128-thread consumer warpgroups.
+        # block_i=64 stages 230KB of SMEM for the worst test shape (kv_group=1,
+        # h_per_block=64, d=512: q 64KB + q_tail 8KB + 2x (kv 64KB + kv_tail
+        # 8KB) + s 8KB), over the 163KB per-block cap every pre-Hopper card
+        # launches with — verified failing on real sm80 hardware. block_i=32
+        # halves the pipelined KV tiles to 148KB, which fits sm80; sm89's
+        # 99KB cap still needs the smaller h_per_block of a realistic MLA
+        # shape (heads // kv_group) or an autotuned block_i.
+        if get_sm_version() < 90:
+            return {"block_i": 32, "threads": 128, "num_stages": 2}
+        return {"block_i": 64, "threads": 128, "num_stages": 2}
+
+    @property
+    def autotune_configs(self) -> list[dict]:
+        """
+        Generates a list of autotuning configurations for the kernel.
+
+        ``block_i=32`` halves the pipelined KV shared-memory footprint, which
+        matters on archs with a tighter per-block shared memory limit
+        (A100 164KB / sm89 100KB vs H100 227KB).
+
+        Returns:
+            list[dict]: Configs with 'block_i', 'threads' and 'num_stages'.
+        """
+        block_i = [32, 64]
+        # threads=256 is kept for targets that support it; the autotuner
+        # prunes configs that fail to compile.
+        threads = [128, 256]
+        _configs = list(itertools.product(block_i, threads))
+
+        return [
+            {
+                "block_i": c[0],
+                "threads": c[1],
+                "num_stages": 2,
+            }
+            for c in _configs
+        ]
+
+    def forward(self, q: torch.Tensor, kv: torch.Tensor, indices: torch.Tensor) -> torch.Tensor:
+        """
+        Performs the forward pass of the sparse multi-head attention kernel.
+
+        Args:
+            q (torch.Tensor): Query tensor.
+            kv (torch.Tensor): Key-value tensor.
+            indices (torch.Tensor): Indices tensor.
+
+        Returns:
+           torch.Tensor: Result of the sparse multi-head attention.
+        """
+        return _sparse_mla_basic_wrapped_kernel(
+            self.batch,
+            self.seq_len,
+            self.seq_len_kv,
+            self.heads,
+            self.dim,
+            self.tail_dim,
+            self.topk,
+            self.kv_stride,
+            self.q_start_index_s,
+            self.kv_group,
+            self.sm_scale,
+            self.is_causal,
+            self.cp0,
+            self.dtype_str,
+            self.config["block_i"],
+            self.config["threads"],
+            self.config["num_stages"],
+            q,
+            kv,
+            indices,
+        )
+
+    @property
+    def autotune_supply_prog(self) -> Optional[Callable]:
+        # supply_prog generates inputs from instance shape attributes and takes
+        # no JIT params; discard whatever TileLang passes in.
+        return lambda *args, **kwargs: self.supply_prog()
+
+    def supply_prog(self) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """
+        Generates synthetic data for the kernel program.
+
+        Returns:
+            tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+                        Generated query, key-value, and indices tensors.
+        """
+        q = torch.randn(
+            self.batch,
+            self.seq_len,
+            self.heads,
+            self.dim + self.tail_dim,
+            device="cuda",
+            dtype=self.dtype,
+        )
+        kv = torch.randn(
+            self.batch,
+            self.seq_len_kv,
+            self.kv_group,
+            self.dim + self.tail_dim,
+            device="cuda",
+            dtype=self.dtype,
+        )
+        indices = torch.full(
+            (self.batch, self.seq_len, self.kv_group, self.topk),
+            self.seq_len_kv,
+            dtype=torch.int32,
+            device="cuda",
+        )
+        for b in range(self.batch):
+            for t in range(self.seq_len):
+                for h in range(self.kv_group):
+                    i_i = torch.randperm(
+                        min(
+                            max(1, ((t + int(self.q_start_index_s)) // self.kv_stride)),
+                            self.seq_len_kv,
+                        )
+                    )[: self.topk]
+                    indices[b, t, h, : len(i_i)] = i_i
+
+        return q, kv, indices
 
 
 class SparseMlaKernel(Kernel):

--- a/src/tileops/kernels/gemm/__init__.py
+++ b/src/tileops/kernels/gemm/__init__.py
@@ -7,6 +7,7 @@ over a group offset table rather than a single ``(m, n, k)``.
 from .bmm import BmmFp8Kernel, BmmKernel
 from .call_spec import GemmCall
 from .dense import (
+    GemmBasicKernel,
     GemmFp8BlockScaledKernel,
     GemmFp8EpilogueKernel,
     GemmKernel,
@@ -19,6 +20,7 @@ from .w4a16_decode import GemmW4A16DecodeKernel
 __all__ = [
     "BmmFp8Kernel",
     "BmmKernel",
+    "GemmBasicKernel",
     "GemmCall",
     "GemmFp8BlockScaledKernel",
     "GemmFp8EpilogueKernel",

--- a/src/tileops/kernels/gemm/bmm.py
+++ b/src/tileops/kernels/gemm/bmm.py
@@ -684,7 +684,7 @@ class BmmKernel(Kernel):
 
 
 class BmmFp8Kernel(Kernel):
-    supported_archs: list[int] = [90]
+    supported_archs: list[int] = [89, 90]
 
     def __init__(
         self,
@@ -699,15 +699,15 @@ class BmmFp8Kernel(Kernel):
         tune: bool = False,
     ) -> None:
         super().__init__()
-        # Every dispatched variant emits WGMMA + TMA (SM90+ only); fail fast
-        # with a clear message on pre-Hopper GPUs instead of a downstream
-        # nvcc / PTX error at JIT time.
         if device is None:
             device = torch.device(torch.cuda.current_device())
         cc = torch.cuda.get_device_capability(device)
-        if cc[0] != 9:
+        if cc[0] < 9 and cc != (8, 9):
+            # Fail fast with a clear message instead of a downstream
+            # nvcc / PTX error at JIT time.
             raise NotImplementedError(
-                f"BmmFp8Kernel requires SM90 (Hopper); got sm{cc[0]}{cc[1]} on the current device"
+                f"BmmFp8Kernel requires FP8 tensor cores (sm89+); "
+                f"got sm{cc[0]}{cc[1]} on the current device"
             )
         if k % 32 != 0:
             raise ValueError(
@@ -721,12 +721,19 @@ class BmmFp8Kernel(Kernel):
         self.dtype = dtype
         self.out_dtype = out_dtype
         # Dispatch policy (in order of preference):
-        #   1) 3-WG WS persistent (best throughput on aligned shapes);
-        #   2) plain persistent (removes wave quantisation);
-        #   3) classic 3D grid (handles arbitrary M/N tails).
+        #   1) 3-WG WS persistent (best throughput on aligned shapes;
+        #      Hopper only — TMA + WGMMA);
+        #   2) plain persistent (removes wave quantisation; Hopper only —
+        #      the plain T.gemm body could run on pre-Hopper archs but is
+        #      unvalidated there);
+        #   3) classic 3D grid (handles arbitrary M/N tails; plain T.gemm,
+        #      runs on any FP8 tensor-core target, sm89+).
         self._sm_count = torch.cuda.get_device_properties(device).multi_processor_count
-        self._use_ws = self._ws_eligible(batch, m, n, k, self._sm_count)
-        self._use_persistent = self._use_ws or self._persistent_eligible(m, n, k, self._use_ws)
+        self._is_hopper = cc[0] == 9
+        self._use_ws = self._is_hopper and self._ws_eligible(batch, m, n, k, self._sm_count)
+        self._use_persistent = self._is_hopper and (
+            self._use_ws or self._persistent_eligible(m, n, k, self._use_ws)
+        )
         if self._use_ws:
             self.kernel = _bmm_fp8_persistent_ws_kernel(
                 batch, m, n, k, self.dtype_str, self.out_dtype_str, self._sm_count
@@ -785,6 +792,16 @@ class BmmFp8Kernel(Kernel):
                 "threads": 384,
                 "group_size_m": 8,
             }
+        if not self._is_hopper:
+            # Sized for the sm89 100KB per-block SMEM cap; K tails are
+            # zero-padded by the classic copy path.
+            return {
+                "block_m": 128,
+                "block_n": 128,
+                "block_k": 64 if self.k % 64 == 0 else 128,
+                "num_stages": 2,
+                "threads": 128,
+            }
         return {
             "block_m": 128,
             "block_n": 128,
@@ -825,6 +842,28 @@ class BmmFp8Kernel(Kernel):
                                         "group_size_m": gsm,
                                     }
                                 )
+            return configs
+
+        if not self._is_hopper:
+            # Classic 3D-grid sweep for the sm89 100KB cap.
+            SMEM_BUDGET_BYTES = 100 * 1024
+            configs = []
+            for bm in (64, 128):
+                for bn in (64, 128):
+                    for bk in (64, 128):
+                        for ns in (2, 3):
+                            smem = (bm * bk + bk * bn) * ns + bm * bn * 2
+                            if smem > SMEM_BUDGET_BYTES:
+                                continue
+                            configs.append(
+                                {
+                                    "block_m": bm,
+                                    "block_n": bn,
+                                    "block_k": bk,
+                                    "num_stages": ns,
+                                    "threads": 128,
+                                }
+                            )
             return configs
 
         SMEM_BUDGET_BYTES = 200 * 1024

--- a/src/tileops/kernels/gemm/dense.py
+++ b/src/tileops/kernels/gemm/dense.py
@@ -70,6 +70,7 @@ def _b_eviction(m: int, block_m: int) -> Optional[str]:
 
 
 __all__ = [
+    "GemmBasicKernel",
     "GemmFp8BlockScaledKernel",
     "GemmFp8EpilogueKernel",
     "GemmKernel",
@@ -3033,3 +3034,261 @@ class SmallBatchGemmKernel(Kernel):
             self.config["reduce_threads"],
             self.config["num_stages"],
         )(a, b)
+
+
+@functools.lru_cache(maxsize=32)
+def _gemm_basic_kernel(
+    m: int, n: int, k: int, trans_a: bool, trans_b: bool, dtype: str = "float16"
+) -> Callable:
+    """Pipelined dense GEMM ``C = op(A) @ op(B)`` for any tensor-core target.
+
+    The non-warp-specialized counterpart of ``_gemm_kernel``: the same four
+    ``(trans_a, trans_b)`` layouts, but with ``T.Pipelined`` software
+    pipelining and plain ``T.gemm`` so it compiles on pre-SM90 targets
+    (sm80 / sm86 / sm89). SMEM tile shapes follow the storage layout and the
+    ``T.gemm`` transpose flags reconcile them with the logical (M, K) x
+    (K, N) contraction (cf. the WGMMA version, which forwards them to WGMMA).
+    """
+    accum_dtype = "float"
+    a_shape = (k, m) if trans_a else (m, k)
+    b_shape = (n, k) if trans_b else (k, n)
+
+    @tilelang.jit(
+        out_idx=[-1],
+        pass_configs={"tl.disable_warp_specialized": True},
+        compile_flags=["-O3", "-DENABLE_BF16"],
+    )
+    def _gemm_basic_func(
+        block_m: int = 64,
+        block_n: int = 64,
+        block_k: int = 64,
+        num_stages: int = 2,
+        threads: int = 128,
+    ) -> Callable:
+        # SMEM tile shapes follow the storage layout; the T.gemm transpose
+        # flags reconcile them with the logical (M,K) x (K,N) contraction.
+        a_tile = (block_k, block_m) if trans_a else (block_m, block_k)
+        b_tile = (block_n, block_k) if trans_b else (block_k, block_n)
+        n_exact = n % block_n == 0
+
+        @T.prim_func
+        def _gemm_basic_main(
+            a: T.Tensor(a_shape, dtype),  # type: ignore
+            b: T.Tensor(b_shape, dtype),  # type: ignore
+            c: T.Tensor((m, n), dtype),  # type: ignore
+        ) -> None:
+            with T.Kernel(T.ceildiv(n, block_n), T.ceildiv(m, block_m), threads=threads) as (
+                bx,
+                by,
+            ):
+                a_smem = T.alloc_shared(a_tile, dtype)
+                b_smem = T.alloc_shared(b_tile, dtype)
+                c_smem = T.alloc_shared((block_m, block_n), dtype)
+                c_local = T.alloc_fragment((block_m, block_n), accum_dtype)
+
+                T.annotate_layout(
+                    {
+                        a_smem: tilelang.layout.make_swizzled_layout(a_smem),
+                        b_smem: tilelang.layout.make_swizzled_layout(b_smem),
+                        c_smem: tilelang.layout.make_swizzled_layout(c_smem),
+                    }
+                )
+
+                # L2 rasterization: same panel traversal as the BMM kernel.
+                T.use_swizzle(10, enable=True)
+
+                T.clear(c_local)
+                m_start = by * block_m
+                n_start = bx * block_n
+
+                for ki in T.Pipelined(T.ceildiv(k, block_k), num_stages=num_stages):
+                    k_start = ki * block_k
+                    # M/N tail reads land in c_local rows/cols that the
+                    # epilogue guard skips; a K tail would corrupt live
+                    # outputs, so block_k must divide k (enforced by the
+                    # config chain / autotune filter).
+                    if trans_a:
+                        T.copy(
+                            a[k_start : k_start + block_k, m_start : m_start + block_m],
+                            a_smem,
+                        )
+                    else:
+                        T.copy(
+                            a[m_start : m_start + block_m, k_start : k_start + block_k],
+                            a_smem,
+                        )
+                    if trans_b:
+                        T.copy(
+                            b[n_start : n_start + block_n, k_start : k_start + block_k],
+                            b_smem,
+                        )
+                    elif n_exact:
+                        T.copy(
+                            b[k_start : k_start + block_k, n_start : n_start + block_n],
+                            b_smem,
+                        )
+                    else:
+                        # NN with an N tail: the b tile's innermost (N) dim can
+                        # be narrower than one vectorised cp_async transfer
+                        # (cp_async only accepts 4/8/16-byte accesses — e.g.
+                        # an n=1 fp16 GEMV-replacement shape has 2-byte rows),
+                        # so mask the copy instead
+                        # (cf. _bmm_fp8_kernel's tail path).
+                        for i, j in T.Parallel(block_k, block_n):
+                            b_smem[i, j] = T.if_then_else(
+                                n_start + j < n,
+                                b[k_start + i, n_start + j],
+                                T.cast(0, dtype),
+                            )
+                    T.gemm(
+                        a_smem,
+                        b_smem,
+                        c_local,
+                        transpose_A=trans_a,
+                        transpose_B=trans_b,
+                        policy=T.GemmWarpPolicy.FullRow,
+                    )
+
+                # Epilogue: stage fp32 accum through SMEM before the GMEM
+                # store and guard the M/N tails (cf. BmmKernel).
+                T.copy(c_local, c_smem)
+                for i, j in T.Parallel(block_m, block_n):
+                    if m_start + i < m and n_start + j < n:
+                        c[m_start + i, n_start + j] = c_smem[i, j]
+
+        return _gemm_basic_main
+
+    return _gemm_basic_func
+
+
+@torch.library.custom_op("tileops::gemm_basic_wrapped_kernel", mutates_args=())
+def _gemm_basic_wrapped_kernel(
+    m: int,
+    n: int,
+    k: int,
+    trans_a: bool,
+    trans_b: bool,
+    dtype: str,
+    block_m: int,
+    block_n: int,
+    block_k: int,
+    num_stages: int,
+    threads: int,
+    a: torch.Tensor,
+    b: torch.Tensor,
+) -> torch.Tensor:
+    """Run the pipelined GEMM ``C = op(A) @ op(B)`` (torch custom op).
+
+    Kept for ``torch.compile`` compatibility (registered op +
+    ``register_fake``); ``GemmBasicKernel.forward`` calls the compiled JIT
+    directly, cf. ``GemmKernel``.
+    """
+    return _gemm_basic_kernel(m, n, k, trans_a, trans_b, dtype)(
+        block_m, block_n, block_k, num_stages, threads
+    )(a, b)
+
+
+@_gemm_basic_wrapped_kernel.register_fake
+def _(
+    m: int,
+    n: int,
+    k: int,
+    trans_a: bool,
+    trans_b: bool,
+    dtype: str,
+    block_m: int,
+    block_n: int,
+    block_k: int,
+    num_stages: int,
+    threads: int,
+    a: torch.Tensor,
+    b: torch.Tensor,
+) -> torch.Tensor:
+    return torch.empty((m, n), dtype=a.dtype, device=a.device)
+
+
+class GemmBasicKernel(Kernel):
+    """Dense GEMM kernel: pipelined, architecture-agnostic (sm80+).
+
+    Computes ``C = op(A) @ op(B)`` for any ``(trans_a, trans_b)`` layout —
+    the same contract as ``GemmKernel`` — via ``T.Pipelined`` + plain
+    ``T.gemm`` so it runs on pre-SM90 tensor-core targets (sm80 / sm86 /
+    sm89). fp16 / bf16 inputs, fp32 accumulation. ``block_k`` must divide
+    ``k`` (the smallest fallback is 16); M / N need not be multiples of the
+    block sizes (epilogue guard).
+    """
+
+    supported_archs: list[int] = [80, 86, 89, 90]
+    general = True
+
+    def __init__(
+        self,
+        m: int,
+        n: int,
+        k: int,
+        dtype: torch.dtype,
+        config: Optional[dict] = None,
+        tune: bool = False,
+        trans_a: bool = False,
+        trans_b: bool = False,
+    ) -> None:
+        super().__init__()
+        # k only has to span one vectorized load along the innermost (k)
+        # dim: k * itemsize >= 4 bytes (a k=1 fp16/bf16 row is 2 bytes and is
+        # rejected by the backend). k need NOT be 16-aligned — the backend
+        # zero-pads K tails (verified on real sm80 and sm89 hardware).
+        itemsize = torch.empty((), dtype=dtype).element_size()
+        if k * itemsize < 4:
+            raise ValueError(
+                f"GemmBasicKernel requires k * itemsize >= 4 bytes for the "
+                f"vectorized loads, got k={k} of a {itemsize}-byte dtype"
+            )
+        self.m = m
+        self.n = n
+        self.k = k
+        self.dtype = dtype
+        self.trans_a = trans_a
+        self.trans_b = trans_b
+
+        self.kernel = _gemm_basic_kernel(m, n, k, trans_a, trans_b, self.dtype_str)
+
+        self.init_config(config, tune)
+
+    @property
+    def default_config(self) -> dict:
+        # Modal winner shape of the pipelined BMM kernel (H20-3e manifest).
+        # Prefer block_k dividing k; k with no 32/64 factor (or not
+        # 16-aligned at all) falls back to 16 — the mma.sync floor — and
+        # the backend zero-pads the K tail.
+        block_k = 64 if self.k % 64 == 0 else (32 if self.k % 32 == 0 else 16)
+        return {
+            "block_m": 64,
+            "block_n": 64,
+            "block_k": block_k,
+            "num_stages": 2,
+            "threads": 128,
+        }
+
+    @property
+    def autotune_configs(self) -> list[dict]:
+        # Prefer block_k that divides k; when k has no 32/64 factor (or is
+        # not 16-aligned at all), fall back to 16 — the mma.sync floor — and
+        # let the backend zero-pad the K tail (any k with k * itemsize >= 4).
+        block_k_options = [bk for bk in (64, 32) if self.k % bk == 0]
+        if not block_k_options:
+            block_k_options = [16]
+        return [
+            {"block_m": bm, "block_n": bn, "block_k": bk, "num_stages": ns, "threads": 128}
+            for bm in [64, 128]
+            for bn in [64, 128]
+            for bk in block_k_options
+            for ns in [2, 3, 4]
+        ]
+
+    def forward(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+        # Call the compiled JIT directly (cf. BmmKernel); the torch custom-op
+        # is retained only for torch.compile compatibility.
+        if not hasattr(self, "_compiled_kernel"):
+            jit_config = {k: v for k, v in self.config.items() if k != "pass_configs"}
+            self._compiled_kernel = self.kernel(**jit_config)
+        return self._compiled_kernel(a, b)

--- a/src/tileops/kernels/moe/shared_expert_mlp.py
+++ b/src/tileops/kernels/moe/shared_expert_mlp.py
@@ -7,11 +7,20 @@ import tilelang
 import tilelang.language as T
 import torch
 
-from tileops.kernels.gemm.dense import GemmKernel
+from tileops.kernels.gemm.dense import GemmBasicKernel, GemmKernel
 from tileops.kernels.kernel_base import Kernel
+from tileops.utils import get_sm_version
 
 __all__ = ["SharedExpertMLPKernel"]
 
+# Hopper default. NOTE: its 3-stage pipelined SMEM footprint is
+# (128+256)*64*2B*3 = 144KB for the loads plus a 64KB C tile (208KB total),
+# which exceeds the per-block dynamic shared-memory limit of every pre-Hopper
+# CUDA card (163KB on sm80 — launch fails, verified on real sm80 hardware —
+# and 99KB on sm86/sm89): pass an explicit ``config=`` with a smaller tile
+# there.
+# The rasterization switch is inert for GemmBasicKernel (init_config keeps
+# only its own config keys).
 _DEFAULT_CONFIG = {
     "block_m": 128,
     "block_n": 256,
@@ -98,7 +107,13 @@ class SharedExpertMLPKernel(Kernel):
         self.dtype = dtype
         self.init_config(config, tune)
 
-        self._gemm_gate_up = GemmKernel(
+        # GemmKernel is the WGMMA + TMA sm90 build (_gemm_kernel factory).
+        # Mirror GemmFwdOp's dispatch: route to the pipelined GemmBasicKernel
+        # (plain T.gemm) on pre-Hopper targets so the shared expert stays
+        # arch-valid — this ctor builds the GEMM kernels directly, bypassing
+        # the op-level arch check that normally guards GemmKernel.
+        gemm_cls = GemmKernel if get_sm_version() == 90 else GemmBasicKernel
+        self._gemm_gate_up = gemm_cls(
             m=num_tokens,
             n=ffn_size * 2,
             k=hidden_size,
@@ -106,7 +121,7 @@ class SharedExpertMLPKernel(Kernel):
             trans_b=True,
             config=self.config,
         )
-        self._gemm_down = GemmKernel(
+        self._gemm_down = gemm_cls(
             m=num_tokens,
             n=hidden_size,
             k=ffn_size,

--- a/src/tileops/ops/attention/deepseek_dsa.py
+++ b/src/tileops/ops/attention/deepseek_dsa.py
@@ -2,9 +2,10 @@ from typing import Dict, Optional
 
 import torch
 
-from tileops.kernels.attention import SparseMlaKernel
+from tileops.kernels.attention import SparseMlaBasicKernel, SparseMlaKernel
 from tileops.kernels.kernel_base import Kernel
 from tileops.perf.profile import tensor_core_roof
+from tileops.utils import get_sm_version
 
 from ..op_base import Op
 
@@ -118,9 +119,13 @@ class DeepSeekSparseAttentionDecodeWithKVCacheFwdOp(Op):
 
         Returns:
             Dict[str, Kernel]: A dictionary mapping kernel names to kernel functions.
-            The default map includes the "sparse_mla_kernel".
+            The default map includes the "sparse_mla_kernel": the WGMMA
+            warp-specialized SparseMlaKernel on Hopper, and the
+            architecture-agnostic SparseMlaBasicKernel (plain T.gemm) elsewhere.
         """
-        return {"sparse_mla_kernel": SparseMlaKernel}
+        return {
+            "sparse_mla_kernel": SparseMlaKernel if get_sm_version() == 90 else SparseMlaBasicKernel
+        }
 
     def _infer_output_shapes(
         self,

--- a/src/tileops/ops/gemm/gemm.py
+++ b/src/tileops/ops/gemm/gemm.py
@@ -4,6 +4,7 @@ import torch
 
 from tileops.kernels.gemm.call_spec import GemmCall
 from tileops.kernels.gemm.dense import (
+    GemmBasicKernel,
     GemmFp8BlockScaledKernel,
     GemmFp8EpilogueKernel,
     GemmKernel,
@@ -14,6 +15,7 @@ from tileops.kernels.gemm.w4a16 import GROUP_SIZE, GemmW4A16Kernel
 from tileops.kernels.gemm.w4a16_decode import GemmW4A16DecodeKernel
 from tileops.kernels.kernel_base import Kernel
 from tileops.perf.profile import tensor_core_roof
+from tileops.utils import get_sm_version
 
 from ..op_base import Op
 
@@ -71,8 +73,10 @@ class GemmFwdOp(Op):
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
+        # GemmKernel is the WGMMA + TMA SM90 build; pre-Hopper targets take
+        # the pipelined GemmBasicKernel (plain T.gemm).
         return {
-            "gemm_kernel": GemmKernel,
+            "gemm_kernel": GemmKernel if get_sm_version() == 90 else GemmBasicKernel,
             "gemv_kernel": GemvKernel,
             "small_batch_kernel": SmallBatchGemmKernel,
         }
@@ -107,8 +111,10 @@ class GemmFwdOp(Op):
 
         ``mode`` is ``GemmCall.gemv_mode`` for the GEMV fast path (which operand
         is the vector decides how ``forward`` reshapes it), ``"small_batch"`` for
-        the low-``m`` NT bandwidth kernel, else ``"gemm"`` — ``GemmKernel``
-        (SM90), covering all four ``(trans_a, trans_b)`` layouts.
+        the low-``m`` NT bandwidth kernel, else ``"gemm"`` — the hand-written
+        warp-specialized ``GemmKernel`` on Hopper or the pipelined
+        ``GemmBasicKernel`` elsewhere, both covering all four
+        ``(trans_a, trans_b)`` layouts.
 
         Which one serves the call is stated by the candidates themselves
         (each kernel's ``applies``, read through

--- a/tests/ops/test_gemm.py
+++ b/tests/ops/test_gemm.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 
 from tests.test_base import FixtureBase, TestBase
-from tileops.kernels.gemm import GemmKernel, SmallBatchGemmKernel
+from tileops.kernels.gemm import GemmBasicKernel, GemmKernel, SmallBatchGemmKernel
 from tileops.kernels.gemm.dense import GemmFp8BlockScaledKernel, _b_eviction
 from tileops.kernels.gemm.heuristics import best_config
 from tileops.ops import GemmFp8FwdOp, GemmFwdOp, GemmW4A16FwdOp
@@ -934,3 +934,27 @@ def test_config_selector_declines_a_board_it_was_not_measured_on() -> None:
     assert best_config(1024, 1024, 1024, False, False, 132, "NVIDIA H200") is not None
     assert best_config(1024, 1024, 1024, False, False, 132, "NVIDIA H20-3e") is None
     assert best_config(1024, 1024, 1024, False, False, 132, "no such board") is None
+
+
+@pytest.mark.smoke
+def test_gemm_basic_kernel_k_tail_padding() -> None:
+    """Non-16-aligned k rides on the backend zero-padding the K tail.
+
+    Verified on real sm80 and sm89 hardware: any k with
+    k * itemsize >= 4 compiles and matches the reference with
+    block_k = 16 (the mma.sync floor); the K tail is zero-padded.
+    """
+    for k in (2, 8, 24):
+        kern = GemmBasicKernel(m=32, n=64, k=k, dtype=torch.bfloat16, trans_b=True)
+        a = torch.randn(32, k, dtype=torch.bfloat16, device="cuda") * 0.05
+        b = torch.randn(64, k, dtype=torch.bfloat16, device="cuda") * 0.05
+        out = kern(a, b)
+        ref = a.float() @ b.float().t()
+        torch.testing.assert_close(out.float(), ref, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.smoke
+def test_gemm_basic_kernel_rejects_narrow_k() -> None:
+    """k narrower than one vectorized load (k=1 fp16/bf16 = 2 bytes) is rejected."""
+    with pytest.raises(ValueError, match="itemsize"):
+        GemmBasicKernel(m=32, n=64, k=1, dtype=torch.bfloat16, trans_b=True)


### PR DESCRIPTION
## Summary

- Add `GemmBasicKernel` (pipelined plain-T.gemm, sm80+, all four `(trans_a, trans_b)` layouts); `GemmFwdOp` routes to it wherever `get_sm_version() != 90`. `k` only needs `k * itemsize >= 4` — the backend zero-pads K tails — and M/N tails are guarded in the epilogue.
- Add `SparseMlaBasicKernel`: the WGMMA sparse-MLA decode math re-implemented on one homogeneous thread group with `T.Pipelined` + per-row `T.copy` KV gather; the DSA decode op dispatches to it off Hopper. Its default `block_i` is 32 below sm90 — the Hopper-sized 64 stages 230KB of SMEM for `kv_group=1` shapes and fails to launch on sm80's 163KB cap (verified on real hardware), while 32 halves the pipelined KV tiles to 148KB.
- `SharedExpertMLPKernel` mirrors `GemmFwdOp`'s dispatch when it builds its gate/up and down GEMMs (its ctor bypasses the op-level arch check). The default config stays Hopper-sized; its 3-stage 208KB footprint fails to launch on every pre-Hopper card (verified on real sm80, 163KB / 99KB caps), so pre-Hopper callers pass a smaller explicit config (e.g. a 2-stage 64x128 tile budgeted to 64KB) — documented at the config site.
- Open `BmmFp8Kernel` to sm89: the WS and persistent variants stay Hopper-only, the classic 3D-grid variant serves sm89 with shared-memory-budgeted configs (100KB cap).
- Correctness of the K-tail zero-padding and the `block_i` SMEM budget was verified on real sm80 (A800) and sm90 (H200) hardware.

## Test plan

- [x] `pytest` on the affected files, on real GPUs:
  - **H200 (sm90, CUDA_VISIBLE_DEVICES=4)**: `test_gemm.py` 29 passed / 2 failed — the same 2 (`test_explicit_structure_config_is_taken_verbatim`, `test_structure_routing_matches_test_ids`) fail identically on the untouched `main` baseline in the same container, so they are environment-specific (heuristic drift with the container's tilelang build), not regressions; the 2 new GemmBasicKernel cases pass. `test_deepseek_dsa_decode.py`, `test_bmm.py` smoke all pass. `test_moe_shared_fused_moe.py` 4 failed — the identical 4 fail on the `main` baseline too (a kernel-cache aliasing bug in the container's tilelang 0.1.11 build: `gating_output ... expected: 32, got: 16`), pre-existing and unrelated.
  - **A800 (sm80, CUDA_VISIBLE_DEVICES=0)**: `test_gemm.py` 19 passed / 7 failed — all 7 fail identically on the `main` baseline, and the change additionally fixes 7 cases that failed on the baseline (`smoke-fp16/bf16-square` and the four GEMV-boundary cases), a net +7 with zero new failures; the GEMV-boundary cases run on the fallback as-is (their k values all clear the `k * itemsize >= 4` vectorized-load floor). `test_deepseek_dsa_decode.py` smoke passes (after the `block_i=32` shared-memory fix). `test_bmm.py` 10 failed / 11 passed — the identical set fails on the baseline (sm80 has no FP8 tensor cores; `BmmKernel` small-batch cases fail on the baseline too). `test_moe_shared_fused_moe.py` fails with the same environment-specific cache bug as on H200; the shared-expert `GemmBasicKernel` GEMMs were exercised on sm80 with a 64x128 2-stage tile (the config pre-Hopper callers pass explicitly) and matched the reference.
- [x] `pre-commit run --all-files` — locally ran ruff 0.14.13 check + format (matching the pinned rev), `tilelang_idioms_lint`, `shipped_refs_lint`, `op_docstrings_lint`, and a trailing-whitespace scan on the touched files; the remaining hooks (gitleaks, mdformat, codespell) need the CI run.

## Test node delta

`python scripts/test_node_delta.py --base upstream/main` cannot run on the authoring machine (no torch). Manual count over the diff:

| File | Delta | New cases |
| ---- | ----- | --------- |
| tests/ops/test_gemm.py | +2 | `test_gemm_basic_kernel_k_tail_padding` (k=2/8/24 bf16 on the zero-padded K tail, smoke), `test_gemm_basic_kernel_rejects_narrow_k` (k=1 bf16 refused, smoke) |

`tests/ops/test_moe_shared_fused_moe.py` is unchanged from `main`.

## Regression

A pre-Hopper device previously failed kernel selection (`GemmKernel` / `SparseMlaKernel` are `[90]`) or hit a raw nvcc/PTX error at JIT time with no fallback — on A800 the `main` baseline fails 14 of 26 collected smoke cases in `test_gemm.py`; this change turns 7 of those green (including the four GEMV-boundary cases, which now run through the fallback unconditionally) and adds the two K-tail guard cases.
