### PR TITLE
[Perf][MoE] Parallelize staged token movement

### DIFF
--- a/src/tileops/kernels/moe/permute_contiguous.py
+++ b/src/tileops/kernels/moe/permute_contiguous.py
@@ -1,6 +1,5 @@
 """Layout-specialized contiguous materialization for staged MoE PrePermute."""
 
-import functools
 from typing import Optional
 
 import tilelang
@@ -13,97 +12,178 @@ from tileops.kernels.moe.call_spec import PrePermuteCall
 __all__ = ["MoePrePermuteContiguousKernel"]
 
 
-# Past this many routed rows the fused launch loses: merged, the gather loop
-# compiles at 32 registers against the standalone 46, so it holds far fewer loads
-# in flight -- 73 us against 28 us at T=512, H=7168, and 779 against 253 at T=4096.
-_FUSED_TIGHT_MAX_NUMEL = 64
-
-
-def _make_tight_scan_body(numel: int, num_experts: int, top_k: int, threads: int):
-    """Shared tight count/prefix/scatter body for split and fused launches."""
-
-    @T.macro
-    def scan(
-        flat_ids,
-        physical_ends,
-        permuted_idx,
-        inverse_indices,
-        write_offsets,
-        counts,
-        offsets,
-        slot_buf,
-    ):
-        tx = T.get_thread_binding()
-        for i in T.serial(T.ceildiv(num_experts, threads)):
-            idx = i * threads + tx
-            if idx < num_experts:
-                counts[idx] = T.int32(0)
-        T.sync_threads()
-
-        for i in T.serial(T.ceildiv(numel, threads)):
-            idx = i * threads + tx
-            if idx < numel:
-                T.atomic_add(counts[flat_ids[idx]], 1)
-        T.sync_threads()
-
-        if tx == 0:
-            offsets[0] = T.int64(0)
-            for expert in T.serial(num_experts):
-                offsets[expert + 1] = offsets[expert] + T.Cast(T.int64, counts[expert])
-        T.sync_threads()
-
-        for i in T.serial(T.ceildiv(num_experts, threads)):
-            idx = i * threads + tx
-            if idx < num_experts:
-                physical_ends[idx] = T.Cast(T.int32, offsets[idx + 1])
-                write_offsets[idx] = T.Cast(T.int32, offsets[idx])
-        T.sync_threads()
-
-        for i in T.serial(T.ceildiv(numel, threads)):
-            idx = i * threads + tx
-            if idx < numel:
-                expert = flat_ids[idx]
-                slot_buf[0] = T.atomic_add(write_offsets[expert], T.int32(1), return_prev=True)
-                slot = slot_buf[0]
-                permuted_idx[slot] = idx // T.int32(top_k)
-                inverse_indices[idx] = slot
-
-    return scan
-
-
 def _make_tight_scan(numel: int, num_experts: int, top_k: int):
     """Count assignments and produce tight physical-PSUM metadata."""
 
     @tilelang.jit(out_idx=[], compile_flags=["-O3"])
     def _scan(threads: int):
-        scan = _make_tight_scan_body(numel, num_experts, top_k, threads)
-
         @T.prim_func
         def _scan_main(
             flat_ids: T.Tensor([numel], "int32"),
             physical_ends: T.Tensor([num_experts], "int32"),
             permuted_idx: T.Tensor([numel], "int32"),
             inverse_indices: T.Tensor([numel], "int32"),
-            write_offsets: T.Tensor([num_experts], "int32"),
         ):
             with T.Kernel(1, threads=threads) as (_,):
                 counts = T.alloc_shared([num_experts], "int32")
-                offsets = T.alloc_shared([num_experts + 1], "int64")
+                offsets = T.alloc_shared([num_experts + 1], "int32")
                 slot_buf = T.alloc_local([1], "int32")
-                scan(
-                    flat_ids,
-                    physical_ends,
-                    permuted_idx,
-                    inverse_indices,
-                    write_offsets,
-                    counts,
-                    offsets,
-                    slot_buf,
-                )
+                tx = T.get_thread_binding()
+
+                for i in T.serial(T.ceildiv(num_experts, threads)):
+                    expert = i * threads + tx
+                    if expert < num_experts:
+                        counts[expert] = T.int32(0)
+                T.sync_threads()
+
+                for i in T.serial(T.ceildiv(numel, threads)):
+                    idx = i * threads + tx
+                    if idx < numel:
+                        T.atomic_add(counts[flat_ids[idx]], 1)
+                T.sync_threads()
+
+                if tx == 0:
+                    offsets[0] = T.int32(0)
+                    for expert in T.serial(num_experts):
+                        offsets[expert + 1] = offsets[expert] + counts[expert]
+                T.sync_threads()
+
+                for i in T.serial(T.ceildiv(num_experts, threads)):
+                    expert = i * threads + tx
+                    if expert < num_experts:
+                        physical_ends[expert] = offsets[expert + 1]
+                        counts[expert] = offsets[expert]
+                T.sync_threads()
+
+                for i in T.serial(T.ceildiv(numel, threads)):
+                    idx = i * threads + tx
+                    if idx < numel:
+                        expert = flat_ids[idx]
+                        slot_buf[0] = T.atomic_add(counts[expert], T.int32(1), return_prev=True)
+                        slot = slot_buf[0]
+                        permuted_idx[slot] = idx // T.int32(top_k)
+                        inverse_indices[idx] = slot
 
         return _scan_main
 
     return _scan
+
+
+def _make_parallel_tight_scan(
+    numel: int,
+    num_experts: int,
+    top_k: int,
+    routes_per_block: int,
+    threads: int,
+):
+    """Count and scatter large route tables across independent CTAs."""
+    blocks = (numel + routes_per_block - 1) // routes_per_block
+    prefix_threads = min(1024, 1 << max(0, (num_experts - 1).bit_length()))
+
+    @tilelang.jit(out_idx=[], compile_flags=["-O3"])
+    def _count():
+        @T.prim_func
+        def _count_main(
+            flat_ids: T.Tensor([numel], "int32"),
+            block_counts: T.Tensor([blocks, num_experts], "int32"),
+        ):
+            with T.Kernel(blocks, threads=threads) as (bid,):
+                tx = T.get_thread_binding()
+                counts = T.alloc_shared([num_experts], "int32")
+
+                for i in T.serial(T.ceildiv(num_experts, threads)):
+                    expert = i * threads + tx
+                    if expert < num_experts:
+                        counts[expert] = T.int32(0)
+                T.sync_threads()
+
+                for i in T.serial(T.ceildiv(routes_per_block, threads)):
+                    idx = bid * routes_per_block + i * threads + tx
+                    if idx < numel:
+                        T.atomic_add(counts[flat_ids[idx]], 1)
+                T.sync_threads()
+
+                for i in T.serial(T.ceildiv(num_experts, threads)):
+                    expert = i * threads + tx
+                    if expert < num_experts:
+                        block_counts[bid, expert] = counts[expert]
+
+        return _count_main
+
+    @tilelang.jit(out_idx=[], compile_flags=["-O3"])
+    def _prefix():
+        @T.prim_func
+        def _prefix_main(
+            block_offsets: T.Tensor([blocks, num_experts], "int32"),
+            physical_ends: T.Tensor([num_experts], "int32"),
+        ):
+            with T.Kernel(1, threads=prefix_threads) as (_,):
+                tx = T.get_thread_binding()
+                totals = T.alloc_shared([num_experts], "int32")
+                offsets = T.alloc_shared([num_experts + 1], "int32")
+                total = T.alloc_local([1], "int32")
+                running = T.alloc_local([1], "int32")
+                count = T.alloc_local([1], "int32")
+
+                for i in T.serial(T.ceildiv(num_experts, prefix_threads)):
+                    expert = i * prefix_threads + tx
+                    if expert < num_experts:
+                        total[0] = T.int32(0)
+                        for block in T.serial(blocks):
+                            total[0] = total[0] + block_offsets[block, expert]
+                        totals[expert] = total[0]
+                T.sync_threads()
+
+                if tx == 0:
+                    offsets[0] = T.int32(0)
+                    for expert in T.serial(num_experts):
+                        offsets[expert + 1] = offsets[expert] + totals[expert]
+                T.sync_threads()
+
+                for i in T.serial(T.ceildiv(num_experts, prefix_threads)):
+                    expert = i * prefix_threads + tx
+                    if expert < num_experts:
+                        physical_ends[expert] = offsets[expert + 1]
+                        running[0] = offsets[expert]
+                        for block in T.serial(blocks):
+                            count[0] = block_offsets[block, expert]
+                            block_offsets[block, expert] = running[0]
+                            running[0] = running[0] + count[0]
+
+        return _prefix_main
+
+    @tilelang.jit(out_idx=[], compile_flags=["-O3"])
+    def _scatter():
+        @T.prim_func
+        def _scatter_main(
+            flat_ids: T.Tensor([numel], "int32"),
+            block_offsets: T.Tensor([blocks, num_experts], "int32"),
+            permuted_idx: T.Tensor([numel], "int32"),
+            inverse_indices: T.Tensor([numel], "int32"),
+        ):
+            with T.Kernel(blocks, threads=threads) as (bid,):
+                tx = T.get_thread_binding()
+                cursors = T.alloc_shared([num_experts], "int32")
+                slot_buf = T.alloc_local([1], "int32")
+
+                for i in T.serial(T.ceildiv(num_experts, threads)):
+                    expert = i * threads + tx
+                    if expert < num_experts:
+                        cursors[expert] = block_offsets[bid, expert]
+                T.sync_threads()
+
+                for i in T.serial(T.ceildiv(routes_per_block, threads)):
+                    idx = bid * routes_per_block + i * threads + tx
+                    if idx < numel:
+                        expert = flat_ids[idx]
+                        slot_buf[0] = T.atomic_add(cursors[expert], T.int32(1), return_prev=True)
+                        slot = slot_buf[0]
+                        permuted_idx[slot] = idx // T.int32(top_k)
+                        inverse_indices[idx] = slot
+
+        return _scatter_main
+
+    return (_count, _prefix, _scatter), blocks
 
 
 def _make_aligned_per_row_scan(
@@ -125,7 +205,6 @@ def _make_aligned_per_row_scan(
             row_expert_ids: T.Tensor([capacity], "int32"),
             permuted_idx: T.Tensor([capacity], "int32"),
             inverse_indices: T.Tensor([numel], "int32"),
-            write_offsets: T.Tensor([num_experts], "int32"),
         ):
             with T.Kernel(1, threads=threads) as (_,):
                 tx = T.get_thread_binding()
@@ -166,7 +245,7 @@ def _make_aligned_per_row_scan(
                 for i in T.serial(T.ceildiv(num_experts, threads)):
                     expert = i * threads + tx
                     if expert < num_experts:
-                        write_offsets[expert] = offsets[expert]
+                        counts[expert] = offsets[expert]
                 for i in T.serial(T.ceildiv(capacity, threads)):
                     row = i * threads + tx
                     if row < capacity:
@@ -188,9 +267,7 @@ def _make_aligned_per_row_scan(
                     idx = i * threads + tx
                     if idx < numel:
                         expert = flat_ids[idx]
-                        slot_buf[0] = T.atomic_add(
-                            write_offsets[expert], T.int32(1), return_prev=True
-                        )
+                        slot_buf[0] = T.atomic_add(counts[expert], T.int32(1), return_prev=True)
                         slot = slot_buf[0]
                         permuted_idx[slot] = idx // T.int32(top_k)
                         inverse_indices[idx] = slot
@@ -207,6 +284,7 @@ def _make_gather(
     dtype: str,
     *,
     zero_fill: bool,
+    rows_per_block: int,
 ):
     """Gather real rows and optionally zero-fill padding and capacity rows."""
     vector = 8
@@ -214,7 +292,6 @@ def _make_gather(
     while threads > 0 and hidden_size % threads != 0:
         threads -= 1
     threads = max(threads, 1)
-    rows_per_block = 8
     grid = (physical_rows + rows_per_block - 1) // rows_per_block
 
     @tilelang.jit(out_idx=[], compile_flags=["-O3", "-DENABLE_BF16"])
@@ -253,70 +330,6 @@ def _make_gather(
     return _gather
 
 
-@functools.lru_cache(maxsize=64)
-def _make_fused_tight(
-    num_tokens: int,
-    numel: int,
-    num_experts: int,
-    top_k: int,
-    hidden_size: int,
-    dtype: str,
-    grid: int,
-    rows_per_block: int,
-):
-    """Build tight metadata and gather rows in one cooperative launch."""
-    vector = 8
-    gather_threads = min(1024, hidden_size // vector)
-    while gather_threads > 0 and hidden_size % gather_threads != 0:
-        gather_threads -= 1
-    scan_threads = 1 << min(10, max(0, numel - 1).bit_length())
-    threads = max(gather_threads, scan_threads, 1)
-    scan = _make_tight_scan_body(numel, num_experts, top_k, threads)
-
-    @tilelang.jit(out_idx=[], compile_flags=["-O3", "-DENABLE_BF16"])
-    def _fused():
-        @T.prim_func
-        def _fused_main(
-            hidden_states: T.Tensor([num_tokens, hidden_size], dtype),
-            flat_ids: T.Tensor([numel], "int32"),
-            physical_ends: T.Tensor([num_experts], "int32"),
-            permuted_idx: T.Tensor([numel], "int32"),
-            inverse_indices: T.Tensor([numel], "int32"),
-            write_offsets: T.Tensor([num_experts], "int32"),
-            expert_input: T.Tensor([numel, hidden_size], dtype),
-        ):
-            with T.Kernel(grid, threads=threads) as (bid,):
-                counts = T.alloc_shared([num_experts], "int32")
-                offsets = T.alloc_shared([num_experts + 1], "int64")
-                slot_buf = T.alloc_local([1], "int32")
-
-                if bid == 0:
-                    scan(
-                        flat_ids,
-                        physical_ends,
-                        permuted_idx,
-                        inverse_indices,
-                        write_offsets,
-                        counts,
-                        offsets,
-                        slot_buf,
-                    )
-
-                T.sync_grid()
-
-                for local_row in T.serial(rows_per_block):
-                    row = bid * rows_per_block + local_row
-                    if row < numel:
-                        T.copy(
-                            hidden_states[permuted_idx[row], 0:hidden_size],
-                            expert_input[row, 0:hidden_size],
-                        )
-
-        return _fused_main
-
-    return _fused
-
-
 class MoePrePermuteContiguousKernel(Kernel):
     """Build one contiguous PrePermute specialization from ``call.layout``."""
 
@@ -346,8 +359,6 @@ class MoePrePermuteContiguousKernel(Kernel):
         self.num_experts = call.num_experts
         self.hidden_size = call.hidden_size
         self.dtype = call.input_dtype
-        self.h200 = call.h200
-        self.sm_count = call.sm_count
         self.numel = call.num_tokens * call.top_k
         self.alignment = getattr(layout, "alignment", 1)
         self.capacity = (
@@ -355,10 +366,24 @@ class MoePrePermuteContiguousKernel(Kernel):
             if self.layout_key == "tight_physical_psum"
             else self.numel + self.num_experts * (self.alignment - 1)
         )
+        self.init_config(config, tune)
 
         if self.layout_key == "tight_physical_psum":
-            self._scan_fn = _make_tight_scan(self.numel, self.num_experts, self.top_k)
+            self._parallel_scan_fns = None
+            routes_per_block = self.config["scan_routes_per_block"]
+            if self.numel >= 8 * routes_per_block:
+                self._parallel_scan_fns, self._scan_blocks = _make_parallel_tight_scan(
+                    self.numel,
+                    self.num_experts,
+                    self.top_k,
+                    routes_per_block,
+                    self.config["parallel_scan_threads"],
+                )
+                self._scan_fn = None
+            else:
+                self._scan_fn = _make_tight_scan(self.numel, self.num_experts, self.top_k)
         else:
+            self._parallel_scan_fns = None
             self._scan_fn = _make_aligned_per_row_scan(
                 self.num_tokens,
                 self.numel,
@@ -373,12 +398,23 @@ class MoePrePermuteContiguousKernel(Kernel):
             self.hidden_size,
             self.dtype_str,
             zero_fill=self.layout_key == "aligned_per_row",
+            rows_per_block=self.config["gather_rows_per_block"],
         )
-        self.init_config(config, tune)
 
     @property
     def default_config(self) -> dict:
-        return {"threads": 1024}
+        work = max(self.numel, self.num_experts)
+        threads = min(512, 1 << max(0, (work - 1).bit_length()))
+        if self.capacity <= 512:
+            rows_per_block = 2
+        elif self.capacity <= 4096:
+            rows_per_block = 4
+        else:
+            rows_per_block = 8
+        config = {"threads": threads, "gather_rows_per_block": rows_per_block}
+        if self.layout_key == "tight_physical_psum":
+            config.update(parallel_scan_threads=256, scan_routes_per_block=512)
+        return config
 
     def forward(
         self,
@@ -398,44 +434,25 @@ class MoePrePermuteContiguousKernel(Kernel):
         layout_metadata = torch.empty(metadata_rows, dtype=torch.int32, device=device)
         permuted_idx = torch.empty(self.capacity, dtype=torch.int32, device=device)
         inverse_indices = torch.empty(self.numel, dtype=torch.int32, device=device)
-        write_offsets = torch.empty(self.num_experts, dtype=torch.int32, device=device)
 
         expert_input = torch.empty(
             (self.capacity, self.hidden_size), dtype=self.dtype, device=device
         )
-        use_fused_tight = (
-            self.layout_key == "tight_physical_psum"
-            and self.h200
-            and self.numel <= _FUSED_TIGHT_MAX_NUMEL
-        )
-        if use_fused_tight:
-            rows_per_block = max(1, (self.numel + self.sm_count - 1) // self.sm_count)
-            grid = (self.numel + rows_per_block - 1) // rows_per_block
-            _make_fused_tight(
-                self.num_tokens,
-                self.numel,
-                self.num_experts,
-                self.top_k,
-                self.hidden_size,
-                self.dtype_str,
-                grid,
-                rows_per_block,
-            )()(
-                hidden_states,
-                flat_ids,
-                layout_metadata,
-                permuted_idx,
-                inverse_indices,
-                write_offsets,
-                expert_input,
+        if self._parallel_scan_fns is not None:
+            block_offsets = torch.empty(
+                (self._scan_blocks, self.num_experts), dtype=torch.int32, device=device
             )
+            count, prefix, scatter = (make() for make in self._parallel_scan_fns)
+            count(flat_ids, block_offsets)
+            prefix(block_offsets, layout_metadata)
+            scatter(flat_ids, block_offsets, permuted_idx, inverse_indices)
         else:
+            assert self._scan_fn is not None
             self._scan_fn(self.config["threads"])(
                 flat_ids,
                 layout_metadata,
                 permuted_idx,
                 inverse_indices,
-                write_offsets,
             )
-            self._gather_fn()(hidden_states, permuted_idx, expert_input)
+        self._gather_fn()(hidden_states, permuted_idx, expert_input)
         return expert_input, layout_metadata, inverse_indices

--- a/src/tileops/kernels/moe/unpermute.py
+++ b/src/tileops/kernels/moe/unpermute.py
@@ -1,13 +1,4 @@
-"""Weighted inverse-permute kernel used by staged MoE PostPermute.
-
-Scatters expert outputs back to original token order, applies routing weights,
-and reduces K expert contributions per token.
-
-One block per token (T blocks total):
-  - For each of K expert slots: load expert_output[inverse_indices[i*K+k]]
-  - Multiply by topk_weights[i, k] (float32)
-  - Accumulate into float32 thread-local buffer
-  - Cast to output dtype and store to output[i]
+"""Weighted inverse permute for staged MoE PostPermute.
 
 Inputs:
   expert_output    [materialized_rows, H] bf16/fp16 expert output
@@ -15,7 +6,7 @@ Inputs:
   topk_weights     [T, K]                 float32 routing weights
 
 Output:
-  output           [T, H]     bf16/fp16
+  output           [T, H]                 bf16/fp16
 """
 
 import functools
@@ -27,6 +18,7 @@ import torch
 
 from tileops.kernels.buffer_utils import tensors_overlap
 from tileops.kernels.kernel_base import Kernel
+from tileops.utils import get_sm_count
 
 __all__ = ["MoeUnpermuteKernel"]
 
@@ -38,24 +30,10 @@ def _make_unpermute_kernel(
     hidden_size: int,
     materialized_rows: int,
     dtype: str,
+    threads: int,
     scaling: float = 1.0,
 ):
-    """One block per token; threads cooperate over the H dimension.
-
-    Threads are capped at 256 (see below), so each thread handles ceil(H /
-    threads) elements: a clean multiple of VEC=8 (128-bit uint4 load/store)
-    when H // threads is, otherwise partially vectorized (e.g. H=7168 -> 256
-    threads -> 28 elems/thread = 3.5x VEC). Accumulation is in float32, cast to
-    dtype on store.
-    """
-    # 1024 threads spill the fp32 acc[H] accumulator to local memory, and a count
-    # that is not hidden_size // VEC drops the 128-bit load/store for scalar ops.
-    VEC = 8  # 8 x bf16/fp16 = 128 bits
-    threads = min(256, hidden_size // VEC)
-    if threads > 0:
-        threads = 1 << (threads.bit_length() - 1)
-    threads = max(threads, 1)
-
+    """Build one block per output token with an fp32 reduction."""
     numel = num_tokens * top_k
 
     @tilelang.jit(out_idx=[], compile_flags=["-O3", "-DENABLE_BF16"])
@@ -111,11 +89,9 @@ class MoeUnpermuteKernel(Kernel):
         scaling: Scalar multiplied into the reduced output before the cast/store
             (folds ``routed_scaling_factor``). Defaults to 1.0 (no scaling).
         dtype: Data type of expert output and final output (bf16 or fp16).
-        config: Optional config dict. This kernel exposes no tunable knobs.
-        tune: Whether to autotune. The launch geometry is one block per token
-            with a fixed thread count, so ``autotune_configs`` is undefined and
-            ``tune=True`` degrades to the default config with a warning from
-            ``Kernel.init_config``.
+        config: Optional config dict with ``threads``.
+        tune: Whether to autotune.
+        sm_count: Device SM count used to choose the low-token launch width.
 
     Example:
         ```python linenums="1"
@@ -136,6 +112,7 @@ class MoeUnpermuteKernel(Kernel):
         dtype: torch.dtype = torch.bfloat16,
         config: Optional[dict] = None,
         tune: bool = False,
+        sm_count: Optional[int] = None,
     ):
         super().__init__()
         self.num_tokens = num_tokens
@@ -144,16 +121,33 @@ class MoeUnpermuteKernel(Kernel):
         self.materialized_rows = materialized_rows
         self.dtype = dtype
         self.numel = num_tokens * top_k
+        self.sm_count = get_sm_count() if sm_count is None else sm_count
+        if self.sm_count <= 0:
+            raise ValueError("sm_count must be positive")
+        self.init_config(config, tune)
 
         self._unpermute_fn = _make_unpermute_kernel(
-            num_tokens, top_k, hidden_size, materialized_rows, self.dtype_str, scaling
+            num_tokens,
+            top_k,
+            hidden_size,
+            materialized_rows,
+            self.dtype_str,
+            self.config["threads"],
+            scaling,
         )
-
-        self.init_config(config, tune)
 
     @property
     def default_config(self) -> dict:
-        return {}
+        vector = 8
+        vector_threads = min(1024, self.hidden_size // vector)
+        while vector_threads > 0 and self.hidden_size % vector_threads != 0:
+            vector_threads -= 1
+        if self.num_tokens <= self.sm_count:
+            return {"threads": max(vector_threads, 1)}
+        threads = min(256, self.hidden_size // vector)
+        if threads > 0:
+            threads = 1 << (threads.bit_length() - 1)
+        return {"threads": max(threads, 1)}
 
     def forward(
         self,

--- a/src/tileops/ops/moe/staged.py
+++ b/src/tileops/ops/moe/staged.py
@@ -73,6 +73,7 @@ class _ContiguousPostPermuteKernel(Kernel):
             call.materialized_rows,
             scaling=call.epilogue.routed_scaling_factor,
             dtype=call.input_dtype,
+            sm_count=call.sm_count,
         )
 
     def forward(

--- a/tests/ops/test_moe_staged_contracts.py
+++ b/tests/ops/test_moe_staged_contracts.py
@@ -504,6 +504,35 @@ def test_staged_tight_pre_post_round_trip(dtype: torch.dtype) -> None:
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="staged kernels require CUDA")
+@pytest.mark.parametrize(
+    "tokens,top_k,experts,hidden",
+    [(512, 8, 128, 128), (32, 8, 128, 7168)],
+)
+def test_staged_tight_optimized_shapes_round_trip(
+    tokens: int, top_k: int, experts: int, hidden: int
+) -> None:
+    x = torch.randn(tokens, hidden, dtype=torch.bfloat16, device="cuda")
+    local_ids = (
+        torch.arange(tokens * top_k, dtype=torch.int32, device="cuda")
+        .remainder(experts)
+        .reshape(tokens, top_k)
+    )
+    weights = torch.rand(tokens, top_k, dtype=torch.float32, device="cuda")
+    layout = ContiguousLayoutSpec.tight_physical_psum()
+    pre = MoePrePermuteFwdOp(layout, num_local_experts=experts)
+
+    expert_input, physical_ends, inverse = pre(x, local_ids)
+
+    token_rows = torch.arange(tokens * top_k, device="cuda") // top_k
+    torch.testing.assert_close(expert_input[inverse.long()], x[token_rows], rtol=0, atol=0)
+    counts = torch.bincount(local_ids.flatten().long(), minlength=experts)
+    torch.testing.assert_close(physical_ends, counts.cumsum(0).int(), rtol=0, atol=0)
+    output = MoePostPermuteFwdOp(layout)(expert_input, weights, inverse)
+    expected = x.float() * weights.sum(dim=1, keepdim=True)
+    torch.testing.assert_close(output.float(), expected, rtol=2e-2, atol=2e-2)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="staged kernels require CUDA")
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 def test_staged_aligned_per_row_pre_post_round_trip(dtype: torch.dtype) -> None:
     tokens, top_k, experts, hidden, alignment = 4, 2, 4, 64, 4


### PR DESCRIPTION
## Summary

- parallelize large tight PrePermute route tables as block count, prefix/block-offset, and block scatter; keep cursors in shared memory and choose gather rows per CTA from the kernel config
- widen low-token Unpermute CTAs to the largest fully vectorized row width while retaining the 256-thread default for launches that already cover the SMs

## Benchmark

**Environment**: NVIDIA H200, CUDA 13.2, PyTorch 2.13.0+cu132, TileLang 0.1.12, vLLM 0.27.1; BF16; event median over three runs

### MoePrePermuteFwdOp

Shape is `(tokens, top_k, experts, hidden)`.

| Shape | dtype | TileOPs (ms) | vLLM Triton (ms) | Speedup | BW (TB/s) |
| --- | --- | ---: | ---: | ---: | ---: |
| (32, 8, 128, 7168) | bfloat16 | 0.009088 | 0.022560 | 2.482 | 0.455 |
| (128, 8, 128, 7168) | bfloat16 | 0.013504 | 0.028608 | 2.118 | 1.224 |
| (512, 8, 128, 7168) | bfloat16 | 0.031872 | 0.054624 | 1.714 | 2.074 |
| (4096, 8, 128, 7168) | bfloat16 | 0.220384 | 0.274944 | 1.248 | 2.399 |

**Takeaways:** the adaptive gather geometry improves low-token occupancy, while the parallel route scan keeps the prefill row from serializing 32768 assignments through one CTA.

### MoePostPermuteFwdOp

Shape is `(tokens, top_k, hidden)`.

| Shape | dtype | TileOPs (ms) | vLLM Triton (ms) | Speedup | BW (TB/s) |
| --- | --- | ---: | ---: | ---: | ---: |
| (32, 8, 7168) | bfloat16 | 0.007968 | 0.021888 | 2.747 | 0.518 |
| (128, 8, 7168) | bfloat16 | 0.011008 | 0.023616 | 2.145 | 1.501 |
| (512, 8, 7168) | bfloat16 | 0.025120 | 0.033152 | 1.320 | 2.631 |
| (4096, 8, 7168) | bfloat16 | 0.136704 | 0.142496 | 1.042 | 3.868 |

**Takeaways:** wide CTAs recover parallelism when token blocks do not cover the H200 SMs; the existing 256-thread path remains selected at 512 and 4096 tokens.

## Regression

- the two added round-trip cases fail if block-local route offsets overlap, if the gather plan drops a routed row, or if the low-token launch changes the fp32 weighted reduction
