### PR TITLE
[Feat][GEMM] Extend GemmTemplate to dense coop1 and coop2

### DIFF
--- a/src/tileops/kernels/grouped_gemm/__init__.py
+++ b/src/tileops/kernels/grouped_gemm/__init__.py
@@ -1,11 +1,12 @@
 from .call import GroupedGemmCall
 from .grouped_gemm import GroupedGemmKernel
 from .grouped_gemm_persistent import GroupedGemmPersistentKernel
-from .template import GroupedGemmTemplate
+from .template import GemmTemplate, GroupedGemmTemplate
 
 __all__ = [
     "GroupedGemmCall",
     "GroupedGemmKernel",
     "GroupedGemmPersistentKernel",
+    "GemmTemplate",
     "GroupedGemmTemplate",
 ]

--- a/src/tileops/kernels/grouped_gemm/grouped_gemm_persistent.py
+++ b/src/tileops/kernels/grouped_gemm/grouped_gemm_persistent.py
@@ -5,7 +5,7 @@ from typing import Optional
 import torch
 
 from tileops.kernels.grouped_gemm.heuristics import GemmType
-from tileops.kernels.grouped_gemm.template import GroupedGemmTemplate
+from tileops.kernels.grouped_gemm.template import GemmTemplate
 from tileops.kernels.kernel_base import Kernel
 
 __all__ = ["GroupedGemmPersistentKernel"]
@@ -61,7 +61,7 @@ class GroupedGemmPersistentKernel(Kernel):
         self.transpose_a = transpose_a
         self.transpose_b = transpose_b
         gemm_type = GemmType.K_GROUPED_CONTIGUOUS if transpose_a else GemmType.M_GROUPED_TIGHT_PSUM
-        self.inner = GroupedGemmTemplate(gemm_type, num_groups=batch_count, tune=tune)
+        self.inner = GemmTemplate(gemm_type, num_groups=batch_count, tune=tune)
 
     def forward(
         self,

--- a/src/tileops/kernels/grouped_gemm/heuristics.py
+++ b/src/tileops/kernels/grouped_gemm/heuristics.py
@@ -1,4 +1,4 @@
-"""Configuration and selection policy for ``GroupedGemmTemplate``.
+"""Configuration and selection policy for ``GemmTemplate``.
 
 ``GroupedGemmSpec`` contains compile-time kernel parameters; ``GemmDesc``
 describes one call and drives tile selection.
@@ -41,6 +41,7 @@ class _HeuristicPolicy:
 class GemmType(str, enum.Enum):
     """Which rows of ``A`` and which ``B`` a tile reads.
 
+    * ``DENSE``: one ordinary 2-D GEMM, with no group metadata.
     * ``M_GROUPED_ALIGNED_PER_ROW``: rows are
       packed per group into segments whose length is a multiple of ``block_m``,
       ``grouped_layout[row]`` names the group of each row, and rows past the
@@ -65,6 +66,7 @@ class GemmType(str, enum.Enum):
       next group, and a group with no tokens stores zeros.
     """
 
+    DENSE = "dense"
     M_GROUPED_ALIGNED_PER_ROW = "m_grouped_aligned_per_row"
     M_GROUPED_ALIGNED_PSUM = "m_grouped_aligned_psum"
     M_GROUPED_TIGHT_PSUM = "m_grouped_tight_psum"
@@ -86,7 +88,7 @@ PER_ROW_TYPES = (GemmType.M_GROUPED_ALIGNED_PER_ROW, GemmType.M_GROUPED_TIGHT_PE
 # The one type whose A carries no grouping in its rows: it may be MN-major and
 # takes the widest tiles.
 # One full tile grid per group, and no M-grouping to constrain the tile.
-_FLAT_LIKE_TYPES = (GemmType.BATCHED, GemmType.K_GROUPED_CONTIGUOUS)
+_FLAT_LIKE_TYPES = (GemmType.DENSE, GemmType.BATCHED, GemmType.K_GROUPED_CONTIGUOUS)
 
 
 # Gated activations the epilogue can fuse: B stacks gate and up along N; a tile's B
@@ -127,10 +129,24 @@ class GroupedGemmSpec:
     num_math_threads: int
     num_sms: int
     activation: str = "none"
+    epilogue_stage_n: int = 0
+    swizzle_group_m: int = 0
 
     def __post_init__(self) -> None:
         if self.activation not in ACTIVATIONS:
             raise ValueError(f"activation must be one of {ACTIVATIONS}, got {self.activation!r}")
+        c_tile_n = self.block_n // 2 if self.activation != "none" else self.block_n
+        if self.epilogue_stage_n < 0:
+            raise ValueError("epilogue_stage_n must be non-negative")
+        if self.epilogue_stage_n:
+            if self.gemm_type is not GemmType.DENSE or self.activation != "none":
+                raise ValueError("epilogue_stage_n only supports an unfused dense GEMM")
+            if c_tile_n % self.epilogue_stage_n:
+                raise ValueError("epilogue_stage_n must divide the output tile width")
+        if self.swizzle_group_m and self.gemm_type is not GemmType.DENSE:
+            raise ValueError("swizzle_group_m only supports dense GEMM")
+        if self.swizzle_group_m < 0:
+            raise ValueError("swizzle_group_m must be non-negative")
         if self.activation != "none" and self.major_b is not Major.K:
             raise ValueError(
                 "a fused gated activation half-loads the B tile; an MN-major B would split "
@@ -151,10 +167,12 @@ class GroupedGemmSpec:
             raise ValueError(f"block_n must be a multiple of 8 in [8, 256], got {self.block_n}")
         if self.block_k not in (64, 128):
             raise ValueError(f"block_k must be 64 or 128, got {self.block_k}")
-        if self.num_math_threads != (128 if self.block_m <= 64 else 256):
+        if self.num_math_threads not in (128, 256):
+            raise ValueError("num_math_threads must be 128 or 256")
+        if self.block_m // self.num_math_warpgroups not in (64, 128):
             raise ValueError(
-                "num_math_threads is 128 for block_m <= 64 and 256 otherwise, "
-                f"got {self.num_math_threads} for block_m={self.block_m}"
+                f"num_math_threads={self.num_math_threads} makes each math warpgroup own "
+                f"{self.block_m // self.num_math_warpgroups} rows; expected 64 or 128"
             )
         if self.num_stages < 2:
             # The mainloop keeps one WGMMA group in flight and releases a stage
@@ -240,9 +258,9 @@ def _align(x: int, a: int) -> int:
     return (x + a - 1) // a * a
 
 
-def _num_stages(desc: GemmDesc, layout: _Layout) -> int:
+def _num_stages(desc: GemmDesc, layout: _Layout, epilogue_stage_n: int = 0) -> int:
     cd_bytes = 4 if desc.cd_dtype == "float32" else 2
-    c_width = layout.block_n // 2 if desc.fused else layout.block_n
+    c_width = epilogue_stage_n or (layout.block_n // 2 if desc.fused else layout.block_n)
     smem_cd = _align(layout.block_m * c_width * cd_bytes, 1024)
     prefix_ints = desc.num_groups + 2
     if desc.gemm_type is GemmType.M_GROUPED_TIGHT_PER_ROW:
@@ -254,7 +272,11 @@ def _num_stages(desc: GemmDesc, layout: _Layout) -> int:
         policy.smem_capacity
         - smem_cd
         - policy.barrier_bytes
-        - policy.smem_alignment_slack
+        - (
+            0
+            if epilogue_stage_n and desc.gemm_type is GemmType.DENSE
+            else policy.smem_alignment_slack
+        )
         - smem_prefix
     )
     return min(budget // per_stage, policy.max_stages)
@@ -355,7 +377,15 @@ def _best_layout(desc: GemmDesc, candidates: list[_Layout]) -> _Layout:
     return min(candidates, key=lambda lay: _num_cycles(desc, lay)[1])
 
 
-def _spec(desc: GemmDesc, layout: _Layout, num_stages: int) -> GroupedGemmSpec:
+def _spec(
+    desc: GemmDesc,
+    layout: _Layout,
+    num_stages: int,
+    *,
+    epilogue_stage_n: int = 0,
+    swizzle_group_m: int = 0,
+    num_math_wgs: int = 0,
+) -> GroupedGemmSpec:
     return GroupedGemmSpec(
         gemm_type=desc.gemm_type,
         major_a=desc.major_a,
@@ -370,9 +400,13 @@ def _spec(desc: GemmDesc, layout: _Layout, num_stages: int) -> GroupedGemmSpec:
         block_n=layout.block_n,
         block_k=layout.block_k,
         num_stages=num_stages,
-        num_math_threads=_num_math_threads(layout.block_m),
+        num_math_threads=(
+            128 * num_math_wgs if num_math_wgs else _num_math_threads(layout.block_m)
+        ),
         num_sms=desc.num_sms,
         activation=desc.activation,
+        epilogue_stage_n=epilogue_stage_n,
+        swizzle_group_m=swizzle_group_m,
     )
 
 
@@ -392,7 +426,15 @@ def spec_from_config(desc: GemmDesc, config: dict) -> GroupedGemmSpec:
     pipeline depth alone; a pinned one past the budget is refused rather than
     launched.
     """
-    unknown = set(config) - {"block_m", "block_n", "block_k", "num_stages"}
+    unknown = set(config) - {
+        "block_m",
+        "block_n",
+        "block_k",
+        "num_stages",
+        "epilogue_stage_n",
+        "swizzle_group_m",
+        "num_math_wgs",
+    }
     if unknown:
         raise ValueError(f"config names no such template parameter: {sorted(unknown)}")
     layout = _Layout(
@@ -404,7 +446,8 @@ def spec_from_config(desc: GemmDesc, config: dict) -> GroupedGemmSpec:
             f"starts up to block_m and reads a tile's group off its first row, so a block_m of "
             f"{layout.block_m} does not fit m_alignment={desc.m_alignment}"
         )
-    max_stages = _num_stages(desc, layout)
+    epilogue_stage_n = config.get("epilogue_stage_n", 0)
+    max_stages = _num_stages(desc, layout, epilogue_stage_n)
     stages = config.get("num_stages", max_stages)
     if not 2 <= stages <= max_stages:
         raise ValueError(
@@ -412,4 +455,13 @@ def spec_from_config(desc: GemmDesc, config: dict) -> GroupedGemmSpec:
             f"{max_stages} stages in shared memory, got num_stages={stages}; the pipeline "
             "needs at least 2"
         )
-    return _spec(desc, layout, stages)
+    return _spec(
+        desc,
+        layout,
+        stages,
+        epilogue_stage_n=epilogue_stage_n,
+        swizzle_group_m=config.get(
+            "swizzle_group_m", 16 if desc.gemm_type is GemmType.DENSE else 0
+        ),
+        num_math_wgs=config.get("num_math_wgs", 0),
+    )

--- a/src/tileops/kernels/grouped_gemm/template.py
+++ b/src/tileops/kernels/grouped_gemm/template.py
@@ -1,6 +1,6 @@
 """Persistent grouped GEMM template for grouped, batched, and MoE layouts.
 
-Inputs and output shapes are documented by ``GroupedGemmTemplate``.
+Inputs and output shapes are documented by ``GemmTemplate``.
 """
 
 import functools
@@ -30,6 +30,7 @@ __all__ = [
     "GemmDesc",
     "GemmType",
     "Major",
+    "GemmTemplate",
     "GroupedGemmTemplate",
     "GroupedGemmSpec",
 ]
@@ -62,6 +63,8 @@ def _make_prim_func(
     num_math_wgs: int,
     num_sms: int,
     activation: str,
+    epilogue_stage_n: int,
+    swizzle_group_m: int,
 ):
     """Build the ``@T.prim_func`` for one spec; parameters are the spec's scalars."""
     dtype = ab_dtype
@@ -72,25 +75,33 @@ def _make_prim_func(
     threads = tma_threads + math_threads
     wg_rows = block_m // num_math_wgs
     math_warps = math_threads // 32
-    blocks_per_group = _num_1d_blocks_per_group(block_m, block_n, num_sms)
-    tma_regs = 48
-    math_regs = 248 if num_math_wgs == 1 else 224
+    blocks_per_group = (
+        swizzle_group_m
+        if gtype is GemmType.DENSE and swizzle_group_m
+        else _num_1d_blocks_per_group(block_m, block_n, num_sms)
+    )
+    dense_coop2 = gtype is GemmType.DENSE and num_math_wgs == 2
+    tma_regs = 24 if dense_coop2 else 48
+    math_regs = 240 if dense_coop2 else (248 if num_math_wgs == 1 else 224)
     swizzle_atom = 64
     epilogue_barrier_base = 8
     cast_output = cd_dtype != "float32"
     fused = activation != "none"
     c_tile_n = block_n // 2 if fused else block_n  # output columns per tile
+    staged_n = epilogue_stage_n or c_tile_n
+    epilogue_chunks = c_tile_n // staged_n
 
     # Scheduler family and what each operand looks like.
     masked = gtype is GemmType.M_GROUPED_MASKED
     aligned_psum = gtype is GemmType.M_GROUPED_ALIGNED_PSUM
     tight_per_row = gtype is GemmType.M_GROUPED_TIGHT_PER_ROW
     tight = gtype in (GemmType.M_GROUPED_TIGHT_PSUM, GemmType.M_GROUPED_TIGHT_PER_ROW)
+    dense = gtype is GemmType.DENSE
     batched = gtype is GemmType.BATCHED
     k_grouped = gtype is GemmType.K_GROUPED_CONTIGUOUS
     per_group = gtype in PER_GROUP_TYPES
     a_has_group = masked or batched
-    b_has_group = not k_grouped  # K-grouped shares one B across the groups
+    b_has_group = not (dense or k_grouped)
     c_has_group = a_has_group or k_grouped
     # A K-major operand's TMA box must start 16 bytes aligned along K, so a
     # K-grouped GEMM with one rounds each group's start down to 8 elements and
@@ -141,6 +152,8 @@ def _make_prim_func(
     def b_half_region(B, group, n0, k0, atom):
         """``block_n / 2`` columns and one K atom of a K-major B (the fused path takes no other)."""
         kk = k0 + atom * swizzle_atom
+        if dense:
+            return B[n0 : n0 + half_n, kk : kk + swizzle_atom]
         return B[group, n0 : n0 + half_n, kk : kk + swizzle_atom]
 
     def align_up(x):
@@ -236,7 +249,12 @@ def _make_prim_func(
         t_k0[0] = T.int32(0)
         t_klen[0] = k
         t_khead[0] = T.int32(0)
-        if batched or k_grouped:
+        if dense:
+            swizzle_block(block_idx, num_m_blocks, num_n_blocks, m_blk, n_blk)
+            t_group[0] = T.int32(0)
+            t_row0[0] = m_blk[0] * T.int32(block_m)
+            t_rows[0] = T.int32(block_m)
+        elif batched or k_grouped:
             per_batch = num_m_blocks * num_n_blocks
             rem = block_idx % per_batch
             t_group[0] = block_idx // per_batch
@@ -368,40 +386,27 @@ def _make_prim_func(
 
     @T.macro
     def store_tile(C, C_src, C_up, C_s, group, row0, col0, rows, wg):
-        """Store one warp-group's rows of a tile from its shared staging buffer.
-
-        Every tile is staged fragment -> shared first (the fused epilogue does its
-        arithmetic on the way); the previous tile's TMA store may still be reading
-        ``C_s``, hence the barrier before. A full tile then goes out through TMA. A
-        tight group's ragged last tile cannot: TMA clips against the tensor, not the
-        group, and would overwrite the next group's rows, so its valid rows are
-        written back with row-predicated vector stores. (Writing the accumulator
-        fragment straight from registers scattered 4-byte stores across the tile
-        and produces scattered stores.)
-        """
-        T.sync_threads(barrier_id=epilogue_barrier_base + wg, arrive_count=128)
-        if fused:
-            gate_multiply(C_src, C_up, C_s)
-        else:
-            T.copy(C_src, C_s)
-        if tight:
-            if rows < T.int32(wg_rows):
+        """Stage and store one warp-group's rows of a tile."""
+        for chunk in range(epilogue_chunks):
+            chunk_col = chunk * staged_n
+            T.sync_threads(barrier_id=epilogue_barrier_base + wg, arrive_count=128)
+            if fused:
+                gate_multiply(C_src, C_up, C_s)
+            else:
+                T.copy(C_src[:, chunk_col : chunk_col + staged_n], C_s)
+            if tight and rows < T.int32(wg_rows):
                 T.sync_threads(barrier_id=epilogue_barrier_base + wg, arrive_count=128)
                 if rows > 0:
-                    for i, j in T.Parallel(wg_rows, c_tile_n):
-                        if i < rows and col0 + j < c_cols:
-                            C[row0 + i, col0 + j] = C_s[i, j]
+                    for i, j in T.Parallel(wg_rows, staged_n):
+                        if i < rows and col0 + chunk_col + j < c_cols:
+                            C[row0 + i, col0 + chunk_col + j] = C_s[i, j]
             else:
                 T.fence_proxy_async()
                 T.sync_threads(barrier_id=epilogue_barrier_base + wg, arrive_count=128)
-                T.copy(C_s, C[row0, col0])
-        else:
-            T.fence_proxy_async()
-            T.sync_threads(barrier_id=epilogue_barrier_base + wg, arrive_count=128)
-            if c_has_group:
-                T.copy(C_s, C[group, row0, col0])
-            else:
-                T.copy(C_s, C[row0, col0])
+                if c_has_group:
+                    T.copy(C_s, C[group, row0, col0 + chunk_col])
+                else:
+                    T.copy(C_s, C[row0, col0 + chunk_col])
 
     @T.macro
     def release_stage(empty, slot, lane):
@@ -523,7 +528,7 @@ def _make_prim_func(
                 else C_l0
             )
             C_up0 = T.alloc_fragment((wg_rows, half_n), accum_dtype) if fused else C_l0
-            C_s0 = T.alloc_shared((wg_rows, c_tile_n), cd_dtype)
+            C_s0 = T.alloc_shared((wg_rows, staged_n), cd_dtype)
             if num_math_wgs > 1:
                 C_l1 = T.alloc_fragment((wg_rows, block_n), accum_dtype)
                 C_cast1 = (
@@ -532,10 +537,13 @@ def _make_prim_func(
                     else C_l1
                 )
                 C_up1 = T.alloc_fragment((wg_rows, half_n), accum_dtype) if fused else C_l1
-                C_s1 = T.alloc_shared((wg_rows, c_tile_n), cd_dtype)
-            # Per-group tile prefix sum and the call's tile count (per_group family).
-            s_cum = T.alloc_shared((num_groups + 1,), "int32")
-            s_total = T.alloc_shared((1,), "int32")
+                C_s1 = T.alloc_shared((wg_rows, staged_n), cd_dtype)
+            if dense:
+                s_cum = T.alloc_local((1,), "int32")
+                s_total = T.alloc_local((1,), "int32")
+            else:
+                s_cum = T.alloc_shared((num_groups + 1,), "int32")
+                s_total = T.alloc_shared((1,), "int32")
             if tight_per_row:
                 s_ends = T.alloc_shared((num_groups,), "int32")
 
@@ -570,7 +578,8 @@ def _make_prim_func(
                 if tx == 0:
                     k_cumsum(grouped_layout, s_cum)
 
-            T.sync_threads()
+            if not dense:
+                T.sync_threads()
 
             if per_group:
                 num_blocks = s_total[0]
@@ -700,6 +709,8 @@ def _grouped_gemm_kernel(spec: GroupedGemmSpec):
     num_math_wgs = spec.num_math_warpgroups
     num_sms = spec.num_sms
     activation = spec.activation
+    epilogue_stage_n = spec.epilogue_stage_n
+    swizzle_group_m = spec.swizzle_group_m
 
     @tilelang.jit(
         out_idx=[],
@@ -727,6 +738,8 @@ def _grouped_gemm_kernel(spec: GroupedGemmSpec):
             num_math_wgs,
             num_sms,
             activation,
+            epilogue_stage_n,
+            swizzle_group_m,
         )
 
     return _func
@@ -746,7 +759,7 @@ def _torch_dtype_str(dtype: torch.dtype) -> str:
     return str(dtype).split(".")[-1]
 
 
-class GroupedGemmTemplate(Kernel):
+class GemmTemplate(Kernel):
     """16-bit grouped GEMM template for Hopper.
 
     ``C = A @ B^T`` per group on bf16 or fp16 operands with fp32 accumulation and
@@ -757,6 +770,7 @@ class GroupedGemmTemplate(Kernel):
 
     | ``gemm_type``               | ``a``            | ``b``          | ``c``            | ``grouped_layout``           |
     | --------------------------- | ---------------- | -------------- | ---------------- | ---------------------------- |
+    | ``DENSE``                   | ``[M, K]``       | ``[N, K]``     | ``[M, N]``       | none                         |
     | ``M_GROUPED_ALIGNED_PER_ROW`` | ``[M, K]``     | ``[G, N, K]``  | ``[M, N]``       | ``[M]`` group of each row    |
     | ``M_GROUPED_ALIGNED_PSUM``  | ``[M, K]``       | ``[G, N, K]``  | ``[M, N]``       | ``[G]`` psum row ends        |
     | ``M_GROUPED_TIGHT_PSUM``    | ``[M, K]``       | ``[G, N, K]``  | ``[M, N]``       | ``[G]`` psum row ends        |
@@ -765,19 +779,17 @@ class GroupedGemmTemplate(Kernel):
     | ``BATCHED``                 | ``[G, M, K]``    | ``[G, N, K]``  | ``[G, M, N]``    | none                         |
     | ``K_GROUPED_CONTIGUOUS``    | ``[M, sum_k]``   | ``[N, sum_k]`` | ``[G, M, N]``    | ``[G]`` K per group          |
 
-    With ``activation`` set, ``b`` stacks the gate and up projections along ``N``
-    (``[G, 2 * ffn, K]``) and ``c`` is ``act(gate) * up`` with ``ffn`` columns; the
-    activation is fused into the epilogue, so the ``[M, 2 * ffn]`` intermediate is
-    never written.
+    With ``activation`` set, ``b`` stacks gate and up along ``N`` and ``c`` has
+    half as many columns.
 
     A selector chooses a legal tile layout per call; ``config`` may pin one.
     Dimensions absent from ``static_dims`` remain dynamic.
 
     Example:
         ```python linenums="1"
-        kernel = GroupedGemmTemplate(GemmType.M_GROUPED_TIGHT_PSUM, num_groups=E)
+        kernel = GemmTemplate(GemmType.M_GROUPED_TIGHT_PSUM, num_groups=E)
         c = kernel(a, b, grouped_layout=ends)  # a: [M, K], b: [E, N, K], ends: [E] int32
-        kernel = GroupedGemmTemplate(GemmType.BATCHED, num_groups=G)
+        kernel = GemmTemplate(GemmType.BATCHED, num_groups=G)
         c = kernel(a, b)  # a: [G, M, K], b: [G, N, K]
         ```
     """
@@ -822,6 +834,8 @@ class GroupedGemmTemplate(Kernel):
         super().__init__(device_index=device_index)
         if num_groups < 1:
             raise ValueError(f"num_groups must be positive, got {num_groups}")
+        if GemmType(gemm_type) is GemmType.DENSE and num_groups != 1:
+            raise ValueError(f"dense requires num_groups=1, got {num_groups}")
         if m_alignment < 1:
             raise ValueError(f"m_alignment must be positive, got {m_alignment}")
         if activation not in ACTIVATIONS:
@@ -837,6 +851,8 @@ class GroupedGemmTemplate(Kernel):
         self.expected_m = expected_m
         self.sm_count = get_sm_count(device_index) if sm_count is None else sm_count
         self.explicit_config = config
+        self._spec_cache: dict[GemmDesc, GroupedGemmSpec] = {}
+        self._empty_layout = None
         self.init_config(config, tune)
 
     @property
@@ -857,6 +873,9 @@ class GroupedGemmTemplate(Kernel):
         if self.gemm_type is GemmType.K_GROUPED_CONTIGUOUS:
             if a.ndim != 2 or b.ndim != 2:
                 raise ValueError("k_grouped_contiguous takes A as [M, sum_k] and B as [N, sum_k]")
+        elif self.gemm_type is GemmType.DENSE:
+            if a.ndim != 2 or b.ndim != 2:
+                raise ValueError("dense takes A as [M, K] and B as [N, K]")
         else:
             a_ndim = 3 if self._a_has_group else 2
             if a.ndim != a_ndim:
@@ -896,9 +915,15 @@ class GroupedGemmTemplate(Kernel):
         return self._spec_of(self.describe(a, b))
 
     def _spec_of(self, desc: GemmDesc) -> GroupedGemmSpec:
-        if self.explicit_config:
-            return spec_from_config(desc, self.explicit_config)
-        return get_best_config(desc)
+        spec = self._spec_cache.get(desc)
+        if spec is None:
+            spec = (
+                spec_from_config(desc, self.explicit_config)
+                if self.explicit_config
+                else get_best_config(desc)
+            )
+            self._spec_cache[desc] = spec
+        return spec
 
     def output_dtype(self, a: torch.Tensor) -> torch.dtype:
         """The dtype ``C`` is written in: ``cd_dtype`` when set, else the operand dtype."""
@@ -927,9 +952,9 @@ class GroupedGemmTemplate(Kernel):
 
     def _check_layout(self, desc: GemmDesc, grouped_layout: Optional[torch.Tensor]) -> None:
         gtype = self.gemm_type
-        if gtype is GemmType.BATCHED:
+        if gtype in (GemmType.DENSE, GemmType.BATCHED):
             if grouped_layout is not None:
-                raise ValueError("batched takes no grouped_layout")
+                raise ValueError(f"{gtype.value} takes no grouped_layout")
             return
         if grouped_layout is None:
             raise ValueError(f"{gtype.value} needs grouped_layout")
@@ -951,15 +976,14 @@ class GroupedGemmTemplate(Kernel):
         grouped_layout: Optional[torch.Tensor] = None,
         out: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        """Run ``C = A @ B^T`` per group or batch and return ``C``.
+        """Run dense ``C = A @ B^T`` or its grouped/batched forms.
 
         Args:
-            a: Logical ``[M, K]`` bf16 or fp16, ``[G, M, K]`` for masked and batched,
-                ``[M, sum_k]`` for K-grouped; a transposed view of contiguous storage is
-                MN-major.
-            b: Logical ``[G, N, K]`` in ``a``'s dtype, ``[N, sum_k]`` for K-grouped; a
-                transposed view of ``[G, K, N]`` storage is MN-major.
-            grouped_layout: int32 layout metadata per the class table; none for batched.
+            a: ``[M, K]``, ``[G, M, K]`` for masked/batched, or ``[M, sum_k]``
+                for K-grouped.
+            b: ``[N, K]`` for dense, ``[G, N, K]`` for grouped/batched, or
+                ``[N, sum_k]`` for K-grouped.
+            grouped_layout: int32 metadata per the class table; none for dense/batched.
             out: Optional preallocated output in ``cd_dtype``.
         """
         self._require_cuda(a=a, b=b, grouped_layout=grouped_layout, out=out)
@@ -979,7 +1003,9 @@ class GroupedGemmTemplate(Kernel):
         if not a_phys.is_contiguous() or not b_phys.is_contiguous():
             raise ValueError("a and b must be contiguous in their physical (K- or MN-major) layout")
         if grouped_layout is None:
-            grouped_layout = torch.zeros(1, dtype=torch.int32, device=a.device)
+            if self._empty_layout is None or self._empty_layout.device != a.device:
+                self._empty_layout = torch.zeros(1, dtype=torch.int32, device=a.device)
+            grouped_layout = self._empty_layout
         c_cols = desc.c_cols
         c_shape = (self.num_groups, desc.m, c_cols) if self._c_has_group else (desc.m, c_cols)
         cd_dtype = self.output_dtype(a)
@@ -1000,3 +1026,6 @@ class GroupedGemmTemplate(Kernel):
         fn = _grouped_gemm_kernel(spec)()
         fn(a_phys, b_phys, out, grouped_layout)
         return out
+
+
+GroupedGemmTemplate = GemmTemplate

--- a/src/tileops/kernels/moe/moe_grouped_gemm.py
+++ b/src/tileops/kernels/moe/moe_grouped_gemm.py
@@ -5,7 +5,7 @@ from typing import Optional
 import torch
 
 from tileops.kernels.grouped_gemm.heuristics import ACTIVATIONS, GemmType
-from tileops.kernels.grouped_gemm.template import GroupedGemmTemplate
+from tileops.kernels.grouped_gemm.template import GemmTemplate
 from tileops.kernels.kernel_base import Kernel
 
 __all__ = ["MoeGroupedGemmKernel"]
@@ -40,7 +40,7 @@ class MoeGroupedGemmKernel(Kernel):
     def __init__(self, call) -> None:
         super().__init__()
         self.call = call
-        self.inner = GroupedGemmTemplate(
+        self.inner = GemmTemplate(
             self._TYPES[(call.kind, call.packing, call.metadata_kind)],
             num_groups=call.num_groups,
             m_alignment=call.alignment if call.packing == "aligned" else 128,

--- a/src/tileops/kernels/moe/shared_expert_mlp.py
+++ b/src/tileops/kernels/moe/shared_expert_mlp.py
@@ -8,37 +8,17 @@ import tilelang.language as T
 import torch
 
 from tileops.kernels.gemm.dense import GemmBasicKernel, GemmKernel
+from tileops.kernels.grouped_gemm.heuristics import GemmType
+from tileops.kernels.grouped_gemm.template import GemmTemplate
 from tileops.kernels.kernel_base import Kernel
 from tileops.utils import get_sm_version
 
 __all__ = ["SharedExpertMLPKernel"]
 
-# Hopper default. NOTE: its 3-stage pipelined SMEM footprint is
-# (128+256)*64*2B*3 = 144KB for the loads plus a 64KB C tile (208KB total),
-# which exceeds the per-block dynamic shared-memory limit of every pre-Hopper
-# CUDA card (163KB on sm80 — launch fails, verified on real sm80 hardware —
-# and 99KB on sm86/sm89): pass an explicit ``config=`` with a smaller tile
-# there.
-# The rasterization switch is inert for GemmBasicKernel (init_config keeps
-# only its own config keys).
-_DEFAULT_CONFIG = {
-    "block_m": 128,
-    "block_n": 256,
-    "block_k": 64,
-    "num_stages": 3,
-    "threads": 256,
-    "enable_rasterization": True,
-}
-
 
 @functools.lru_cache(maxsize=16)
 def _silu_mul_fused_kernel(M: int, N: int, dtype_str: str):
-    """Fused SiLU + elementwise multiply operating on a combined [M, 2N] gate_up tensor.
-
-    Reads gate = gate_up[:, :N] and up = gate_up[:, N:] via index offset,
-    avoiding intermediate buffer allocations for the split.
-    Uses FP32 accumulation for numerical stability.
-    """
+    """Map ``gate_up[M, 2N]`` to ``silu(gate) * up[M, N]``."""
     dtype = dtype_str
 
     @tilelang.jit(
@@ -79,14 +59,11 @@ def _silu_mul_fused_kernel(M: int, N: int, dtype_str: str):
 
 
 class SharedExpertMLPKernel(Kernel):
-    """Shared expert MLP: gate_up GEMM + SiLU + down GEMM.
+    """Shared expert MLP producing ``[T, H]``.
 
-    Uses GemmKernel (trans_b=True) for both GEMMs.
-
-    Forward signature:
-        hidden:    [T, H]
-        w_gate_up: [2F, H]  — gate and up weights concatenated along dim 0
-        w_down:    [H, F]
+    Inputs are ``hidden[T, H]``, concatenated ``w_gate_up[2F, H]``, and
+    ``w_down[H, F]``. Hopper uses the dense template for wide shared experts
+    above ``template_min_m``; other calls use the existing dense implementations.
     """
 
     supported_archs: list[int] = [80, 86, 89, 90]
@@ -107,32 +84,72 @@ class SharedExpertMLPKernel(Kernel):
         self.dtype = dtype
         self.init_config(config, tune)
 
-        # GemmKernel is the WGMMA + TMA sm90 build (_gemm_kernel factory).
-        # Mirror GemmFwdOp's dispatch: route to the pipelined GemmBasicKernel
-        # (plain T.gemm) on pre-Hopper targets so the shared expert stays
-        # arch-valid — this ctor builds the GEMM kernels directly, bypassing
-        # the op-level arch check that normally guards GemmKernel.
-        gemm_cls = GemmKernel if get_sm_version() == 90 else GemmBasicKernel
-        self._gemm_gate_up = gemm_cls(
-            m=num_tokens,
-            n=ffn_size * 2,
-            k=hidden_size,
-            dtype=dtype,
-            trans_b=True,
-            config=self.config,
-        )
-        self._gemm_down = gemm_cls(
-            m=num_tokens,
-            n=hidden_size,
-            k=ffn_size,
-            dtype=dtype,
-            trans_b=True,
-            config=self.config,
-        )
+        sm_version = get_sm_version()
+        if (
+            sm_version == 90
+            and num_tokens >= self.config["template_min_m"]
+            and ffn_size >= hidden_size
+        ):
+            template_config = {
+                key: self.config[key] for key in ("block_m", "block_n", "block_k", "num_stages")
+            }
+            template_config.update(num_math_wgs=2, swizzle_group_m=16)
+            self._gemm_gate_up = GemmTemplate(
+                GemmType.DENSE,
+                static_dims="mnk",
+                config=template_config,
+            )
+            self._gemm_down = GemmTemplate(
+                GemmType.DENSE,
+                static_dims="mnk",
+                config=template_config,
+            )
+        elif sm_version == 90:
+            gemm_config = self.config if config is not None else None
+            self._gemm_gate_up = GemmKernel(
+                m=num_tokens,
+                n=ffn_size * 2,
+                k=hidden_size,
+                dtype=dtype,
+                trans_b=True,
+                config=gemm_config,
+            )
+            self._gemm_down = GemmKernel(
+                m=num_tokens,
+                n=hidden_size,
+                k=ffn_size,
+                dtype=dtype,
+                trans_b=True,
+                config=gemm_config,
+            )
+        else:
+            self._gemm_gate_up = GemmBasicKernel(
+                m=num_tokens,
+                n=ffn_size * 2,
+                k=hidden_size,
+                dtype=dtype,
+                trans_b=True,
+                config=self.config,
+            )
+            self._gemm_down = GemmBasicKernel(
+                m=num_tokens,
+                n=hidden_size,
+                k=ffn_size,
+                dtype=dtype,
+                trans_b=True,
+                config=self.config,
+            )
 
     @property
     def default_config(self) -> dict:
-        return dict(_DEFAULT_CONFIG)
+        return {
+            "block_m": 128,
+            "block_n": 256,
+            "block_k": 64,
+            "num_stages": 3,
+            "threads": 256,
+            "template_min_m": 512,
+        }
 
     @property
     def autotune_configs(self) -> list[dict]:
@@ -146,7 +163,6 @@ class SharedExpertMLPKernel(Kernel):
 
         gate_up_out = self._gemm_gate_up(hidden, w_gate_up)
 
-        # The kernel splits gate and up by index offset, allocating nothing.
         silu_mul_fn = _silu_mul_fused_kernel(T_dim, F, self.dtype_str)(
             self.config["block_m"], self.config["block_n"], self.config["threads"]
         )

--- a/tests/kernels/test_grouped_gemm_template.py
+++ b/tests/kernels/test_grouped_gemm_template.py
@@ -11,7 +11,7 @@ from tileops.kernels.grouped_gemm.heuristics import (
     layout_candidates,
     spec_from_config,
 )
-from tileops.kernels.grouped_gemm.template import GemmType, GroupedGemmTemplate, Major
+from tileops.kernels.grouped_gemm.template import GemmTemplate, GemmType, Major
 
 pytestmark = pytest.mark.hopper
 
@@ -38,6 +38,61 @@ def _assert_gemm(out, ref):
 
 @pytest.mark.smoke
 @pytest.mark.parametrize(
+    "activation,cd_dtype",
+    [
+        pytest.param("none", None, id="plain"),
+        pytest.param("silu_and_mul", None, id="gated"),
+        pytest.param("none", torch.float32, id="fp32-output"),
+    ],
+)
+def test_dense(activation, cd_dtype):
+    """Dense inputs are ``A[M,K]`` and ``B[N,K]``; gated output has ``N/2`` columns."""
+    torch.manual_seed(0)
+    m, n, k = 256, 512, 512
+    b_rows = 2 * n if activation != "none" else n
+    a = torch.randn(m, k, device="cuda", dtype=torch.bfloat16)
+    b = torch.randn(b_rows, k, device="cuda", dtype=torch.bfloat16)
+    config = dict(block_m=128, block_n=128)
+    if activation == "none" and cd_dtype is None:
+        config.update(
+            block_k=64,
+            num_stages=4,
+            epilogue_stage_n=64,
+            swizzle_group_m=16,
+        )
+    kernel = GemmTemplate(
+        GemmType.DENSE,
+        activation=activation,
+        cd_dtype=cd_dtype,
+        config=config,
+    )
+    ref = a.float() @ b.float().T
+    if activation != "none":
+        gate, up = ref.chunk(2, dim=-1)
+        ref = torch.nn.functional.silu(gate) * up
+    out = kernel(a, b)
+    assert out.shape == (m, n)
+    _assert_gemm(out, ref)
+
+    if activation == "none" and cd_dtype is None:
+        assert kernel.spec_for(a, b).num_math_warpgroups == 2
+        _assert_gemm(kernel(a.T.contiguous().T, b), ref)
+        coop1 = GemmTemplate(
+            GemmType.DENSE,
+            config=dict(
+                block_m=128,
+                block_n=128,
+                block_k=64,
+                num_stages=4,
+                num_math_wgs=1,
+            ),
+        )
+        assert coop1.spec_for(a, b).num_math_warpgroups == 1
+        _assert_gemm(coop1(a, b), ref)
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
     "m,n,k,config",
     [
         pytest.param(512, 512, 512, dict(block_m=64, block_n=128), id="one-math-warpgroup"),
@@ -48,7 +103,7 @@ def _assert_gemm(out, ref):
 def test_batched_tile_shapes(m, n, k, config):
     """Each math warp-group arrangement the template offers, on the batched scheduler."""
     a, b = _batched_operands(2, m, n, k)
-    kernel = GroupedGemmTemplate(GemmType.BATCHED, num_groups=2, config=config)
+    kernel = GemmTemplate(GemmType.BATCHED, num_groups=2, config=config)
     _assert_gemm(kernel(a, b), _bmm_ref(a, b))
 
 
@@ -64,7 +119,7 @@ def test_batched_tile_shapes(m, n, k, config):
 def test_batched_layouts_from_strides(major_a, major_b):
     """Majorness is read off the operands and picks the transposed TMA/WGMMA path."""
     a, b = _batched_operands(3, 1000, 1000, 1024, major_a, major_b)
-    kernel = GroupedGemmTemplate(GemmType.BATCHED, num_groups=3)
+    kernel = GemmTemplate(GemmType.BATCHED, num_groups=3)
     spec = kernel.spec_for(a, b)
     assert spec.major_a is Major(major_a) and spec.major_b is Major(major_b)
     _assert_gemm(kernel(a, b), _bmm_ref(a, b))
@@ -73,7 +128,7 @@ def test_batched_layouts_from_strides(major_a, major_b):
 @pytest.mark.full
 def test_fp32_output():
     a, b = _batched_operands(2, 1000, 1000, 1024)
-    kernel = GroupedGemmTemplate(GemmType.BATCHED, num_groups=2, cd_dtype=torch.float32)
+    kernel = GemmTemplate(GemmType.BATCHED, num_groups=2, cd_dtype=torch.float32)
     out = kernel(a, b)
     assert out.dtype == torch.float32
     torch.testing.assert_close(out, _bmm_ref(a, b), rtol=1e-3, atol=1e-2)
@@ -82,9 +137,7 @@ def test_fp32_output():
 @pytest.mark.full
 def test_dynamic_m_shares_one_spec():
     """M is dynamic by default: two row counts resolve to one spec, hence one compiled kernel."""
-    kernel = GroupedGemmTemplate(
-        GemmType.BATCHED, num_groups=2, config=dict(block_m=128, block_n=128)
-    )
+    kernel = GemmTemplate(GemmType.BATCHED, num_groups=2, config=dict(block_m=128, block_n=128))
     a1, b = _batched_operands(2, 1024, 1024, 1024)
     a2 = torch.randn(2, 1000, 1024, device="cuda", dtype=torch.bfloat16)
     spec1, spec2 = kernel.spec_for(a1, b), kernel.spec_for(a2, b)
@@ -149,7 +202,7 @@ def _grouped_operands(sizes, n, k, layout, *, alignment=128, major_b="k", dtype=
 def test_m_grouped_aligned_per_row(sizes, n, k, major_b, config):
     """Rows follow their group's B; padding rows and the sentinel tail are never read back."""
     a, b, ids, ref, valid = _grouped_operands(sizes, n, k, "per_row", major_b=major_b)
-    kernel = GroupedGemmTemplate(
+    kernel = GemmTemplate(
         GemmType.M_GROUPED_ALIGNED_PER_ROW, num_groups=len(sizes), m_alignment=128, config=config
     )
     out = kernel(a, b, grouped_layout=ids)
@@ -159,7 +212,7 @@ def test_m_grouped_aligned_per_row(sizes, n, k, major_b, config):
 @pytest.mark.full
 def test_grouped_requires_layout_and_alignment():
     a, b, ids, _, _ = _grouped_operands([64, 64], 256, 256, "per_row")
-    kernel = GroupedGemmTemplate(GemmType.M_GROUPED_ALIGNED_PER_ROW, num_groups=2)
+    kernel = GemmTemplate(GemmType.M_GROUPED_ALIGNED_PER_ROW, num_groups=2)
     with pytest.raises(ValueError, match="grouped_layout"):
         kernel(a, b)
     with pytest.raises(ValueError, match="m_alignment"):
@@ -170,9 +223,14 @@ def test_grouped_requires_layout_and_alignment():
 def test_refuses_operands_tma_cannot_address():
     a = torch.randn(2, 64, 60, device="cuda", dtype=torch.bfloat16)
     b = torch.randn(2, 64, 60, device="cuda", dtype=torch.bfloat16)
-    assert "multiple of 8" in GroupedGemmTemplate.refusal_for(a, b)
+    assert "multiple of 8" in GemmTemplate.refusal_for(a, b)
     with pytest.raises(ValueError, match="multiple of 8"):
-        GroupedGemmTemplate(GemmType.BATCHED, num_groups=2)(a, b)
+        GemmTemplate(GemmType.BATCHED, num_groups=2)(a, b)
+    with pytest.raises(ValueError, match="multiple of 8"):
+        GemmTemplate(
+            GemmType.DENSE,
+            config=dict(block_m=128, block_n=64),
+        )(a[0], b[0])
 
 
 def _desc(m, n, k, **kw):
@@ -258,9 +316,7 @@ def test_spec_rejects_inconsistent_template_parameters():
 def test_m_grouped_tight_psum_masks_each_groups_last_tile(sizes, config):
     """Tight rows: a group's ragged last tile is stored under a row mask, not over its neighbour."""
     a, b, ends, ref, _ = _grouped_operands(sizes, 2048, 1024, "tight")
-    kernel = GroupedGemmTemplate(
-        GemmType.M_GROUPED_TIGHT_PSUM, num_groups=len(sizes), config=config
-    )
+    kernel = GemmTemplate(GemmType.M_GROUPED_TIGHT_PSUM, num_groups=len(sizes), config=config)
     out = torch.full_like(ref, 1e4, dtype=torch.bfloat16)  # poison: every row must be written
     kernel(a, b, grouped_layout=ends, out=out)
     _assert_gemm(out, ref)
@@ -275,10 +331,10 @@ def test_m_grouped_tight_per_row_recovers_the_psum_schedule():
         torch.arange(len(sizes), dtype=torch.int32, device="cuda"),
         torch.tensor(sizes, device="cuda"),
     )
-    per_row = GroupedGemmTemplate(GemmType.M_GROUPED_TIGHT_PER_ROW, num_groups=len(sizes))
+    per_row = GemmTemplate(GemmType.M_GROUPED_TIGHT_PER_ROW, num_groups=len(sizes))
     out = per_row(a, b, grouped_layout=ids)
     _assert_gemm(out, ref)
-    psum = GroupedGemmTemplate(GemmType.M_GROUPED_TIGHT_PSUM, num_groups=len(sizes))
+    psum = GemmTemplate(GemmType.M_GROUPED_TIGHT_PSUM, num_groups=len(sizes))
     assert torch.equal(out, psum(a, b, grouped_layout=ends))
 
 
@@ -293,7 +349,7 @@ def test_m_grouped_tight_per_row_recovers_the_psum_schedule():
 def test_m_grouped_aligned_psum(sizes, config):
     """Aligned psum rows: each group starts at the previous end rounded up to block_m."""
     a, b, ends, ref, valid = _grouped_operands(sizes, 2048, 1024, "aligned")
-    kernel = GroupedGemmTemplate(
+    kernel = GemmTemplate(
         GemmType.M_GROUPED_ALIGNED_PSUM, num_groups=len(sizes), m_alignment=128, config=config
     )
     out = kernel(a, b, grouped_layout=ends)
@@ -314,7 +370,7 @@ def test_m_grouped_masked(masked, max_m, config):
     groups = len(masked)
     a = torch.randn(groups, max_m, 512, device="cuda", dtype=torch.bfloat16)
     b = torch.randn(groups, 1024, 512, device="cuda", dtype=torch.bfloat16)
-    kernel = GroupedGemmTemplate(GemmType.M_GROUPED_MASKED, num_groups=groups, config=config)
+    kernel = GemmTemplate(GemmType.M_GROUPED_MASKED, num_groups=groups, config=config)
     out = kernel(a, b, grouped_layout=torch.tensor(masked, dtype=torch.int32).cuda())
     assert out.shape == (groups, max_m, 1024)
     for g, mm in enumerate(masked):
@@ -326,16 +382,16 @@ def test_m_grouped_masked(masked, max_m, config):
 def test_fp16_operands_batched_and_tight():
     """fp16 operands take the same kernel; the output follows the operand dtype."""
     a, b = _batched_operands(2, 1024, 1024, 1024, dtype=torch.float16)
-    out = GroupedGemmTemplate(GemmType.BATCHED, num_groups=2)(a, b)
+    out = GemmTemplate(GemmType.BATCHED, num_groups=2)(a, b)
     assert out.dtype is torch.float16
     _assert_gemm(out, _bmm_ref(a, b))
     ta, tb, ends, ref, _ = _grouped_operands(
         [100, 0, 300, 128, 7, 64], 512, 512, "tight", dtype=torch.float16
     )
-    kernel = GroupedGemmTemplate(GemmType.M_GROUPED_TIGHT_PSUM, num_groups=6)
+    kernel = GemmTemplate(GemmType.M_GROUPED_TIGHT_PSUM, num_groups=6)
     _assert_gemm(kernel(ta, tb, grouped_layout=ends), ref)
     with pytest.raises(ValueError, match="one dtype"):
-        GroupedGemmTemplate(GemmType.BATCHED, num_groups=2)(a, b.bfloat16())
+        GemmTemplate(GemmType.BATCHED, num_groups=2)(a, b.bfloat16())
 
 
 def _gated_ref(ref, activation):
@@ -361,7 +417,7 @@ def test_fused_gated_activation_tight(activation, config):
     """
     sizes = [100, 0, 300, 128, 7, 64]
     a, b, ends, ref, _ = _grouped_operands(sizes, 1024, 512, "tight")
-    kernel = GroupedGemmTemplate(
+    kernel = GemmTemplate(
         GemmType.M_GROUPED_TIGHT_PSUM, num_groups=len(sizes), activation=activation, config=config
     )
     out = kernel(a, b, grouped_layout=ends)
@@ -375,14 +431,14 @@ def test_fused_gated_activation_masked_and_fp32_output():
     masked = [64, 0, 17, 33]
     a, b = _batched_operands(len(masked), 64, 1024, 512)
     counts = torch.tensor(masked, dtype=torch.int32, device="cuda")
-    kernel = GroupedGemmTemplate(
+    kernel = GemmTemplate(
         GemmType.M_GROUPED_MASKED, num_groups=len(masked), activation="silu_and_mul"
     )
     out = kernel(a, b, grouped_layout=counts)
     ref = _gated_ref(_bmm_ref(a, b), "silu_and_mul")
     for g, rows in enumerate(masked):
         _assert_gemm(out[g, :rows], ref[g, :rows])
-    fp32 = GroupedGemmTemplate(
+    fp32 = GemmTemplate(
         GemmType.BATCHED, num_groups=len(masked), activation="silu_and_mul", cd_dtype=torch.float32
     )(a, b)
     assert fp32.dtype is torch.float32
@@ -393,13 +449,13 @@ def test_fused_gated_activation_masked_and_fp32_output():
 def test_fused_gated_activation_refusals():
     """A fused call needs an even split of N into gate and up, a K-major B, a known name."""
     with pytest.raises(ValueError, match="activation"):
-        GroupedGemmTemplate(GemmType.BATCHED, num_groups=2, activation="relu")
+        GemmTemplate(GemmType.BATCHED, num_groups=2, activation="relu")
     a, b = _batched_operands(2, 64, 1032, 512)
     with pytest.raises(ValueError, match="multiple of 16"):
-        GroupedGemmTemplate(GemmType.BATCHED, num_groups=2, activation="silu_and_mul")(a, b)
+        GemmTemplate(GemmType.BATCHED, num_groups=2, activation="silu_and_mul")(a, b)
     a, b = _batched_operands(2, 64, 1024, 512, major_b="mn")
     with pytest.raises(ValueError, match="K-major B"):
-        GroupedGemmTemplate(GemmType.BATCHED, num_groups=2, activation="silu_and_mul")(a, b)
+        GemmTemplate(GemmType.BATCHED, num_groups=2, activation="silu_and_mul")(a, b)
 
 
 def _k_grouped_operands(sizes, m, n, major_a="mn", major_b="mn", dtype=torch.bfloat16):
@@ -441,9 +497,7 @@ def test_k_grouped_contiguous(major_a, major_b, config):
     """
     sizes = [100, 0, 300, 64, 7, 1]
     a, b, ks, ref = _k_grouped_operands(sizes, 200, 136, major_a, major_b)
-    kernel = GroupedGemmTemplate(
-        GemmType.K_GROUPED_CONTIGUOUS, num_groups=len(sizes), config=config
-    )
+    kernel = GemmTemplate(GemmType.K_GROUPED_CONTIGUOUS, num_groups=len(sizes), config=config)
     out = torch.full_like(ref, 1e4, dtype=torch.bfloat16)  # poison: every tile must be written
     kernel(a, b, grouped_layout=ks, out=out)
     _assert_gemm(out, ref)
@@ -453,7 +507,7 @@ def test_k_grouped_contiguous(major_a, major_b, config):
 def test_k_grouped_contiguous_without_tokens_and_refusals():
     """Every group empty gives zeros without a launch; the fused epilogue is not offered."""
     a, b, ks, ref = _k_grouped_operands([0, 0, 0], 64, 64)
-    out = GroupedGemmTemplate(GemmType.K_GROUPED_CONTIGUOUS, num_groups=3)(a, b, grouped_layout=ks)
+    out = GemmTemplate(GemmType.K_GROUPED_CONTIGUOUS, num_groups=3)(a, b, grouped_layout=ks)
     assert out.shape == (3, 64, 64) and not out.any()
     with pytest.raises(ValueError, match="per-group B"):
-        GroupedGemmTemplate(GemmType.K_GROUPED_CONTIGUOUS, num_groups=3, activation="silu_and_mul")
+        GemmTemplate(GemmType.K_GROUPED_CONTIGUOUS, num_groups=3, activation="silu_and_mul")

--- a/tests/ops/test_moe_grouped_gemm.py
+++ b/tests/ops/test_moe_grouped_gemm.py
@@ -9,7 +9,7 @@ workload's per-expert reference.
 import pytest
 import torch
 
-from tileops.kernels.grouped_gemm import GroupedGemmTemplate
+from tileops.kernels.grouped_gemm import GemmTemplate
 from tileops.kernels.moe import MoeGroupedGemmKernel
 from tileops.ops.moe import (
     ContiguousLayoutSpec,
@@ -87,7 +87,7 @@ def test_grouped_gemm_runs_each_layout_through_the_op(layout_name, layout_args, 
     _assert_valid_rows(out, workload.ref_program(a, b, metadata), workload.valid_rows)
     (kernel,) = op.built_kernels("grouped_gemm").values()
     assert isinstance(kernel, MoeGroupedGemmKernel)
-    assert isinstance(kernel.inner, GroupedGemmTemplate)
+    assert isinstance(kernel.inner, GemmTemplate)
     # A second call with a new row count reuses the instance: M is not in the key.
     if layout_name == "masked":
         a2_shape = a_shape

--- a/tests/ops/test_moe_shared_fused_moe.py
+++ b/tests/ops/test_moe_shared_fused_moe.py
@@ -11,15 +11,20 @@ Verifies:
 import pytest
 import torch
 
+from tileops.kernels.gemm.dense import GemmKernel
+from tileops.kernels.grouped_gemm.template import GemmTemplate
+from tileops.kernels.moe import SharedExpertMLPKernel
 from tileops.ops.moe import SharedFusedMoE
 from tileops.ops.moe.fused_moe import FusedMoeFwdOp
+from tileops.utils import get_sm_version
 
 
 @pytest.mark.smoke
-def test_shared_fused_moe_basic():
+@pytest.mark.parametrize("num_tokens", [32, 512])
+def test_shared_fused_moe_basic(num_tokens):
     """SharedFusedMoE with shared expert kernel."""
     torch.manual_seed(42)
-    T, E, K, H, F, F_s = 32, 8, 2, 64, 32, 16
+    T, E, K, H, F, F_s = num_tokens, 8, 2, 64, 32, 16
     dtype = torch.bfloat16
     dev = "cuda"
 
@@ -61,6 +66,15 @@ def test_shared_fused_moe_basic():
     gate_up_act = torch.nn.functional.silu(gate_ref) * up_ref
     shared_ref = (gate_up_act @ shared_w_down.float().T).to(dtype)
     torch.testing.assert_close(shared_out, shared_ref, rtol=1e-2, atol=1e-2)
+
+    if get_sm_version() == 90:
+        shared_kernel = next(iter(op.built_kernels("shared_expert_mlp").values()))
+        assert isinstance(shared_kernel._gemm_gate_up, GemmKernel)
+        assert isinstance(shared_kernel._gemm_down, GemmKernel)
+        if T == 512:
+            wide = SharedExpertMLPKernel(512, 7168, 18432, dtype)
+            assert isinstance(wide._gemm_gate_up, GemmTemplate)
+            assert isinstance(wide._gemm_down, GemmTemplate)
 
     # routed_out matches FusedMoe
     op_routed = FusedMoeFwdOp(
@@ -252,8 +266,6 @@ def test_shared_fused_moe_tp_rejects_local_shards():
 @pytest.mark.smoke
 def test_a_replaced_shared_expert_kernel_is_the_one_built():
     """The shared half is reachable through kernel_map, like the routed half."""
-    from tileops.kernels.moe import SharedExpertMLPKernel
-
     built = []
 
     class Replacement(SharedExpertMLPKernel):


### PR DESCRIPTION
## Summary

- extend `GemmTemplate` with dense `[M, K] x [N, K] -> [M, N]` operands
- generate coop1 and coop2 from one kernel body through `num_math_wgs`
- add dense tile swizzling and chunked epilogue staging while skipping grouped metadata work
- use dense coop2 for wide SM90 shared experts with at least 512 tokens
- retain `GroupedGemmTemplate` as a compatibility alias; existing `gemm/dense.py` dispatch is unchanged

## Benchmark

**Environment**: NVIDIA H200

Both implementations were warmed together and sampled in alternating order. Speedup is existing dense latency divided by template latency.

### Dense coop2

| Shape `(M, N, K)` | dtype | Speedup |
| --- | --- | ---: |
| `(4096, 2112, 7168)` | BF16 | 1.008x |
| `(4096, 7168, 2048)` | BF16 | 1.017x |
| `(4096, 4096, 7168)` | FP16 | 1.018x |
| `(4096, 4096, 7168)` | BF16 | 1.001x |
| `(4096, 7168, 16384)` | BF16 | 1.005x |
| `(4096, 24576, 1536)` | BF16 | 1.010x |

### Dense coop1

| Layout | Shape `(M, N, K)` | dtype | Tile | Speedup |
| --- | --- | --- | --- | ---: |
| NT | `(1024, 1024, 1024)` | BF16 | `(64, 128, 64)` | 1.119x |
| NN | `(1024, 1024, 1024)` | BF16 | `(64, 128, 64)` | 1.103x |
| NT | `(4096, 2112, 7168)` | BF16 | `(64, 128, 64)` | 1.007x |
| NT | `(512, 7168, 2048)` | BF16 | `(64, 128, 64)` | 1.059x |

### Shared expert MLP

Kimi K2 dimensions: `H=7168`, `F=18432`, BF16.

| Tokens | Pre-PR (ms) | PR (ms) | Speedup |
| ---: | ---: | ---: | ---: |
| 512 | 0.693 | 0.658 | 1.053x |
| 2048 | 2.454 | 2.471 | 0.993x |
| 4096 | 4.701 | 4.713 | 0.997x |

The new production path is limited to SM90 shared experts with `tokens >= 512` and `ffn_size >= hidden_size`; all other shared-expert calls retain the existing kernels.